### PR TITLE
Added error codes for segment matcher

### DIFF
--- a/src/meili/traffic_segment_matcher.cc
+++ b/src/meili/traffic_segment_matcher.cc
@@ -42,9 +42,8 @@ std::string  TrafficSegmentMatcher::match(const std::string& json) {
   try {
     std::stringstream stream(json);
     boost::property_tree::read_json(stream, request);
-  } catch (...) {
-    LOG_ERROR("Error parsing JSON= " + json);
-    return "{\"foo\":\"bar\"}";
+  } catch (const std::exception&) {
+    throw valhalla_exception_t{400, 600};
   }
 
   // Form trace positions
@@ -60,8 +59,7 @@ std::string  TrafficSegmentMatcher::match(const std::string& json) {
       times.push_back(pt.second.get<int>("time"));
     }
   } else {
-    LOG_ERROR("Could not form trace from input JSON= " + json);
-    return "{\"foo\":\"bar\"}";
+    throw valhalla_exception_t{400, 601};
   }
 
   // Need to add a ptree to set the mode to use within matching
@@ -75,9 +73,8 @@ std::string  TrafficSegmentMatcher::match(const std::string& json) {
   std::shared_ptr<valhalla::meili::MapMatcher> matcher;
   try {
     matcher.reset(matcher_factory.Create(trace_config));
-  } catch (const std::invalid_argument& ex) {
-    // TODO - what to return?
-    return "{\"foo\":\"bar\"}";
+  } catch (const std::exception&x) {
+    throw valhalla_exception_t{400, 601};
   }
 
   // Populate a measurement sequence to pass to the map matcher
@@ -95,8 +92,7 @@ std::string  TrafficSegmentMatcher::match(const std::string& json) {
   }
 
   if (sequence.size() != results.size()) {
-    LOG_ERROR("Sequence size not equal to match result size");
-    return "{\"foo\":\"bar\"}";
+    throw valhalla_exception_t{400, 603};
   }
 
   // TODO - more robust list of edges. Handle cases where multiple

--- a/valhalla/baldr/errorcode_util.h
+++ b/valhalla/baldr/errorcode_util.h
@@ -194,7 +194,13 @@ namespace baldr {
     {500,"Failed to parse intermediate request format"},
     {501,"Failed to parse TripDirections"},
 
-    {599,"Unknown"}
+    {599,"Unknown"},
+
+    // meili project 6xx
+    {600,"Failed to parse json request"},
+    {601,"Insufficiently specified required parameter 'trace'"},
+    {602,"The config is incorrectly loaded"},
+    {603,"Sequence size not equal to match result size"}
   };
 
   struct valhalla_exception_t: public std::runtime_error {

--- a/valhalla/meili/traffic_segment_matcher.h
+++ b/valhalla/meili/traffic_segment_matcher.h
@@ -5,6 +5,7 @@
 #include <sstream>
 #include <boost/property_tree/ptree.hpp>
 
+#include "valhalla/baldr/errorcode_util.h"
 #include "baldr/graphreader.h"
 #include "baldr/graphid.h"
 #include "baldr/json.h"


### PR DESCRIPTION
Replacing the return "{\"foo\":\"bar\"}"