### PR TITLE
Fix issues with A* expansion

### DIFF
--- a/src/baldr/laneconnectivity.cc
+++ b/src/baldr/laneconnectivity.cc
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <vector>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
 #include <valhalla/midgard/logging.h>

--- a/src/city_test.cc
+++ b/src/city_test.cc
@@ -268,6 +268,7 @@ int main(int argc, char *argv[]) {
         if (cost->AllowMultiPass()) {
           pathalgorithm.Clear();
           cost->RelaxHierarchyLimits(16.0f, 4.0f);
+          cost->EnableDestinationOnly();
           pathedges = pathalgorithm.GetBestPath(origin, dest, reader, mode_costing, mode);
           np++;
           if (pathedges.size() == 0) {

--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -16,7 +16,7 @@ namespace sif {
 // Default options/values
 namespace {
 constexpr float kDefaultManeuverPenalty         = 5.0f;   // Seconds
-constexpr float kDefaultDestinationOnlyPenalty  = 600.0f; // Seconds
+constexpr float kDefaultDestinationOnlyPenalty  = 3600.0f; // Seconds
 constexpr float kDefaultAlleyPenalty            = 5.0f;   // Seconds
 constexpr float kDefaultGateCost                = 30.0f;  // Seconds
 constexpr float kDefaultGatePenalty             = 300.0f; // Seconds

--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -76,13 +76,6 @@ class AutoCost : public DynamicCost {
   virtual bool AllowMultiPass() const;
 
   /**
-   * Disables entrance into destination only areas. This should only be used
-   * for bidirectional path algorithms (and generally only for driving),
-   * otherwise a destination only penalty should be used.
-   */
-  virtual void DisableDestinationOnly();
-
-  /**
    * Get the access mode used by this costing method.
    * @return  Returns access mode.
    */
@@ -302,6 +295,9 @@ AutoCost::AutoCost(const boost::property_tree::ptree& pt)
   for (uint32_t d = 0; d < 16; d++) {
     density_factor_[d] = 0.85f + (d * 0.025f);
   }
+
+  // Default to disable destination-only segments
+  DisableDestinationOnly();
 }
 
 // Destructor
@@ -312,12 +308,6 @@ AutoCost::~AutoCost() {
 // limits).
 bool AutoCost::AllowMultiPass() const {
   return true;
-}
-
-// Set to disable destination only transitions.
-void AutoCost::DisableDestinationOnly() {
-  disable_destination_only_ = true;
-  destination_only_penalty_ = 0;
 }
 
 // Get the access mode used by this costing method.
@@ -408,7 +398,7 @@ Cost AutoCost::TransitionCost(const baldr::DirectedEdge* edge,
 
   // Additional penalties without any time cost
   uint32_t idx = pred.opp_local_idx();
-  if (!pred.destonly() && edge->destonly()) {
+  if (!disable_destination_only_ && !pred.destonly() && edge->destonly()) {
     penalty += destination_only_penalty_;
   }
   if (pred.use() != Use::kAlley && edge->use() == Use::kAlley) {
@@ -470,7 +460,7 @@ Cost AutoCost::TransitionCostReverse(const uint32_t idx,
   }
 
   // Additional penalties without any time cost
-  if (!pred->destonly() && edge->destonly()) {
+  if (!disable_destination_only_ && !pred->destonly() && edge->destonly()) {
     penalty += destination_only_penalty_;
   }
   if (pred->use() != Use::kAlley && edge->use() == Use::kAlley) {

--- a/src/sif/dynamiccost.cc
+++ b/src/sif/dynamiccost.cc
@@ -164,9 +164,14 @@ void DynamicCost::SetAllowTransitConnections(const bool allow) {
   allow_transit_connections_ = allow;
 }
 
-// Set to allow use of transit connections.
+// Set to disable use of destination-only segments.
 void DynamicCost::DisableDestinationOnly() {
   disable_destination_only_ = true;
+}
+
+// Set to allow use of destination-only segments.
+void DynamicCost::EnableDestinationOnly() {
+  disable_destination_only_ = false;
 }
 
 // Returns the maximum transfer distance between stops that you are willing

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -23,6 +23,7 @@ namespace valhalla {
 namespace thor {
 
 constexpr uint64_t kInitialEdgeLabelCountBD = 1000000;
+constexpr float kAdditionalExpansion = 600.0;
 
 // Default constructor
 BidirectionalAStar::BidirectionalAStar(): PathAlgorithm() {
@@ -329,9 +330,9 @@ std::vector<PathInfo> BidirectionalAStar::GetBestPath(PathLocation& origin,
   travel_type_ = costing_->travel_type();
   access_mode_ = costing_->access_mode();
 
-  // Disable destination only transitions (based on costing) since this
-  // algorithm is bidirectional.
-  costing_->DisableDestinationOnly();
+  // Allow destination-only segments (with a penalty). This is needed
+  // to avoid route failures in case of destination-only donuts.
+  // costing_->DisableDestinationOnly();
 
   // Initialize - create adjacency list, edgestatus support, A*, etc.
   Init(origin.edges.front().projected, destination.edges.front().projected);
@@ -374,6 +375,37 @@ std::vector<PathInfo> BidirectionalAStar::GetBestPath(PathLocation& origin,
         if (edgestatus_reverse_->Get(pred.opp_edgeid()).set() != EdgeSet::kUnreached) {
           SetForwardConnection(pred);
         }
+
+        // Settle this edge.
+        edgestatus_forward_->Update(pred.edgeid(), EdgeSet::kPermanent);
+
+        // Prune path if predecessor is not a through edge
+        if (pred.not_thru() && pred.not_thru_pruning()) {
+          continue;
+        }
+
+        // Get the end node of the prior directed edge. Do not expand on this
+        // hierarchy level if the maximum number of upward transitions has
+        // been exceeded.
+        GraphId node = pred.endnode();
+        if (hierarchy_limits_forward_[node.level()].StopExpanding()) {
+          continue;
+        }
+
+        // Get the tile and the node info. Skip if tile is null (can happen
+        // with regional data sets) or if no access at the node.
+        if ((tile = graphreader.GetGraphTile(node)) == nullptr) {
+          continue;
+        }
+        const NodeInfo* nodeinfo = tile->node(node);
+        if (!costing_->Allowed(nodeinfo)) {
+          continue;
+        }
+
+        // Expand from the end node in forward direction.
+        ExpandForward(graphreader, tile, node, nodeinfo, pred,
+                      forward_pred_idx, false);
+
       } else {
         // Search is exhausted. If a connection has been found, return it
         if (best_connection_.cost < std::numeric_limits<float>::max()) {
@@ -387,6 +419,7 @@ std::vector<PathInfo> BidirectionalAStar::GetBestPath(PathLocation& origin,
         }
       }
     }
+
     if (expand_reverse) {
       reverse_pred_idx = adjacencylist_reverse_->pop();
       if (reverse_pred_idx != kInvalidLabel) {
@@ -396,6 +429,45 @@ std::vector<PathInfo> BidirectionalAStar::GetBestPath(PathLocation& origin,
         if (edgestatus_forward_->Get(pred2.opp_edgeid()).set() != EdgeSet::kUnreached) {
           SetReverseConnection(pred2);
         }
+
+        // Settle this edge
+        edgestatus_reverse_->Update(pred2.edgeid(), EdgeSet::kPermanent);
+
+        // Prune path if predecessor is not a through edge
+        if (pred2.not_thru() && pred2.not_thru_pruning()) {
+          continue;
+        }
+
+        // Get the end node of the prior directed edge. Do not expand on this
+        // hierarchy level if the maximum number of upward transitions has
+        // been exceeded.
+        GraphId node = pred2.endnode();
+        if (hierarchy_limits_reverse_[node.level()].StopExpanding()) {
+          continue;
+        }
+
+        // Get the tile and the node info. Skip if tile is null (can happen
+        // with regional data sets) or if no access at the node.
+        if ((tile2 = graphreader.GetGraphTile(node)) == nullptr) {
+          continue;
+        }
+        const NodeInfo* nodeinfo = tile2->node(node);
+        if (!costing_->Allowed(nodeinfo)) {
+          continue;
+        }
+
+        // Get the opposing predecessor directed edge. Need to make sure we get
+        // the correct one if a transition occurred
+        const DirectedEdge* opp_pred_edge =
+        (pred2.opp_edgeid().Tile_Base() == tile2->id().Tile_Base()) ?
+        tile2->directededge(pred2.opp_edgeid().id()) :
+        graphreader.GetGraphTile(pred2.opp_edgeid().
+                                 Tile_Base())->directededge(pred2.opp_edgeid());
+
+        // Expand from the end node in reverse direction.
+        ExpandReverse(graphreader, tile2, node, nodeinfo,pred2, reverse_pred_idx,
+                      opp_pred_edge, false);
+
       } else {
         // Search is exhausted. If a connection has been found, return it
         if (best_connection_.cost < std::numeric_limits<float>::max()) {
@@ -415,7 +487,7 @@ std::vector<PathInfo> BidirectionalAStar::GetBestPath(PathLocation& origin,
     // the max edge cost but that has performance limitations,
     // so for now we use this bit of a hack...stay tuned.
     if (best_connection_.cost < std::numeric_limits<float>::max()) {
-      if (edgelabels_forward_.size() + edgelabels_reverse_.size() > threshold_) {
+      if (pred.cost().cost + pred2.cost().cost > best_connection_.cost + kAdditionalExpansion) {
         return FormPath(graphreader);
       }
     }
@@ -426,79 +498,11 @@ std::vector<PathInfo> BidirectionalAStar::GetBestPath(PathLocation& origin,
       // on the next pass
       expand_forward = true;
       expand_reverse = false;
-
-      // Settle this edge.
-      edgestatus_forward_->Update(pred.edgeid(), EdgeSet::kPermanent);
-
-      // Prune path if predecessor is not a through edge
-      if (pred.not_thru() && pred.not_thru_pruning()) {
-        continue;
-      }
-
-      // Get the end node of the prior directed edge. Do not expand on this
-      // hierarchy level if the maximum number of upward transitions has
-      // been exceeded.
-      GraphId node = pred.endnode();
-      if (hierarchy_limits_forward_[node.level()].StopExpanding()) {
-        continue;
-      }
-
-      // Get the tile and the node info. Skip if tile is null (can happen
-      // with regional data sets) or if no access at the node.
-      if ((tile = graphreader.GetGraphTile(node)) == nullptr) {
-        continue;
-      }
-      const NodeInfo* nodeinfo = tile->node(node);
-      if (!costing_->Allowed(nodeinfo)) {
-        continue;
-      }
-
-      // Expand from the end node in forward direction.
-      ExpandForward(graphreader, tile, node, nodeinfo, pred,
-                    forward_pred_idx, false);
     } else {
       // Expand reverse - set to get next edge from reverse adj. list
       // on the next pass
       expand_forward = false;
       expand_reverse = true;
-
-      // Settle this edge
-      edgestatus_reverse_->Update(pred2.edgeid(), EdgeSet::kPermanent);
-
-      // Prune path if predecessor is not a through edge
-      if (pred2.not_thru() && pred2.not_thru_pruning()) {
-        continue;
-      }
-
-      // Get the end node of the prior directed edge. Do not expand on this
-      // hierarchy level if the maximum number of upward transitions has
-      // been exceeded.
-      GraphId node = pred2.endnode();
-      if (hierarchy_limits_reverse_[node.level()].StopExpanding()) {
-        continue;
-      }
-
-      // Get the tile and the node info. Skip if tile is null (can happen
-      // with regional data sets) or if no access at the node.
-      if ((tile2 = graphreader.GetGraphTile(node)) == nullptr) {
-        continue;
-      }
-      const NodeInfo* nodeinfo = tile2->node(node);
-      if (!costing_->Allowed(nodeinfo)) {
-        continue;
-      }
-
-      // Get the opposing predecessor directed edge. Need to make sure we get
-      // the correct one if a transition occurred
-      const DirectedEdge* opp_pred_edge =
-          (pred2.opp_edgeid().Tile_Base() == tile2->id().Tile_Base()) ?
-              tile2->directededge(pred2.opp_edgeid().id()) :
-              graphreader.GetGraphTile(pred2.opp_edgeid().
-                     Tile_Base())->directededge(pred2.opp_edgeid());
-
-      // Expand from the end node in reverse direction.
-      ExpandReverse(graphreader, tile2, node, nodeinfo,pred2, reverse_pred_idx,
-                    opp_pred_edge, false);
     }
   }
   return {};    // If we are here the route failed
@@ -615,7 +619,7 @@ void BidirectionalAStar::SetOrigin(GraphReader& graphreader,
   if (nodeinfo != nullptr && origin.date_time_ &&
       *origin.date_time_ == "current") {
     origin.date_time_= DateTime::iso_date_time(
-    		DateTime::get_tz_db().from_index(nodeinfo->timezone()));
+               DateTime::get_tz_db().from_index(nodeinfo->timezone()));
   }
 }
 

--- a/src/thor/route_action.cc
+++ b/src/thor/route_action.cc
@@ -94,6 +94,7 @@ namespace valhalla {
         float relax_factor = using_astar ? 16.0f : 8.0f;
         float expansion_within_factor = using_astar ? 4.0f : 2.0f;
         cost->RelaxHierarchyLimits(relax_factor, expansion_within_factor);
+        cost->EnableDestinationOnly();
         path = path_algorithm->GetBestPath(origin, destination,
                                   reader, mode_costing, mode);
       }

--- a/src/valhalla_run_route.cc
+++ b/src/valhalla_run_route.cc
@@ -98,6 +98,7 @@ TripPath PathTest(GraphReader& reader, PathLocation& origin,
       float relax_factor = (using_astar) ? 16.0f : 8.0f;
       float expansion_within_factor = (using_astar) ? 4.0f : 2.0f;
       cost->RelaxHierarchyLimits(using_astar, expansion_within_factor);
+      cost->EnableDestinationOnly();
       pathedges = pathalgorithm->GetBestPath(origin, dest, reader, mode_costing, mode);
       data.incPasses();
     }

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -253,6 +253,11 @@ class DynamicCost {
   virtual void DisableDestinationOnly();
 
   /**
+   * Enables entrance into destination only areas with a transition penalty.
+   */
+  virtual void EnableDestinationOnly();
+
+  /**
    * Set to allow use of transit connections.
    * @param  allow  Flag indicating whether transit connections are allowed.
    */


### PR DESCRIPTION
1. End when we surpass a certain cost (instead of # nodes in queue).
2. Enqueue next nodes immediately after dequeuing current node.