### PR TITLE
traffic segment matcher json was junk

### DIFF
--- a/src/meili/traffic_segment_matcher.cc
+++ b/src/meili/traffic_segment_matcher.cc
@@ -109,7 +109,7 @@ std::string  TrafficSegmentMatcher::match(const std::string& json) {
   for (auto res : results) {
     // Make sure edge is valid
     if (res.edgeid().Is_Valid()) {
-      trace_edges.emplace_back(res.edgeid(), GetEdgeDist(res, matcher), times[idx]);
+      trace_edges.emplace_back(EdgeOnTrace{res.edgeid(), GetEdgeDist(res, matcher), static_cast<float>(times[idx])});
     }
     idx++;
   }
@@ -119,7 +119,7 @@ std::string  TrafficSegmentMatcher::match(const std::string& json) {
   std::vector<UniqueEdgeOnTrace> edges;
   for (auto edge : trace_edges) {
     if (!prior_edge.Is_Valid()) {
-      edges.emplace_back(edge.edge_id, edge.dist, edge.dist, edge.secs, edge.secs);
+      edges.emplace_back(UniqueEdgeOnTrace{edge.edge_id, edge.dist, edge.dist, edge.secs, edge.secs});
     } else  if (edge.edge_id == prior_edge) {
       // Update the time at the end
       edges.back().end_pct = edge.dist;
@@ -133,7 +133,7 @@ std::string  TrafficSegmentMatcher::match(const std::string& json) {
       edges.back().secs2   = edge.secs ;
 
       // New edge
-      edges.emplace_back(edge.edge_id, 0.0f, edge.dist, edge.secs, edge.secs);
+      edges.emplace_back(UniqueEdgeOnTrace{edge.edge_id, 0.0f, edge.dist, edge.secs, edge.secs});
     }
     prior_edge = edge.edge_id;
   }
@@ -168,8 +168,8 @@ std::string  TrafficSegmentMatcher::match(const std::string& json) {
       } else {
         bool starts = (seg.starts_segment_ && edge.start_pct == 0.0f);
         bool ends =   (seg.ends_segment_ && edge.end_pct == 1.0f);
-        traffic_segment.emplace_back(!starts, !ends, seg.segment_id_,
-                              edge.secs1, edge.secs2, length);
+        traffic_segment.emplace_back(MatchedTrafficSegments{!starts, !ends, seg.segment_id_,
+                              edge.secs1, edge.secs2, static_cast<uint32_t>(length)});
         prior_segment = seg.segment_id_;
       }
     } else if (segments.size() > 1) {
@@ -204,8 +204,8 @@ std::string  TrafficSegmentMatcher::match(const std::string& json) {
           bool ends =   seg.ends_segment_;
           float start_secs = edge.secs1;  // TODO!l
           float end_secs = edge.secs2;    // TODO!!
-          traffic_segment.emplace_back(!starts, !ends, seg.segment_id_,
-                                start_secs, end_secs, seg_length);
+          traffic_segment.emplace_back(MatchedTrafficSegments{!starts, !ends, seg.segment_id_,
+                                start_secs, end_secs, static_cast<uint32_t>(seg_length)});
           prior_segment = seg.segment_id_;
         }
       }
@@ -219,14 +219,21 @@ std::string  TrafficSegmentMatcher::match(const std::string& json) {
   }
 
   // Serialize and return as a string
-  boost::property_tree::ptree result;
-  boost::property_tree::ptree segments;
+  auto segments_json = json::array({});
   for (const auto& seg : traffic_segment) {
-    segments.push_back(std::make_pair("", seg.ToPtree()));
+    segments_json->emplace_back(json::map
+      ({
+        {"partial_start", seg.partial_start},
+        {"partial_end", seg.partial_end},
+        {"segment_id", seg.segment_id.value},
+        {"begin_time", json::fp_t{seg.start_time, 1}},
+        {"end_time", json::fp_t{seg.end_time, 1}},
+        {"length", static_cast<uint64_t>(seg.length)},
+      })
+    );
   }
-  result.put_child("segments", segments);
   std::stringstream ss;
-  boost::property_tree::write_json(ss, result);
+  ss << *segments_json;
   return ss.str();
 }
 

--- a/src/meili/traffic_segment_matcher.cc
+++ b/src/meili/traffic_segment_matcher.cc
@@ -219,9 +219,9 @@ std::string  TrafficSegmentMatcher::match(const std::string& json) {
   }
 
   // Serialize and return as a string
-  auto segments_json = json::array({});
+  auto segments = json::array({});
   for (const auto& seg : traffic_segment) {
-    segments_json->emplace_back(json::map
+    segments->emplace_back(json::map
       ({
         {"partial_start", seg.partial_start},
         {"partial_end", seg.partial_end},
@@ -232,9 +232,8 @@ std::string  TrafficSegmentMatcher::match(const std::string& json) {
       })
     );
   }
-  auto result = json::map({{"segments",segments_json}});
   std::stringstream ss;
-  ss << *result;
+  ss << *json::map({{"segments",segments}});
   return ss.str();
 }
 

--- a/valhalla/meili/traffic_segment_matcher.h
+++ b/valhalla/meili/traffic_segment_matcher.h
@@ -5,11 +5,12 @@
 #include <sstream>
 #include <boost/property_tree/ptree.hpp>
 
-#include <valhalla/baldr/graphreader.h>
-#include <valhalla/baldr/graphid.h>
-#include <valhalla/meili/map_matcher.h>
-#include <valhalla/meili/map_matcher_factory.h>
-#include <valhalla/meili/match_route.h>
+#include "baldr/graphreader.h"
+#include "baldr/graphid.h"
+#include "baldr/json.h"
+#include "meili/map_matcher.h"
+#include "meili/map_matcher_factory.h"
+#include "meili/match_route.h"
 
 namespace valhalla {
 namespace meili {
@@ -19,13 +20,6 @@ struct EdgeOnTrace {
   valhalla::baldr::GraphId edge_id;
   float dist;
   float secs;
-
-  EdgeOnTrace(const valhalla::baldr::GraphId& id, const float d,
-              const float s)
-      : edge_id(id),
-        dist(d),
-        secs(s) {
-  }
 };
 
 // Unique edges along the GPS trace
@@ -35,15 +29,6 @@ struct UniqueEdgeOnTrace {
   float end_pct;
   float secs1;
   float secs2;
-
-  UniqueEdgeOnTrace(const valhalla::baldr::GraphId& id, const float p1,
-              const float p2, const float t1, const float t2)
-      : edge_id(id),
-        start_pct(p1),
-        end_pct(p2),
-        secs1(t1),
-        secs2(t2) {
-  }
 };
 
 
@@ -52,31 +37,9 @@ struct MatchedTrafficSegments {
   bool partial_start;                   // Begins along the segment
   bool partial_end;                     // Ends along the segment
   valhalla::baldr::GraphId segment_id;  // Traffic segment unique Id.
-  float begin_time;                     // Begin time along this segment.
+  float start_time;                     // Begin time along this segment.
   float end_time;                       // End time along this segment.
   uint32_t length;                      // Length in meters along this segment
-
-  MatchedTrafficSegments(const bool start, const bool end,
-                         const valhalla::baldr::GraphId& id,
-                         const float bt, const float et, const float l)
-      : partial_start(start),
-        partial_end(end),
-        segment_id(id),
-        begin_time(bt),
-        end_time(et),
-        length(l) {
-  }
-
-  boost::property_tree::ptree ToPtree() const {
-    boost::property_tree::ptree segment;
-    segment.put<bool>("partial_start", partial_start);
-    segment.put<bool>("partial_end", partial_end);
-    segment.put("segment_id", segment_id.value);
-    segment.put<float>("begin_time", begin_time);
-    segment.put<float>("end_time", end_time);
-    segment.put("length", length);
-    return segment;
-  }
 };
 
 /**


### PR DESCRIPTION
`ptree::write_json` was garbage it made everything strings. we should make use of rapid json here but i dont know the api yet so we'll save that for another day. anyway this makes it so that the reporter doesnt have to cast everything to the proper data types.