### PR TITLE
Add connecting wayId to a transit stop. 

### DIFF
--- a/src/baldr/nodeinfo.cc
+++ b/src/baldr/nodeinfo.cc
@@ -246,13 +246,26 @@ void NodeInfo::set_name_consistency(const uint32_t from,
   }
 }
 
+// Get the connecting way id for a transit stop.
+uint64_t NodeInfo::connecting_wayid() const {
+  return way_heading_.connecting_wayid_;
+}
+
+/**
+ * Set the connecting way id for a transit stop.
+ * @param  wayid  Connecting wayid.
+ */
+void NodeInfo::set_connecting_wayid(const uint64_t wayid) {
+  way_heading_.connecting_wayid_ = wayid;
+}
+
 // Get the heading of the local edge given its local index. Supports
 // up to 8 local edges. Headings are expanded from 8 bits.
 uint32_t NodeInfo::heading(const uint32_t localidx) const {
   // Make sure everything is 64 bit!
   uint64_t shift = localidx * 8;     // 8 bits per index
   return static_cast<uint32_t>(std::round(
-      ((headings_ & (static_cast<uint64_t>(255) << shift)) >> shift)
+      ((way_heading_.headings_ & (static_cast<uint64_t>(255) << shift)) >> shift)
           * kHeadingExpandFactor));
 }
 
@@ -265,7 +278,7 @@ void NodeInfo::set_heading(uint32_t localidx, uint32_t heading) {
     // Has to be 64 bit!
     uint64_t hdg = static_cast<uint64_t>(std::round(
         (heading % 360) * kHeadingShrinkFactor));
-    headings_ |= hdg << static_cast<uint64_t>(localidx * 8);
+    way_heading_.headings_ |= hdg << static_cast<uint64_t>(localidx * 8);
   }
 }
 

--- a/valhalla/baldr/nodeinfo.h
+++ b/valhalla/baldr/nodeinfo.h
@@ -293,6 +293,18 @@ class NodeInfo {
                             const bool c);
 
   /**
+   * Get the connecting way id for a transit stop.
+   * @return Returns the connecting way id for a transit stop.
+   */
+  uint64_t connecting_wayid() const;
+
+  /**
+   * Set the connecting way id for a transit stop.
+   * @param  wayid  Connecting wayid.
+   */
+  void set_connecting_wayid(const uint64_t wayid);
+
+  /**
    * Get the heading of the local edge given its local index. Supports
    * up to 8 local edges. Headings are stored rounded off to 2 degree
    * values.
@@ -341,16 +353,22 @@ class NodeInfo {
   uint32_t traffic_signal_     : 1;  // Traffic signal
   uint32_t spare_1             : 6;
 
-  // Transit stop index
+  // Transit stop index (for transit level) / name consistency for all
+  // other levels
   union NodeStop {
     uint32_t stop_index;
     uint32_t name_consistency;
   };
   NodeStop stop_;
 
-  // Headings of up to kMaxLocalEdgeIndex+1 local edges (rounded to
-  // nearest 2 degrees)
-  uint64_t headings_;
+  // Connecting way Id (for transit level) / headings of up to
+  // kMaxLocalEdgeIndex+1 local edges (rounded to nearest 2 degrees)
+  // for all other levels.
+  union WayHeading {
+    uint64_t connecting_wayid_;
+    uint64_t headings_;
+  };
+  WayHeading way_heading_;
 };
 
 }


### PR DESCRIPTION
Repurpose the headings_ field to be a union that stores the connecting way id for transit nodes and the headings to connected edges for OSM network nodes.