### PR TITLE
Add more logic for avoid locations.

### DIFF
--- a/src/loki/isochrone_action.cc
+++ b/src/loki/isochrone_action.cc
@@ -13,9 +13,9 @@ const headers_t::value_type CORS{"Access-Control-Allow-Origin", "*"};
 namespace valhalla {
   namespace loki {
 
-    void loki_worker_t::init_isochrones(const boost::property_tree::ptree& request) {
+    void loki_worker_t::init_isochrones(boost::property_tree::ptree& request) {
       //strip off unused information
-      parse_locations(request);
+      locations = parse_locations(request, "locations");
       if(locations.size() < 1)
         throw valhalla_exception_t{400, 120};
       for(auto& l : locations)

--- a/src/loki/locate_action.cc
+++ b/src/loki/locate_action.cc
@@ -123,8 +123,8 @@ namespace {
 namespace valhalla {
   namespace loki {
 
-    void loki_worker_t::init_locate(const boost::property_tree::ptree& request) {
-      parse_locations(request);
+    void loki_worker_t::init_locate(boost::property_tree::ptree& request) {
+      locations = parse_locations(request, "locations");
       if(locations.size() < 1)
         throw valhalla_exception_t{400, 120};
       auto costing = request.get_optional<std::string>("costing");
@@ -136,7 +136,7 @@ namespace valhalla {
       }
     }
 
-    worker_t::result_t loki_worker_t::locate(const boost::property_tree::ptree& request, http_request_info_t& request_info) {
+    worker_t::result_t loki_worker_t::locate(boost::property_tree::ptree& request, http_request_info_t& request_info) {
       init_locate(request);
       //correlate the various locations to the underlying graph
       auto json = json::array({});

--- a/src/loki/route_action.cc
+++ b/src/loki/route_action.cc
@@ -37,8 +37,8 @@ namespace {
 namespace valhalla {
   namespace loki {
 
-    void loki_worker_t::init_route(const boost::property_tree::ptree& request) {
-      parse_locations(request);
+    void loki_worker_t::init_route(boost::property_tree::ptree& request) {
+      locations = parse_locations(request, "locations");
       //need to check location size here instead of in parse_locations because of locate action needing a different size
       if(locations.size() < 2)
         throw valhalla_exception_t{400, 120};

--- a/src/loki/service.cc
+++ b/src/loki/service.cc
@@ -193,7 +193,11 @@ namespace valhalla {
             }
           }
           auto &avoid_edges = costing_options.add_child("avoid_edges", boost::property_tree::ptree{});
-          for(auto avoid : avoids) avoid_edges.put("", avoid);
+          for(auto avoid : avoids) {
+            boost::property_tree::ptree value;
+            value.put("", avoid);
+            avoid_edges.push_back(std::make_pair("", value));
+          }
         }//swallow all failures on optional avoids
         catch(...) {
           LOG_WARN("Failed to find avoid_locations");

--- a/src/loki/service.cc
+++ b/src/loki/service.cc
@@ -132,25 +132,24 @@ namespace valhalla {
       return result;
     }
 
-    void loki_worker_t::parse_locations(const boost::property_tree::ptree& request) {
-      //we require locations
-      auto request_locations = request.get_child_optional("locations");
-      if (!request_locations)
-        throw valhalla_exception_t{400, 110};
-
-      for(const auto& location : *request_locations) {
-        try{
-          locations.push_back(baldr::Location::FromPtree(location.second));
+    std::vector<baldr::Location> loki_worker_t::parse_locations(const boost::property_tree::ptree& request, const std::string& node,
+      boost::optional<baldr::valhalla_exception_t> required_exception) {
+      std::vector<baldr::Location> parsed;
+      auto request_locations = request.get_child_optional(node);
+      if (request_locations) {
+        for(const auto& location : *request_locations) {
+          try { parsed.push_back(baldr::Location::FromPtree(location.second)); }
+          catch (...) { throw valhalla_exception_t{400, 130}; }
         }
-        catch (...) {
-          throw valhalla_exception_t{400, 130};
-        }
+        if (!healthcheck)
+          valhalla::midgard::logging::Log(node + "_count::" + std::to_string(request_locations->size()), " [ANALYTICS] ");
       }
-      if (!healthcheck)
-        valhalla::midgard::logging::Log("location_count::" + std::to_string(request_locations->size()), " [ANALYTICS] ");
+      else if(required_exception)
+        throw *required_exception;
+      return parsed;
     }
 
-    void loki_worker_t::parse_costing(const boost::property_tree::ptree& request) {
+    void loki_worker_t::parse_costing(boost::property_tree::ptree& request) {
       //using the costing we can determine what type of edge filtering to use
       auto costing = request.get_optional<std::string>("costing");
       if (!costing)
@@ -162,10 +161,14 @@ namespace valhalla {
       if(*costing == "multimodal")
         *costing = "pedestrian";
 
-      // Get the costing options if in the config or get the empty default.
+      // Get the costing options if in the config or make a blank one.
       // Creates the cost in the cost factory
       std::string method_options = "costing_options." + *costing;
-      auto costing_options = request.get_child(method_options,{});
+      if(!request.get_child_optional(method_options)) {
+        request.add_child("costing_options", boost::property_tree::ptree{})
+                 .add_child(*costing, boost::property_tree::ptree{});
+      }
+      auto& costing_options = request.get_child(method_options);
       try{
         auto c = factory.Create(*costing, costing_options);
         edge_filter = c->GetEdgeFilter();
@@ -173,6 +176,28 @@ namespace valhalla {
       }
       catch(const std::runtime_error&) {
         throw valhalla_exception_t{400, 125, "'" + *costing + "'"};
+      }
+
+      // See if we have avoids and take care of them
+      auto avoid_locations = parse_locations(request, "avoid_locations", boost::none);
+      if(!avoid_locations.empty()) {
+        try {
+          auto results = loki::Search(avoid_locations, reader, edge_filter, node_filter);
+          std::unordered_set<uint64_t> avoids;
+          for(const auto& result : results) {
+            for(const auto& edge : result.second.edges) {
+              auto inserted = avoids.insert(edge.id);
+              GraphId shortcut;
+              if(inserted.second && (shortcut = reader.GetShortcut(edge.id)).Is_Valid())
+                avoids.insert(shortcut);
+            }
+          }
+          auto &avoid_edges = costing_options.add_child("avoid_edges", boost::property_tree::ptree{});
+          for(auto avoid : avoids) avoid_edges.put("", avoid);
+        }//swallow all failures on optional avoids
+        catch(...) {
+          LOG_WARN("Failed to find avoid_locations");
+        }
       }
     }
 

--- a/src/sif/dynamiccost.cc
+++ b/src/sif/dynamiccost.cc
@@ -67,6 +67,14 @@ DynamicCost::DynamicCost(const boost::property_tree::ptree& pt,
   for (uint32_t level = 0; level < n_levels; level++) {
     hierarchy_limits_.emplace_back(HierarchyLimits(pt, level));
   }
+
+  // Parse property tree to get avoid edges
+  auto avoid_edges = pt.get_child_optional("avoid_edges");
+  if (avoid_edges) {
+    for (auto& edgeid : *avoid_edges) {
+      user_avoid_edges_.insert(GraphId(edgeid.second.get_value<uint64_t>()));
+    }
+  }
 }
 
 DynamicCost::~DynamicCost() {

--- a/valhalla/loki/service.h
+++ b/valhalla/loki/service.h
@@ -31,18 +31,19 @@ namespace valhalla {
      protected:
 
       prime_server::worker_t::result_t jsonify_error(const baldr::valhalla_exception_t& exception, prime_server::http_request_info_t& request_info) const;
-      void parse_locations(const boost::property_tree::ptree& request);
+      std::vector<baldr::Location> parse_locations(const boost::property_tree::ptree& request, const std::string& node,
+        boost::optional<baldr::valhalla_exception_t> required_exception = baldr::valhalla_exception_t{400, 110});
       void parse_trace(boost::property_tree::ptree& request);
-      void parse_costing(const boost::property_tree::ptree& request);
+      void parse_costing(boost::property_tree::ptree& request);
       void locations_from_shape(boost::property_tree::ptree& request);
 
-      void init_locate(const boost::property_tree::ptree& request);
-      void init_route(const boost::property_tree::ptree& request);
+      void init_locate(boost::property_tree::ptree& request);
+      void init_route(boost::property_tree::ptree& request);
       void init_matrix(ACTION_TYPE action, boost::property_tree::ptree& request);
-      void init_isochrones(const boost::property_tree::ptree& request);
+      void init_isochrones(boost::property_tree::ptree& request);
       void init_trace(boost::property_tree::ptree& request);
 
-      prime_server::worker_t::result_t locate(const boost::property_tree::ptree& request, prime_server::http_request_info_t& request_info);
+      prime_server::worker_t::result_t locate(boost::property_tree::ptree& request, prime_server::http_request_info_t& request_info);
       prime_server::worker_t::result_t route(boost::property_tree::ptree& request, prime_server::http_request_info_t& request_info);
       prime_server::worker_t::result_t matrix(ACTION_TYPE action,boost::property_tree::ptree& request, prime_server::http_request_info_t& request_info);
       prime_server::worker_t::result_t isochrones(boost::property_tree::ptree& request, prime_server::http_request_info_t& request_info);

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -333,10 +333,21 @@ class DynamicCost {
   virtual bool IsExcluded(const baldr::GraphTile*& tile,
                           const baldr::NodeInfo* node);
 
-  // Adds a list of edges (GraphIds) to the user specified avoid list.
+  /**
+   * Adds a list of edges (GraphIds) to the user specified avoid list.
+   * This can be used by test programs - alternatively a list of avoid
+   * edges will be passed in the property tree for the costing options
+   * of a specified type.
+   * @param  avoid_edges  Set of edge Ids to avoid.
+   */
   void AddUserAvoidEdges(const std::vector<baldr::GraphId>& avoid_edges);
 
-  // Check if the edge is in the user-specified avoid list.
+  /**
+   * Check if the edge is in the user-specified avoid list.
+   * @param  edgeid  Directed edge Id.
+   * @return Returns true if the edge Id is in the user avoid edges set,
+   *         false otherwise.
+   */
   bool IsUserAvoidEdge(const baldr::GraphId& edgeid) const {
     return (user_avoid_edges_.size() != 0 &&
             user_avoid_edges_.find(edgeid) != user_avoid_edges_.end());


### PR DESCRIPTION
Within DynamicCosting base class constructor parse any avoid edges that are passed via the costing options ptree for the particular costing type.