### PR TITLE
Edge merge updates to allow local level

### DIFF
--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -494,12 +494,7 @@ std::pair<GraphId, GraphId> GraphReader::GetDirectedEdgeNodes(const GraphTile* t
   const GraphTile* t2 = (edge->leaves_tile()) ? GetGraphTile(end_node) : tile;
   if (t2 != nullptr) {
     auto edge_idx = t2->node(end_node)->edge_index() + edge->opp_index();
-
-    // TODO - this check is needed for older data where invalid opposing edge
-    // offsets could (rarely) be assigned.
-    if (edge_idx < t2->header()->directededgecount()) {
-      start_node = t2->directededge(edge_idx)->endnode();
-    }
+    start_node = t2->directededge(edge_idx)->endnode();
   }
   return std::make_pair(start_node, end_node);
 }

--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -486,6 +486,23 @@ uint32_t GraphReader::GetEdgeDensity(const GraphId& edgeid) {
   return (tile != nullptr) ? tile->node(id)->density() : 0;
 }
 
+// Get the end nodes of a directed edge.
+std::pair<GraphId, GraphId> GraphReader::GetDirectedEdgeNodes(const GraphTile* tile,
+                     const DirectedEdge* edge) {
+  GraphId end_node = edge->endnode();
+  GraphId start_node;
+  const GraphTile* t2 = (edge->leaves_tile()) ? GetGraphTile(end_node) : tile;
+  if (t2 != nullptr) {
+    auto edge_idx = t2->node(end_node)->edge_index() + edge->opp_index();
+
+    // TODO - this check is needed for older data where invalid opposing edge
+    // offsets could (rarely) be assigned.
+    if (edge_idx < t2->header()->directededgecount()) {
+      start_node = t2->directededge(edge_idx)->endnode();
+    }
+  }
+  return std::make_pair(start_node, end_node);
+}
 
 std::unordered_set<GraphId> GraphReader::GetTileSet() const {
   //either mmap'd tiles

--- a/src/baldr/merge.cc
+++ b/src/baldr/merge.cc
@@ -230,21 +230,6 @@ void edge_collapser::explore(GraphId prev, GraphId cur, path &forward, path &rev
   } while (maybe_next);
 }
 
-// utility function to make a path out of a single edge. this is called once all
-// the collapsible paths have been found and single edges are all that's left.
-path make_single_edge_path(GraphReader &reader, GraphId edge_id) {
-  auto *edge = reader.GetGraphTile(edge_id)->directededge(edge_id);
-  auto node_id = edge->endnode();
-  auto opp_edge_idx = edge->opp_index();
-  auto edge_idx = reader.GetGraphTile(node_id)->node(node_id)->edge_index() + opp_edge_idx;
-  GraphId opp_edge_id(node_id.tileid(), node_id.level(), edge_idx);
-  auto *opp_edge = reader.GetGraphTile(opp_edge_id)->directededge(opp_edge_id);
-  auto start_node_id = opp_edge->endnode();
-
-  path p(segment(start_node_id, edge_id, node_id));
-  return p;
-}
-
 } // namespace detail
 
 segment::segment(GraphId start, GraphId edge, GraphId end)

--- a/valhalla/baldr/graphreader.h
+++ b/valhalla/baldr/graphreader.h
@@ -298,6 +298,18 @@ class GraphReader {
   uint32_t GetEdgeDensity(const GraphId& edgeid);
 
   /**
+   * Get the end nodes of a directed edge.
+   * @param  tile  Tile of the directed edge (tile of the start node).
+   * @param  edge  Directed edge.
+   * @return Returns a pair of GraphIds: the first is the start node
+   *         and the second is the end node. An invalid start node
+   *         can occur in regional extracts (where the end node tile
+   *         is not available).
+   */
+  std::pair<GraphId, GraphId> GetDirectedEdgeNodes(const GraphTile* tile,
+                       const DirectedEdge* edge);
+
+  /**
    * Gets back a set of available tiles
    * @return  returns the list of available tiles
    */

--- a/valhalla/baldr/merge.h
+++ b/valhalla/baldr/merge.h
@@ -55,8 +55,6 @@ private:
   std::function<void(const path &)> m_func;
 };
 
-path make_single_edge_path(GraphReader &reader, GraphId edge_id);
-
 } // namespace detail
 
 /**
@@ -90,6 +88,11 @@ void merge(TileSet &tiles, GraphReader &reader,
     for (uint32_t i = 0; i < node_count; ++i, ++node_id) {
       e.explore(node_id);
     }
+
+    // Clear cache if over committed
+    if (reader.OverCommitted()) {
+      reader.Clear();
+    }
   }
 
   // Iterate over tiles. Handle single edges that remain.
@@ -99,9 +102,23 @@ void merge(TileSet &tiles, GraphReader &reader,
     GraphId edge_id(tile_id.tileid(), tile_id.level(), 0);
     for (uint32_t i = 0; i < num_edges; ++i, ++edge_id) {
       if (!tracker.get(edge_id)) {
-        auto p = detail::make_single_edge_path(reader, edge_id);
-        func(p);
+        // Store single edge paths if the edge is allowed.
+        auto* edge = tile->directededge(edge_id);
+        if (edge_allowed_pred(edge)) {
+          // Store the single edge path if the start node is valid. It can be
+          // invalid if the end node tile is null (as in a regional extract)
+          auto end_nodes = reader.GetDirectedEdgeNodes(tile, edge);
+          path p(segment(end_nodes.first, edge_id, end_nodes.second));
+          if (p.m_start.Is_Valid()) {
+            func(p);
+          }
+        }
       }
+    }
+
+    // Clear cache if over committed
+    if (reader.OverCommitted()) {
+      reader.Clear();
     }
   }
 }


### PR DESCRIPTION
Add convenience method to get the end nodes of a directed edge. Returns them as a pair: start node first then end node.

Update handling of single edge paths to check if the edge is allowed and also to use the new GetDirectedEdgeNodes method to simplify.

Clear GraphReader cache if overcommitted.