### PR TITLE
Tao support macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,10 @@ Valhalla uses the [GNU Build System](http://www.gnu.org/software/automake/manual
 
 To install on macOS, you need to install its dependencies with [Homebrew](http://brew.sh):
 
+    # install dependencies (czmq is required by prime_server)
     brew install autoconf automake libtool protobuf-c boost-python libspatialite pkg-config lua czmq
+
+    # clone and build prime_server https://github.com/kevinkreiser/prime_server#build-and-install
 
 And then run to install it:
 
@@ -85,7 +88,7 @@ And then run to install it:
     # on macOS you need to tell linkers how to reach home-brewed sqlite3
     # export LDFLAGS="-L/usr/local/opt/sqlite/lib/ -lsqlite3"
     ./configure
-    make test -j8
+    make test -j$(nproc)
     sudo make install
 
 Please see `./configure --help` for more options on how to control the build process. There are a few notable options that you might want to try out:

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ And then run to install it:
 
     git submodule update --init --recursive
     ./autogen.sh
+    # on macOS you need to tell linkers how to reach home-brewed sqlite3
+    # export LDFLAGS="-L/usr/local/opt/sqlite/lib/ -lsqlite3"
     ./configure
     make test -j8
     sudo make install

--- a/README.md
+++ b/README.md
@@ -74,11 +74,16 @@ Valhalla uses the [GNU Build System](http://www.gnu.org/software/automake/manual
     #if you plan to compile with python bindings, see below for more info
     sudo apt-get install -y python-all-dev
 
+To install on macOS, you need to install its dependencies with [Homebrew](http://brew.sh):
+
+    brew install autoconf automake libtool protobuf-c boost-python libspatialite pkg-config lua czmq
+
 And then run to install it:
 
+    git submodule update --init --recursive
     ./autogen.sh
     ./configure
-    make test -j$(nproc)
+    make test -j8
     sudo make install
 
 Please see `./configure --help` for more options on how to control the build process. There are a few notable options that you might want to try out:

--- a/src/bindings/python/python.cc
+++ b/src/bindings/python/python.cc
@@ -1,15 +1,15 @@
 #include <string>
 #include <sstream>
-#include <boost/python.hpp>
-#include <boost/python/str.hpp>
-#include <boost/python/dict.hpp>
-#include <boost/python/extract.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/make_shared.hpp>
 #include <boost/optional.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
+#include <boost/python/str.hpp>
+#include <boost/python/dict.hpp>
+#include <boost/python/extract.hpp>
+#include <boost/python.hpp>
 
 #include "midgard/logging.h"
 #include "meili/traffic_segment_matcher.h"

--- a/src/loki/node_search.cc
+++ b/src/loki/node_search.cc
@@ -199,6 +199,8 @@ private:
 
 // functor to sort GraphId objects by level, tile then id within the tile.
 struct sort_by_tile {
+  sort_by_tile() {}
+
   inline bool operator()(vb::GraphId a, vb::GraphId b) const {
     return ((a.fields.level < b.fields.level) ||
             ((a.fields.level == b.fields.level) &&

--- a/src/thor/trippathbuilder.cc
+++ b/src/thor/trippathbuilder.cc
@@ -228,6 +228,10 @@ TripPath_Use GetTripPathUse(Use use) {
       return TripPath_Use_kBusConnectionUse;
     case Use::kTransitConnection:
       return TripPath_Use_kTransitConnectionUse;
+    case Use::kTransitionUp:
+    case Use::kTransitionDown: {
+      // TODO should we throw a runtime error?
+    }
   }
 }
 

--- a/src/valhalla_associate_segments.cc
+++ b/src/valhalla_associate_segments.cc
@@ -844,7 +844,7 @@ void edge_association::add_tile(const std::string &file_name) {
     if (!entry.has_marker()) {
       assert(entry.has_segment());
       auto &segment = entry.segment();
-      match_segment(base_id + entry_id, segment);
+      match_segment(base_id + static_cast<uint64_t>(entry_id), segment);
     }
     entry_id += 1;
   }

--- a/src/valhalla_associate_segments.cc
+++ b/src/valhalla_associate_segments.cc
@@ -839,12 +839,12 @@ void edge_association::add_tile(const std::string &file_name) {
 
   //do the matching of the segments in this osmlr tile
   std::cout.precision(16);
-  size_t entry_id = 0;
+  uint64_t entry_id = 0;
   for (auto &entry : tile.entries()) {
     if (!entry.has_marker()) {
       assert(entry.has_segment());
       auto &segment = entry.segment();
-      match_segment(base_id + static_cast<uint64_t>(entry_id), segment);
+      match_segment(base_id + entry_id, segment);
     }
     entry_id += 1;
   }

--- a/valhalla/baldr/graphconstants.h
+++ b/valhalla/baldr/graphconstants.h
@@ -439,6 +439,9 @@ inline float GetOffsetForHeading(RoadClass road_class, Use use) {
     case Use::kBridleway: {
       offset *= 0.5f;
     }
+    default: {
+      break;
+    }
   }
 
   return offset;

--- a/valhalla/mjolnir/validatetransit.h
+++ b/valhalla/mjolnir/validatetransit.h
@@ -1,6 +1,7 @@
 #ifndef VALHALLA_MJOLNIR_VALIDATETRANSIT_H
 #define VALHALLA_MJOLNIR_VALIDATETRANSIT_H
 
+#include <vector>
 #include <boost/property_tree/ptree.hpp>
 #include <unordered_set>
 


### PR DESCRIPTION
This PR adds initial support for macOS (only for development, no production).

Still 3 tests failed. `test/json` failed because at line https://github.com/valhalla/valhalla/blob/master/test/json.cc#L79-L80 `"\"status\": \"0\"," != "\"status\": \"0\""`. Can anyone help?

```
======================================
   valhalla 2.0.7: ./test-suite.log
======================================

# TOTAL: 77
# PASS:  74
# SKIP:  0
# XFAIL: 0
# FAIL:  3
# XPASS: 0
# ERROR: 0

.. contents:: :depth: 2

FAIL: test/json
===============

=== Testing json ===
               TestJsonSerialize  [FAIL: Wrong json!]
=== Failed 1 tests ===
FAIL test/json (exit status: 1)

FAIL: test/narrativebuilder
===========================

=== Testing narrativebuilder ===
 TestFormRampStraightInstruction  [PASS]
    TestFormRampRightInstruction  [PASS]
     TestFormRampLeftInstruction  [PASS]
    TestFormExitRightInstruction  [PASS]
     TestFormExitLeftInstruction  [PASS]
TestFormVerbalPostTransitionInstruction  [PASS]
TestBuildStartInstructions_0_miles_en_US  [PASS]
TestBuildStartInstructions_1_miles_en_US  [PASS]
TestBuildStartInstructions_2_miles_en_US  [PASS]
TestBuildStartInstructions_4_miles_en_US  [PASS]
TestBuildStartInstructions_5_miles_en_US  [PASS]
TestBuildStartInstructions_6_miles_en_US  [PASS]
TestBuildStartInstructions_8_miles_en_US  [PASS]
TestBuildStartInstructions_9_miles_en_US  [PASS]
TestBuildStartInstructions_9_unnamed_walkway_miles_en_US  [PASS]
TestBuildStartInstructions_10_miles_en_US  [PASS]
TestBuildStartInstructions_16_miles_en_US  [PASS]
TestBuildStartInstructions_17_miles_en_US  [PASS]
TestBuildStartInstructions_17_unnamed_cycleway_miles_en_US  [PASS]
TestBuildStartInstructions_17_unnamed_mountain_bike_trail_miles_en_US  [PASS]
TestBuildStartInstructions_18_miles_en_US  [PASS]
TestBuildStartInstructions_0_kilometers_en_US  [PASS]
TestBuildStartInstructions_1_kilometers_en_US  [PASS]
TestBuildStartInstructions_2_kilometers_en_US  [PASS]
TestBuildDestinationInstructions_0_miles_en_US  [PASS]
TestBuildDestinationInstructions_1_miles_en_US  [PASS]
TestBuildDestinationInstructions_2_miles_en_US  [PASS]
TestBuildDestinationInstructions_3_miles_en_US  [PASS]
TestBuildBecomesInstructions_0_miles_en_US  [PASS]
TestBuildContinueInstructions_0_miles_en_US  [PASS]
TestBuildContinueInstructions_1_miles_en_US  [PASS]
TestBuildTurnInstructions_0_miles_en_US  [PASS]
TestBuildTurnInstructions_1_miles_en_US  [PASS]
TestBuildTurnInstructions_1_miles_cs_CZ  [PASS]
TestBuildTurnInstructions_1_miles_de_DE  [PASS]
TestBuildTurnInstructions_1_miles_it_IT  [PASS]
TestBuildTurnInstructions_2_miles_en_US  [PASS]
TestBuildTurnInstructions_3_miles_en_US  [PASS]
TestBuildSharpInstructions_0_miles_en_US  [PASS]
TestBuildSharpInstructions_1_miles_en_US  [PASS]
TestBuildSharpInstructions_2_miles_en_US  [PASS]
TestBuildSharpInstructions_0_miles_en_US  [PASS]
TestBuildBearInstructions_0_miles_en_US  [PASS]
TestBuildBearInstructions_1_miles_en_US  [PASS]
TestBuildBearInstructions_2_miles_en_US  [PASS]
TestBuildBearInstructions_3_miles_en_US  [PASS]
TestBuildUturnInstructions_0_miles_en_US  [PASS]
TestBuildUturnInstructions_1_miles_en_US  [PASS]
TestBuildUturnInstructions_2_miles_en_US  [PASS]
TestBuildUturnInstructions_3_miles_en_US  [PASS]
TestBuildUturnInstructions_4_miles_en_US  [PASS]
TestBuildUturnInstructions_5_miles_en_US  [PASS]
TestBuildRampStraight_0_miles_en_US  [PASS]
TestBuildRampStraight_1_miles_en_US  [PASS]
TestBuildRampStraight_2_miles_en_US  [PASS]
TestBuildRampStraight_3_miles_en_US  [PASS]
TestBuildRampStraight_4_miles_en_US  [PASS]
     TestBuildRamp_0_miles_en_US  [PASS]
     TestBuildRamp_1_miles_en_US  [PASS]
     TestBuildRamp_2_miles_en_US  [PASS]
     TestBuildRamp_3_miles_en_US  [PASS]
     TestBuildRamp_4_miles_en_US  [PASS]
     TestBuildRamp_5_miles_en_US  [PASS]
     TestBuildRamp_6_miles_en_US  [PASS]
     TestBuildRamp_7_miles_en_US  [PASS]
     TestBuildRamp_8_miles_en_US  [PASS]
     TestBuildRamp_9_miles_en_US  [PASS]
     TestBuildExit_0_miles_en_US  [PASS]
     TestBuildExit_1_miles_en_US  [PASS]
     TestBuildExit_2_miles_en_US  [PASS]
     TestBuildExit_3_miles_en_US  [PASS]
     TestBuildExit_4_miles_en_US  [PASS]
     TestBuildExit_5_miles_en_US  [PASS]
     TestBuildExit_6_miles_en_US  [PASS]
     TestBuildExit_7_miles_en_US  [PASS]
     TestBuildExit_8_miles_en_US  [PASS]
    TestBuildExit_10_miles_en_US  [PASS]
    TestBuildExit_12_miles_en_US  [PASS]
    TestBuildExit_14_miles_en_US  [PASS]
     TestBuildKeep_0_miles_en_US  [PASS]
     TestBuildKeep_1_miles_en_US  [PASS]
     TestBuildKeep_2_miles_en_US  [PASS]
     TestBuildKeep_3_miles_en_US  [PASS]
     TestBuildKeep_4_miles_en_US  [PASS]
     TestBuildKeep_5_miles_en_US  [PASS]
     TestBuildKeep_6_miles_en_US  [PASS]
     TestBuildKeep_7_miles_en_US  [PASS]
TestBuildKeepToStayOn_0_miles_en_US  [PASS]
TestBuildKeepToStayOn_1_miles_en_US  [PASS]
TestBuildKeepToStayOn_2_miles_en_US  [PASS]
TestBuildKeepToStayOn_3_miles_en_US  [PASS]
    TestBuildMerge_0_miles_en_US  [PASS]
  TestBuildMerge_1_1_miles_en_US  [PASS]
  TestBuildMerge_1_2_miles_en_US  [PASS]
TestBuildEnterRoundabout_0_miles_en_US  [PASS]
TestBuildEnterRoundabout_1_miles_en_US  [PASS]
TestBuildExitRoundabout_0_miles_en_US  [PASS]
TestBuildExitRoundabout_1_miles_en_US  [PASS]
TestBuildExitRoundabout_2_miles_en_US  [PASS]
TestBuildEnterFerry_0_miles_en_US  [PASS]
TestBuildEnterFerry_1_miles_en_US  [PASS]
TestBuildEnterFerry_2_miles_en_US  [PASS]
TestBuildExitFerry_0_miles_en_US  [PASS]
TestBuildExitFerry_1_miles_en_US  [PASS]
TestBuildExitFerry_2_miles_en_US  [PASS]
TestBuildExitFerry_4_miles_en_US  [PASS]
TestBuildExitFerry_5_miles_en_US  [PASS]
TestBuildExitFerry_6_miles_en_US  [PASS]
TestBuildExitFerry_8_miles_en_US  [PASS]
TestBuildExitFerry_9_miles_en_US  [PASS]
TestBuildExitFerry_10_miles_en_US  [PASS]
TestBuildExitFerry_16_miles_en_US  [PASS]
TestBuildExitFerry_17_miles_en_US  [PASS]
TestBuildExitFerry_18_miles_en_US  [PASS]
TestBuildTransitConnectionStart_0_miles_en_US  [PASS]
TestBuildTransitConnectionStart_1_miles_en_US  [PASS]
TestBuildTransitConnectionStart_2_miles_en_US  [PASS]
TestBuildTransitConnectionTransfer_0_miles_en_US  [PASS]
TestBuildTransitConnectionTransfer_1_miles_en_US  [PASS]
TestBuildTransitConnectionTransfer_2_miles_en_US  [PASS]
TestBuildTransitConnectionDestination_0_miles_en_US  [PASS]
TestBuildTransitConnectionDestination_1_miles_en_US  [PASS]
TestBuildTransitConnectionDestination_2_miles_en_US  [PASS]
TestBuildTransit_0_train_miles_en_US  [FAIL: Incorrect maneuver depart_instruction - expected: Depart: 8:02 AM from 8 St - NYU.  |  produced: Depart: 08:02 from 8 St - NYU.]
  TestBuildTransit_0_miles_en_US  [FAIL: Incorrect maneuver depart_instruction - expected: Depart: 8:02 AM from 8 St - NYU.  |  produced: Depart: 08:02 from 8 St - NYU.]
TestBuildTransit_1_cable_car_miles_en_US  [FAIL: Incorrect maneuver depart_instruction - expected: Depart: 8:03 AM from Hyde St & Bay St.  |  produced: Depart: 08:03 from Hyde St & Bay St.]
TestBuildTransit_1_stop_count_1_miles_en_US  [FAIL: Incorrect maneuver depart_instruction - expected: Depart: 8:06 AM from Union St.  |  produced: Depart: 08:06 from Union St.]
TestBuildTransit_1_stop_count_2_miles_en_US  [FAIL: Incorrect maneuver depart_instruction - expected: Depart: 8:05 AM from 28 St.  |  produced: Depart: 08:05 from 28 St.]
TestBuildTransit_1_stop_count_4_miles_en_US  [FAIL: Incorrect maneuver depart_instruction - expected: Depart: 8:02 AM from 8 St - NYU.  |  produced: Depart: 08:02 from 8 St - NYU.]
TestBuildTransit_1_stop_count_8_miles_en_US  [FAIL: Incorrect maneuver depart_instruction - expected: Depart: 8:11 AM from Flushing Av.  |  produced: Depart: 08:11 from Flushing Av.]
TestBuildTransit_1_stop_count_1_miles_cs_CZ  [PASS]
TestBuildTransit_1_stop_count_2_miles_cs_CZ  [PASS]
TestBuildTransit_1_stop_count_4_miles_cs_CZ  [PASS]
TestBuildTransit_1_stop_count_8_miles_cs_CZ  [PASS]
TestBuildTransitTransfer_0_no_name_miles_en_US  [FAIL: Incorrect maneuver depart_instruction - expected: Depart: 8:02 AM from 8 St - NYU.  |  produced: Depart: 08:02 from 8 St - NYU.]
TestBuildTransitTransfer_0_miles_en_US  [FAIL: Incorrect maneuver depart_instruction - expected: Depart: 8:02 AM from 8 St - NYU.  |  produced: Depart: 08:02 from 8 St - NYU.]
TestBuildTransitTransfer_1_miles_en_US  [FAIL: Incorrect maneuver depart_instruction - expected: Depart: 8:02 AM from 8 St - NYU.  |  produced: Depart: 08:02 from 8 St - NYU.]
TestBuildTransitRemainOn_0_no_name_miles_en_US  [FAIL: Incorrect maneuver depart_instruction - expected: Depart: 8:02 AM from 8 St - NYU.  |  produced: Depart: 08:02 from 8 St - NYU.]
TestBuildTransitRemainOn_0_miles_en_US  [FAIL: Incorrect maneuver depart_instruction - expected: Depart: 8:02 AM from 8 St - NYU.  |  produced: Depart: 08:02 from 8 St - NYU.]
TestBuildTransitRemainOn_1_miles_en_US  [FAIL: Incorrect maneuver depart_instruction - expected: Depart: 8:02 AM from 8 St - NYU.  |  produced: Depart: 08:02 from 8 St - NYU.]
TestBuildPostTransitConnectionDestination_0_miles_en_US  [PASS]
TestBuildPostTransitConnectionDestination_1_miles_en_US  [PASS]
TestBuildPostTransitConnectionDestination_2_miles_en_US  [PASS]
TestBuildPostTransitConnectionDestination_4_miles_en_US  [PASS]
TestBuildPostTransitConnectionDestination_5_miles_en_US  [PASS]
TestBuildPostTransitConnectionDestination_6_miles_en_US  [PASS]
TestBuildPostTransitConnectionDestination_8_miles_en_US  [PASS]
TestBuildPostTransitConnectionDestination_9_miles_en_US  [PASS]
TestBuildPostTransitConnectionDestination_10_miles_en_US  [PASS]
TestBuildPostTransitConnectionDestination_16_miles_en_US  [PASS]
TestBuildPostTransitConnectionDestination_17_miles_en_US  [PASS]
TestBuildPostTransitConnectionDestination_18_miles_en_US  [PASS]
TestBuildVerbalMultiCue_0_miles_en_US  [PASS]
=== Failed 13 tests ===
FAIL test/narrativebuilder (exit status: 1)

FAIL: test/util_odin
====================

=== Testing util ===
          test_supported_locales  [FAIL: Locale not found for: hi_IN.UTF-8]
                test_get_locales  [PASS]
                       test_time  [FAIL: Incorrect Time: 23:59 ---> 11:59 PM for locale: en_US.UTF-8]
                       test_date  [FAIL: Incorrect Date: 2014/01/01 ---> 1.1.2014 for locale: cs_CZ.UTF-8]
=== Failed 3 tests ===
FAIL test/util_odin (exit status: 1)
```

fixes #491 