### PR TITLE
Add new method to trim the front of a polyline by a specified distance.

### DIFF
--- a/src/midgard/util.cc
+++ b/src/midgard/util.cc
@@ -60,7 +60,7 @@ container_t trim_front(container_t& pts, const float dist) {
   container_t result;
   result.push_back(pts.front());
   double d = 0.0f;
-  for (auto p1 = pts.cbegin(), p2 = std::next(pts.cbegin()); p2 != pts.cend(); ++p1, ++p2) {
+  for (auto p1 = pts.begin(), p2 = std::next(pts.begin()); p2 != pts.end(); ++p1, ++p2) {
     double segdist = p1->Distance(*p2);
     if ((d + segdist) > dist) {
       double frac = (dist - d) / segdist;

--- a/src/midgard/util.cc
+++ b/src/midgard/util.cc
@@ -46,6 +46,48 @@ float FastInvSqrt(float x) {
   // x *= 1.5f - xhalf*x*x;          // repeating step increases accuracy
 }
 
+// Trim the front of a polyline (represented as a list or vector of Point2).
+// Returns the trimmed portion of the polyline. The supplied polyline is
+// altered (the trimmed part is removed).
+template <class container_t>
+container_t trim_front(container_t& pts, const float dist) {
+  // Return if less than 2 points
+  if (pts.size() < 2) {
+    return {};
+  }
+
+  // Walk the polyline and accumulate length until it exceeds dist
+  container_t result;
+  result.push_back(pts.front());
+  double d = 0.0f;
+  for (auto p1 = pts.cbegin(), p2 = std::next(pts.cbegin()); p2 != pts.cend(); ++p1, ++p2) {
+    double segdist = p1->Distance(*p2);
+    if ((d + segdist) > dist) {
+      double frac = (dist - d) / segdist;
+      auto midpoint = p1->AffineCombination((1.0-frac), frac, *p2);
+      result.push_back(midpoint);
+
+      // Remove used part of polyline
+      pts.erase(pts.begin(), p1);
+      pts.front() = midpoint;
+      return result;
+    } else {
+      d += segdist;
+      result.push_back(*p2);
+    }
+  }
+
+  // Used all of the polyline without exceeding dist
+  pts.clear();
+  return result;
+}
+
+// Explicit instantiations
+template std::vector<PointLL> trim_front<std::vector<PointLL> >(std::vector<PointLL>&, const float);
+template std::vector<Point2> trim_front<std::vector<Point2> >(std::vector<Point2>&, const float);
+template std::list<PointLL> trim_front<std::list<PointLL> >(std::list<PointLL>&, const float);
+template std::list<Point2> trim_front<std::list<Point2> >(std::list<Point2>&, const float);
+
 memory_status::memory_status(const std::unordered_set<std::string> interest){
   //grab the vm stats from the file
   std::ifstream file("/proc/self/status");

--- a/test/util_midgard.cc
+++ b/test/util_midgard.cc
@@ -217,6 +217,23 @@ void TestTrimFront() {
   if (std::abs(d2 - l2) > tolerance) {
     throw std::logic_error("length of remaining polyline 2 does not match");
   }
+
+  // Make sure if trim distance exceeds polyline length that the entire
+  // polyline is returned and none remains
+  std::list<Point2> pts3 = { { -81.0f, -45.0f }, { -18.0f, 17.0f}, { 8.0f, 8.0f },
+             { 6.0f, 19.0f }, { 49.0f,  -5.0f }, { 75.0f, 45.0f } };
+  size_t n = pts3.size();
+  l = length(pts3);
+  auto trim3 = trim_front(pts3, l + 1.0f);
+  if (std::abs(length(trim3) - l) > tolerance) {
+    throw std::logic_error("length of trimmed polyline not equal to original length when trim distance exceeds length");
+  }
+  if (trim3.size() != n) {
+    throw std::logic_error("trimmed polyline not equal size of original when trim distance exceeds length");
+  }
+  if (pts3.size() > 0)  {
+    throw std::logic_error("some of original polyline remains when trim distance exceeds length");
+  }
 }
 
 }

--- a/test/util_midgard.cc
+++ b/test/util_midgard.cc
@@ -187,6 +187,38 @@ void TestIterable() {
     throw std::logic_error("cumulative product failed");
 }
 
+void TestTrimFront() {
+  std::vector<Point2> pts = { { -1.0f, -1.0f }, { -1.0f, 1.0f}, { 0.0f, 1.0f },
+         { 1.0f, 1.0f }, { 4.0f,  5.0f }, { 5.0f, 5.0f } };
+
+  constexpr float tolerance = 0.0001f;
+  float l = length(pts);
+  auto trim = trim_front(pts, 9.0f);
+  if (std::abs(length(trim) - 9.0f) > tolerance) {
+    throw std::logic_error("incorrect length of trimmed polyline");
+  }
+  if (std::abs(l - length(pts) - 9.0f) > tolerance) {
+    throw std::logic_error("length of remaining polyline not correct");
+  }
+  if (pts.size() != 2) {
+    throw std::logic_error("number of remaining points not correct");
+  }
+
+  std::list<Point2> pts2 = { { -81.0f, -45.0f }, { -18.0f, 17.0f}, { 8.0f, 8.0f },
+           { 6.0f, 19.0f }, { 49.0f,  -5.0f }, { 75.0f, 45.0f } };
+  l = length(pts2);
+  float d = l * 0.75f;
+  auto trim2 = trim_front(pts2, d);
+  if (std::abs(length(trim2) - d) >tolerance) {
+    throw std::logic_error("incorrect length of trimmed polyline 2");
+  }
+  float d2 = l * 0.25f;
+  float l2 = length(pts2);
+  if (std::abs(d2 - l2) > tolerance) {
+    throw std::logic_error("length of remaining polyline 2 does not match");
+  }
+}
+
 }
 
 int main() {
@@ -207,6 +239,9 @@ int main() {
   suite.test(TEST_CASE(TestResample));
 
   suite.test(TEST_CASE(TestIterable));
+
+  // trim_front of a polyline
+  suite.test(TEST_CASE(TestTrimFront));
 
   return suite.tear_down();
 }

--- a/valhalla/midgard/util.h
+++ b/valhalla/midgard/util.h
@@ -73,6 +73,19 @@ T sqr(const T a) {
   return a * a;
 }
 
+/**
+ * Trim the front of a polyline (represented as a list or vector of Point2).
+ * Returns the trimmed portion of the polyline. The supplied polyline is
+ * altered (the trimmed part is removed).
+ * @param  pts    List of points. This is modified - the result is the
+ *                remaining points after trimming the front.
+ * @param  dist   Distance to trim.
+ * @return Returns a list of points along the supplied polyline. The total
+ *         length of the returned polyline is dist.
+ */
+template <class container_t>
+container_t trim_front(container_t& pts, const float dist);
+
 // Compute the length of the polyline represented by a set of lat,lng points.
 // Avoids having to copy the points into a polyline, polyline should really just extend
 // A container class like vector or list


### PR DESCRIPTION
The trimmed portion is returned and the supplied polyline is altered to remove the trimmed portion.
Adapted from code from @zerebubuth. A couple tests added.