### PR TITLE
Add match shape to trace attributes action

### DIFF
--- a/src/meili/match_route.cc
+++ b/src/meili/match_route.cc
@@ -305,5 +305,55 @@ ConstructRoute<std::vector<MatchResult>::const_iterator>(
     std::vector<MatchResult>::const_iterator,
     std::vector<MatchResult>::const_iterator);
 
+
+template <typename segment_iterator_t>
+std::vector<std::vector<midgard::PointLL>>
+ConstructRouteShapes(baldr::GraphReader& graphreader,
+                     segment_iterator_t begin,
+                     segment_iterator_t end)
+{
+  if (begin == end) {
+    return {};
+  }
+
+  std::vector<std::vector<midgard::PointLL>> shapes;
+
+  for (auto segment = begin, prev_segment = end; segment != end; segment++) {
+    const auto& shape = segment->Shape(graphreader);
+    if (shape.empty()) {
+      continue;
+    }
+
+    auto shape_begin = shape.begin();
+    if (prev_segment != end && prev_segment->Adjoined(graphreader, *segment)) {
+      // The beginning vertex has been written. Hence skip
+      std::advance(shape_begin, 1);
+    } else {
+      // Disconnected. Hence a new start
+      shapes.emplace_back();
+    }
+
+    for (auto vertex = shape_begin; vertex != shape.end(); vertex++) {
+      shapes.back().push_back(*vertex);
+    }
+
+    prev_segment = segment;
+  }
+
+  return shapes;
+}
+
+
+template std::vector<std::vector<midgard::PointLL>>
+ConstructRouteShapes<std::vector<EdgeSegment>::const_iterator>(
+    baldr::GraphReader&,
+    std::vector<EdgeSegment>::const_iterator,
+    std::vector<EdgeSegment>::const_iterator);
+
+template std::vector<std::vector<midgard::PointLL>>
+ConstructRouteShapes<std::vector<EdgeSegment>::iterator>(
+    baldr::GraphReader&,
+    std::vector<EdgeSegment>::iterator,
+    std::vector<EdgeSegment>::iterator);
 }
 }

--- a/valhalla/meili/geojson_writer.h
+++ b/valhalla/meili/geojson_writer.h
@@ -308,55 +308,6 @@ GeoJSONRouteWriter<buffer_t>::GeoJSONRouteWriter(bool verbose)
 
 
 template <typename buffer_t>
-void WriteRoute(rapidjson::Writer<buffer_t>& writer,
-                MapMatcher& matcher,
-                const std::vector<EdgeSegment>& route)
-{
-  // A state indicating if array is open (i.e. called
-  // writer.StartArray() already but not writer.EndArray() yet)
-  bool open = false;
-
-  for (auto segment = route.cbegin(), prev_segment = route.cend();
-       segment != route.cend(); segment++) {
-    // Dummy segments should have been filtered out, however we still
-    // do a check here
-    if (!segment->edgeid.Is_Valid()) {
-      continue;
-    }
-
-    const auto& shape = segment->Shape(matcher.graphreader());
-    if (!shape.empty()) {
-      const auto adjoined = prev_segment != route.cend() && prev_segment->Adjoined(matcher.graphreader(), *segment);
-      // If current segment and previous segment adjoin, skip the
-      // first coordinate since it's been written already
-      if (adjoined) {
-        for (auto vertex = std::next(shape.begin()); vertex != shape.end(); vertex++) {
-          serialize_coordinate(writer, *vertex);
-        }
-      } else {
-        // If current segment and previous segment don't adjoin, close
-        // current array and start a new array
-        if (open) {
-          writer.EndArray();
-          open = false;
-        }
-        writer.StartArray();
-        open = true;
-        for (auto vertex = shape.begin(); vertex != shape.end(); vertex++) {
-          serialize_coordinate(writer, *vertex);
-        }
-      }
-    }
-    prev_segment = segment;
-  }
-  if (open) {
-    writer.EndArray();
-    open = false;
-  }
-}
-
-
-template <typename buffer_t>
 void GeoJSONRouteWriter<buffer_t>::WriteGeometry(rapidjson::Writer<buffer_t>& writer,
                                                  MapMatcher& mapmatcher,
                                                  const std::vector<MatchResult>& results) const
@@ -367,11 +318,16 @@ void GeoJSONRouteWriter<buffer_t>::WriteGeometry(rapidjson::Writer<buffer_t>& wr
   writer.String("MultiLineString");
 
   writer.String("coordinates");
+  const auto& segments = ConstructRoute(mapmatcher.mapmatching(), results.cbegin(), results.cend());
+  const auto& shapes = ConstructRouteShapes(mapmatcher.graphreader(), segments.begin(), segments.end());
   writer.StartArray();
-  const auto& segments = ConstructRoute(mapmatcher.mapmatching(),
-                                        results.cbegin(),
-                                        results.cend());
-  WriteRoute(writer, mapmatcher, segments);
+  for (const auto& shape: shapes) {
+    writer.StartArray();
+    for (const auto& vertex: shape) {
+      serialize_coordinate(writer, vertex);
+    }
+    writer.EndArray();
+  }
   writer.EndArray();
 
   writer.EndObject();
@@ -380,7 +336,7 @@ void GeoJSONRouteWriter<buffer_t>::WriteGeometry(rapidjson::Writer<buffer_t>& wr
 
 template <typename buffer_t>
 void GeoJSONRouteWriter<buffer_t>::WriteProperties(rapidjson::Writer<buffer_t>& writer,
-                                                   MapMatcher& matcher,
+                                                   MapMatcher& mapmatcher,
                                                    const std::vector<MatchResult>& results) const
 {
   writer.StartObject();
@@ -395,7 +351,7 @@ void GeoJSONRouteWriter<buffer_t>::WriteProperties(rapidjson::Writer<buffer_t>& 
   }
   writer.EndArray();
   if (verbose_) {
-    serialize_verbose(writer, matcher, results);
+    serialize_verbose(writer, mapmatcher, results);
   }
   writer.EndObject();
 }

--- a/valhalla/meili/match_route.h
+++ b/valhalla/meili/match_route.h
@@ -50,6 +50,13 @@ ConstructRoute(const MapMatching& mapmaching,
                match_iterator_t begin,
                match_iterator_t end);
 
+
+template <typename segment_iterator_t>
+std::vector<std::vector<midgard::PointLL>>
+ConstructRouteShapes(baldr::GraphReader& graphreader,
+                     segment_iterator_t begin,
+                     segment_iterator_t end);
+
 }
 }
 #endif // MMP_MATCH_ROUTE_H_


### PR DESCRIPTION
Fixes https://github.com/valhalla/valhalla/issues/75

- [ ] add a member function `map_match_shape()` that returns the match shapes. It should be similar to `odin::TripPath thor_worker_t::map_match(const TripPathController& controller)`
- [ ] refactor `map_match` and `map_match_shape` to accept a list of `MatchResult` (from `OfflineMatch`) to only match once per request


If time allowed,
- [ ] read meili parameters from request (`search_radius`, `gps_accuracy` etc.)