### PR TITLE
fix tile naming to be robust to all kinds of stuff. fixes #651

### DIFF
--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -1,7 +1,6 @@
 #include "baldr/graphtile.h"
 #include "baldr/datetime.h"
 #include "baldr/tilehierarchy.h"
-#include "baldr/reutil.h"
 #include "midgard/tiles.h"
 #include "midgard/aabb2.h"
 #include "midgard/pointll.h"

--- a/src/baldr/tilehierarchy.cc
+++ b/src/baldr/tilehierarchy.cc
@@ -16,6 +16,10 @@ std::map<uint8_t, TileLevel> TileHierarchy::levels_  = {
     midgard::Tiles<midgard::PointLL>{{{-180, -90}, {180, 90}}, 4, static_cast<unsigned short>(kBinsDim)}}}
 };
 
+//Should we make a class lower than service other for transit?
+TileLevel TileHierarchy::transit_level_ = {2, stringToRoadClass.find("ServiceOther")->second, "transit",
+  midgard::Tiles<midgard::PointLL>{{{-180, -90}, {180, 90}}, .25, static_cast<unsigned short>(kBinsDim)}};
+
 // Returns the GraphId of the requested tile based on a lat,lng and a level.
 // If the level is not supported an invalid id will be returned.
 GraphId TileHierarchy::GetGraphId(const midgard::PointLL& pointll, const uint8_t level) {

--- a/src/valhalla_associate_segments.cc
+++ b/src/valhalla_associate_segments.cc
@@ -814,10 +814,6 @@ bool edge_association::match_segment(vb::GraphId segment_id, const pbf::Segment 
   return true;
 }
 
-vb::GraphId parse_file_name(const std::string &file_name) {
-  return vb::GraphTile::GetTileId(file_name);
-}
-
 void edge_association::add_tile(const std::string &file_name) {
   //read the osmlr tile
   pbf::Tile tile;
@@ -829,7 +825,7 @@ void edge_association::add_tile(const std::string &file_name) {
   }
 
   //get a tile builder ready for this tile
-  auto base_id = parse_file_name(file_name);
+  auto base_id = vb::GraphTile::GetTileId(file_name);
   m_tile_builder.reset(new vj::GraphTileBuilder(m_reader.tile_dir(),
                        base_id, false));
   m_tile_builder->InitializeTrafficSegments();

--- a/test/graphtile.cc
+++ b/test/graphtile.cc
@@ -19,19 +19,53 @@ struct testable_graphtile : public valhalla::baldr::GraphTile {
 void file_suffix() {
 
   if(GraphTile::FileSuffix(GraphId(2, 2, 0)) != "2/000/000/002.gph")
-    throw std::runtime_error("Unexpected graphtile suffix");
+    throw std::logic_error("Unexpected graphtile suffix");
 
   if(GraphTile::FileSuffix(GraphId(4, 2, 0)) != "2/000/000/004.gph")
-    throw std::runtime_error("Unexpected graphtile suffix");
+    throw std::logic_error("Unexpected graphtile suffix");
 
   if(GraphTile::FileSuffix(GraphId(1197468, 2, 0)) != "2/001/197/468.gph")
-    throw std::runtime_error("Unexpected graphtile suffix");
+    throw std::logic_error("Unexpected graphtile suffix");
 
   if(GraphTile::FileSuffix(GraphId(64799, 1, 0)) != "1/064/799.gph")
-    throw std::runtime_error("Unexpected graphtile suffix");
+    throw std::logic_error("Unexpected graphtile suffix");
 
   if(GraphTile::FileSuffix(GraphId(49, 0, 0)) != "0/000/049.gph")
-    throw std::runtime_error("Unexpected graphtile suffix");
+    throw std::logic_error("Unexpected graphtile suffix");
+}
+
+void id_from_string() {
+
+  if(GraphTile::GetTileId("foo/bar/baz/qux/corge/1/000/002.gph") != GraphId(2,1,0))
+      throw std::logic_error("Unexpected graphtile id");
+
+  if(GraphTile::GetTileId("foo2/8675309/bar/1baz2/qux42corge/1/000/002.gph") != GraphId(2,1,0))
+    throw std::logic_error("Unexpected graphtile id");
+
+  try {
+    GraphTile::GetTileId("foo2/8675309/bar/1baz2/qux42corge/1/000/002/.gph");
+    throw std::logic_error("Should fail to get graphtile id");
+  } catch(const std::runtime_error&) { }
+
+  try {
+    GraphTile::GetTileId("foo2/8675309/bar/1baz2/qux42corge/0/004/050.gph");
+    throw std::logic_error("Should fail to get graphtile id");
+  } catch(const std::runtime_error&) { }
+
+  try {
+    GraphTile::GetTileId("foo/bar/0/004/0-1.gph");
+    throw std::logic_error("Should fail to get graphtile id");
+  } catch(const std::runtime_error&) { }
+
+  try {
+    GraphTile::GetTileId("foo/bar/0/004//001.gph");
+    throw std::logic_error("Should fail to get graphtile id");
+  } catch(const std::runtime_error&) { }
+
+  try {
+    GraphTile::GetTileId("foo/bar/1/000/004/001.gph");
+    throw std::logic_error("Should fail to get graphtile id");
+  } catch(const std::runtime_error&) { }
 }
 
 void bin() {
@@ -72,6 +106,8 @@ int main() {
   test::suite suite("graphtile");
 
   suite.test(TEST_CASE(file_suffix));
+
+  suite.test(TEST_CASE(id_from_string));
 
   suite.test(TEST_CASE(bin));
 

--- a/valhalla/baldr/tilehierarchy.h
+++ b/valhalla/baldr/tilehierarchy.h
@@ -44,6 +44,14 @@ class TileHierarchy {
   }
 
   /**
+   * Get the transit level in this hierarchy.
+   * @return the transit TileLevel object.
+   */
+  static const TileLevel& GetTransitLevel() {
+    return transit_level_;
+  }
+
+  /**
    * Returns the GraphId of the requested tile based on a lat,lng and a level.
    * If the level is not supported an invalid id will be returned.
    * @param pointll  Lat,lng location within the tile.
@@ -76,6 +84,7 @@ class TileHierarchy {
 
  private:
   static std::map<uint8_t, TileLevel> levels_;
+  static TileLevel transit_level_;
 };
 
 }


### PR DESCRIPTION
added lots of tests
made it so we can actually support numbers in the parts of the path that arent the tiles themselves
lots of other tests in there to reject stuff that almost looks like valid tiles names but arent