### PR TITLE
Updates to fix GraphTileBuilder::UpdateTrafficSegments

### DIFF
--- a/src/loki/node_search.cc
+++ b/src/loki/node_search.cc
@@ -1,5 +1,6 @@
 #include <cmath>
 #include "loki/node_search.h"
+#include "midgard/logging.h"
 #include "midgard/tiles.h"
 #include "baldr/tilehierarchy.h"
 
@@ -262,11 +263,15 @@ struct node_collector {
       // node is in this tile, so add it to the collection
       m_nodes.push_back(node_id, node);
 
-      assert(opp_index < node.edge_count());
-      // add the node at the other end of the opposite - which would be the
-      // start node of the original edge.
-      auto opp_id = tile_id + uint64_t(node.edge_index() + opp_index);
-      add_node(m_cache.edge(opp_id).endnode());
+      if (opp_index < node.edge_count()) {
+        //assert(opp_index < node.edge_count());
+        // add the node at the other end of the opposite - which would be the
+        // start node of the original edge.
+        auto opp_id = tile_id + uint64_t(node.edge_index() + opp_index);
+        add_node(m_cache.edge(opp_id).endnode());
+      } else {
+        LOG_ERROR("Opposing index >= node edge count!");
+      }
     }
     // the node is not in this tile, so we cannot look up its position or edge
     // offset yet. save the (node, index) pair for later.

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -961,9 +961,17 @@ void GraphTileBuilder::AddTrafficSegments(const baldr::GraphId& edgeid,
 }
 
 /**
- * Updates a tile with traffic segment and chunk data.
+ * Updates a tile with traffic segment and chunk data. UpdateTrafficSegments
+ * is called 3 times - first to add segments within the tile, then to add any
+ * "leftover" segments for OSMLR segments that cross tiles, and then to add
+ * "chunks". Need to make sure the "shift" for offsets to data after the
+ * traffic information are only increased by the amount of "new" segments.
  */
 void GraphTileBuilder::UpdateTrafficSegments() {
+  // Get the number of new segments added with this call.
+  uint32_t new_segments = traffic_segment_builder_.size() -
+                          header_->traffic_id_count();
+
   // Update header to include the traffic segment count and update the
   // offset to chunks (based on size of traffic segments).
   // Padding should already be done so we start traffic info on an 8-byte boundary
@@ -972,7 +980,7 @@ void GraphTileBuilder::UpdateTrafficSegments() {
           traffic_segment_builder_.size() * sizeof(TrafficAssociation));
 
   // Shift offsets to anything that comes after traffic
-  uint32_t shift = traffic_segment_builder_.size() * sizeof(TrafficAssociation) +
+  uint32_t shift = new_segments * sizeof(TrafficAssociation) +
                    traffic_chunk_builder_.size() * sizeof(TrafficChunk);
   header_builder_.set_lane_connectivity_offset(header_builder_.lane_connectivity_offset() + shift);
   header_builder_.set_edge_elevation_offset(header_builder_.edge_elevation_offset() + shift);
@@ -993,9 +1001,9 @@ void GraphTileBuilder::UpdateTrafficSegments() {
     // Write a new header
     file.write(reinterpret_cast<const char*>(&header_builder_), sizeof(GraphTileHeader));
 
-    // Copy the rest of the tile contents
-    const auto* begin = reinterpret_cast<const char*>(nodes_);
-    file.write(begin, header_->traffic_segmentid_offset() - sizeof(GraphTileHeader));
+    // Copy the tile contents from nodes to the beginning of traffic segments
+    file.write(reinterpret_cast<const char*>(nodes_),
+               header_->traffic_segmentid_offset() - sizeof(GraphTileHeader));
 
     // Append the traffic segment list
     file.write(reinterpret_cast<const char*>(&traffic_segment_builder_[0]),
@@ -1007,8 +1015,10 @@ void GraphTileBuilder::UpdateTrafficSegments() {
 
     // Write rest of the stuff after traffic chunks (includes lane connectivity
     // and edge elevation...so far).
-    begin = reinterpret_cast<const char*>(header_ + header_->lane_connectivity_offset());
-    const auto* end = reinterpret_cast<const char*>(header_ + header_->end_offset());
+    const auto* begin = reinterpret_cast<const char*>(header_) +
+                header_->lane_connectivity_offset();
+    const auto* end = reinterpret_cast<const char*>(header_) +
+                header_->end_offset();
     file.write(begin, end - begin);
 
     // Close the file

--- a/src/valhalla_associate_segments.cc
+++ b/src/valhalla_associate_segments.cc
@@ -50,7 +50,7 @@ std::string to_string(const vm::PointLL &p) {
 
 std::string to_string(const vb::GraphId &i) {
   std::ostringstream out;
-  out << "GraphId(" << i.tileid() << ", " << i.level() << ", " << i.id() << ")";
+  out << "OSMLR GraphId(" << i.tileid() << ", " << i.level() << ", " << i.id() << ")";
   return out.str();
 }
 } // namespace std
@@ -187,7 +187,6 @@ private:
   std::shared_ptr<vt::PathAlgorithm> m_path_algo;
   std::shared_ptr<vs::DynamicCost> m_costing;
   std::shared_ptr<vj::GraphTileBuilder> m_tile_builder;
-  const vb::GraphTile* m_tile;
 
   // Statistics
   uint32_t success_count_;
@@ -207,9 +206,9 @@ private:
 // segments.
 bool allow_edge_pred(const vb::DirectedEdge *edge) {
   return (!edge->trans_up() && !edge->trans_down() && !edge->is_shortcut() &&
-           edge->use() != vb::Use::kTransitConnection &&
-           edge->use() != vb::Use::kTurnChannel && !edge->internal() &&
-           edge->use() != vb::Use::kFerry && !edge->roundabout() &&
+           edge->classification() != vb::RoadClass::kServiceOther &&
+          (edge->use() == vb::Use::kRoad || edge->use() == vb::Use::kRamp) &&
+          !edge->roundabout() && !edge->internal() &&
           (edge->forwardaccess() & vb::kVehicularAccess) != 0);
 }
 
@@ -383,9 +382,11 @@ private:
   const vb::GraphTile *m_last_tile;
 };
 
-// Find nodes within a specified distance of lat,lon location
+// Find nodes on the specified level that are within a specified distance
+// from the lat,lon location
 std::vector<vb::GraphId> find_nearby_nodes(vb::GraphReader& reader,
-                              const float dist, const vm::PointLL& pt) {
+                              const float dist, const vm::PointLL& pt,
+                              const uint8_t level) {
   // Create a bounding box
   float meters_per_lng = vm::DistanceApproximator::MetersPerLngDegree(pt.lat());
   float delta_lng = kNodeDistanceTolerance / meters_per_lng;
@@ -394,14 +395,14 @@ std::vector<vb::GraphId> find_nearby_nodes(vb::GraphReader& reader,
                               {pt.lng() + delta_lng, pt.lat() + delta_lat});
   auto nodes = vl::nodes_in_bbox(bbox, reader);
 
-  // Remove nodes on the local level (TODO-make this configurable?)
-  std::vector<vb::GraphId> non_local_nodes;
+  // Remove nodes that are not on the specified level
+  std::vector<vb::GraphId> level_nodes;
   for (const auto node : nodes) {
-    if (node.level() < 2) {
-      non_local_nodes.emplace_back(node);
+    if (node.level() == level) {
+      level_nodes.emplace_back(node);
     }
   }
-  return non_local_nodes;
+  return level_nodes;
 }
 
 // Add edges from each node
@@ -419,12 +420,11 @@ std::vector<CandidateEdge> GetEdgesFromNodes(vb::GraphReader& reader,
     GraphId edgeid(node.tileid(), node.level(), nodeinfo->edge_index());
     const DirectedEdge* directededge = tile->directededge(nodeinfo->edge_index());
     for (uint32_t i = 0; i < nodeinfo->edge_count(); i++, directededge++, ++edgeid) {
-      // Skip non-regular edges
+      // Skip non-regular edges - must be a road or ramp
       if (directededge->trans_up() || directededge->trans_down() ||
           directededge->is_shortcut() || directededge->roundabout() ||
-          directededge->use() == vb::Use::kTransitConnection ||
-          directededge->use() == vb::Use::kTurnChannel ||
-          directededge->internal() || directededge->use() == vb::Use::kFerry) {
+         (directededge->use() != vb::Use::kRoad && directededge->use() != vb::Use::kRamp) ||
+          directededge->internal()) {
         continue;
       }
 
@@ -487,8 +487,7 @@ edge_association::edge_association(const bpt::ptree &pt)
     m_reader(pt.get_child("mjolnir")),
     m_travel_mode(vs::TravelMode::kDrive),
     m_path_algo(new vt::AStarPathAlgorithm()),
-    m_costing(new DistanceOnlyCost(m_travel_mode)),
-    m_tile(nullptr) {
+    m_costing(new DistanceOnlyCost(m_travel_mode)) {
 }
 
 // Get a list of candidate edges for the location.
@@ -499,7 +498,7 @@ std::vector<CandidateEdge> edge_association::candidate_edges(bool origin,
   std::vector<CandidateEdge> edges;
   if (lrp.at_node()) {
     // Find nearby nodes and get allowed edges
-    auto nodes = find_nearby_nodes(m_reader, kNodeDistanceTolerance, ll);
+    auto nodes = find_nearby_nodes(m_reader, kNodeDistanceTolerance, ll, level);
     edges = GetEdgesFromNodes(m_reader, nodes, ll, origin);
   } else {
     // Use edge search with loki
@@ -816,7 +815,7 @@ bool edge_association::match_segment(vb::GraphId segment_id, const pbf::Segment 
   return true;
 }
 
-void edge_association::add_tile(const std::string &file_name) {
+void edge_association::add_tile(const std::string& file_name) {
   //read the osmlr tile
   pbf::Tile tile;
   {
@@ -831,7 +830,6 @@ void edge_association::add_tile(const std::string &file_name) {
   m_tile_builder.reset(new vj::GraphTileBuilder(m_reader.tile_dir(),
                        base_id, false));
   m_tile_builder->InitializeTrafficSegments();
-  m_tile = m_reader.GetGraphTile(base_id);
 
   //do the matching of the segments in this osmlr tile
   std::cout.precision(16);
@@ -855,9 +853,9 @@ void edge_association::add_tile(const std::string &file_name) {
     entry_id += 1;
   }
 
-  //finish this tile
-  m_reader.Clear();
+  // Finish this tile
   m_tile_builder->UpdateTrafficSegments();
+  m_reader.Clear();
 }
 
 // Add OSMLR segment associations to each tile in the list. Any "local"


### PR DESCRIPTION
Fixes for data that follows traffic associations. The begin and end pointers were incorrect (casting should have just been the header_ pointer!). Update to only shift by the number of new traffic segments
(which should be 0) rather than by the size of the builder list. Prior to this fix it was shifting again by the full size each time UpdateTrafficSegments was called. Update valhalla_associate_segments to allow local level.

Successfully associated to the entire planet at levels 0, 1, 2 (skipping non-driveable roads and service roads).

Tested that elevation data is now properly read on the updated planet data.