### PR TITLE
Set the connecting OSM way Id in NodeInfo for the stop

### DIFF
--- a/src/mjolnir/valhalla_build_transit.cc
+++ b/src/mjolnir/valhalla_build_transit.cc
@@ -1331,6 +1331,7 @@ void AddToGraph(GraphTileBuilder& tilebuilder_transit,
     node.set_stop_index(stop_index);
     node.set_edge_index(tilebuilder_transit.directededges().size());
     node.set_timezone(stop.timezone());
+    node.set_connecting_wayid(stop.osm_way_id());
 
  /** TODO - future when we get egress, station, platform hierarchy
     // Add any intra-station connections - these are always in the same tile?


### PR DESCRIPTION
Paves the way for refactoring valhalla_build_tiles (TransitBuilder) to no require the transit pbf tiles.