### PR TITLE
fixed LLVM errors and warnings

### DIFF
--- a/src/loki/isochrone_action.cc
+++ b/src/loki/isochrone_action.cc
@@ -31,7 +31,7 @@ namespace valhalla {
         throw valhalla_exception_t{400, 152, std::to_string(max_contours)};
       size_t prev = 0;
       for(const auto& contour : *contours) {
-        const size_t c = GetOptionalFromRapidJson<size_t>(contour, "/time").get_value_or(-1);
+        const int c = GetOptionalFromRapidJson<int>(contour, "/time").get_value_or(-1);
         if(c < prev || c == -1)
           throw valhalla_exception_t{400, 111};
         if(c > max_time)

--- a/src/loki/matrix_action.cc
+++ b/src/loki/matrix_action.cc
@@ -119,7 +119,7 @@ namespace valhalla {
 
     worker_t::result_t loki_worker_t::matrix(ACTION_TYPE action, rapidjson::Document& request, http_request_info_t& request_info) {
       init_matrix(action, request);
-      auto costing = request["costing"].GetString();
+      std::string costing = request["costing"].GetString();
       if (costing == "multimodal")
         return jsonify_error({400, 140, ACTION_TO_STRING.find(action)->second}, request_info);
 


### PR DESCRIPTION
```
src/loki/matrix_action.cc:123:19: warning: result of comparison against a string literal is unspecified (use strncmp instead) [-Wstring-compare]`
```

```
./valhalla/rapidjson/document.h:1744:66: error: no member named 'Is' in 'rapidjson::internal::TypeHelper<rapidjson::GenericValue<rapidjson::UTF8<char>,
      rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >, unsigned long>'
    bool Is() const { return internal::TypeHelper<ValueType, T>::Is(*this); }
                                                                 ^
```
