### PR TITLE
interpolate strictly in the time region the point occured

### DIFF
--- a/src/meili/map_matcher.cc
+++ b/src/meili/map_matcher.cc
@@ -46,8 +46,7 @@ InterpolateMeasurement(const MapMatching& mapmatching,
                        segment_iterator_t begin,
                        segment_iterator_t end,
                        const Measurement& measurement,
-                       float match_measurement_distance,
-                       bool reverse)
+                       float match_measurement_distance)
 {
   const baldr::GraphTile* tile(nullptr);
   midgard::DistanceApproximator approximator(measurement.lnglat());
@@ -83,7 +82,7 @@ InterpolateMeasurement(const MapMatching& mapmatching,
 
     // Distance from the projected point to the segment begin, or
     // segment begin if we walk reversely
-    const auto distance_to_segment_ends = std::abs(directededge->length() * (reverse? (segment->target - offset) : (offset - segment->source)));
+    const auto distance_to_segment_ends = std::abs(directededge->length() * (offset - segment->source));
 
     // The absolute route distance from projected point to the
     // beginning segment
@@ -113,74 +112,34 @@ InterpolateMeasurements(const MapMatching& mapmatching,
                         const MapMatching::state_iterator& next_state,
                         const std::vector<Measurement>& interpolated_measurements)
 {
-  if (interpolated_measurements.empty()) {
+  //nothing to do here
+  if (interpolated_measurements.empty())
     return {};
-  }
 
+  //can't interpolate these because they don't happen between two valid states or
+  //we weren't able to get a downstream route
   std::vector<MatchResult> results;
-
-  if (!state.IsValid()) {
-    for (const auto& measurement: interpolated_measurements) {
+  std::vector<EdgeSegment> route;
+  if (!state.IsValid() || !next_state.IsValid() ||
+    MergeRoute(route, *state, *next_state).empty()) {
+    for (const auto& measurement: interpolated_measurements)
       results.emplace_back(MatchResult{measurement.lnglat(), 0.f, baldr::GraphId{}, -1.f, measurement.epoch_time(), kInvalidStateId});
-    }
     return results;
   }
 
-  std::vector<EdgeSegment> upstream_route;
-  if (previous_state.IsValid()) {
-    MergeRoute(upstream_route, *previous_state, *state);
-  }
-
-  std::vector<EdgeSegment> downstream_route;
-  if (next_state.IsValid()) {
-    MergeRoute(downstream_route, *state, *next_state);
-  }
-
-  if (upstream_route.empty() && downstream_route.empty()) {
-    for (const auto& measurement: interpolated_measurements) {
-      results.emplace_back(MatchResult{measurement.lnglat(), 0.f, baldr::GraphId{}, -1.f, measurement.epoch_time(), kInvalidStateId});
-    }
-    return results;
-  }
-
+  //for each point that needs interpolated
   for (const auto& measurement: interpolated_measurements) {
     const auto& match_measurement = mapmatching.measurement(state->time());
     const auto match_measurement_distance = GreatCircleDistance(measurement, match_measurement);
+    //interpolate this point along the route
+    const auto& interp = InterpolateMeasurement(mapmatching, route.begin(), route.end(), measurement, match_measurement_distance);
 
-    const auto& up_interp = InterpolateMeasurement(
-        mapmatching,
-        upstream_route.rbegin(),
-        upstream_route.rend(),
-        measurement,
-        match_measurement_distance,
-        true);
-
-    const auto& down_interp = InterpolateMeasurement(
-        mapmatching,
-        downstream_route.begin(),
-        downstream_route.end(),
-        measurement,
-        match_measurement_distance,
-        false);
-
-    if (up_interp.edgeid.Is_Valid() && down_interp.edgeid.Is_Valid()) {
-      const auto down_cost = down_interp.sortcost(mapmatching, match_measurement_distance),
-                   up_cost = up_interp.sortcost(mapmatching, match_measurement_distance);
-      if (down_cost < up_cost) {
-        results.emplace_back(MatchResult{down_interp.projected, std::sqrt(down_interp.sq_distance), down_interp.edgeid, down_interp.edge_distance, measurement.epoch_time(), kInvalidStateId});
-      } else {
-        results.emplace_back(MatchResult{up_interp.projected, std::sqrt(up_interp.sq_distance), up_interp.edgeid, up_interp.edge_distance, measurement.epoch_time(), kInvalidStateId});
-      }
-
-    } else if (up_interp.edgeid.Is_Valid()) {
-      results.emplace_back(MatchResult{up_interp.projected, std::sqrt(up_interp.sq_distance), up_interp.edgeid, up_interp.edge_distance, measurement.epoch_time(), kInvalidStateId});
-
-    } else if (down_interp.edgeid.Is_Valid()) {
-      results.emplace_back(MatchResult{down_interp.projected, std::sqrt(down_interp.sq_distance), down_interp.edgeid, down_interp.edge_distance, measurement.epoch_time(), kInvalidStateId});
-
-    } else {
+    //if it was able to do the interpolation
+    if (interp.edgeid.Is_Valid())
+      results.emplace_back(MatchResult{interp.projected, std::sqrt(interp.sq_distance), interp.edgeid, interp.edge_distance, measurement.epoch_time(), kInvalidStateId});
+    //couldnt interpolate this point
+    else
       results.emplace_back(MatchResult{measurement.lnglat(), 0.f, baldr::GraphId{}, -1.f, measurement.epoch_time(), kInvalidStateId});
-    }
   }
 
   return results;


### PR DESCRIPTION
so let me explain. in map matching one of the main costs is the sheer number of mini routes that are run. to mitigate this cost its advantageous to skip some points when they are very close to other points. one could imagine that this is also useful when for example a person is sitting in the same place for a long period of time and the only real movement is due to jitter.

so when the map matching happens we end up with some points which arent used to compute the path, these points are then interpolated along the final path. when doing this interpolation the code was considering two parts of the final path. lets say we have the points from the input that were used to make the path call them p<sub>0</sub>,p<sub>1</sub>,...,p<sub>n</sub>. Between any two used points p<sub>n</sub> and p<sub>n+1</sub> there may be 0 or more points that need interpolated, call them i<sub>n,0</sub>,i<sub>n,1</sub>,...,i<sub>n,k</sub>. So for a given interpolation, i<sub>n,k</sub> we were interpolating against route from p<sub>n</sub> to p<sub>n+1</sub> but also interpolating against the route from p<sub>n-1</sub> to p<sub>n</sub>. 

If i<sub>n,k</sub> were closer to the route from p<sub>n-1</sub> to p<sub>n</sub> it would then snap to the shape between those two points. This is confusing from the point of correctness because it would make it seem like even though the i<sub>n,k</sub> occurred after p<sub>n</sub> in time, it occurred prior to p<sub>n</sub> in the path.

this pr removes that possibility and insures that i<sub>n,k</sub> always lies between p<sub>n</sub> and  p<sub>n+1</sub>. it should be noted that this is a bit of a design decision change. in other words there are inputs who will look better if we allow them to time travel. also there is some randomness in that had it ended up using i<sub>n,k</sub> as one of the points in the path instead of p<sub>n</sub> then you'd possibly not even notice the effects of this change or it could snap points to the same spot if the jitter is really bad and make it look like the trace isnt moving.