### PR TITLE
Update edge_collapser to be more general

### DIFF
--- a/test/edgecollapser.cc
+++ b/test/edgecollapser.cc
@@ -116,6 +116,7 @@ void TestCollapseEdgeSimple() {
   vb::merge::merge(
     tiles, reader,
     [](const vb::DirectedEdge *) -> bool { return true; },
+    [](const vb::DirectedEdge *) -> bool { return true; },
     [&](const vb::merge::path &p) {
       count += 1;
       for (auto id : p.m_edges) {
@@ -178,6 +179,7 @@ void TestCollapseEdgeJunction() {
   vb::merge::merge(
     tiles, reader,
     [](const vb::DirectedEdge *) -> bool { return true; },
+    [](const vb::DirectedEdge *) -> bool { return true; },
     [&](const vb::merge::path &p) {
       count += 1;
       for (auto id : p.m_edges) {
@@ -236,6 +238,7 @@ void TestCollapseEdgeChain() {
 
   vb::merge::merge(
     tiles, reader,
+    [](const vb::DirectedEdge *) -> bool { return true; },
     [](const vb::DirectedEdge *) -> bool { return true; },
     [&](const vb::merge::path &p) {
       count += 1;


### PR DESCRIPTION
Add a second predicate function. The first predicate method states whether an edge should preclude merging/collapsing at the current node. The new, second predicate determines whether an edge should be included in the collapsed path. These 2 methods fully determine whether edges can be collapsed - no longer any special logic within the edge_collapser itself.

@zerebubuth - please take a quick look if you'd like