### PR TITLE
Missing segments

### DIFF
--- a/src/meili/traffic_segment_matcher.cc
+++ b/src/meili/traffic_segment_matcher.cc
@@ -50,8 +50,8 @@ namespace {
 
   //is this edge considered an internal type, an edge that can be ignored for the purposes of ots's
   bool is_internal(const valhalla::baldr::DirectedEdge* edge) {
-    //TODO:
-    return false;
+    return edge->trans_up() || edge->trans_down() || edge->roundabout() ||
+      edge->internal() || edge->use() == vb::Use::kTurnChannel;
   }
 
   struct merged_traffic_segment_t {

--- a/src/meili/traffic_segment_matcher.cc
+++ b/src/meili/traffic_segment_matcher.cc
@@ -59,7 +59,6 @@ namespace {
     std::vector<merged_traffic_segment_t> merged;
     const valhalla::baldr::GraphTile* tile = nullptr;
     valhalla::baldr::GraphId edge;
-    bool continuable = false;
     for(const auto& marker : markers) {
       //skip if its a repeat or we cant get the tile
       if(marker.edge == edge || !reader.GetGraphTile(marker.edge, tile))
@@ -67,10 +66,14 @@ namespace {
       //get segments for this edge
       edge = marker.edge;
       auto segments = tile->GetTrafficSegments(edge);
+      //if there were no segments we'll start an invalid one to serve
+      //as a placeholder for the section of the path that has no ots's
+      if(segments.empty())
+        segments = { valhalla::baldr::TrafficSegment{{}, marker.edge_distance, marker.edge_distance, true, true} };
       //merge them into single entries per segment id
       for(const auto& segment : segments) {
         //continue one
-        if(continuable && merged.back()->segment_id_ == segment.segment_id_){
+        if(!merged.empty() && merged.back()->segment_id_ == segment.segment_id_){
           merged.back().end_edge = edge;
           merged.back()->end_percent_ = segment.end_percent_;
           merged.back()->ends_segment_ = segment.ends_segment_;
@@ -78,8 +81,6 @@ namespace {
         else
           merged.emplace_back(merged_traffic_segment_t{segment, edge, edge});
       }
-      //if we just handled some segments we could continue them
-      continuable = !segments.empty();
     }
     return merged;
   }
@@ -354,16 +355,17 @@ std::vector<meili::Measurement> TrafficSegmentMatcher::parse_measurements(const 
 std::string TrafficSegmentMatcher::serialize(const std::vector<traffic_segment_t>& traffic_segments) {
   auto segments = baldr::json::array({});
   for (const auto& seg : traffic_segments) {
-    segments->emplace_back(baldr::json::map
-      ({
-        {"segment_id", seg.segment_id.value},
-        {"start_time", baldr::json::fp_t{seg.start_time, 3}},
-        {"end_time", baldr::json::fp_t{seg.end_time, 3}},
-        {"length", static_cast<int64_t>(seg.length)},
-        {"begin_shape_index", static_cast<uint64_t>(seg.begin_shape_index)},
-        {"end_shape_index", static_cast<uint64_t>(seg.end_shape_index)},
-      })
-    );
+    auto segment = baldr::json::map({
+      {"start_time", baldr::json::fp_t{seg.start_time, 3}},
+      {"end_time", baldr::json::fp_t{seg.end_time, 3}},
+      {"length", static_cast<int64_t>(seg.length)},
+      {"begin_shape_index", static_cast<uint64_t>(seg.begin_shape_index)},
+      {"end_shape_index", static_cast<uint64_t>(seg.end_shape_index)},
+    });
+    //some of the segments are just sections of the path with no ots's
+    if(seg.segment_id.Is_Valid())
+      segment->emplace("segment_id", seg.segment_id.value);
+    segments->emplace_back(segment);
   }
   std::stringstream ss;
   ss << *baldr::json::map({{"segments",segments}});

--- a/test/traffic_matcher.cc
+++ b/test/traffic_matcher.cc
@@ -94,12 +94,19 @@ namespace {
       boost::property_tree::read_json(json_ss, answer);
 
       const auto& a_segs = test_case.second;
-      const auto& b_segs = matcher.segments;
+      auto& b_segs = matcher.segments;
+
+      //TODO: for portions of routes with no ots coverage add matching fake segments
+      //for now we just remove the fake ones from the result
+      auto seg_itr = std::remove_if(b_segs.begin(), b_segs.end(),
+        [](const meili::traffic_segment_t& ots){ return !ots.segment_id.Is_Valid(); });
+      b_segs.erase(seg_itr, b_segs.end());
+
       if(a_segs.size() != b_segs.size())
         throw std::logic_error("wrong number of segments matched");
-      for(size_t i = 0; i < test_case.second.size(); ++i) {
-        const auto& a = test_case.second[i];
-        const auto& b = matcher.segments[i];
+      for(size_t i = 0; i < a_segs.size(); ++i) {
+        const auto& a = a_segs[i];
+        const auto& b = b_segs[i];
         if(a.begin_shape_index != b.begin_shape_index)
           throw std::logic_error("begin_shape_index mismatch");
         if(a.end_shape_index != b.end_shape_index)

--- a/valhalla/meili/traffic_segment_matcher.h
+++ b/valhalla/meili/traffic_segment_matcher.h
@@ -34,6 +34,7 @@ struct traffic_segment_t {
   double end_time;             // End time along this segment, if < 0 then no end match
   size_t end_shape_index;      // Ends at this index of original input
   int length;                  // Length in meters along this segment, if < 0 then no match
+  bool internal;               // Is the set of edges making up this segment internal edge types
 };
 
 /**


### PR DESCRIPTION
this will add segments for the portions of the matched traces that dont have ots/osmlr coverage. segments returned for those sections will have everything that a real ots has except for the segment_id. additionally there is a boolean returned denoting whether the edges comprising the segment were `internal` or not. we'll need to update the `is_internal` method to correctly identify such edges in the same way that we do when generating the ots's in osmlr

fixes opentraffic/reporter#42