### PR TITLE
Simplify bidirectional A*

### DIFF
--- a/valhalla/thor/bidirectional_astar.h
+++ b/valhalla/thor/bidirectional_astar.h
@@ -114,19 +114,15 @@ class BidirectionalAStar : public PathAlgorithm {
    * Expand from the node along the forward search path.
    */
   void ExpandForward(baldr::GraphReader& graphreader,
-           const baldr::GraphTile* tile,
-           const baldr::GraphId& node, const baldr::NodeInfo* nodeinfo,
-           const sif::EdgeLabel& pred, const uint32_t pred_idx,
-           const bool from_transition);
+           const baldr::GraphId& node, const sif::EdgeLabel& pred,
+           const uint32_t pred_idx, const bool from_transition);
 
   /**
    * Expand from the node along the reverse search path.
    */
   void ExpandReverse(baldr::GraphReader& graphreader,
-           const baldr::GraphTile* tile,
-           const baldr::GraphId& node, const baldr::NodeInfo* nodeinfo,
-           const sif::EdgeLabel& pred, const uint32_t pred_idx,
-           const baldr::DirectedEdge* opp_pred_edge,
+           const baldr::GraphId& node, const sif::EdgeLabel& pred,
+           const uint32_t pred_idx, const baldr::DirectedEdge* opp_pred_edge,
            const bool from_transition);
 
   /**


### PR DESCRIPTION
Simplify ExpandForward and ExpandReverse by accessing tile and node within the method (rather than passing into the method). Simplifies the transition logic a little. Group some of the access checks to make code more clear. Also make sure complex restriction is tested before checking the priority queue (fixes a potential bug with complex restrictions).