### PR TITLE
Updated edge walk stop logic

### DIFF
--- a/src/thor/route_matcher.cc
+++ b/src/thor/route_matcher.cc
@@ -2,6 +2,8 @@
 #include <algorithm>
 #include <exception>
 #include "midgard/logging.h"
+#include "midgard/util.h"
+
 #include "baldr/errorcode_util.h"
 
 #include "thor/route_matcher.h"
@@ -22,6 +24,12 @@ namespace thor {
  */
 
 namespace {
+
+using end_edge_t = std::pair<PathLocation::PathEdge, float>;
+using end_node_t = std::unordered_map<GraphId, end_edge_t>;
+
+// Total distance match delta
+constexpr float kTotalDistanceEpsilon = 5.0f;
 
 // Minimum tolerance for edge length
 constexpr float kMinLengthTolerance = 10.0f;
@@ -44,10 +52,9 @@ float length_comparison(const float length, const bool exact_match) {
 
 // Get a map of end edges and the start node of each edge. This is used
 // to terminate the edge walking method.
-std::unordered_map<GraphId, PathLocation::PathEdge> GetEndEdges(
-        GraphReader& reader,
+end_node_t GetEndEdges(GraphReader& reader,
         const std::vector<PathLocation>& correlated) {
-  std::unordered_map<GraphId, PathLocation::PathEdge> end_nodes;
+  end_node_t end_nodes;
   for (const auto& edge : correlated.back().edges) {
     // If destination is at a node - skip any outbound edge
     if (edge.begin_node() || !edge.id.Is_Valid()) {
@@ -61,14 +68,19 @@ std::unordered_map<GraphId, PathLocation::PathEdge> GetEndEdges(
       // If this edge ends at a node add its end node
       auto* tile = reader.GetGraphTile(edge.id);
       auto* directededge = tile->directededge(edge.id);
-      end_nodes.insert({directededge->endnode(), edge});
+      end_nodes.insert({directededge->endnode(), std::make_pair(edge, 0.0f)});
     } else {
       // Get the start node of this edge
-      auto* opp_edge = reader.GetOpposingEdge(edge.id);
-      if (opp_edge == nullptr) {
-        throw std::runtime_error("Couldn't get the opposing edge");
+      GraphId opp_edge_id = reader.GetOpposingEdgeId(edge.id);
+      auto* tile = reader.GetGraphTile(opp_edge_id);
+      if (tile == nullptr) {
+        throw std::runtime_error("Couldn't get the opposing edge tile");
       }
-      end_nodes.insert({opp_edge->endnode(), edge});
+      auto* opp_edge = tile->directededge(opp_edge_id);
+
+      // Compute partial distance along end edge
+      float dist = opp_edge->length() * edge.dist;
+      end_nodes.insert({opp_edge->endnode(), std::make_pair(edge, dist)});
     }
   }
   if (end_nodes.size() == 0) {
@@ -83,17 +95,27 @@ bool expand_from_node(const std::shared_ptr<DynamicCost>* mode_costing,
                       const std::vector<midgard::PointLL>& shape,
                       const std::vector<float>& distances,
                       size_t& correlated_index, const GraphTile* tile,
-                      const GraphId& node,
-                      std::unordered_map<GraphId, PathLocation::PathEdge>& end_nodes,
+                      const GraphId& node, end_node_t& end_nodes,
                       EdgeLabel& prev_edge_label, float& elapsed_time,
                       std::vector<PathInfo>& path_infos,
-                      const bool from_transition, GraphId& end_node) {
-
-  // If node equals stop node then when are done expanding
+                      const bool from_transition, GraphId& end_node,
+                      const float total_distance) {
+  // Done expanding when node equals stop node and the accumulated distance plus
+  // the partial last edge distance is approximately equal to the total distance
   auto n = end_nodes.find(node);
   if (n != end_nodes.end()) {
-    end_node = node;
-    return true;
+    // Accumulate distance through correlated index
+    float acc_distance = 0.0f;
+    for (uint32_t idx = 0; idx <= correlated_index; idx++) {
+      acc_distance += distances[idx];
+    }
+
+    // Verify distance is approximately equal to the total distance
+    if (midgard::equal<float>((acc_distance + n->second.second), total_distance,
+        kTotalDistanceEpsilon)) {
+      end_node = node;
+      return true;
+    }
   }
 
   const NodeInfo* node_info = tile->node(node);
@@ -126,7 +148,7 @@ bool expand_from_node(const std::shared_ptr<DynamicCost>* mode_costing,
         if (expand_from_node(mode_costing, mode, reader, shape, distances,
                              correlated_index, end_node_tile, de->endnode(),
                              end_nodes, prev_edge_label, elapsed_time,
-                             path_infos, true, end_node)) {
+                             path_infos, true, end_node, total_distance)) {
           return true;
         } else {
           continue;
@@ -173,7 +195,7 @@ bool expand_from_node(const std::shared_ptr<DynamicCost>* mode_costing,
         if (expand_from_node(mode_costing, mode, reader, shape, distances,
                              index, end_node_tile, de->endnode(),
                              end_nodes, prev_edge_label, elapsed_time,
-                             path_infos, false, end_node)) {
+                             path_infos, false, end_node, total_distance)) {
           return true;
         } else {
           // Match failed along this edge, pop the last entry off path_infos
@@ -197,13 +219,14 @@ bool RouteMatcher::FormPath(
     const std::vector<midgard::PointLL>& shape,
     const std::vector<PathLocation>& correlated,
     std::vector<PathInfo>& path_infos) {
-  float elapsed_time = 0.0f;
-
   // Form distances between shape points
+  float total_distance = 0.0f;
   std::vector<float> distances;
   distances.push_back(0.0f);
   for (size_t i = 1; i < shape.size(); i++) {
-    distances.push_back(shape[i].Distance(shape[i-1]));
+    float d = shape[i].Distance(shape[i-1]);
+    distances.push_back(d);
+    total_distance += d;
   }
 
   // Process and validate end edges (can be more than 1). Create a map of
@@ -211,6 +234,7 @@ bool RouteMatcher::FormPath(
   auto end_nodes = GetEndEdges(reader, correlated);
 
   // Iterate through start edges
+  float elapsed_time = 0.0f;
   for (const auto& edge : correlated.front().edges) {
     // If origin is at a node - skip any inbound edge
     if (edge.end_node()) {
@@ -264,7 +288,7 @@ bool RouteMatcher::FormPath(
         if (expand_from_node(mode_costing, mode, reader, shape, distances, index,
                              end_node_tile, de->endnode(), end_nodes,
                              prev_edge_label, elapsed_time, path_infos,
-                             false, end_node)) {
+                             false, end_node, total_distance)) {
           // If node equals stop node then when are done expanding - get
           // the matching end edge
           auto n = end_nodes.find(end_node);
@@ -272,18 +296,20 @@ bool RouteMatcher::FormPath(
             return false;
           }
 
-          // If the end edge distance = 1.0 then we are done
-          if (n->second.dist == 1.0f) {
+          // If the end edge is at a node then we are done (no partial time
+          // along a destination edge)
+          auto end_edge = n->second.first;
+          if (end_edge.end_node()) {
             return true;
           }
 
           // Get the end edge and add transition time and partial time along
           // the destination edge.
-          const GraphTile* end_edge_tile = reader.GetGraphTile(n->second.id);
+          const GraphTile* end_edge_tile = reader.GetGraphTile(end_edge.id);
           if (end_edge_tile == nullptr) {
             throw std::runtime_error("End edge tile is null");
           }
-          const DirectedEdge* end_de = end_edge_tile->directededge(n->second.id);
+          const DirectedEdge* end_de = end_edge_tile->directededge(end_edge.id);
 
           // Update the elapsed time based on transition cost
           elapsed_time += mode_costing[static_cast<int>(mode)]->TransitionCost(
@@ -291,10 +317,10 @@ bool RouteMatcher::FormPath(
 
           // Update the elapsed time based on edge cost
           elapsed_time += mode_costing[static_cast<int>(mode)]->EdgeCost(end_de).secs *
-                                  n->second.dist;
+                          end_edge.dist;
 
           // Add end edge
-          path_infos.emplace_back(mode, elapsed_time, n->second.id, 0);
+          path_infos.emplace_back(mode, elapsed_time, end_edge.id, 0);
 
           return true;
         } else {
@@ -308,10 +334,10 @@ bool RouteMatcher::FormPath(
     // Did not find the end of the origin edge. Check for special case where
     // end is along the same edge.
     for (auto end : end_nodes) {
-      if (end.second.id == edge.id) {
+      if (end.second.first.id == edge.id) {
         // Update the elapsed time based on edge cost
         elapsed_time += mode_costing[static_cast<int>(mode)]->EdgeCost(de).secs *
-                               (end.second.dist - edge.dist);
+                               (end.second.first.dist - edge.dist);
 
         // Add end edge
         path_infos.emplace_back(mode, elapsed_time, edge.id, 0);


### PR DESCRIPTION
Done expanding when node equals stop node and the accumulated distance plus
the partial last edge distance is approximately equal to the total distance

paired with @dnesbitt61 
closes #638
test results:
```
src/thor/route_matcher.cc:115 | correlated_index=14 | acc_distance=75.8234 | n->second.second=22.0107| value to check=97.834 | kTotalDistanceEpsilon=5 | total_distance=40714.2
src/thor/route_matcher.cc:115 | correlated_index=1075 | acc_distance=40692.2 | n->second.second=22.0107| value to check=40714.2 | kTotalDistanceEpsilon=5 | total_distance=40714.2
src/thor/route_matcher.cc:115 | correlated_index=6 | acc_distance=430.898 | n->second.second=107.107| value to check=538.004 | kTotalDistanceEpsilon=5 | total_distance=538.004
src/thor/route_matcher.cc:115 | correlated_index=538 | acc_distance=47390.3 | n->second.second=0| value to check=47390.3 | kTotalDistanceEpsilon=5 | total_distance=47390.3
src/thor/route_matcher.cc:115 | correlated_index=1063 | acc_distance=107613 | n->second.second=410.874| value to check=108024 | kTotalDistanceEpsilon=5 | total_distance=108024
src/thor/route_matcher.cc:115 | correlated_index=55 | acc_distance=3387.78 | n->second.second=17.9865| value to check=3405.77 | kTotalDistanceEpsilon=5 | total_distance=3405.66
src/thor/route_matcher.cc:115 | correlated_index=24 | acc_distance=1840.25 | n->second.second=116.084| value to check=1956.33 | kTotalDistanceEpsilon=5 | total_distance=1956.71
src/thor/route_matcher.cc:115 | correlated_index=172 | acc_distance=14415.2 | n->second.second=319.753| value to check=14734.9 | kTotalDistanceEpsilon=5 | total_distance=14734.9
src/thor/route_matcher.cc:115 | correlated_index=41 | acc_distance=4442.6 | n->second.second=360.13| value to check=4802.73 | kTotalDistanceEpsilon=5 | total_distance=4802.73
src/thor/route_matcher.cc:115 | correlated_index=43 | acc_distance=4470.69 | n->second.second=66.2722| value to check=4536.96 | kTotalDistanceEpsilon=5 | total_distance=4536.96
src/thor/route_matcher.cc:115 | correlated_index=268 | acc_distance=18146.1 | n->second.second=23.8004| value to check=18169.9 | kTotalDistanceEpsilon=5 | total_distance=18169.9
src/thor/route_matcher.cc:115 | correlated_index=96 | acc_distance=5047.48 | n->second.second=28.3835| value to check=5075.86 | kTotalDistanceEpsilon=5 | total_distance=5075.59
src/thor/route_matcher.cc:115 | correlated_index=47 | acc_distance=3289.79 | n->second.second=0| value to check=3289.79 | kTotalDistanceEpsilon=5 | total_distance=3289.79
src/thor/route_matcher.cc:115 | correlated_index=105 | acc_distance=4811.62 | n->second.second=98.8825| value to check=4910.5 | kTotalDistanceEpsilon=5 | total_distance=4910.39
src/thor/route_matcher.cc:115 | correlated_index=104 | acc_distance=7254.56 | n->second.second=114.169| value to check=7368.73 | kTotalDistanceEpsilon=5 | total_distance=7369.09
src/thor/route_matcher.cc:115 | correlated_index=542 | acc_distance=46654.3 | n->second.second=38.9956| value to check=46693.3 | kTotalDistanceEpsilon=5 | total_distance=46693.6
src/thor/route_matcher.cc:115 | correlated_index=112 | acc_distance=4603.38 | n->second.second=29.2024| value to check=4632.59 | kTotalDistanceEpsilon=5 | total_distance=4632.11
src/thor/route_matcher.cc:115 | correlated_index=96 | acc_distance=4419.46 | n->second.second=0| value to check=4419.46 | kTotalDistanceEpsilon=5 | total_distance=4419.46
src/thor/route_matcher.cc:115 | correlated_index=598 | acc_distance=50351.3 | n->second.second=41.9355| value to check=50393.2 | kTotalDistanceEpsilon=5 | total_distance=50393.2
src/thor/route_matcher.cc:115 | correlated_index=136 | acc_distance=9748.95 | n->second.second=106.498| value to check=9855.45 | kTotalDistanceEpsilon=5 | total_distance=9855.9
src/thor/route_matcher.cc:115 | correlated_index=119 | acc_distance=10171.8 | n->second.second=154.17| value to check=10325.9 | kTotalDistanceEpsilon=5 | total_distance=10325.9
src/thor/route_matcher.cc:115 | correlated_index=90 | acc_distance=8798.98 | n->second.second=79.1522| value to check=8878.13 | kTotalDistanceEpsilon=5 | total_distance=8877.86
src/thor/route_matcher.cc:115 | correlated_index=125 | acc_distance=10584.3 | n->second.second=62.2678| value to check=10646.6 | kTotalDistanceEpsilon=5 | total_distance=10646.6
src/thor/route_matcher.cc:115 | correlated_index=255 | acc_distance=11988.4 | n->second.second=51.8873| value to check=12040.3 | kTotalDistanceEpsilon=5 | total_distance=12258.3
src/thor/route_matcher.cc:115 | correlated_index=271 | acc_distance=12206.4 | n->second.second=51.8873| value to check=12258.3 | kTotalDistanceEpsilon=5 | total_distance=12258.3
src/thor/route_matcher.cc:115 | correlated_index=53 | acc_distance=2023.53 | n->second.second=44.6256| value to check=2068.15 | kTotalDistanceEpsilon=5 | total_distance=3659.42
src/thor/route_matcher.cc:115 | correlated_index=86 | acc_distance=3614.8 | n->second.second=44.6256| value to check=3659.42 | kTotalDistanceEpsilon=5 | total_distance=3659.42
src/thor/route_matcher.cc:115 | correlated_index=82 | acc_distance=5571.73 | n->second.second=73.2456| value to check=5644.97 | kTotalDistanceEpsilon=5 | total_distance=30331.8
src/thor/route_matcher.cc:115 | correlated_index=239 | acc_distance=15581.3 | n->second.second=73.2456| value to check=15654.6 | kTotalDistanceEpsilon=5 | total_distance=30331.8
src/thor/route_matcher.cc:115 | correlated_index=376 | acc_distance=24279.5 | n->second.second=73.2456| value to check=24352.7 | kTotalDistanceEpsilon=5 | total_distance=30331.8
src/thor/route_matcher.cc:115 | correlated_index=461 | acc_distance=30258.5 | n->second.second=73.2456| value to check=30331.8 | kTotalDistanceEpsilon=5 | total_distance=30331.8
src/thor/route_matcher.cc:115 | correlated_index=2491 | acc_distance=84932.5 | n->second.second=0| value to check=84932.5 | kTotalDistanceEpsilon=5 | total_distance=84932.5
src/thor/route_matcher.cc:115 | correlated_index=14 | acc_distance=75.8234 | n->second.second=22.0107| value to check=97.834 | kTotalDistanceEpsilon=5 | total_distance=40714.2
src/thor/route_matcher.cc:115 | correlated_index=1075 | acc_distance=40692.2 | n->second.second=22.0107| value to check=40714.2 | kTotalDistanceEpsilon=5 | total_distance=40714.2
src/thor/route_matcher.cc:115 | correlated_index=12 | acc_distance=64.5829 | n->second.second=22.0107| value to check=86.5936 | kTotalDistanceEpsilon=5 | total_distance=49574
src/thor/route_matcher.cc:115 | correlated_index=1154 | acc_distance=49552 | n->second.second=22.0107| value to check=49574 | kTotalDistanceEpsilon=5 | total_distance=49574
src/thor/route_matcher.cc:115 | correlated_index=1 | acc_distance=6.41375 | n->second.second=10.6904| value to check=17.1042 | kTotalDistanceEpsilon=5 | total_distance=20189.4
src/thor/route_matcher.cc:115 | correlated_index=725 | acc_distance=20178.7 | n->second.second=10.6904| value to check=20189.4 | kTotalDistanceEpsilon=5 | total_distance=20189.4
src/thor/route_matcher.cc:115 | correlated_index=285 | acc_distance=10567.3 | n->second.second=122.383| value to check=10689.6 | kTotalDistanceEpsilon=5 | total_distance=10689.6
src/thor/route_matcher.cc:115 | correlated_index=598 | acc_distance=31480.2 | n->second.second=33.6814| value to check=31513.9 | kTotalDistanceEpsilon=5 | total_distance=31513.9
src/thor/route_matcher.cc:115 | correlated_index=1352 | acc_distance=60886.2 | n->second.second=101.73| value to check=60987.9 | kTotalDistanceEpsilon=5 | total_distance=60987.9
src/thor/route_matcher.cc:115 | correlated_index=248 | acc_distance=12458.6 | n->second.second=0| value to check=12458.6 | kTotalDistanceEpsilon=5 | total_distance=12458.6
src/thor/route_matcher.cc:115 | correlated_index=331 | acc_distance=9826.53 | n->second.second=45.0188| value to check=9871.55 | kTotalDistanceEpsilon=5 | total_distance=9871.55
src/thor/route_matcher.cc:115 | correlated_index=1063 | acc_distance=107613 | n->second.second=410.874| value to check=108024 | kTotalDistanceEpsilon=5 | total_distance=108024
src/thor/route_matcher.cc:115 | correlated_index=1282 | acc_distance=45017.1 | n->second.second=36.0903| value to check=45053.1 | kTotalDistanceEpsilon=5 | total_distance=45052.8
src/thor/route_matcher.cc:115 | correlated_index=81 | acc_distance=3216.38 | n->second.second=8.99592| value to check=3225.37 | kTotalDistanceEpsilon=5 | total_distance=3225.37
src/thor/route_matcher.cc:115 | correlated_index=31 | acc_distance=1146.34 | n->second.second=0| value to check=1146.34 | kTotalDistanceEpsilon=5 | total_distance=1146.34
src/thor/route_matcher.cc:115 | correlated_index=8 | acc_distance=138.285 | n->second.second=137.971| value to check=276.256 | kTotalDistanceEpsilon=5 | total_distance=5223.52
src/thor/route_matcher.cc:115 | correlated_index=234 | acc_distance=5085.24 | n->second.second=137.971| value to check=5223.21 | kTotalDistanceEpsilon=5 | total_distance=5223.52
src/thor/route_matcher.cc:115 | correlated_index=1 | acc_distance=24.7084 | n->second.second=8.10157| value to check=32.8099 | kTotalDistanceEpsilon=5 | total_distance=35539.4
src/thor/route_matcher.cc:115 | correlated_index=1 | acc_distance=24.7084 | n->second.second=8.10157| value to check=32.8099 | kTotalDistanceEpsilon=5 | total_distance=35539.4
```