### PR TITLE
Add compiler caching to circle build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ machine:
 
 dependencies:
   override:
-    - (if [[ $(grep -cF trusty /etc/lsb-release) > 0 ]]; then sudo add-apt-repository -y ppa:kevinkreiser/libsodium; sudo add-apt-repository -y ppa:kevinkreiser/libpgm; sudo add-apt-repository -y ppa:kevinkreiser/zeromq3; sudo add-apt-repository -y ppa:kevinkreiser/czmq; fi)
+    - (if [[ $(grep -cF trusty /etc/lsb-release) > 0 ]]; then sudo add-apt-repository -y ppa:kevinkreiser/libsodium; sudo add-apt-repository -y ppa:kevinkreiser/libpgm; sudo add-apt-repository -y ppa:kevinkreiser/zeromq3; sudo add-apt-repository -y ppa:kevinkreiser/czmq; sudo add-apt-repository -y ppa:zerebubuth/ccache; fi)
     - sudo add-apt-repository -y ppa:kevinkreiser/prime-server
     - sudo apt-get update
     - sudo apt-get install -y autoconf automake make libtool pkg-config g++ gcc jq lcov protobuf-compiler vim-common libboost1.54-all-dev libboost-all-dev libcurl4-openssl-dev libgeos-dev libgeos++-dev liblua5.2-dev libprime-server0.6.3-dev libprotobuf-dev libspatialite-dev libsqlite3-dev lua5.2 prime-server0.6.3-bin ccache

--- a/circle.yml
+++ b/circle.yml
@@ -18,14 +18,15 @@ dependencies:
     - (rc=0; for f in *.json; do python -c "import json; json.load(open('$f'))" || rc=$?; done; exit $rc;)
     - (rc=0; for f in lua/*.lua; do lua $f || rc=$?; done; exit $rc;)
     - (rc=0; for f in locales/*.json; do python -c "import json; json.load(open('$f'))" || rc=$?; done; exit $rc;)
+    # great sadness: this has to go here if we want to have caching, as the cache is _only_ saved after the dependencies step.
+    - ./autogen.sh
+    - ./configure CC="ccache gcc" CXX="ccache g++" CPPFLAGS="-DBOOST_SPIRIT_THREADSAFE -DBOOST_NO_CXX11_SCOPED_ENUMS" --enable-coverage --enable-python-bindings
+    - make test -j$(nproc)
   cache_directories:
     - "~/.ccache"
 
 test:
   override:
-    - ./autogen.sh
-    - ./configure CC="ccache gcc" CXX="ccache g++" CPPFLAGS="-DBOOST_SPIRIT_THREADSAFE -DBOOST_NO_CXX11_SCOPED_ENUMS" --enable-coverage --enable-python-bindings
-    - make test -j$(nproc)
     - sudo make install
 
 general:

--- a/circle.yml
+++ b/circle.yml
@@ -19,6 +19,7 @@ dependencies:
     - (rc=0; for f in lua/*.lua; do lua $f || rc=$?; done; exit $rc;)
     - (rc=0; for f in locales/*.json; do python -c "import json; json.load(open('$f'))" || rc=$?; done; exit $rc;)
     # great sadness: this has to go here if we want to have caching, as the cache is _only_ saved after the dependencies step.
+    - (echo "max_size = 2.5G" > $HOME/.ccache/ccache.conf)
     - ./autogen.sh
     - ./configure CC="ccache gcc" CXX="ccache g++" CPPFLAGS="-DBOOST_SPIRIT_THREADSAFE -DBOOST_NO_CXX11_SCOPED_ENUMS" --enable-coverage --enable-python-bindings
     - make test -j$(nproc)

--- a/circle.yml
+++ b/circle.yml
@@ -14,15 +14,17 @@ dependencies:
     - (if [[ $(grep -cF trusty /etc/lsb-release) > 0 ]]; then sudo add-apt-repository -y ppa:kevinkreiser/libsodium; sudo add-apt-repository -y ppa:kevinkreiser/libpgm; sudo add-apt-repository -y ppa:kevinkreiser/zeromq3; sudo add-apt-repository -y ppa:kevinkreiser/czmq; fi)
     - sudo add-apt-repository -y ppa:kevinkreiser/prime-server
     - sudo apt-get update
-    - sudo apt-get install -y autoconf automake make libtool pkg-config g++ gcc jq lcov protobuf-compiler vim-common libboost1.54-all-dev libboost-all-dev libcurl4-openssl-dev libgeos-dev libgeos++-dev liblua5.2-dev libprime-server0.6.3-dev libprotobuf-dev libspatialite-dev libsqlite3-dev lua5.2 prime-server0.6.3-bin
+    - sudo apt-get install -y autoconf automake make libtool pkg-config g++ gcc jq lcov protobuf-compiler vim-common libboost1.54-all-dev libboost-all-dev libcurl4-openssl-dev libgeos-dev libgeos++-dev liblua5.2-dev libprime-server0.6.3-dev libprotobuf-dev libspatialite-dev libsqlite3-dev lua5.2 prime-server0.6.3-bin ccache
     - (rc=0; for f in *.json; do python -c "import json; json.load(open('$f'))" || rc=$?; done; exit $rc;)
     - (rc=0; for f in lua/*.lua; do lua $f || rc=$?; done; exit $rc;)
     - (rc=0; for f in locales/*.json; do python -c "import json; json.load(open('$f'))" || rc=$?; done; exit $rc;)
+  cache_directories:
+    - "~/.ccache"
 
 test:
   override:
     - ./autogen.sh
-    - ./configure CPPFLAGS="-DBOOST_SPIRIT_THREADSAFE -DBOOST_NO_CXX11_SCOPED_ENUMS" --enable-coverage --enable-python-bindings
+    - ./configure CC="ccache gcc" CXX="ccache g++" CPPFLAGS="-DBOOST_SPIRIT_THREADSAFE -DBOOST_NO_CXX11_SCOPED_ENUMS" --enable-coverage --enable-python-bindings
     - make test -j$(nproc)
     - sudo make install
 

--- a/circle.yml
+++ b/circle.yml
@@ -21,7 +21,7 @@ dependencies:
     # great sadness: this has to go here if we want to have caching, as the cache is _only_ saved after the dependencies step.
     - (echo "max_size = 2.5G" > $HOME/.ccache/ccache.conf)
     - ./autogen.sh
-    - ./configure CC="ccache gcc" CXX="ccache g++" CPPFLAGS="-DBOOST_SPIRIT_THREADSAFE -DBOOST_NO_CXX11_SCOPED_ENUMS" --enable-coverage --enable-python-bindings
+    - ./configure CC="ccache gcc" CXX="ccache g++"
     - ccache -z
     - ccache -s
     - make test -j$(nproc)

--- a/circle.yml
+++ b/circle.yml
@@ -21,7 +21,7 @@ dependencies:
     # great sadness: this has to go here if we want to have caching, as the cache is _only_ saved after the dependencies step.
     - (echo "max_size = 2.5G" > $HOME/.ccache/ccache.conf)
     - ./autogen.sh
-    - ./configure CC="ccache gcc" CXX="ccache g++"
+    - ./configure CC="ccache gcc" CXX="ccache g++" --enable-coverage
     - ccache -z
     - ccache -s
     - make test -j$(nproc)

--- a/circle.yml
+++ b/circle.yml
@@ -22,7 +22,10 @@ dependencies:
     - (echo "max_size = 2.5G" > $HOME/.ccache/ccache.conf)
     - ./autogen.sh
     - ./configure CC="ccache gcc" CXX="ccache g++" CPPFLAGS="-DBOOST_SPIRIT_THREADSAFE -DBOOST_NO_CXX11_SCOPED_ENUMS" --enable-coverage --enable-python-bindings
+    - ccache -z
+    - ccache -s
     - make test -j$(nproc)
+    - ccache -s
   cache_directories:
     - "~/.ccache"
 


### PR DESCRIPTION
This adds compiler caching using [ccache](https://ccache.samba.org/) to the Circle build. Ccache works by keeping a cache of previously compiled object files, so that things where the preprocessor output hasn't changed can be fetched from the cache rather than rebuild. On my local system, this brings a `make clean && make -j 4` down from 7m48s wall clock time (26m56s processor time) down to 20s (33s). Unfortunately, the gains on Circle aren't quite that large since there's setup time and it runs the tests - down from [31m37s](https://circleci.com/gh/valhalla/valhalla/11) to [13m20s](https://circleci.com/gh/valhalla/valhalla/28).

Extra contortions:

* I had to use a [PPA](https://launchpad.net/~zerebubuth/+archive/ubuntu/ccache) to get ccache 3.3, as the version which is shipped with Ubuntu 14.04 (3.1) doesn't support the use of `-fprofile-arcs`.
* The build has to take place in the "dependencies" section, as the cache is [saved at the end of this section](https://circleci.com/docs/how-cache-works/), which is aesthetically annoying but doesn't appear to interfere with the build working.

@kevinkreiser, what do you think?