### PR TITLE
Fix PPA instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,19 +59,18 @@ Get Valhalla from Personal Package Archive (PPA)
 If you are running Ubuntu (trusty or xenial) Valhalla can be installed quickly and easily via PPA. Try the following:
 
 ```bash
-#get some dependencies in other ppas
+# get some dependencies in other ppas
 if [[ $(grep -cF trusty /etc/lsb-release) > 0 ]]; then
   sudo add-apt-repository -y ppa:kevinkreiser/libsodium
   sudo add-apt-repository -y ppa:kevinkreiser/libpgm
   sudo add-apt-repository -y ppa:kevinkreiser/zeromq3
   sudo add-apt-repository -y ppa:kevinkreiser/czmq
 fi
+# grab all of the valhalla software from ppa
 sudo add-apt-repository -y ppa:kevinkreiser/prime-server
-#grab all of the valhalla software from ppa
-sudo add-apt-repository ppa:kevinkreiser/prime-server
-sudo add-apt-repository ppa:valhalla-routing/valhalla
+sudo add-apt-repository -y ppa:valhalla-routing/valhalla
 sudo apt-get update
-sudo apt-get install valhalla-bin
+sudo apt-get install -y valhalla-bin
 ```
 
 Building from Source


### PR DESCRIPTION
Basic fixes for the PPA instructions. The `-y` flag was missing on some instructions so if you copy/pasted these then everything after the first command missing the `-y` was swallowed by the [ENTER] prompt. Additionally, it looks like it tries to add the prime-server PPA twice.