### PR TITLE
Handle EdgeElevation cases where no data exists.

### DIFF
--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -38,8 +38,6 @@ namespace {
 namespace valhalla {
 namespace baldr {
 
-static EdgeElevation kNoElevationData(32768.0f, 0.0f, 0.0f);
-
 // Default constructor
 GraphTile::GraphTile()
     : header_(nullptr),
@@ -881,22 +879,6 @@ std::vector<TrafficSegment> GraphTile::GetTrafficSegments(const uint32_t idx) co
                          std::to_string(idx)  + " traffic Id count= " +
                          std::to_string(header_->traffic_id_count()));
 }
-
-/**
- * Get a pointer to a edge elevation data for the specified edge.
- * @param  edge  GraphId of the directed edge.
- * @return  Returns a pointer to the edge elevation data for the edge.
- *          Returns nullptr if no elevation data exists.
- */
-const EdgeElevation* GraphTile::edge_elevation(const GraphId& edge) const {
-  if (header_->has_edge_elevation() &&
-      edge.id() < header_->directededgecount()) {
-    return &edge_elevation_[edge.id()];
-  } else {
-    return &kNoElevationData;
-  }
-}
-
 
 }
 }

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -11,6 +11,7 @@
 #include <set>
 #include <boost/format.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/filesystem/operations.hpp>
 
 #include "midgard/logging.h"
 #include "midgard/util.h"
@@ -983,7 +984,7 @@ void GraphBuilder::Build(const boost::property_tree::ptree& pt, const OSMData& o
   // Crack open some elevation data if its there
   boost::optional<std::string> elevation = pt.get_optional<std::string>("additional_data.elevation");
   std::unique_ptr<const skadi::sample> sample;
-  if(elevation)
+  if(elevation && boost::filesystem::exists(*elevation))
     sample.reset(new skadi::sample(*elevation));
 
   // Build tiles at the local level. Form connected graph from nodes and edges.

--- a/src/mjolnir/shortcutbuilder.cc
+++ b/src/mjolnir/shortcutbuilder.cc
@@ -11,6 +11,7 @@
 #include <utility>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/format.hpp>
+#include <boost/filesystem/operations.hpp>
 
 #include "midgard/pointll.h"
 #include "midgard/logging.h"
@@ -698,7 +699,7 @@ void ShortcutBuilder::Build(const boost::property_tree::ptree& pt) {
   // Crack open some elevation data if its there
   boost::optional<std::string> elevation = pt.get_optional<std::string>("additional_data.elevation");
   std::unique_ptr<const skadi::sample> sample;
-  if (elevation) {
+  if (elevation && boost::filesystem::exists(*elevation)) {
     sample.reset(new skadi::sample(*elevation));
   }
 

--- a/src/thor/trace_attributes_action.cc
+++ b/src/thor/trace_attributes_action.cc
@@ -84,8 +84,15 @@ namespace {
           edge_map->emplace("max_upward_grade", static_cast<int64_t>(edge.max_upward_grade()));
         if (edge.has_weighted_grade())
           edge_map->emplace("weighted_grade", json::fp_t{edge.weighted_grade(), 3});
-        if (edge.has_mean_elevation())
-           edge_map->emplace("mean_elevation", static_cast<int64_t>(edge.mean_elevation()));
+        if (edge.has_mean_elevation()) {
+          // Convert to feet if a valid elevation and units are miles
+          float mean = edge.mean_elevation();
+          if (mean != kNoElevationData && directions_options.has_units()
+              && directions_options.units() == DirectionsOptions::kMiles) {
+            mean *= kFeetPerMeter;
+          }
+          edge_map->emplace("mean_elevation", static_cast<int64_t>(mean));
+        }
         if (edge.has_way_id())
           edge_map->emplace("way_id", static_cast<uint64_t>(edge.way_id()));
         if (edge.has_id())

--- a/src/thor/trippathbuilder.cc
+++ b/src/thor/trippathbuilder.cc
@@ -1272,6 +1272,13 @@ TripPath_Edge* TripPathBuilder::AddTripEdge(const TripPathController& controller
         trip_edge->set_max_downward_grade(elev->max_down_slope());
       if (controller.attributes.at(kEdgeMeanElevation))
         trip_edge->set_mean_elevation(elev->mean_elevation());
+    } else {
+      if (controller.attributes.at(kEdgeMaxUpwardGrade))
+        trip_edge->set_max_upward_grade(kNoElevationData);
+      if (controller.attributes.at(kEdgeMaxDownwardGrade))
+        trip_edge->set_max_downward_grade(kNoElevationData);
+      if (controller.attributes.at(kEdgeMeanElevation))
+        trip_edge->set_mean_elevation(kNoElevationData);
     }
   }
 

--- a/valhalla/baldr/edge_elevation.h
+++ b/valhalla/baldr/edge_elevation.h
@@ -10,6 +10,7 @@ constexpr uint32_t kMaxStoredElevation = 4095;  // 12 bits
 constexpr float kElevationBinSize = 2.0f;
 constexpr float kMinElevation = -500.0f;
 constexpr float kMaxElevation = kMinElevation + (kElevationBinSize * kMaxStoredElevation);
+constexpr float kNoElevationData = 32768.0f;
 
 /**
  * Structure to store elevation information for a directed edge.

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -389,9 +389,16 @@ class GraphTile {
    * Get a pointer to a edge elevation data for the specified edge.
    * @param  edge  GraphId of the directed edge.
    * @return  Returns a pointer to the edge elevation data for the edge.
-   *          Returns a pointer to kNoElevationData if no elevation data exists.
+   *          Returns nullptr if no elevation data exists.
    */
-  const EdgeElevation* edge_elevation(const GraphId& edge) const;
+  const EdgeElevation* edge_elevation(const GraphId& edge) const  {
+    if (header_->has_edge_elevation() &&
+        edge.id() < header_->directededgecount()) {
+      return &edge_elevation_[edge.id()];
+    } else {
+      return nullptr;
+    }
+  }
 
  protected:
 

--- a/valhalla/midgard/constants.h
+++ b/valhalla/midgard/constants.h
@@ -13,6 +13,7 @@ constexpr float kHourPerSec = 1.0f / 3600.0f;
 constexpr uint32_t kSecondsPerDay = 86400;
 
 // Distance constants
+constexpr float kFeetPerMeter       = 3.2808399f;
 constexpr float kMetersPerKm        = 1000.0f;
 constexpr float kKmPerMeter         = 0.001f;
 constexpr float kMilePerKm          = 0.621371f;


### PR DESCRIPTION
Add kNoElevationData and set this value in TripPath if GraphTile::edge_elevation returns nullptr. A check against nullptr was easier than testing against a static structure. 

Make sure the elevation directory exists (in addition to being in the config file).