### PR TITLE
Improve "balance" between forward and reverse paths in bidirectional search

### DIFF
--- a/valhalla/thor/bidirectional_astar.h
+++ b/valhalla/thor/bidirectional_astar.h
@@ -81,6 +81,7 @@ class BidirectionalAStar : public PathAlgorithm {
   std::vector<sif::HierarchyLimits> hierarchy_limits_reverse_;
 
   // A* heuristic
+  float cost_diff_;
   AStarHeuristic astarheuristic_forward_;
   AStarHeuristic astarheuristic_reverse_;
 


### PR DESCRIPTION
Compute the difference in initial sort costs between the forward and reverse path and use this difference when comparing lowest sortcost to decide whether to expand the forward or reverse path. Differences
in sort cost can occur due to the distance approximation's use of the location's latitude when computing distances in longitude. This change helps balance the forward and reverse search paths, which before
could expand only on one path until the sortcost difference is absorbed.

Example - Lancaster,PA to San Diego,CA
prior: forward EdgeLabels = 511700, Reverse EdgeLabels = 188916
after: forward EdgeLabels = 265719, Reverse EdgeLabels = 334363