### PR TITLE
Increase stop impact for a link to link transition

### DIFF
--- a/src/mjolnir/graphenhancer.cc
+++ b/src/mjolnir/graphenhancer.cc
@@ -726,8 +726,9 @@ uint32_t GetStopImpact(uint32_t from, uint32_t to,
   // (ramps and turn channels) are involved.
   if (allramps) {
     stop_impact /= 2;
-  } else if (edges[from].use() == Use::kRamp && edges[to].use() == Use::kRamp) {
-    // Ramp may be crossing a road
+  } else if (edges[from].use() == Use::kRamp && edges[to].use() == Use::kRamp &&
+             bestrc < RoadClass::kUnclassified) {
+    // Ramp may be crossing a road (not a path or service road)
     if (nodeinfo.traffic_signal()) {
       stop_impact = 4;
     } else if (count > 3) {

--- a/src/mjolnir/graphenhancer.cc
+++ b/src/mjolnir/graphenhancer.cc
@@ -726,6 +726,13 @@ uint32_t GetStopImpact(uint32_t from, uint32_t to,
   // (ramps and turn channels) are involved.
   if (allramps) {
     stop_impact /= 2;
+  } else if (edges[from].use() == Use::kRamp && edges[to].use() == Use::kRamp) {
+    // Ramp may be crossing a road
+    if (nodeinfo.traffic_signal()) {
+      stop_impact = 4;
+    } else if (count > 3) {
+      stop_impact += 2;
+    }
   } else if (edges[from].use() == Use::kRamp && edges[to].use() != Use::kRamp) {
     // Increase stop impact on merge
     stop_impact += 2;


### PR DESCRIPTION
when the node has a traffic signal or there are more than 3 edges (and best other road class
indicates a road rather than a path/service road).