### PR TITLE
Make TileHierarchy static. Remove tile_dir.

### DIFF
--- a/src/baldr/merge.cc
+++ b/src/baldr/merge.cc
@@ -1,4 +1,5 @@
 #include "baldr/merge.h"
+#include "baldr/tilehierarchy.h"
 #include "baldr/graphreader.h"
 
 #include <boost/range/adaptor/map.hpp>
@@ -13,7 +14,7 @@ namespace {
 
 uint64_t count_tiles_in_levels(GraphReader &reader) {
   uint64_t tile_count = 0;
-  for (auto level : reader.GetTileHierarchy().levels() | bra::map_values) {
+  for (auto level : TileHierarchy::levels() | bra::map_values) {
     tile_count += level.tiles.ncolumns() * level.tiles.nrows();
   }
   return tile_count;

--- a/src/baldr/tilehierarchy.cc
+++ b/src/baldr/tilehierarchy.cc
@@ -6,27 +6,21 @@ using namespace valhalla::midgard;
 namespace valhalla {
 namespace baldr {
 
-TileHierarchy::TileHierarchy(const std::string& tile_dir):tile_dir_(tile_dir) {
-  levels_ = {
-    {2, TileLevel{2, stringToRoadClass.find("ServiceOther")->second, "local", Tiles<PointLL>{{{-180, -90}, {180, 90}}, .25, kBinsDim}}},
-    {1, TileLevel{1, stringToRoadClass.find("Tertiary")->second, "arterial", Tiles<PointLL>{{{-180, -90}, {180, 90}}, 1, kBinsDim}}},
-    {0, TileLevel{0, stringToRoadClass.find("Primary")->second, "highway", Tiles<PointLL>{{{-180, -90}, {180, 90}}, 4, kBinsDim}}}
-  };
-}
+// Static tile levels
+std::map<uint8_t, TileLevel> TileHierarchy::levels_  = {
+  {2, TileLevel{2, stringToRoadClass.find("ServiceOther")->second, "local",
+    midgard::Tiles<midgard::PointLL>{{{-180, -90}, {180, 90}}, .25, static_cast<unsigned short>(kBinsDim)}}},
+  {1, TileLevel{1, stringToRoadClass.find("Tertiary")->second, "arterial",
+    midgard::Tiles<midgard::PointLL>{{{-180, -90}, {180, 90}}, 1, static_cast<unsigned short>(kBinsDim)}}},
+  {0, TileLevel{0, stringToRoadClass.find("Primary")->second, "highway",
+    midgard::Tiles<midgard::PointLL>{{{-180, -90}, {180, 90}}, 4, static_cast<unsigned short>(kBinsDim)}}}
+};
 
-TileHierarchy::TileHierarchy(){}
-
-const std::map<unsigned char, TileHierarchy::TileLevel>& TileHierarchy::levels() const {
-  return levels_;
-}
-
-const std::string& TileHierarchy::tile_dir() const {
-  return tile_dir_;
-}
-
-GraphId TileHierarchy::GetGraphId(const midgard::PointLL& pointll, const unsigned char level) const {
+// Returns the GraphId of the requested tile based on a lat,lng and a level.
+// If the level is not supported an invalid id will be returned.
+GraphId TileHierarchy::GetGraphId(const midgard::PointLL& pointll, const uint8_t level) {
   GraphId id;
-  const auto& tl = levels_.find(level);
+  const auto& tl = levels().find(level);
   if(tl != levels_.end()) {
     auto tile_id = tl->second.tiles.TileId(pointll);
     if (tile_id >= 0) {
@@ -37,24 +31,24 @@ GraphId TileHierarchy::GetGraphId(const midgard::PointLL& pointll, const unsigne
 }
 
 // Gets the hierarchy level given the road class.
-uint8_t TileHierarchy::get_level(const RoadClass roadclass) const {
-  if (roadclass <= levels_.find(0)->second.importance) {
+uint8_t TileHierarchy::get_level(const RoadClass roadclass) {
+  if (roadclass <= levels().find(0)->second.importance) {
     return 0;
-  } else if (roadclass <= levels_.find(1)->second.importance) {
+  } else if (roadclass <= levels().find(1)->second.importance) {
     return 1;
   } else {
     return 2;
   }
 }
 
+// Returns all the GraphIds of the tiles which intersect the given bounding
+// box at that level.
 std::vector<GraphId> TileHierarchy::GetGraphIds(
-  const midgard::AABB2<midgard::PointLL> &bbox,
-  uint8_t level) const {
-
+        const midgard::AABB2<midgard::PointLL> &bbox,
+        const uint8_t level) {
   std::vector<GraphId> ids;
-
-  auto itr = levels_.find(level);
-  if (itr != levels_.end()) {
+  auto itr = levels().find(level);
+  if (itr != levels().end()) {
     auto tile_ids = itr->second.tiles.TileList(bbox);
     ids.reserve(tile_ids.size());
 
@@ -62,21 +56,19 @@ std::vector<GraphId> TileHierarchy::GetGraphIds(
       ids.emplace_back(tile_id, level, 0);
     }
   }
-
   return ids;
 }
 
+// Returns all the GraphIds of the tiles which intersect the given bounding
+// box at any level.
 std::vector<GraphId> TileHierarchy::GetGraphIds(
-  const midgard::AABB2<midgard::PointLL> &bbox) const {
-
+        const midgard::AABB2<midgard::PointLL> &bbox) {
   std::vector<GraphId> ids;
-
-  for (const auto &entry : levels_) {
+  for (const auto &entry : levels()) {
     auto level_ids = GetGraphIds(bbox, entry.first);
     ids.reserve(ids.size() + level_ids.size());
     ids.insert(ids.end(), level_ids.begin(), level_ids.end());
   }
-
   return ids;
 }
 

--- a/src/loki/matrix_action.cc
+++ b/src/loki/matrix_action.cc
@@ -4,6 +4,7 @@
 #include <boost/property_tree/info_parser.hpp>
 #include <unordered_map>
 
+#include "baldr/tilehierarchy.h"
 #include "baldr/datetime.h"
 #include "baldr/rapidjson_utils.h"
 #include "midgard/logging.h"
@@ -147,7 +148,7 @@ namespace valhalla {
           rapidjson::Pointer("/correlated_" + std::to_string(i)).Set(request, projection.ToRapidJson(i, request.GetAllocator()));
           //TODO: get transit level for transit costing
           //TODO: if transit send a non zero radius
-          auto colors = connectivity_map.get_colors(reader.GetTileHierarchy().levels().rbegin()->first, projection, 0);
+          auto colors = connectivity_map.get_colors(TileHierarchy::levels().rbegin()->first, projection, 0);
           for(auto& color : colors){
             auto itr = color_counts.find(color);
             if(itr == color_counts.cend())

--- a/src/loki/node_search.cc
+++ b/src/loki/node_search.cc
@@ -1,5 +1,6 @@
 #include "loki/node_search.h"
-#include "valhalla/midgard/tiles.h"
+#include "midgard/tiles.h"
+#include "baldr/tilehierarchy.h"
 
 namespace vm = valhalla::midgard;
 namespace vb = valhalla::baldr;
@@ -363,9 +364,8 @@ std::vector<baldr::GraphId>
 nodes_in_bbox(const vm::AABB2<vm::PointLL> &bbox, baldr::GraphReader& reader) {
   std::vector<vb::GraphId> nodes;
 
-  auto hierarchy = reader.GetTileHierarchy();
-  auto tiles = hierarchy.levels().rbegin()->second.tiles;
-  const uint8_t bin_level = hierarchy.levels().rbegin()->second.level;
+  auto tiles = vb::TileHierarchy::levels().rbegin()->second.tiles;
+  const uint8_t bin_level = vb::TileHierarchy::levels().rbegin()->second.level;
 
   // if the bbox only touches the edge of the tile or bin, then we need to
   // include neighbouring bins as well, in case both the edge and its opposite

--- a/src/loki/route_action.cc
+++ b/src/loki/route_action.cc
@@ -4,6 +4,7 @@
 #include <boost/property_tree/info_parser.hpp>
 
 #include "baldr/datetime.h"
+#include "baldr/tilehierarchy.h"
 #include "baldr/rapidjson_utils.h"
 #include "midgard/logging.h"
 
@@ -23,7 +24,7 @@ namespace {
 
   void check_distance(const GraphReader& reader, const std::vector<Location>& locations, float max_distance){
     //see if any locations pairs are unreachable or too far apart
-    auto lowest_level = reader.GetTileHierarchy().levels().rbegin();
+    auto lowest_level = TileHierarchy::levels().rbegin();
     for(auto location = ++locations.cbegin(); location != locations.cend(); ++location) {
       //check if distance between latlngs exceed max distance limit for each mode of travel
       auto path_distance = std::prev(location)->latlng_.Distance(location->latlng_);
@@ -117,7 +118,7 @@ namespace valhalla {
           rapidjson::Pointer("/correlated_" + std::to_string(i)).Set(request, correlated.ToRapidJson(i,allocator));
           //TODO: get transit level for transit costing
           //TODO: if transit send a non zero radius
-          auto colors = connectivity_map.get_colors(reader.GetTileHierarchy().levels().rbegin()->first, correlated, 0);
+          auto colors = connectivity_map.get_colors(TileHierarchy::levels().rbegin()->first, correlated, 0);
           for(auto color : colors){
             auto itr = color_counts.find(color);
             if(itr == color_counts.cend())

--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -1,6 +1,7 @@
 #include "loki/search.h"
 #include "midgard/linesegment2.h"
 #include "midgard/distanceapproximator.h"
+#include "baldr/tilehierarchy.h"
 
 #include <unordered_set>
 #include <list>
@@ -273,8 +274,8 @@ struct Segment {
 };
 
 std::function<std::tuple<int32_t, unsigned short, float>()>
-make_binner(const PointLL& p, const GraphReader& reader) {
-  const auto& tiles = reader.GetTileHierarchy().levels().rbegin()->second.tiles;
+make_binner(const PointLL& p) {
+  const auto& tiles = TileHierarchy::levels().rbegin()->second.tiles;
   return tiles.ClosestFirst(p);
 }
 
@@ -392,9 +393,9 @@ struct ProjectPoint {
   // hot spot.
   struct Box {
     Box(const Location& location, GraphReader& reader)
-      : binner(make_binner(location.latlng_, reader)),
+      : binner(make_binner(location.latlng_)),
         location(location),
-        level(reader.GetTileHierarchy().levels().rbegin()->first) {}
+        level(TileHierarchy::levels().rbegin()->first) {}
     std::function<std::tuple<int32_t, unsigned short, float>()> binner;
     const GraphTile* cur_tile = nullptr;
     Segment closest_segment;

--- a/src/meili/candidate_search.cc
+++ b/src/meili/candidate_search.cc
@@ -1,3 +1,4 @@
+#include "baldr/tilehierarchy.h"
 #include "meili/candidate_search.h"
 #include "meili/graph_helpers.h"
 #include "meili/geometry_helpers.h"
@@ -157,11 +158,10 @@ void IndexBin(const baldr::GraphTile& tile, const int32_t bin_index,
 
 CandidateGridQuery::CandidateGridQuery(baldr::GraphReader& reader, float cell_width, float cell_height)
     : CandidateQuery(reader),
-      hierarchy_(reader.GetTileHierarchy()),
       cell_width_(cell_width),
       cell_height_(cell_height),
       grid_cache_() {
-  bin_level_ = hierarchy_.levels().rbegin()->second.level;
+  bin_level_ = baldr::TileHierarchy::levels().rbegin()->second.level;
 }
 
 
@@ -195,7 +195,7 @@ CandidateGridQuery::GetGrid(const int32_t bin_id, const Tiles<PointLL>& tiles,
 
   // Insert the bin into the cache and index the bin
   const auto inserted = grid_cache_.emplace(bin_id,
-          grid_t(tile->BoundingBox(hierarchy_), cell_width_, cell_height_));
+          grid_t(tile->BoundingBox(), cell_width_, cell_height_));
   IndexBin(*tile, bin_index, reader_, inserted.first->second);
   return &(inserted.first->second);
 }
@@ -205,8 +205,7 @@ CandidateGridQuery::RangeQuery(const AABB2<midgard::PointLL>& range) const
 {
   // Get the tiles object from the tile hierarchy and create the bin tiles
   // (subidivisions within the tile)
-  const auto& tl = hierarchy_.levels().rbegin();
-  Tiles<PointLL> tiles = tl->second.tiles;
+  Tiles<PointLL> tiles = baldr::TileHierarchy::levels().rbegin()->second.tiles;
   Tiles<PointLL> bins(tiles.TileBounds(), tiles.SubdivisionSize());
 
   // Get a list of bins within the range. These are "tile Ids" that must

--- a/src/meili/map_matcher_factory.cc
+++ b/src/meili/map_matcher_factory.cc
@@ -5,6 +5,7 @@
 #include "sif/bicyclecost.h"
 #include "sif/pedestriancost.h"
 #include "baldr/graphreader.h"
+#include "baldr/tilehierarchy.h"
 
 #include "meili/candidate_search.h"
 #include "meili/map_matcher.h"
@@ -16,10 +17,9 @@
 namespace {
 
 inline float
-local_tile_size(const valhalla::baldr::GraphReader& graphreader)
+local_tile_size()
 {
-  const auto& tile_hierarchy = graphreader.GetTileHierarchy();
-  const auto& tiles = tile_hierarchy.levels().rbegin()->second.tiles;
+  const auto& tiles = valhalla::baldr::TileHierarchy::levels().rbegin()->second.tiles;
   return tiles.TileSize();
 }
 
@@ -33,8 +33,8 @@ MapMatcherFactory::MapMatcherFactory(const boost::property_tree::ptree& root)
     : config_(root.get_child("meili")),
       graphreader_(root.get_child("mjolnir")),
       candidatequery_(graphreader_,
-                      local_tile_size(graphreader_)/root.get<size_t>("meili.grid.size"),
-                      local_tile_size(graphreader_)/root.get<size_t>("meili.grid.size")),
+                      local_tile_size()/root.get<size_t>("meili.grid.size"),
+                      local_tile_size()/root.get<size_t>("meili.grid.size")),
       max_grid_cache_size_(root.get<float>("meili.grid.cache_size"))
       { 
   cost_factory_.Register("auto", sif::CreateAutoCost);

--- a/src/mjolnir/graphenhancer.cc
+++ b/src/mjolnir/graphenhancer.cc
@@ -879,9 +879,8 @@ void enhance(const boost::property_tree::ptree& pt,
 
   // Get some things we need throughout
   enhancer_stats stats{std::numeric_limits<float>::min(), 0};
-  const auto& tile_hierarchy = reader.GetTileHierarchy();
-  const auto& local_level = tile_hierarchy.levels().rbegin()->second.level;
-  const auto& tiles = tile_hierarchy.levels().rbegin()->second.tiles;
+  const auto& local_level = TileHierarchy::levels().rbegin()->second.level;
+  const auto& tiles = TileHierarchy::levels().rbegin()->second.tiles;
 
   // Iterate through the tiles in the queue and perform enhancements
   while (true) {
@@ -905,7 +904,7 @@ void enhance(const boost::property_tree::ptree& pt,
     }
 
     // Tile builder - serialize in existing tile so we can add admin names
-    GraphTileBuilder tilebuilder(tile_hierarchy, tile_id, true);
+    GraphTileBuilder tilebuilder(reader.tile_dir(), tile_id, true);
     lock.unlock();
 
     // this will be our updated list of restrictions.
@@ -1190,9 +1189,8 @@ void GraphEnhancer::Enhance(const boost::property_tree::ptree& pt,
   std::deque<GraphId> tempqueue;
   boost::property_tree::ptree hierarchy_properties = pt.get_child("mjolnir");
   GraphReader reader(hierarchy_properties);
-  auto tile_hierarchy = reader.GetTileHierarchy();
-  auto local_level = tile_hierarchy.levels().rbegin()->second.level;
-  auto tiles = tile_hierarchy.levels().rbegin()->second.tiles;
+  auto local_level = TileHierarchy::levels().rbegin()->second.level;
+  auto tiles = TileHierarchy::levels().rbegin()->second.tiles;
   for (uint32_t id = 0; id < tiles.TileCount(); id++) {
     // If tile exists add it to the queue
     GraphId tile_id(id, local_level, 0);

--- a/src/mjolnir/graphvalidator.cc
+++ b/src/mjolnir/graphvalidator.cc
@@ -280,9 +280,8 @@ void validate(const boost::property_tree::ptree& pt,
     // Local Graphreader
     GraphReader graph_reader(pt.get_child("mjolnir"));
     // Get some things we need throughout
-    const auto& hierarchy = graph_reader.GetTileHierarchy();
-    auto numLevels = hierarchy.levels().size() + 1;    // To account for transit
-    auto transit_level = hierarchy.levels().rbegin()->second.level + 1;
+    auto numLevels = TileHierarchy::levels().size() + 1;    // To account for transit
+    auto transit_level = TileHierarchy::levels().rbegin()->second.level + 1;
 
     // vector to hold densities for each level
     std::vector<std::vector<float>> densities(numLevels);
@@ -307,15 +306,15 @@ void validate(const boost::property_tree::ptree& pt,
 
       // Point tiles to the set we need for current level
       auto level = tile_id.level();
-      if (hierarchy.levels().rbegin()->second.level+1 == level)
-        level = hierarchy.levels().rbegin()->second.level;
+      if (TileHierarchy::levels().rbegin()->second.level+1 == level)
+        level = TileHierarchy::levels().rbegin()->second.level;
 
-      const auto& tiles = hierarchy.levels().find(level)->second.tiles;
+      const auto& tiles = TileHierarchy::levels().find(level)->second.tiles;
       level = tile_id.level();
       auto tileid = tile_id.tileid();
 
       // Get the tile
-      GraphTileBuilder tilebuilder(hierarchy, tile_id, false);
+      GraphTileBuilder tilebuilder(graph_reader.tile_dir(), tile_id, false);
 
       // Update nodes and directed edges as needed
       std::vector<NodeInfo> nodes;
@@ -463,16 +462,16 @@ void validate(const boost::property_tree::ptree& pt,
       tilebuilder.header_builder().set_density(relative_density);
 
       // Bin the edges
-      auto bins = GraphTileBuilder::BinEdges(hierarchy, tile, tweeners);
+      auto bins = GraphTileBuilder::BinEdges(tile, tweeners);
 
       // Write the new tile
       lock.lock();
       tilebuilder.Update(nodes, directededges);
 
       // Write the bins to it
-      if (tile->header()->graphid().level() == hierarchy.levels().rbegin()->first) {
-        auto reloaded = GraphTile(hierarchy, tile_id);
-        GraphTileBuilder::AddBins(hierarchy, &reloaded, bins);
+      if (tile->header()->graphid().level() == TileHierarchy::levels().rbegin()->first) {
+        auto reloaded = GraphTile(graph_reader.tile_dir(), tile_id);
+        GraphTileBuilder::AddBins(graph_reader.tile_dir(), &reloaded, bins);
       }
 
       // Check if we need to clear the tile cache
@@ -511,7 +510,9 @@ void validate(const boost::property_tree::ptree& pt,
   }
 
   //crack open tiles and bin edges that pass through them but dont end or begin in them
-  void bin_tweeners(const TileHierarchy& hierarchy, tweeners_t::iterator& start, const tweeners_t::iterator& end, uint64_t dataset_id, std::mutex& lock) {
+  void bin_tweeners(const std::string& tile_dir, tweeners_t::iterator& start,
+                    const tweeners_t::iterator& end,
+                    uint64_t dataset_id, std::mutex& lock) {
     //go while we have tiles to update
     while(true) {
       lock.lock();
@@ -525,16 +526,16 @@ void validate(const boost::property_tree::ptree& pt,
       lock.unlock();
 
       //if there is nothing there we need to make something
-      GraphTile tile(hierarchy, tile_bin.first);
+      GraphTile tile(tile_dir, tile_bin.first);
 
       if(!tile.header()) {
-        GraphTileBuilder empty(hierarchy, tile_bin.first, false);
+        GraphTileBuilder empty(tile_dir, tile_bin.first, false);
         empty.header_builder().set_dataset_id(dataset_id);
         empty.StoreTileData();
-        tile = GraphTile(hierarchy, tile_bin.first);
+        tile = GraphTile(tile_dir, tile_bin.first);
       }
       //keep the extra binned edges
-      GraphTileBuilder::AddBins(hierarchy, &tile, tile_bin.second);
+      GraphTileBuilder::AddBins(tile_dir, &tile, tile_bin.second);
     }
   }
 }
@@ -543,17 +544,12 @@ namespace valhalla {
 namespace mjolnir {
 
   void GraphValidator::Validate(const boost::property_tree::ptree& pt) {
-    // Graphreader
     auto hierarchy_properties = pt.get_child("mjolnir");
-    TileHierarchy hierarchy(hierarchy_properties.get<std::string>("tile_dir"));
-    // Make sure there are at least 2 levels!
-    auto numHierarchyLevels = hierarchy.levels().size();
-    if (numHierarchyLevels < 2)
-      throw std::runtime_error("Bad tile hierarchy - need 2 levels");
+    std::string tile_dir = hierarchy_properties.get<std::string>("tile_dir");
 
     // Create a randomized queue of tiles to work from
     std::deque<GraphId> tilequeue;
-    for (auto tier : hierarchy.levels()) {
+    for (auto tier : TileHierarchy::levels()) {
       auto level = tier.second.level;
       auto tiles = tier.second.tiles;
       for (uint32_t id = 0; id < tiles.TileCount(); id++) {
@@ -565,7 +561,7 @@ namespace mjolnir {
       }
 
       //transit level
-      if (level == hierarchy.levels().rbegin()->second.level) {
+      if (level == TileHierarchy::levels().rbegin()->second.level) {
         level += 1;
         for (uint32_t id = 0; id < tiles.TileCount(); id++) {
           // If tile exists add it to the queue
@@ -579,7 +575,7 @@ namespace mjolnir {
     std::random_shuffle(tilequeue.begin(), tilequeue.end());
 
     // Remember what the dataset id is in case we have to make some tiles
-    auto dataset_id = GraphTile(hierarchy, *tilequeue.begin()).header()->dataset_id();
+    auto dataset_id = GraphTile(tile_dir, *tilequeue.begin()).header()->dataset_id();
 
     // An mutex we can use to do the synchronization
     std::mutex lock;
@@ -605,13 +601,13 @@ namespace mjolnir {
     for (auto& thread : threads)
       thread->join();
     // Get the promise from the future
-    std::vector<uint32_t> duplicates(numHierarchyLevels, 0);
+    std::vector<uint32_t> duplicates(TileHierarchy::levels().size(), 0);
     std::vector<std::vector<float>> densities(3);
     tweeners_t tweeners;
     for (auto& result : results) {
       auto data = result.get_future().get();
       // Total up duplicates for each level
-      for (uint8_t i = 0; i < numHierarchyLevels; ++i) {
+      for (uint8_t i = 0; i < TileHierarchy::levels().size(); ++i) {
         duplicates[i] += std::get<0>(data)[i];
         for (auto& d : std::get<1>(data)[i])
           densities[i].push_back(d);
@@ -626,13 +622,15 @@ namespace mjolnir {
     auto start = tweeners.begin();
     auto end = tweeners.end();
     for (auto& thread : threads)
-      thread.reset(new std::thread(bin_tweeners, std::cref(hierarchy), std::ref(start), std::cref(end), dataset_id, std::ref(lock)));
+      thread.reset(new std::thread(bin_tweeners, std::cref(tile_dir),
+                        std::ref(start), std::cref(end),
+                        dataset_id, std::ref(lock)));
     for (auto& thread : threads)
       thread->join();
     LOG_INFO("Finished");
 
     // print dupcount and find densities
-    for (uint8_t level = 0; level < numHierarchyLevels; level++) {
+    for (uint8_t level = 0; level < TileHierarchy::levels().size(); level++) {
       // Print duplicates info for level
       LOG_WARN((boost::format("Possible duplicates at level: %1% = %2%")
         % std::to_string(level) % duplicates[level]).str());

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -43,13 +43,13 @@ struct graph_callback : public OSMPBF::Callback {
   virtual ~graph_callback() {}
 
   graph_callback(const boost::property_tree::ptree& pt, OSMData& osmdata) :
-    shape_(kMaxOSMNodeId), intersection_(kMaxOSMNodeId), tile_hierarchy_(pt.get<std::string>("tile_dir")),
+    shape_(kMaxOSMNodeId), intersection_(kMaxOSMNodeId),
     osmdata_(osmdata), lua_(get_lua(pt)){
 
     current_way_node_index_ = last_node_ = last_way_ = last_relation_ = 0;
 
     highway_cutoff_rc_ = RoadClass::kPrimary;
-    for (auto& level : tile_hierarchy_.levels()) {
+    for (auto& level : TileHierarchy::levels()) {
       if (level.second.name == "highway") {
         highway_cutoff_rc_ = level.second.importance;
       }
@@ -1073,9 +1073,6 @@ struct graph_callback : public OSMPBF::Callback {
     loops_.clear();
     loops_.shrink_to_fit();
   }
-
-  // List of the tile levels to be created
-  TileHierarchy tile_hierarchy_;
 
   //Road class assignment needs to be set to the highway cutoff for ferries and auto trains.
   RoadClass highway_cutoff_rc_;

--- a/src/mjolnir/shortcutbuilder.cc
+++ b/src/mjolnir/shortcutbuilder.cc
@@ -529,7 +529,7 @@ uint32_t AddShortcutEdges(GraphReader& reader, const GraphTile* tile,
 
 // Form shortcuts for tiles in this level.
 uint32_t FormShortcuts(GraphReader& reader,
-            const TileHierarchy::TileLevel& level,
+            const TileLevel& level,
             const std::unique_ptr<const valhalla::skadi::sample>& sample) {
   // Iterate through the tiles at this level (TODO - can we mark the tiles
   // the tiles that shortcuts end within?)
@@ -548,7 +548,7 @@ uint32_t FormShortcuts(GraphReader& reader,
 
     // Create GraphTileBuilder for the new tile
     GraphId new_tile(tileid, tile_level, 0);
-    GraphTileBuilder tilebuilder(reader.GetTileHierarchy(), new_tile, false);
+    GraphTileBuilder tilebuilder(reader.tile_dir(), new_tile, false);
 
     // Create a dummy admin at index 0.  Used if admins are not used/created.
     tilebuilder.AddAdmin("None", "None", "", "");
@@ -663,10 +663,6 @@ void ShortcutBuilder::Build(const boost::property_tree::ptree& pt) {
 
   // Get GraphReader
   GraphReader reader(pt.get_child("mjolnir"));
-  const auto& tile_hierarchy = reader.GetTileHierarchy();
-  if (reader.GetTileHierarchy().levels().size() < 2) {
-    throw std::runtime_error("Bad tile hierarchy - need 2 levels");
-  }
 
   // Crack open some elevation data if its there
   boost::optional<std::string> elevation = pt.get_optional<std::string>("additional_data.elevation");
@@ -675,9 +671,9 @@ void ShortcutBuilder::Build(const boost::property_tree::ptree& pt) {
     sample.reset(new skadi::sample(*elevation));
   }
 
-  auto level = tile_hierarchy.levels().rbegin();
+  auto level = TileHierarchy::levels().rbegin();
   level++;
-  for ( ; level != tile_hierarchy.levels().rend(); ++level) {
+  for ( ; level != TileHierarchy::levels().rend(); ++level) {
     // Create shortcuts on this level
     auto tile_level = level->second;
     LOG_INFO("Creating shortcuts on level " + std::to_string(tile_level.level));

--- a/src/mjolnir/valhalla_benchmark_admins.cc
+++ b/src/mjolnir/valhalla_benchmark_admins.cc
@@ -186,9 +186,8 @@ std::cout << "In Benchmark" << std::endl;
   // Graphreader
   auto hierarchy_properties = pt.get_child("mjolnir");
   GraphReader reader(hierarchy_properties);
-  auto tile_hierarchy = reader.GetTileHierarchy();
-  auto local_level = tile_hierarchy.levels().rbegin()->second.level;
-  auto tiles = tile_hierarchy.levels().rbegin()->second.tiles;
+  auto local_level = TileHierarchy::levels().rbegin()->second.level;
+  auto tiles = TileHierarchy::levels().rbegin()->second.tiles;
 
   // Iterate through the tiles and perform enhancements
   std::unordered_map<uint32_t,multi_polygon_type> polys;

--- a/src/mjolnir/valhalla_build_connectivity.cc
+++ b/src/mjolnir/valhalla_build_connectivity.cc
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "baldr/connectivity_map.h"
+#include "baldr/tilehierarchy.h"
 #include "config.h"
 
 using namespace valhalla::baldr;
@@ -113,10 +114,9 @@ int main(int argc, char** argv) {
   boost::property_tree::read_json(config_file_path.c_str(), pt);
 
   // Get something we can use to fetch tiles
-  valhalla::baldr::TileHierarchy tile_hierarchy(pt.get<std::string>("mjolnir.tile_dir"));
   valhalla::baldr::connectivity_map_t connectivity_map(pt.get_child("mjolnir"));
 
-  uint32_t transit_level = tile_hierarchy.levels().rbegin()->second.level + 1;
+  uint32_t transit_level = TileHierarchy::levels().rbegin()->second.level + 1;
   for (uint32_t level = 0; level <= transit_level; level++) {
     // Make the vector representation of it
     std::string fname = "connectivity" + std::to_string(level) + ".geojson";
@@ -141,11 +141,11 @@ int main(int argc, char** argv) {
 
     uint32_t width, height;
     if (level == transit_level) {
-      auto tiles = tile_hierarchy.levels().rbegin()->second.tiles;
+      auto tiles = TileHierarchy::levels().rbegin()->second.tiles;
       width  = tiles.ncolumns();
       height = tiles.nrows();
     } else {
-      auto tiles = tile_hierarchy.levels().find(level)->second.tiles;
+      auto tiles = TileHierarchy::levels().find(level)->second.tiles;
       width  = tiles.ncolumns();
       height = tiles.nrows();
     }

--- a/src/mjolnir/valhalla_build_speeds.cc
+++ b/src/mjolnir/valhalla_build_speeds.cc
@@ -18,6 +18,7 @@
 #include "midgard/logging.h"
 #include "baldr/graphtile.h"
 #include "baldr/graphreader.h"
+#include "baldr/tilehierarchy.h"
 #include "baldr/directededge.h"
 #include "baldr/edgeinfo.h"
 
@@ -228,9 +229,8 @@ int main(int argc, char** argv) {
   LOG_INFO("Done reading ways to edges file");
 
   // Get Valhalla tiles
-  valhalla::baldr::TileHierarchy tile_hierarchy(pt.get<std::string>("mjolnir.tile_dir"));
-  auto local_level = tile_hierarchy.levels().rbegin()->second.level;
-  auto tiles = tile_hierarchy.levels().rbegin()->second.tiles;
+  auto local_level = TileHierarchy::levels().rbegin()->second.level;
+  auto tiles = TileHierarchy::levels().rbegin()->second.tiles;
 
   // Create a map of tiles with speed table for the specified entry
   std::unordered_map<uint32_t, std::vector<uint8_t>> tile_speeds;

--- a/src/mjolnir/valhalla_build_statistics.cc
+++ b/src/mjolnir/valhalla_build_statistics.cc
@@ -347,8 +347,6 @@ void build(const boost::property_tree::ptree& pt,
     statistics stats;
     // Local Graphreader
     GraphReader graph_reader(pt.get_child("mjolnir"));
-    // Get some things we need throughout
-    const auto& hierarchy = graph_reader.GetTileHierarchy();
 
     // Check for more tiles
     while (true) {
@@ -364,10 +362,10 @@ void build(const boost::property_tree::ptree& pt,
 
       // Point tiles to the set we need for current level
       auto level = tile_id.level();
-      if (hierarchy.levels().rbegin()->second.level+1 == level)
-        level = hierarchy.levels().rbegin()->second.level;
+      if (TileHierarchy::levels().rbegin()->second.level+1 == level)
+        level = TileHierarchy::levels().rbegin()->second.level;
 
-      const auto& tiles = hierarchy.levels().find(level)->second.tiles;
+      const auto& tiles = TileHierarchy::levels().find(level)->second.tiles;
       level = tile_id.level();
       auto tileid = tile_id.tileid();
 
@@ -478,33 +476,29 @@ void build(const boost::property_tree::ptree& pt,
 
 void BuildStatistics(const boost::property_tree::ptree& pt) {
 
-  // Graphreader
-  auto hierarchy_properties = pt.get_child("mjolnir");
-  TileHierarchy hierarchy(hierarchy_properties.get<std::string>("tile_dir"));
-  // Make sure there are at least 2 levels!
-  if (hierarchy.levels().size() < 2)
-    throw std::runtime_error("Bad tile hierarchy - need 2 levels");
+  // Graph tile properties
+  auto tile_properties = pt.get_child("mjolnir");
 
   // Create a randomized queue of tiles to work from
   std::deque<GraphId> tilequeue;
-  for (auto tier : hierarchy.levels()) {
+  for (auto tier : TileHierarchy::levels()) {
     auto level = tier.second.level;
     auto tiles = tier.second.tiles;
     for (uint32_t id = 0; id < tiles.TileCount(); id++) {
       // If tile exists add it to the queue
       GraphId tile_id(id, level, 0);
-      if (GraphReader::DoesTileExist(hierarchy_properties, tile_id)) {
+      if (GraphReader::DoesTileExist(tile_properties, tile_id)) {
         tilequeue.emplace_back(std::move(tile_id));
       }
     }
 
     //transit level
-    if (level == hierarchy.levels().rbegin()->second.level) {
+    if (level == TileHierarchy::levels().rbegin()->second.level) {
       level += 1;
       for (uint32_t id = 0; id < tiles.TileCount(); id++) {
         // If tile exists add it to the queue
         GraphId tile_id(id, level, 0);
-        if (GraphReader::DoesTileExist(hierarchy_properties, tile_id)) {
+        if (GraphReader::DoesTileExist(tile_properties, tile_id)) {
           tilequeue.emplace_back(std::move(tile_id));
         }
       }
@@ -592,10 +586,6 @@ int main (int argc, char** argv) {
     auto loggin_config = valhalla::midgard::ToMap<const boost::property_tree::ptree&, std::unordered_map<std::string, std::string> >(logging_subtree.get());
     valhalla::midgard::logging::Configure(loggin_config);
   }
-
-  //set up directory
-  auto tile_dir = pt.get<std::string>("mjolnir.tile_dir");
-  valhalla::baldr::TileHierarchy hierarchy(tile_dir);
 
   BuildStatistics(pt);
 

--- a/src/mjolnir/valhalla_build_tiles.cc
+++ b/src/mjolnir/valhalla_build_tiles.cc
@@ -93,8 +93,7 @@ int main(int argc, char** argv) {
   //set up the directories and purge old tiles
   pt.get_child("mjolnir").erase("tile_extract");
   auto tile_dir = pt.get<std::string>("mjolnir.tile_dir");
-  valhalla::baldr::TileHierarchy hierarchy(tile_dir);
-  for(const auto& level : hierarchy.levels()) {
+  for(const auto& level : valhalla::baldr::TileHierarchy::levels()) {
     auto level_dir = tile_dir + "/" + std::to_string(level.first);
     if(boost::filesystem::exists(level_dir) && !boost::filesystem::is_empty(level_dir)) {
       LOG_WARN("Non-empty " + level_dir + " will be purged of tiles");
@@ -103,7 +102,8 @@ int main(int argc, char** argv) {
   }
 
   //check for transit level.
-  auto level_dir = tile_dir + "/" + std::to_string(hierarchy.levels().rbegin()->second.level+1);
+  auto level_dir = tile_dir + "/" +
+      std::to_string(valhalla::baldr::TileHierarchy::levels().rbegin()->second.level+1);
   if(boost::filesystem::exists(level_dir) && !boost::filesystem::is_empty(level_dir)) {
     LOG_WARN("Non-empty " + level_dir + " will be purged of tiles");
     boost::filesystem::remove_all(level_dir);

--- a/src/mjolnir/valhalla_ways_to_edges.cc
+++ b/src/mjolnir/valhalla_ways_to_edges.cc
@@ -15,6 +15,7 @@
 
 #include "baldr/graphtile.h"
 #include "baldr/graphreader.h"
+#include "baldr/tilehierarchy.h"
 #include "baldr/directededge.h"
 #include "baldr/edgeinfo.h"
 
@@ -105,10 +106,9 @@ int main(int argc, char** argv) {
   boost::property_tree::read_json(config_file_path.c_str(), pt);
 
   // Get something we can use to fetch tiles
-  auto hierarchy_properties = pt.get_child("mjolnir");
-  valhalla::baldr::TileHierarchy tile_hierarchy(hierarchy_properties.get<std::string>("tile_dir"));
-  auto local_level = tile_hierarchy.levels().rbegin()->second.level;
-  auto tiles = tile_hierarchy.levels().rbegin()->second.tiles;
+  auto tile_properties = pt.get_child("mjolnir");
+  auto local_level = TileHierarchy::levels().rbegin()->second.level;
+  auto tiles = TileHierarchy::levels().rbegin()->second.tiles;
 
   // Create an unordered map of OSM ways Ids and their associated graph edges
   std::unordered_map<uint64_t, std::vector<EdgeAndDirection>> ways_edges;
@@ -118,7 +118,7 @@ int main(int argc, char** argv) {
   for (uint32_t id = 0; id < tiles.TileCount(); id++) {
     // If tile exists add it to the queue
     GraphId edge_id(id, local_level, 0);
-    if (!reader.DoesTileExist(hierarchy_properties, edge_id)) {
+    if (!reader.DoesTileExist(tile_properties, edge_id)) {
       continue;
     }
 

--- a/src/mjolnir/validatetransit.cc
+++ b/src/mjolnir/validatetransit.cc
@@ -149,7 +149,6 @@ void validate(const boost::property_tree::ptree& pt, std::mutex& lock,
 
   uint32_t failure_count = 0;
   GraphReader reader_transit_level(pt);
-  const TileHierarchy& hierarchy_transit_level = reader_transit_level.GetTileHierarchy();
 
   // Iterate through the tiles in the queue and find any that include stops
   for(; tile_start != tile_end; ++tile_start) {
@@ -161,7 +160,7 @@ void validate(const boost::property_tree::ptree& pt, std::mutex& lock,
     lock.lock();
     GraphId transit_tile_id = GraphId(tile_id.tileid(), tile_id.level()+1, tile_id.id());
     const GraphTile* transit_tile = reader_transit_level.GetGraphTile(transit_tile_id);
-    GraphTileBuilder tilebuilder(hierarchy_transit_level, transit_tile_id, true);
+    GraphTileBuilder tilebuilder(reader_transit_level.tile_dir(), transit_tile_id, true);
     lock.unlock();
 
     for (uint32_t i = 0; i < tilebuilder.header()->nodecount(); i++) {
@@ -391,8 +390,7 @@ bool ValidateTransit::Validate(const boost::property_tree::ptree& pt,
     // Also bail if nothing inside
     transit_dir->push_back('/');
     GraphReader reader(hierarchy_properties);
-    const auto& hierarchy = reader.GetTileHierarchy();
-    auto local_level = hierarchy.levels().rbegin()->first;
+    auto local_level = TileHierarchy::levels().rbegin()->first;
     if(boost::filesystem::is_directory(*transit_dir + std::to_string(local_level + 1) + "/")) {
       boost::filesystem::recursive_directory_iterator transit_file_itr(*transit_dir + std::to_string(local_level +1 ) + "/"), end_file_itr;
       for(; transit_file_itr != end_file_itr; ++transit_file_itr) {

--- a/src/thor/trafficalgorithm.cc
+++ b/src/thor/trafficalgorithm.cc
@@ -199,7 +199,7 @@ std::vector<uint8_t>& TrafficAlgorithm::GetRealTimeSpeeds(const uint32_t tileid,
   if (rts == real_time_speeds_.end()) {
     // Try to load the speeds file
     std::ifstream rtsfile;
-    std::string traffic_dir = graphreader.GetTileHierarchy().tile_dir() + "/traffic/";
+    std::string traffic_dir = graphreader.tile_dir() + "/traffic/";
     std::string fname = traffic_dir + std::to_string(tileid) + ".spd";
     rtsfile.open(fname, std::ios::binary | std::ios::in | std::ios::ate);
     if (rtsfile.is_open()) {

--- a/src/thor/trippathbuilder.cc
+++ b/src/thor/trippathbuilder.cc
@@ -12,6 +12,7 @@
 #include "baldr/edgeinfo.h"
 #include "baldr/signinfo.h"
 #include "baldr/graphconstants.h"
+#include "baldr/tilehierarchy.h"
 #include "midgard/pointll.h"
 #include "midgard/encoded.h"
 #include "midgard/logging.h"
@@ -401,7 +402,7 @@ TripPath TripPathBuilder::Build(
   TripPath trip_path;
 
   // Get the local tile level
-  uint32_t local_level = graphreader.GetTileHierarchy().levels().rbegin()->first;
+  uint32_t local_level = TileHierarchy::levels().rbegin()->first;
 
   // Set origin (assumed to be a break)
   odin::Location* tp_orig = trip_path.add_location();

--- a/src/valhalla_associate_segments.cc
+++ b/src/valhalla_associate_segments.cc
@@ -830,7 +830,8 @@ void edge_association::add_tile(const std::string &file_name) {
 
   //get a tile builder ready for this tile
   auto base_id = parse_file_name(file_name);
-  m_tile_builder.reset(new vj::GraphTileBuilder(m_reader.GetTileHierarchy(), base_id, false));
+  m_tile_builder.reset(new vj::GraphTileBuilder(m_reader.tile_dir(),
+                       base_id, false));
   m_tile_builder->InitializeTrafficSegments();
   m_tile = m_reader.GetGraphTile(base_id);
 
@@ -894,8 +895,8 @@ void add_local_associations(const bpt::ptree &pt, std::deque<std::string>& osmlr
 void add_leftover_associations(const bpt::ptree &pt, std::unordered_map<GraphId, leftovers_t>& leftovers,
                                std::mutex& lock) {
 
-  //something so we can open up a tile builder
-  TileHierarchy hierarchy(pt.get<std::string>("mjolnir.tile_dir"));
+  // Get the tile dir
+  std::string tile_dir = pt.get<std::string>("mjolnir.tile_dir");
 
   while(true) {
     // Get leftovers from a tile
@@ -910,7 +911,7 @@ void add_leftover_associations(const bpt::ptree &pt, std::unordered_map<GraphId,
       break;
 
     // Write leftovers
-    vj::GraphTileBuilder tile_builder(hierarchy, associations.front().first.Tile_Base(), false);
+    vj::GraphTileBuilder tile_builder(tile_dir, associations.front().first.Tile_Base(), false);
     tile_builder.InitializeTrafficSegments();
     for(const auto& association : associations)
       tile_builder.AddTrafficSegment(association.first, association.second);
@@ -920,7 +921,7 @@ void add_leftover_associations(const bpt::ptree &pt, std::unordered_map<GraphId,
 
 void add_chunks(const bpt::ptree &pt, std::unordered_map<vb::GraphId, chunks_t>& chunks,
                                std::mutex& lock) {
-  TileHierarchy hierarchy(pt.get<std::string>("mjolnir.tile_dir"));
+  std::string tile_dir = pt.get<std::string>("mjolnir.tile_dir");
   while(true) {
     // Get chunks
     lock.lock();
@@ -934,7 +935,7 @@ void add_chunks(const bpt::ptree &pt, std::unordered_map<vb::GraphId, chunks_t>&
       break;
 
     // Write chunks
-    vj::GraphTileBuilder tile_builder(hierarchy, associated_chunks.front().first.Tile_Base(), false);
+    vj::GraphTileBuilder tile_builder(tile_dir, associated_chunks.front().first.Tile_Base(), false);
     tile_builder.InitializeTrafficSegments();
     for(const auto& chunk : associated_chunks) {
       tile_builder.AddTrafficSegments(chunk.first, chunk.second);

--- a/src/valhalla_export_edges.cc
+++ b/src/valhalla_export_edges.cc
@@ -4,6 +4,7 @@
 
 #include "baldr/graphconstants.h"
 #include "baldr/graphreader.h"
+#include "baldr/tilehierarchy.h"
 #include "midgard/logging.h"
 #include "midgard/encoded.h"
 
@@ -183,9 +184,9 @@ int main(int argc, char *argv[]) {
   //keep the global number of edges encountered at the point we encounter each tile
   //this allows an edge to have a sequential global id and makes storing it very small
   LOG_INFO("Enumerating edges...");
-  std::unordered_map<GraphId, uint64_t> tile_set(kMaxGraphTileId * reader.GetTileHierarchy().levels().size());
+  std::unordered_map<GraphId, uint64_t> tile_set(kMaxGraphTileId * TileHierarchy::levels().size());
   uint64_t edge_count = 0;
-  for(const auto& level : reader.GetTileHierarchy().levels()) {
+  for(const auto& level : TileHierarchy::levels()) {
     for(uint32_t i = 0; i < level.second.tiles.TileCount(); ++i) {
       GraphId tile_id{i, level.first, 0};
       if(reader.DoesTileExist(tile_id)) {

--- a/src/valhalla_run_route.cc
+++ b/src/valhalla_run_route.cc
@@ -14,6 +14,7 @@
 
 #include "midgard/encoded.h"
 #include "baldr/graphreader.h"
+#include "baldr/tilehierarchy.h"
 #include "baldr/pathlocation.h"
 #include "baldr/connectivity_map.h"
 #include "loki/search.h"
@@ -632,7 +633,7 @@ int main(int argc, char *argv[]) {
   if (connectivity) {
     std::unordered_map<size_t, size_t> color_counts;
     connectivity_map_t connectivity_map(pt.get_child("mjolnir"));
-    auto colors = connectivity_map.get_colors(reader.GetTileHierarchy().levels().rbegin()->first,
+    auto colors = connectivity_map.get_colors(TileHierarchy::levels().rbegin()->first,
                                               path_location.back(), 0);
     for(auto color : colors){
       auto itr = color_counts.find(color);

--- a/test/astar.cc
+++ b/test/astar.cc
@@ -61,8 +61,8 @@ namespace {
 //      \ /
 //       g
 //
-vb::TileHierarchy h("test/fake_tiles_astar");
-vb::GraphId tile_id = h.GetGraphId({.125, .125}, 2);
+std::string test_dir = "test/fake_tiles_astar";
+vb::GraphId tile_id = vb::TileHierarchy::GetGraphId({.125, .125}, 2);
 
 namespace node {
 std::pair<vb::GraphId, vm::PointLL> a({tile_id.tileid(), tile_id.level(), 0}, {0.01, 0.10});

--- a/test/countryaccess.cc
+++ b/test/countryaccess.cc
@@ -15,6 +15,7 @@
 #include "baldr/directededge.h"
 #include "baldr/graphid.h"
 #include "baldr/graphreader.h"
+#include "baldr/tilehierarchy.h"
 
 using namespace std;
 using namespace valhalla::mjolnir;
@@ -72,9 +73,8 @@ void CountryAccess(const std::string& config_file) {
 
   //setup and purge
   GraphReader graph_reader(conf.get_child("mjolnir"));
-  const auto& hierarchy = graph_reader.GetTileHierarchy();
-  for(const auto& level : hierarchy.levels()) {
-    auto level_dir = hierarchy.tile_dir() + "/" + std::to_string(level.first);
+  for(const auto& level : TileHierarchy::levels()) {
+    auto level_dir = graph_reader.tile_dir() + "/" + std::to_string(level.first);
     if(boost::filesystem::exists(level_dir) && !boost::filesystem::is_empty(level_dir)) {
       boost::filesystem::remove_all(level_dir);
     }
@@ -91,9 +91,9 @@ void CountryAccess(const std::string& config_file) {
 
   //load a tile and test the default access.
   GraphId id(820099,2,0);
-  GraphTile t(TileHierarchy("test/data/amsterdam_tiles"), id);
+  GraphTile t("test/data/amsterdam_tiles", id);
 
-  GraphTileBuilder tilebuilder(hierarchy, id, true);
+  GraphTileBuilder tilebuilder(graph_reader.tile_dir(), id, true);
 
   for (uint32_t i = 0; i < tilebuilder.header()->nodecount(); i++) {
     NodeInfo& nodeinfo = tilebuilder.node_builder(i);
@@ -150,12 +150,10 @@ void CountryAccess(const std::string& config_file) {
 
   //load a tile and test that the country level access is set.
   GraphId id2(820099,2,0);
-  GraphTile t2(TileHierarchy("test/data/amsterdam_tiles"), id2);
+  GraphTile t2("test/data/amsterdam_tiles", id2);
 
   GraphReader graph_reader2(conf.get_child("mjolnir"));
-  const auto& hierarchy2 = graph_reader2.GetTileHierarchy();
-
-  GraphTileBuilder tilebuilder2(hierarchy2, id2, true);
+  GraphTileBuilder tilebuilder2(graph_reader2.tile_dir(), id2, true);
 
   for (uint32_t i = 0; i < tilebuilder2.header()->nodecount(); i++) {
     NodeInfo& nodeinfo = tilebuilder2.node_builder(i);

--- a/test/edgecollapser.cc
+++ b/test/edgecollapser.cc
@@ -1,6 +1,7 @@
 #include "test.h"
 
 #include "baldr/graphreader.h"
+#include "baldr/tilehierarchy.h"
 #include "baldr/nodeinfo.h"
 #include "baldr/directededge.h"
 #include "baldr/merge.h"
@@ -81,8 +82,7 @@ struct test_graph_reader : public vb::GraphReader {
 };
 
 void TestCollapseEdgeSimple() {
-  vb::TileHierarchy hier("");
-  vb::GraphId base_id = hier.GetGraphId(valhalla::midgard::PointLL(0, 0), 0);
+  vb::GraphId base_id = vb::TileHierarchy::GetGraphId(valhalla::midgard::PointLL(0, 0), 0);
 
   // simplest graph with a collapsible node:
   //
@@ -137,8 +137,7 @@ void TestCollapseEdgeSimple() {
 }
 
 void TestCollapseEdgeJunction() {
-  vb::TileHierarchy hier("");
-  vb::GraphId base_id = hier.GetGraphId(valhalla::midgard::PointLL(0, 0), 0);
+  vb::GraphId base_id = vb::TileHierarchy::GetGraphId(valhalla::midgard::PointLL(0, 0), 0);
 
   // simplest graph with a non-collapsible node:
   //
@@ -200,8 +199,7 @@ void TestCollapseEdgeJunction() {
 }
 
 void TestCollapseEdgeChain() {
-  vb::TileHierarchy hier("");
-  vb::GraphId base_id = hier.GetGraphId(valhalla::midgard::PointLL(0, 0), 0);
+  vb::GraphId base_id = vb::TileHierarchy::GetGraphId(valhalla::midgard::PointLL(0, 0), 0);
 
   // graph with 3 collapsible edges, all chained together. (e.g: think of the
   // middle segment as a bridge).

--- a/test/graphtile.cc
+++ b/test/graphtile.cc
@@ -17,21 +17,20 @@ struct testable_graphtile : public valhalla::baldr::GraphTile {
 };
 
 void file_suffix() {
-  TileHierarchy h("/data/valhalla");
 
-  if(GraphTile::FileSuffix(GraphId(2, 2, 0), h) != "2/000/000/002.gph")
+  if(GraphTile::FileSuffix(GraphId(2, 2, 0)) != "2/000/000/002.gph")
     throw std::runtime_error("Unexpected graphtile suffix");
 
-  if(GraphTile::FileSuffix(GraphId(4, 2, 0), h) != "2/000/000/004.gph")
+  if(GraphTile::FileSuffix(GraphId(4, 2, 0)) != "2/000/000/004.gph")
     throw std::runtime_error("Unexpected graphtile suffix");
 
-  if(GraphTile::FileSuffix(GraphId(1197468, 2, 0), h) != "2/001/197/468.gph")
+  if(GraphTile::FileSuffix(GraphId(1197468, 2, 0)) != "2/001/197/468.gph")
     throw std::runtime_error("Unexpected graphtile suffix");
 
-  if(GraphTile::FileSuffix(GraphId(64799, 1, 0), h) != "1/064/799.gph")
+  if(GraphTile::FileSuffix(GraphId(64799, 1, 0)) != "1/064/799.gph")
     throw std::runtime_error("Unexpected graphtile suffix");
 
-  if(GraphTile::FileSuffix(GraphId(49, 0, 0), h) != "0/000/049.gph")
+  if(GraphTile::FileSuffix(GraphId(49, 0, 0)) != "0/000/049.gph")
     throw std::runtime_error("Unexpected graphtile suffix");
 }
 

--- a/test/graphtilebuilder.cc
+++ b/test/graphtilebuilder.cc
@@ -103,7 +103,8 @@ void TestDuplicateEdgeInfo() {
     throw std::runtime_error("Why on earth would it be found but then insert just fine");
 
   //load a test builder
-  test_graph_tile_builder test(TileHierarchy("test/data/builder_tiles"), GraphId(0,2,0), false);
+  std::string test_dir = "test/data/builder_tiles";
+  test_graph_tile_builder test(test_dir, GraphId(0,2,0), false);
   //add edge info for node 0 to node 1
   bool added = false;
   test.AddEdgeInfo(0, GraphId(0,2,0), GraphId(0,2,1), 1234, std::list<PointLL>{{0, 0}, {1, 1}}, {"einzelweg"}, added);
@@ -138,16 +139,17 @@ void TestAddBins() {
 
     //load a tile
     GraphId id(test_tile.second,2,0);
-    GraphTile t(TileHierarchy("test/data/bin_tiles/no_bin"), id);
+    std::string no_bin_dir = "test/data/bin_tiles/no_bin";
+    GraphTile t(no_bin_dir, id);
     if(!t.header())
       throw std::runtime_error("Couldn't load test tile");
 
     //alter the config to point to another dir
-    TileHierarchy h("test/data/bin_tiles/bin");
+    std::string bin_dir = "test/data/bin_tiles/bin";
 
     //send blank bins
     std::array<std::vector<GraphId>, kBinCount> bins;
-    GraphTileBuilder::AddBins(h, &t, bins);
+    GraphTileBuilder::AddBins(bin_dir, &t, bins);
 
     //check the new tile is the same as the old one
     {
@@ -166,32 +168,32 @@ void TestAddBins() {
     //send fake bins, we'll throw one in each bin
     for(auto& bin : bins)
       bin.emplace_back(test_tile.second,2,0);
-    GraphTileBuilder::AddBins(h, &t, bins);
+    GraphTileBuilder::AddBins(bin_dir, &t, bins);
     auto increase = bins.size() * sizeof(GraphId);
 
     //check the new tile isnt broken and is exactly the right size bigger
-    if(!tile_equalish(t, GraphTile(h, id), increase, bins))
-      throw std::logic_error("New tiles edgeinfo or names arent matching up");
+    if(!tile_equalish(t, GraphTile(bin_dir, id), increase, bins))
+      throw std::logic_error("New tiles edgeinfo or names arent matching up: 1");
 
     //append some more
     for(auto& bin : bins)
       bin.emplace_back(test_tile.second,2,1);
-    GraphTileBuilder::AddBins(h, &t, bins);
+    GraphTileBuilder::AddBins(bin_dir, &t, bins);
     increase = bins.size() * sizeof(GraphId) * 2;
 
     //check the new tile isnt broken and is exactly the right size bigger
-    if(!tile_equalish(t, GraphTile(h, id), increase, bins))
-      throw std::logic_error("New tiles edgeinfo or names arent matching up");
+    if(!tile_equalish(t, GraphTile(bin_dir, id), increase, bins))
+      throw std::logic_error("New tiles edgeinfo or names arent matching up: 2");
 
     //check that appending works
-    t = GraphTile(TileHierarchy("test/data/bin_tiles/bin"), id);
-    GraphTileBuilder::AddBins(h, &t, bins);
+    t = GraphTile(bin_dir, id);
+    GraphTileBuilder::AddBins(bin_dir, &t, bins);
     for(auto& bin : bins)
       bin.insert(bin.end(), bin.begin(), bin.end());
 
     //check the new tile isnt broken and is exactly the right size bigger
-    if(!tile_equalish(t, GraphTile(h, id), increase, bins))
-      throw std::logic_error("New tiles edgeinfo or names arent matching up");
+    if(!tile_equalish(t, GraphTile(bin_dir, id), increase, bins))
+      throw std::logic_error("New tiles edgeinfo or names arent matching up: 3");
   }
 }
 

--- a/test/node_search.cc
+++ b/test/node_search.cc
@@ -28,7 +28,7 @@ namespace {
 const std::string test_tile_dir = "test/node_search_tiles";
 
 struct graph_writer {
-  graph_writer(const vb::TileHierarchy &hierarchy, uint8_t level);
+  graph_writer(uint8_t level);
 
   vj::GraphTileBuilder &builder(vb::GraphId tile_id);
 
@@ -39,20 +39,19 @@ struct graph_writer {
   void write_tiles();
 
 private:
-  const vb::TileHierarchy &m_hierarchy;
   const uint8_t m_level;
   std::unordered_map<vb::GraphId, std::shared_ptr<vj::GraphTileBuilder> > m_builders;
 };
 
-graph_writer::graph_writer(const vb::TileHierarchy &hierarchy, uint8_t level)
-  : m_hierarchy(hierarchy), m_level(level) {}
+graph_writer::graph_writer(uint8_t level)
+  : m_level(level) {}
 
 vj::GraphTileBuilder &graph_writer::builder(vb::GraphId tile_id) {
   auto itr = m_builders.find(tile_id);
 
   if (itr == m_builders.end()) {
     bool inserted = false;
-    auto builder = std::make_shared<vj::GraphTileBuilder>(m_hierarchy, tile_id, false);
+    auto builder = std::make_shared<vj::GraphTileBuilder>(test_tile_dir, tile_id, false);
 
     // Create a dummy admin record at index 0. Used if admin records
     // are not used/created or if none is
@@ -84,9 +83,9 @@ void graph_writer::write_tiles() {
 
     // write the bin data
     GraphTileBuilder::tweeners_t tweeners;
-    GraphTile reloaded(m_hierarchy, tile_id);
-    auto bins = GraphTileBuilder::BinEdges(m_hierarchy, &reloaded, tweeners);
-    GraphTileBuilder::AddBins(m_hierarchy, &reloaded, bins);
+    GraphTile reloaded(test_tile_dir, tile_id);
+    auto bins = GraphTileBuilder::BinEdges(&reloaded, tweeners);
+    GraphTileBuilder::AddBins(test_tile_dir, &reloaded, bins);
 
     // merge tweeners into global
     for (const auto &entry : tweeners) {
@@ -106,8 +105,8 @@ void graph_writer::write_tiles() {
 
   for (const auto &entry : all_tweeners) {
     // re-open tiles to add tweeners back in.
-    vb::GraphTile tile(m_hierarchy, entry.first);
-    vj::GraphTileBuilder::AddBins(m_hierarchy, &tile, entry.second);
+    vb::GraphTile tile(test_tile_dir, entry.first);
+    vj::GraphTileBuilder::AddBins(test_tile_dir, &tile, entry.second);
   }
 }
 
@@ -157,16 +156,16 @@ const sort_by_tile sort_pair_by_tile::sort_tile = {};
 struct graph_builder {
   std::vector<vm::PointLL> nodes;
   std::vector<std::pair<size_t, size_t> > edges;
-  void write_tiles(const vb::TileHierarchy &hierarchy, uint8_t level) const;
+  void write_tiles(uint8_t level) const;
 };
 
-void graph_builder::write_tiles(const TileHierarchy &hierarchy, uint8_t level) const {
+void graph_builder::write_tiles(uint8_t level) const {
   using namespace valhalla::mjolnir;
 
   const size_t num_nodes = nodes.size();
   const size_t num_edges = edges.size();
 
-  graph_writer writer(hierarchy, level);
+  graph_writer writer(level);
   edge_count_tracker edge_counts;
 
   // count the number of edges originating at a node
@@ -180,7 +179,7 @@ void graph_builder::write_tiles(const TileHierarchy &hierarchy, uint8_t level) c
   node_ids.reserve(num_nodes);
   for (size_t i = 0; i < num_nodes; ++i) {
     auto coord = nodes[i];
-    auto tile_id = hierarchy.GetGraphId(coord, level);
+    auto tile_id = TileHierarchy::GetGraphId(coord, level);
     uint32_t n = edges_from_node[i];
 
     NodeInfo node_builder;
@@ -317,9 +316,8 @@ void make_tile() {
     }
   }
 
-  vb::TileHierarchy h(test_tile_dir);
   uint8_t level = 2;
-  builder.write_tiles(h, level);
+  builder.write_tiles(level);
 
   // run the validator to create opposing edges and check connectivity
   std::stringstream json;

--- a/test/search.cc
+++ b/test/search.cc
@@ -36,8 +36,8 @@ namespace {
 //  5 | / 6
 //    |/
 //    c
-TileHierarchy h("test/search_tiles");
-GraphId tile_id = h.GetGraphId({.125,.125}, 2);
+std::string tile_dir = "test/search_tiles";
+GraphId tile_id = TileHierarchy::GetGraphId({.125,.125}, 2);
 std::pair<GraphId, PointLL> b({tile_id.tileid(), tile_id.level(), 0}, {.01, .2});
 std::pair<GraphId, PointLL> a({tile_id.tileid(), tile_id.level(), 1}, {.01, .1});
 std::pair<GraphId, PointLL> c({tile_id.tileid(), tile_id.level(), 2}, {.01, .01});
@@ -48,12 +48,12 @@ void make_tile() {
   using namespace valhalla::baldr;
 
   // make sure that all the old tiles are gone before trying to make new ones.
-  if (boost::filesystem::is_directory(h.tile_dir())) {
-    boost::filesystem::remove_all(h.tile_dir());
+  if (boost::filesystem::is_directory(tile_dir)) {
+    boost::filesystem::remove_all(tile_dir);
   }
 
   //basic tile information
-  GraphTileBuilder tile(h, tile_id, false);
+  GraphTileBuilder tile(tile_dir, tile_id, false);
   uint32_t edge_index = 0;
 
   auto add_node = [&edge_index] (const std::pair<GraphId, PointLL>& v, const uint32_t edge_count) {
@@ -132,9 +132,9 @@ void make_tile() {
 
   //write the bin data
   GraphTileBuilder::tweeners_t tweeners;
-  GraphTile reloaded(h, tile_id);
-  auto bins = GraphTileBuilder::BinEdges(h, &reloaded, tweeners);
-  GraphTileBuilder::AddBins(h, &reloaded, bins);
+  GraphTile reloaded(tile_dir, tile_id);
+  auto bins = GraphTileBuilder::BinEdges(&reloaded, tweeners);
+  GraphTileBuilder::AddBins(tile_dir, &reloaded, bins);
 }
 
 void search(const valhalla::baldr::Location& location, bool expected_node, const valhalla::midgard::PointLL& expected_point,
@@ -142,7 +142,7 @@ void search(const valhalla::baldr::Location& location, bool expected_node, const
   using namespace valhalla::loki;
   //make the config file
   boost::property_tree::ptree conf;
-  conf.put("tile_dir", h.tile_dir());
+  conf.put("tile_dir", tile_dir);
 
   valhalla::baldr::GraphReader reader(conf);
   const auto p = Search({location}, reader, PassThroughEdgeFilter, PassThroughNodeFilter).at(location);

--- a/test/tilehierarchy.cc
+++ b/test/tilehierarchy.cc
@@ -13,43 +13,38 @@ using namespace valhalla::midgard;
 
 namespace {
   void test_parse() {
-    TileHierarchy h("/data/valhalla");
-
-    if(h.tile_dir() != "/data/valhalla")
-      throw runtime_error("The tile directory was not correctly parsed");
-    if(h.levels().size() != 3)
+    if(TileHierarchy::levels().size() != 3)
       throw runtime_error("Incorrect number of hierarchy levels");
-    if((++h.levels().begin())->second.name != "arterial")
+    if((++TileHierarchy::levels().begin())->second.name != "arterial")
       throw runtime_error("Middle hierarchy should be named arterial");
-    if(h.levels().begin()->second.level != 0)
+    if(TileHierarchy::levels().begin()->second.level != 0)
       throw runtime_error("Top hierarchy should have level 0");
-    if(h.levels().rbegin()->second.tiles.TileSize() != .25f)
+    if(TileHierarchy::levels().rbegin()->second.tiles.TileSize() != .25f)
       throw runtime_error("Bottom hierarchy should have tile size of .25f");
-    if(h.levels().find(5) != h.levels().end())
+    if(TileHierarchy::levels().find(5) != TileHierarchy::levels().end())
       throw runtime_error("There should only be levels 0, 1, 2");
-    if(h.levels().find(2) == h.levels().end())
+    if(TileHierarchy::levels().find(2) == TileHierarchy::levels().end())
       throw runtime_error("There should be a level 2");
-    GraphId id = h.GetGraphId(PointLL(0,0), 34);
+    GraphId id = TileHierarchy::GetGraphId(PointLL(0,0), 34);
     if(id.Is_Valid())
       throw runtime_error("GraphId should be invalid as the level doesn't exist");
     //there are 1440 cols and 720 rows, this spot lands on col 414 and row 522
-    id = h.GetGraphId(PointLL(-76.5, 40.5), 2);
+    id = TileHierarchy::GetGraphId(PointLL(-76.5, 40.5), 2);
     if(id.level() != 2 || id.tileid() != (522 * 1440) + 414 || id.id() != 0)
       throw runtime_error("Expected different graph id for this location");
-    if(h.levels().begin()->second.importance != RoadClass::kPrimary)
+    if(TileHierarchy::levels().begin()->second.importance != RoadClass::kPrimary)
       throw runtime_error("Importance should be set to primary");
-    if((++h.levels().begin())->second.importance != RoadClass::kTertiary)
+    if((++TileHierarchy::levels().begin())->second.importance != RoadClass::kTertiary)
       throw runtime_error("Importance should be set to tertiary");
-    if(h.levels().rbegin()->second.importance != RoadClass::kServiceOther)
+    if(TileHierarchy::levels().rbegin()->second.importance != RoadClass::kServiceOther)
       throw runtime_error("Importance should be set to service/other");
   }
 
   void test_tiles() {
-    TileHierarchy h("/data/valhalla");
 
     //there are 1440 cols and 720 rows, this spot lands on col 414 and row 522
     AABB2<PointLL> bbox{{-76.49, 40.51}, {-76.48, 40.52}};
-    auto ids = h.GetGraphIds(bbox, 2);
+    auto ids = TileHierarchy::GetGraphIds(bbox, 2);
     if (ids.size() != 1) {
       throw runtime_error("Should have only found one result.");
     }
@@ -59,7 +54,7 @@ namespace {
     }
 
     bbox = AABB2<PointLL>{{-76.51, 40.49}, {-76.49, 40.51}};
-    ids = h.GetGraphIds(bbox, 2);
+    ids = TileHierarchy::GetGraphIds(bbox, 2);
     if (ids.size() != 4) {
       throw runtime_error("Should have found 4 results.");
     }

--- a/valhalla/baldr/connectivity_map.h
+++ b/valhalla/baldr/connectivity_map.h
@@ -1,7 +1,6 @@
 #ifndef VALHALLA_BALDR_CONNECTIVITY_MAP_H_
 #define VALHALLA_BALDR_CONNECTIVITY_MAP_H_
 
-#include <valhalla/baldr/tilehierarchy.h>
 #include <valhalla/baldr/pathlocation.h>
 
 #include <vector>
@@ -58,7 +57,6 @@ namespace valhalla {
       uint32_t transit_level;
       //this is a map(tile_level, map(tile_id, tile_color))
       std::unordered_map<uint32_t, std::unordered_map<uint32_t, size_t> > colors;
-      TileHierarchy tile_hierarchy;
     };
   }
 }

--- a/valhalla/baldr/graphreader.h
+++ b/valhalla/baldr/graphreader.h
@@ -1,12 +1,12 @@
 #ifndef VALHALLA_BALDR_GRAPHREADER_H_
 #define VALHALLA_BALDR_GRAPHREADER_H_
 
+#include <string>
 #include <unordered_map>
 #include <mutex>
 
 #include <valhalla/baldr/graphid.h>
 #include <valhalla/baldr/graphtile.h>
-#include <valhalla/baldr/tilehierarchy.h>
 #include <boost/property_tree/ptree.hpp>
 
 namespace valhalla {
@@ -184,7 +184,7 @@ class TileCacheFactory final {
    * @param pt  Property tree listing the configuration for the cahce configration
    */
   static TileCache* createTileCache(const boost::property_tree::ptree& pt);
-};
+};f
 
 /**
  * Class that manages access to GraphTiles.
@@ -194,7 +194,7 @@ class GraphReader {
  public:
   /**
    * Constructor using tiles as separate files.
-   * @param pt  Property tree listing the configuration for the tile hierarchy
+   * @param pt  Property tree listing the configuration for the tile storage.
    */
   GraphReader(const boost::property_tree::ptree& pt);
 
@@ -231,17 +231,12 @@ class GraphReader {
   const GraphTile* GetGraphTile(const PointLL& pointll, const uint8_t level);
 
   /**
-   * Get a pointer to a graph tile object given a PointLL and using the highest level in the hierarchy
+   * Get a pointer to a graph tile object given a PointLL and using the highest
+   * level in the hierarchy
    * @param pointll  the lat,lng that the tile covers
    * @return GraphTile* a pointer to the graph tile
    */
   const GraphTile* GetGraphTile(const PointLL& pointll);
-
-  /**
-   * Get the tile hierarchy used in this graph reader
-   * @return hierarchy
-   */
-  const TileHierarchy& GetTileHierarchy() const;
 
   /**
    * Clears the cache
@@ -307,6 +302,14 @@ class GraphReader {
    */
   std::unordered_set<GraphId> GetTileSet() const;
 
+  /**
+   * Returns the tile directory.
+   * @return  Returns the tile directory.
+   */
+  const std::string& tile_dir() const {
+    return tile_dir_;
+  }
+
  protected:
   // (Tar) extract of tiles - the contents are empty if not being used
   struct tile_extract_t;
@@ -314,7 +317,7 @@ class GraphReader {
   static std::shared_ptr<const GraphReader::tile_extract_t> get_extract_instance(const boost::property_tree::ptree& pt);
 
   // Information about where the tiles are kept
-  const TileHierarchy tile_hierarchy_;
+  std::string tile_dir_;
 
   std::unique_ptr<TileCache> cache_;
 };

--- a/valhalla/baldr/graphreader.h
+++ b/valhalla/baldr/graphreader.h
@@ -184,7 +184,7 @@ class TileCacheFactory final {
    * @param pt  Property tree listing the configuration for the cahce configration
    */
   static TileCache* createTileCache(const boost::property_tree::ptree& pt);
-};f
+};
 
 /**
  * Class that manages access to GraphTiles.

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -16,9 +16,9 @@
 #include <valhalla/baldr/sign.h>
 #include <valhalla/baldr/edgeinfo.h>
 #include <valhalla/baldr/admininfo.h>
-#include <valhalla/baldr/tilehierarchy.h>
 
 #include <valhalla/midgard/util.h>
+#include <valhalla/midgard/aabb2.h>
 
 #include <boost/shared_array.hpp>
 #include <memory>
@@ -43,13 +43,17 @@ class GraphTile {
   /**
    * Constructor given a GraphId. Reads the graph tile from file
    * into memory.
-   * @param  hierarchy  Data describing the tiling and hierarchy system.
+   * @param  tile_dir   Tile directory.
    * @param  graphid    GraphId (tileid and level)
    */
-  GraphTile(const TileHierarchy& hierarchy, const GraphId& graphid);
+  GraphTile(const std::string& tile_dir, const GraphId& graphid);
 
   /**
-   * Constructor given the graph Id ... used for mmap
+   * Constructor given the graph Id, pointer to the tile data, and the
+   * size of the tile data. This is used for memory mapped (mmap) tiles.
+   * @param  graphid  Tile Id.
+   * @param  ptr      Pointer to the start of the tile's data.
+   * @param  size     Size in bytes of the tile data.
    */
   GraphTile(const GraphId& graphid, char* ptr, size_t size);
 
@@ -61,10 +65,9 @@ class GraphTile {
   /**
    * Gets the directory like filename suffix given the graphId
    * @param  graphid  Graph Id to construct filename.
-   * @param  hierarchy The tile hierarchy structure to get info about how many tiles can exist at this level
    * @return  Returns a filename including directory path as a suffix to be appended to another uri
    */
-  static std::string FileSuffix(const GraphId& graphid, const TileHierarchy& hierarchy);
+  static std::string FileSuffix(const GraphId& graphid);
 
   /**
    * Get the tile Id given the full path to the file.
@@ -76,10 +79,9 @@ class GraphTile {
 
   /**
    * Get the bounding box of this graph tile.
-   * @param  hierarchy the tile hierarchy this tile is under.
    * @return Returns the bounding box of the tile.
    */
-  midgard::AABB2<PointLL> BoundingBox(const TileHierarchy& hierarchy) const;
+  midgard::AABB2<PointLL> BoundingBox() const;
 
   /**
    * Gets the id of the graph tile
@@ -435,6 +437,14 @@ class GraphTile {
   void Initialize(const GraphId& graphid, char* tile_ptr,
                   const size_t tile_size);
 
+  /**
+   * For transit tiles, save off the pair<tileid,lineid> lookup via
+   * onestop_ids.  This will be used for including or excluding transit lines
+   * for transit routes.  Save 2 maps because operators contain all of their
+   * route's tile_line pairs and it is used to include or exclude the operator
+   * as a whole. Also associates stops.
+   * @param  graphid  Tile Id.
+   */
   void AssociateOneStopIds(const GraphId& graphid);
 };
 

--- a/valhalla/baldr/tilehierarchy.h
+++ b/valhalla/baldr/tilehierarchy.h
@@ -15,87 +15,67 @@
 namespace valhalla {
 namespace baldr {
 
-
-//TODO: hack and slash this. this should just be the levels and operations we commonly do
-//with them like getting the transit level or getting the highest or lowest non transit level
-//this can be static and accessed through a singleton or just static functions on the struct
-//tile_dir doesnt belong here anyway
+/**
+ * TileLevel: Define a level in the hierarchy of the tiles. Includes:
+ *          Hierarchy level.
+ *          Minimum (largest value) road class in this level.
+ *          Name for the level.
+ *          Lat,lon tiling (in particular, tile size) of this level
+ */
+struct TileLevel {
+  uint8_t level;
+  RoadClass importance;
+  std::string name;
+  midgard::Tiles<midgard::PointLL> tiles;
+};
 
 /**
- * class used to get information about a given hierarchy of tiles
+ * Set of static methods used to get information the hierarchy of tiles. The
+ * tile hierarchy levels are static.
  */
 class TileHierarchy {
  public:
   /**
-   * Constructor
+   * Get the set of levels in this hierarchy.
+   * @return set of TileLevel objects.
    */
-  TileHierarchy(const std::string& tile_dir);
+  static const std::map<uint8_t, TileLevel>& levels() {
+    return levels_;
+  }
 
   /**
-   * Encapsulates a few types together to define a level in the hierarchy
+   * Returns the GraphId of the requested tile based on a lat,lng and a level.
+   * If the level is not supported an invalid id will be returned.
+   * @param pointll  Lat,lng location within the tile.
+   * @param level    Level of the requested tile.
    */
-  struct TileLevel{
-    bool operator<(const TileLevel& other) const;
-    uint8_t level;
-    RoadClass importance;
-    std::string name;
-    midgard::Tiles<midgard::PointLL> tiles;
-  };
+  static GraphId GetGraphId(const midgard::PointLL& pointll, const uint8_t level);
 
   /**
-   * Get the set of levels in this hierarchy
-   *
-   * @return set of TileLevel objects
-   */
-  const std::map<uint8_t, TileLevel>& levels() const;
-
-  /**
-   * Get the root tile directory where the tiles are stored
-   *
-   * @return string directory
-   */
-  const std::string& tile_dir() const;
-
-  /**
-   * Returns the graphid of the requested tile based on a lat,lng and a level
-   * if the level is not supported an invalid id will be returned
-   *
-   * @param pointll a lat,lng location within the tile
-   * @param level   the level of the requested tile
-   */
-  GraphId GetGraphId(const midgard::PointLL& pointll, const uint8_t level) const;
-
-  /**
-   * Returns all the graphids of the tiles which intersect the given bounding
+   * Returns all the GraphIds of the tiles which intersect the given bounding
    * box at that level.
-   *
-   * @param bbox  the bounding box of tiles to find.
-   * @param level the level of the tiles to return.
+   * @param bbox  Bounding box of tiles to find.
+   * @param level Level of the tiles to return.
    */
-  std::vector<GraphId> GetGraphIds(const midgard::AABB2<midgard::PointLL> &bbox, uint8_t level) const;
+  static std::vector<GraphId> GetGraphIds(const midgard::AABB2<midgard::PointLL>& bbox,
+                                          const uint8_t level);
 
   /**
-   * Returns all the graphids of the tiles which intersect the given bounding
+   * Returns all the GraphIds of the tiles which intersect the given bounding
    * box at any level.
-   *
-   * @param bbox  the bounding box of tiles to find.
+   * @param bbox  Bounding box of tiles to find.
    */
-  std::vector<GraphId> GetGraphIds(const midgard::AABB2<midgard::PointLL> &bbox) const;
+  static std::vector<GraphId> GetGraphIds(const midgard::AABB2<midgard::PointLL>& bbox);
 
   /**
    * Gets the hierarchy level given the road class.
    * @param  road_class  Road classification.
    * @return Returns the level.
    */
-  uint8_t get_level(const RoadClass roadclass) const;
+  static uint8_t get_level(const RoadClass roadclass);
 
  private:
-  explicit TileHierarchy();
-
-  // a place to keep each level of the hierarchy
-  std::map<uint8_t, TileLevel> levels_;
-  // the tiles are stored
-  std::string tile_dir_;
+  static std::map<uint8_t, TileLevel> levels_;
 };
 
 }

--- a/valhalla/meili/candidate_search.h
+++ b/valhalla/meili/candidate_search.h
@@ -12,6 +12,7 @@
 #include <valhalla/midgard/distanceapproximator.h>
 #include <valhalla/midgard/linesegment2.h>
 #include <valhalla/midgard/pointll.h>
+#include <valhalla/midgard/tiles.h>
 #include <valhalla/baldr/location.h>
 #include <valhalla/baldr/pathlocation.h>
 #include <valhalla/baldr/graphreader.h>
@@ -82,7 +83,6 @@ class CandidateGridQuery final: public CandidateQuery
   RangeQuery(const midgard::AABB2<midgard::PointLL>& range) const;
 
   uint32_t bin_level_;
-  const baldr::TileHierarchy& hierarchy_;
 
   float cell_width_;
   float cell_height_;

--- a/valhalla/mjolnir/graphtilebuilder.h
+++ b/valhalla/mjolnir/graphtilebuilder.h
@@ -23,7 +23,6 @@
 #include <valhalla/baldr/transitroute.h>
 #include <valhalla/baldr/transitschedule.h>
 #include <valhalla/baldr/transitstop.h>
-#include <valhalla/baldr/tilehierarchy.h>
 
 #include <valhalla/mjolnir/complexrestrictionbuilder.h>
 #include <valhalla/mjolnir/directededgebuilder.h>
@@ -46,12 +45,12 @@ class GraphTileBuilder : public baldr::GraphTile {
    * levels. If the deserialize flag is set then all objects are serialized
    * from memory into builders that can be added to and then stored using
    * StoreTileData.
-   * @param  basedir  Base directory path
-   * @param  graphid  GraphId used to determine the tileid and level
+   * @param  tile_dir     Base directory path
+   * @param  graphid      GraphId used to determine the tileid and level
    * @param  deserialize  If true the existing objects in the tile are
    *                      converted into builders so they can be added to.
    */
-  GraphTileBuilder(const baldr::TileHierarchy& hierarchy,
+  GraphTileBuilder(const std::string& tile_dir,
                    const GraphId& graphid,
                    const bool deserialize);
 
@@ -323,16 +322,18 @@ class GraphTileBuilder : public baldr::GraphTile {
    * @param tweeners   the additional bins in other tiles that intersect this tiles edges
    */
   using tweeners_t = std::unordered_map<GraphId, std::array<std::vector<GraphId>, kBinCount> >;
-  static std::array<std::vector<GraphId>, kBinCount> BinEdges(const TileHierarchy& hierarchy, const GraphTile* tile, tweeners_t& tweeners);
+  static std::array<std::vector<GraphId>, kBinCount> BinEdges(const GraphTile* tile, tweeners_t& tweeners);
 
   /**
    * Adds to the bins the tile already has, only modifies the header to reflect the new counts
    * and the bins themselves, everything else is copied directly without ever looking at it
-   * @param hierarchy  to figure out where to save the tile
+   * @param tile_dir   Base tile directory
    * @param tile       the tile that needs the bins added
    * @param more_bins  the extra bin data to append to the tile
    */
-  static void AddBins(const TileHierarchy& hierarchy, const GraphTile* tile, const std::array<std::vector<GraphId>, kBinCount>& more_bins);
+  static void AddBins(const std::string& tile_dir,
+                      const GraphTile* tile,
+                      const std::array<std::vector<GraphId>, kBinCount>& more_bins);
 
   /**
    * Initialize traffic segment association. Sizes the traffic segment
@@ -398,8 +399,8 @@ class GraphTileBuilder : public baldr::GraphTile {
   // Write all textlist items to specified stream
   void SerializeTextListToOstream(std::ostream& out) const;
 
-  // Tile hierarchy for disk access location
-  TileHierarchy hierarchy_;
+  // Base tile directory
+  std::string tile_dir_;
 
   // Header information for the tile
   GraphTileHeader header_builder_;


### PR DESCRIPTION
Make the TileHierarchy a set of static methods and static data member. Switch places that use TileHierarchy to make use of these static methods.

Also removed the tile directory from TileHierarchy and force it to be passed into GraphTile (from GraphReader based on the config file) and into GraphTileBuilder.

Doing more extensive testing now (worked with a small pbf extract) prior to merging, just giving a heads up!