### PR TITLE
fix LLVM error - call to implicitly-deleted default constructor

### DIFF
--- a/valhalla/mjolnir/osmrestriction.h
+++ b/valhalla/mjolnir/osmrestriction.h
@@ -189,6 +189,7 @@ struct OSMRestriction {
   // Via is a node. When parsing OSM this is stored as an OSM node Id.
   // It later gets changed into a GraphId.
   union ViaNode {
+    ViaNode() {}
     baldr::GraphId id;
     uint64_t osmid;
   };


### PR DESCRIPTION
http://stackoverflow.com/questions/26572240/why-does-union-has-deleted-default-constructor-if-one-of-its-member-doesnt-have