### PR TITLE
Better handling of destination only edges

### DIFF
--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -76,13 +76,6 @@ class AutoCost : public DynamicCost {
   virtual bool AllowMultiPass() const;
 
   /**
-   * Disables entrance into destination only areas. This should only be used
-   * for bidirectional path algorithms (and generally only for driving),
-   * otherwise a destination only penalty should be used.
-   */
-  virtual void DisableDestinationOnly();
-
-  /**
    * Get the access mode used by this costing method.
    * @return  Returns access mode.
    */
@@ -314,12 +307,6 @@ bool AutoCost::AllowMultiPass() const {
   return true;
 }
 
-// Set to disable destination only transitions.
-void AutoCost::DisableDestinationOnly() {
-  disable_destination_only_ = true;
-  destination_only_penalty_ = 0;
-}
-
 // Get the access mode used by this costing method.
 uint32_t AutoCost::access_mode() const {
   return kAutoAccess;
@@ -341,7 +328,7 @@ bool AutoCost::Allowed(const baldr::DirectedEdge* edge,
       (pred.restrictions() & (1 << edge->localedgeidx())) ||
        edge->surface() == Surface::kImpassable ||
        IsUserAvoidEdge(edgeid) ||
-      (disable_destination_only_ && !pred.destonly() && edge->destonly())) {
+      (!allow_destination_only_ && !pred.destonly() && edge->destonly())) {
     return false;
   }
   return true;
@@ -363,7 +350,7 @@ bool AutoCost::AllowedReverse(const baldr::DirectedEdge* edge,
        (opp_edge->restrictions() & (1 << pred.opp_local_idx())) ||
         opp_edge->surface() == Surface::kImpassable ||
         IsUserAvoidEdge(opp_edgeid) ||
-       (disable_destination_only_ && !pred.destonly() && opp_edge->destonly())) {
+       (!allow_destination_only_ && !pred.destonly() && opp_edge->destonly())) {
     return false;
   }
   return true;
@@ -716,7 +703,7 @@ bool BusCost::Allowed(const baldr::DirectedEdge* edge,
       (pred.restrictions() & (1 << edge->localedgeidx())) ||
        edge->surface() == Surface::kImpassable ||
        IsUserAvoidEdge(edgeid) ||
-      (disable_destination_only_ && !pred.destonly() && edge->destonly())) {
+      (!allow_destination_only_ && !pred.destonly() && edge->destonly())) {
     return false;
   }
   return true;
@@ -738,7 +725,7 @@ bool BusCost::AllowedReverse(const baldr::DirectedEdge* edge,
        (opp_edge->restrictions() & (1 << pred.opp_local_idx())) ||
         opp_edge->surface() == Surface::kImpassable ||
         IsUserAvoidEdge(opp_edgeid) ||
-       (disable_destination_only_ && !pred.destonly() && opp_edge->destonly())) {
+       (!allow_destination_only_ && !pred.destonly() && opp_edge->destonly())) {
     return false;
   }
   return true;

--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -395,7 +395,7 @@ Cost AutoCost::TransitionCost(const baldr::DirectedEdge* edge,
 
   // Additional penalties without any time cost
   uint32_t idx = pred.opp_local_idx();
-  if (!pred.destonly() && edge->destonly()) {
+  if (allow_destination_only_ && !pred.destonly() && edge->destonly()) {
     penalty += destination_only_penalty_;
   }
   if (pred.use() != Use::kAlley && edge->use() == Use::kAlley) {
@@ -457,7 +457,7 @@ Cost AutoCost::TransitionCostReverse(const uint32_t idx,
   }
 
   // Additional penalties without any time cost
-  if (!pred->destonly() && edge->destonly()) {
+  if (allow_destination_only_ && !pred->destonly() && edge->destonly()) {
     penalty += destination_only_penalty_;
   }
   if (pred->use() != Use::kAlley && edge->use() == Use::kAlley) {
@@ -873,7 +873,8 @@ bool HOVCost::Allowed(const baldr::DirectedEdge* edge,
       (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
       (pred.restrictions() & (1 << edge->localedgeidx())) ||
        edge->surface() == Surface::kImpassable ||
-       IsUserAvoidEdge(edgeid)) {
+       IsUserAvoidEdge(edgeid) ||
+       (!allow_destination_only_ && !pred.destonly() && edge->destonly())) {
     return false;
   }
   return true;
@@ -894,7 +895,8 @@ bool HOVCost::AllowedReverse(const baldr::DirectedEdge* edge,
        (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
        (opp_edge->restrictions() & (1 << pred.opp_local_idx())) ||
         opp_edge->surface() == Surface::kImpassable ||
-        IsUserAvoidEdge(opp_edgeid)) {
+        IsUserAvoidEdge(opp_edgeid) ||
+        (!allow_destination_only_ && !pred.destonly() && opp_edge->destonly())) {
     return false;
   }
   return true;

--- a/src/sif/dynamiccost.cc
+++ b/src/sif/dynamiccost.cc
@@ -58,7 +58,7 @@ namespace sif {
 DynamicCost::DynamicCost(const boost::property_tree::ptree& pt,
                          const TravelMode mode)
     : allow_transit_connections_(false),
-      disable_destination_only_(false),
+      allow_destination_only_(true),
       travel_mode_(mode) {
   // Parse property tree to get hierarchy limits
   // TODO - get the number of levels
@@ -164,9 +164,9 @@ void DynamicCost::SetAllowTransitConnections(const bool allow) {
   allow_transit_connections_ = allow;
 }
 
-// Set to allow use of transit connections.
-void DynamicCost::DisableDestinationOnly() {
-  disable_destination_only_ = true;
+// Sets the flag indicating whether destination only edges are allowed.
+void DynamicCost::set_allow_destination_only(const bool allow) {
+  allow_destination_only_ = allow;
 }
 
 // Returns the maximum transfer distance between stops that you are willing

--- a/src/sif/truckcost.cc
+++ b/src/sif/truckcost.cc
@@ -95,13 +95,6 @@ class TruckCost : public DynamicCost {
   virtual bool AllowMultiPass() const;
 
   /**
-   * Disables entrance into destination only areas. This should only be used
-   * for bidirectional path algorithms (and generally only for driving),
-   * otherwise a destination only penalty should be used.
-   */
-  virtual void DisableDestinationOnly();
-
-  /**
    * Get the access mode used by this costing method.
    * @return  Returns access mode.
    */
@@ -319,12 +312,6 @@ bool TruckCost::AllowMultiPass() const {
   return true;
 }
 
-// Set to disable destination only transitions.
-void TruckCost::DisableDestinationOnly() {
-  disable_destination_only_ = true;
-  destination_only_penalty_ = 0;
-}
-
 // Get the access mode used by this costing method.
 uint32_t TruckCost::access_mode() const {
   return kTruckAccess;
@@ -342,7 +329,7 @@ bool TruckCost::Allowed(const baldr::DirectedEdge* edge,
       (pred.restrictions() & (1 << edge->localedgeidx())) ||
        edge->surface() == Surface::kImpassable ||
        IsUserAvoidEdge(edgeid) ||
-      (disable_destination_only_ && !pred.destonly() && edge->destonly())) {
+      (!allow_destination_only_ && !pred.destonly() && edge->destonly())) {
     return false;
   }
 
@@ -401,7 +388,7 @@ bool TruckCost::AllowedReverse(const baldr::DirectedEdge* edge,
        (opp_edge->restrictions() & (1 << pred.opp_local_idx())) ||
        opp_edge->surface() == Surface::kImpassable ||
        IsUserAvoidEdge(opp_edgeid) ||
-      (disable_destination_only_ && !pred.destonly() && opp_edge->destonly())) {
+      (!allow_destination_only_ && !pred.destonly() && opp_edge->destonly())) {
     return false;
   }
 

--- a/src/sif/truckcost.cc
+++ b/src/sif/truckcost.cc
@@ -483,7 +483,7 @@ Cost TruckCost::TransitionCost(const baldr::DirectedEdge* edge,
 
   // Additional penalties without any time cost
   uint32_t idx = pred.opp_local_idx();
-  if (!pred.destonly() && edge->destonly()) {
+  if (allow_destination_only_ && !pred.destonly() && edge->destonly()) {
     penalty += destination_only_penalty_;
   }
   if (pred.use() != Use::kAlley && edge->use() == Use::kAlley) {
@@ -545,7 +545,7 @@ Cost TruckCost::TransitionCostReverse(const uint32_t idx,
   }
 
   // Additional penalties without any time cost
-  if (!pred->destonly() && edge->destonly()) {
+  if (allow_destination_only_ && !pred->destonly() && edge->destonly()) {
     penalty += destination_only_penalty_;
   }
   if (pred->use() != Use::kAlley && edge->use() == Use::kAlley) {

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -30,6 +30,7 @@ BidirectionalAStar::BidirectionalAStar(): PathAlgorithm() {
   mode_ = TravelMode::kDrive;
   access_mode_ = kAutoAccess;
   travel_type_ = 0;
+  cost_diff_ = 0.0f;
   adjacencylist_forward_ = nullptr;
   adjacencylist_reverse_ = nullptr;
   edgestatus_forward_ = nullptr;
@@ -335,10 +336,6 @@ std::vector<PathInfo> BidirectionalAStar::GetBestPath(PathLocation& origin,
   travel_type_ = costing_->travel_type();
   access_mode_ = costing_->access_mode();
 
-  // Disable destination only transitions (based on costing) since this
-  // algorithm is bidirectional.
-  costing_->DisableDestinationOnly();
-
   // Initialize - create adjacency list, edgestatus support, A*, etc.
   Init(origin.edges.front().projected, destination.edges.front().projected);
 
@@ -375,9 +372,9 @@ std::vector<PathInfo> BidirectionalAStar::GetBestPath(PathLocation& origin,
       forward_pred_idx = adjacencylist_forward_->pop();
       if (forward_pred_idx != kInvalidLabel) {
         // Check if the edge on the forward search connects to a
-        // reached edge on the reverse search tree.
+        // settled edge on the reverse search tree.
         pred = edgelabels_forward_[forward_pred_idx];
-        if (edgestatus_reverse_->Get(pred.opp_edgeid()).set() != EdgeSet::kUnreached) {
+        if (edgestatus_reverse_->Get(pred.opp_edgeid()).set() == EdgeSet::kPermanent) {
           SetForwardConnection(pred);
         }
       } else {
@@ -397,9 +394,9 @@ std::vector<PathInfo> BidirectionalAStar::GetBestPath(PathLocation& origin,
       reverse_pred_idx = adjacencylist_reverse_->pop();
       if (reverse_pred_idx != kInvalidLabel) {
         // Check if the edge on the reverse search connects to a
-        // reached edge on the forward search tree.
+        // settled edge on the forward search tree.
         pred2 = edgelabels_reverse_[reverse_pred_idx];
-        if (edgestatus_forward_->Get(pred2.opp_edgeid()).set() != EdgeSet::kUnreached) {
+        if (edgestatus_forward_->Get(pred2.opp_edgeid()).set() == EdgeSet::kPermanent) {
           SetReverseConnection(pred2);
         }
       } else {

--- a/src/thor/route_action.cc
+++ b/src/thor/route_action.cc
@@ -81,19 +81,25 @@ namespace valhalla {
 
   std::vector<thor::PathInfo> thor_worker_t::get_path(PathAlgorithm* path_algorithm, baldr::PathLocation& origin,
       baldr::PathLocation& destination) {
-    // Find the path.
+    // Find the path. If bidirectional A* disable use of destination only
+    // edges on the first pass. If there is a failure, we allow them on the
+    // second pass.
+    valhalla::sif::cost_ptr_t cost = mode_costing[static_cast<uint32_t>(mode)];
+    if (path_algorithm == &bidir_astar) {
+      cost->set_allow_destination_only(false);
+    }
     auto path = path_algorithm->GetBestPath(origin, destination, reader,
                                              mode_costing, mode);
     // If path is not found try again with relaxed limits (if allowed)
     if (path.empty()) {
-      valhalla::sif::cost_ptr_t cost = mode_costing[static_cast<uint32_t>(mode)];
       if (cost->AllowMultiPass()) {
-        // 2nd pass. Less aggressive hierarchy transitioning
+        // 2nd pass. Less aggressive hierarchy transitioning.
         path_algorithm->Clear();
         bool using_astar = (path_algorithm == &astar);
         float relax_factor = using_astar ? 16.0f : 8.0f;
         float expansion_within_factor = using_astar ? 4.0f : 2.0f;
         cost->RelaxHierarchyLimits(relax_factor, expansion_within_factor);
+        cost->set_allow_destination_only(true);
         path = path_algorithm->GetBestPath(origin, destination,
                                   reader, mode_costing, mode);
       }

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -246,11 +246,10 @@ class DynamicCost {
   virtual uint32_t UnitSize() const;
 
   /**
-   * Disables entrance into destination only areas. This should only be used
-   * for bidirectional path algorithms (and generally only for driving),
-   * otherwise a destination only penalty should be used.
+   * Sets the flag indicating whether destination only edges are allowed.
+   * Bidirectional path algorithms can (usually) disable access.
    */
-  virtual void DisableDestinationOnly();
+  virtual void set_allow_destination_only(const bool allow);
 
   /**
    * Set to allow use of transit connections.
@@ -357,8 +356,10 @@ class DynamicCost {
   // Flag indicating whether transit connections are allowed.
   bool allow_transit_connections_;
 
-  // Disable entrance onto destination only edges
-  bool disable_destination_only_;
+  // Allow entrance onto destination only edges. Bidirectional A* can (usually)
+  // disable access onto destination only edges for driving routes. Pedestrian
+  // and bicycle generally allow access (with small penalties).
+  bool allow_destination_only_;
 
   // Travel mode
   TravelMode travel_mode_;


### PR DESCRIPTION
Thanks to @smWork!

Add method: set_allow_destination_only (replaces DisableDestinationOnly). This allows enabling and disabling use of destination only edges. Change use within driving cost models to use the newly named variable.

For bidirectional A* set the flag allowing use of destination only edges to false on the 1st pass. If a failure occurs, the flag is set to true to allow use of destination only edges on the 2nd pass. This is to protect against "nested" regions marked as destination only.

Form connections between forward and reverse paths when the opposing edge is settled on the opposite search path. This is more valid and makes sure the transition costs are fully considered.