### PR TITLE
Fix for empty std::runtime_error string

### DIFF
--- a/valhalla/baldr/errorcode_util.h
+++ b/valhalla/baldr/errorcode_util.h
@@ -208,6 +208,9 @@ namespace baldr {
       status_code_body = code_itr == kHttpStatusCodes.cend() ? "" : code_itr->second;
 
     }
+    const char* what() const noexcept override {
+      return error_code_message.c_str();
+    }
     unsigned error_code;
     unsigned status_code;
     std::string error_code_message;


### PR DESCRIPTION
added to override the runtime error empty string for all services with the actual message string