### PR TITLE
AddEdgeInfo - add method that takes encoded shape

### DIFF
--- a/src/mjolnir/hierarchybuilder.cc
+++ b/src/mjolnir/hierarchybuilder.cc
@@ -279,10 +279,11 @@ void FormTilesInNewLevel(GraphReader& reader) {
       // encoded shape plus way Id.
       uint32_t idx = directededge->edgeinfo_offset();
       auto edgeinfo = tile->edgeinfo(idx);
-      uint32_t w = hasher(edgeinfo.encoded_shape() +
-                          std::to_string(edgeinfo.wayid()));
+      std::string encoded_shape = edgeinfo.encoded_shape();
+      uint32_t w = hasher(encoded_shape + std::to_string(edgeinfo.wayid()));
       uint32_t edge_info_offset = tilebuilder->AddEdgeInfo(w, nodea, nodeb,
-                    edgeinfo.wayid(), edgeinfo.shape(), tile->GetNames(idx), added);
+                    edgeinfo.wayid(), encoded_shape,
+                    tile->GetNames(idx), added);
       newedge.set_edgeinfo_offset(edge_info_offset);
 
       // Add directed edge

--- a/src/mjolnir/shortcutbuilder.cc
+++ b/src/mjolnir/shortcutbuilder.cc
@@ -614,7 +614,7 @@ uint32_t FormShortcuts(GraphReader& reader,
           // should be a valid key since tile sizes aren't changed)
           auto edgeinfo = tile->edgeinfo(directededge->edgeinfo_offset());
           uint32_t edge_info_offset = tilebuilder.AddEdgeInfo(directededge->edgeinfo_offset(),
-                         node_id, directededge->endnode(), edgeinfo.wayid(), edgeinfo.shape(),
+                         node_id, directededge->endnode(), edgeinfo.wayid(), edgeinfo.encoded_shape(),
                          tile->GetNames(directededge->edgeinfo_offset()), added);
           newedge.set_edgeinfo_offset(edge_info_offset);
 

--- a/valhalla/mjolnir/graphtilebuilder.h
+++ b/valhalla/mjolnir/graphtilebuilder.h
@@ -168,7 +168,7 @@ class GraphTileBuilder : public baldr::GraphTile {
    *                form tuple that uniquely identifies the edge info since
    *                there are two directed edges per edge info.
    * @param  wayid  The target edge is part of this the way id.
-   * @param  lls  The shape of the target edge.
+   * @param  lls    The shape of the target edge.
    * @param  names  The names of the target edge.
    * @param  added  Set to true if the target edge was newly added to the list,
    *                set to false if the target edge was already in the list.
@@ -180,6 +180,33 @@ class GraphTileBuilder : public baldr::GraphTile {
                        const baldr::GraphId& nodeb,
                        const uint64_t wayid,
                        const shape_container_t& lls,
+                       const std::vector<std::string>& names,
+                       bool& added);
+
+  /**
+   * Add the edge info to the tile. This method accepts an encoded shape
+   * string.
+   *
+   * @param  edgeindex  The index of the edge - used with nodea and nodeb to
+   *                    form tuple that uniquely identifies the edge info since
+   *                    there are two directed edges per edge info.
+   * @param  nodea  One of two nodes - used with edgeindex and nodeb to
+   *                form tuple that uniquely identifies the edge info since
+   *                there are two directed edges per edge info.
+   * @param  nodeb  One of two nodes - used with edgeindex and nodea to
+   *                form tuple that uniquely identifies the edge info since
+   *                there are two directed edges per edge info.
+   * @param  wayid  The target edge is part of this the way id.
+   * @param  llstr  The shape of the target edge as an encoded string.
+   * @param  names  The names of the target edge.
+   * @param  added  Set to true if the target edge was newly added to the list,
+   *                set to false if the target edge was already in the list.
+   *
+   * @return  The edge info offset that will be stored in the directed edge.
+   */
+  uint32_t AddEdgeInfo(const uint32_t edgeindex, const baldr::GraphId& nodea,
+                       const baldr::GraphId& nodeb, const uint64_t wayid,
+                       const std::string& llstr,
                        const std::vector<std::string>& names,
                        bool& added);
 


### PR DESCRIPTION
This allows use in HierarchyBuilder and ShortcutBuilder so shape does not have to be decoded, only to be re-encoded when adding back to the updated tile,

Fixes #535 