### PR TITLE
Adjust tile bounds so isochrones remain centered

### DIFF
--- a/src/midgard/gridded_data.cc
+++ b/src/midgard/gridded_data.cc
@@ -294,6 +294,13 @@ typename GriddedData<coord_t>::contours_t GriddedData<coord_t>::GenerateContours
     } // Each tile col
   } // Each tile row
 
+  // If the generalization value equals kOptimalGeneralization then set
+  // the generalization factor to 1/4 of the grid size
+  float gen_factor = generalize;
+  if (generalize == kOptimalGeneralization) {
+    gen_factor = this->tilesize_ * 0.25f * kMetersPerDegreeLat;
+  }
+
   //some info about the area the image covers
   auto c = this->TileBounds().Center();
   auto h = this->tilesize_ / 2;
@@ -313,8 +320,8 @@ typename GriddedData<coord_t>::contours_t GriddedData<coord_t>::GenerateContours
     //clean up the lines
     for(auto& line : contour) {
       //TODO: generalizing makes self intersections which makes other libraries unhappy
-      if(generalize > 0.f)
-        Polyline2<coord_t>::Generalize(line, generalize);
+      if(gen_factor > 0.f)
+        Polyline2<coord_t>::Generalize(line, gen_factor);
       //if this ends up as an inner we'll undo this later
       if(cache[&line] > 0)
         line.reverse();

--- a/src/midgard/gridded_data.cc
+++ b/src/midgard/gridded_data.cc
@@ -298,7 +298,7 @@ typename GriddedData<coord_t>::contours_t GriddedData<coord_t>::GenerateContours
   // the generalization factor to 1/4 of the grid size
   float gen_factor = generalize;
   if (generalize == kOptimalGeneralization) {
-    gen_factor = this->tilesize_ * 0.25f * kMetersPerDegreeLat;
+    gen_factor = this->tilesize_ * 0.125f * kMetersPerDegreeLat;
   }
 
   //some info about the area the image covers

--- a/src/midgard/tiles.cc
+++ b/src/midgard/tiles.cc
@@ -162,6 +162,15 @@ AABB2<coord_t> Tiles<coord_t>::TileBounds() const {
   return tilebounds_;
 }
 
+// Shift the tilebounds
+template <class coord_t>
+void Tiles<coord_t>::ShiftTileBounds(const coord_t& shift) {
+  tilebounds_ = AABB2<coord_t>(tilebounds_.minx() - shift.first,
+                               tilebounds_.miny() - shift.second,
+                               tilebounds_.maxx() - shift.first,
+                               tilebounds_.maxy() - shift.second);
+}
+
 // Get the number of rows in the tiling system.
 template <class coord_t>
 int32_t Tiles<coord_t>::nrows() const {

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -264,7 +264,7 @@ void BidirectionalAStar::ExpandReverse(GraphReader& graphreader,
       continue;
     }
 
-    // Get end node tile, opposing edge Id, and opposing diredted edge.
+    // Get end node tile, opposing edge Id, and opposing directed edge.
     const GraphTile* t2 = directededge->leaves_tile() ?
         graphreader.GetGraphTile(directededge->endnode()) : tile;
     if (t2 == nullptr) {

--- a/src/thor/isochrone.cc
+++ b/src/thor/isochrone.cc
@@ -35,8 +35,6 @@ uint32_t GetOperatorId(const GraphTile* tile, uint32_t routeid,
   return 0;
 }
 
-constexpr float to_minutes = 1.0f / 60.0f;
-
 }
 
 namespace valhalla {
@@ -86,15 +84,26 @@ void Isochrone::ConstructIsoTile(const bool multimodal, const unsigned int max_m
     max_distance = max_seconds * 70.0f * kMPHtoMetersPerSec;
   }
 
-  // Set a fixed grid size (in degrees) - about 220m in latitude
-  float grid_size = 0.002f;
+  // Range of grids in latitude space
+  float dlat = max_distance / kMetersPerDegreeLat;
+
+  // Optimize for 500 cells in latitude - round off to nearest 0.001 degree
+  float grid_size = dlat / 250.0f;
+  if (grid_size < 0.001f) {
+    grid_size = 0.001f;
+  } else if (grid_size > 0.005f) {
+    grid_size = 0.005f;
+  } else {
+    // Round to nearest 0.001
+    int r = std::round(grid_size * 1000.0f);
+    grid_size = static_cast<float>(r) * 0.001f;
+  }
 
   // Set the shape interval in meters
   shape_interval_ = grid_size * kMetersPerDegreeLat * 0.25f;
 
   // Form grid for isotiles.
   PointLL center_ll = origin_locations[0].latlng_;
-  float dlat = max_distance / kMetersPerDegreeLat;
   float dlon = max_distance / DistanceApproximator::MetersPerLngDegree(center_ll.lat());
 
   // Adjust bounds to surround all locations
@@ -141,6 +150,92 @@ void Isochrone::Initialize(const uint32_t bucketsize) {
   edgestatus_.reset(new EdgeStatus());
 }
 
+// Expand from a node in the forward direction
+void Isochrone::ExpandForward(GraphReader& graphreader, const GraphId& node,
+                    const EdgeLabel& pred, const uint32_t pred_idx,
+                    const bool from_transition) {
+  // Get the tile and the node info. Skip if tile is null (can happen
+  // with regional data sets) or if no access at the node.
+  const GraphTile* tile = graphreader.GetGraphTile(node);
+  if (tile == nullptr) {
+    return;
+  }
+
+  // Get the nodeinfo and update the isotile
+  const NodeInfo* nodeinfo = tile->node(node);
+  if (!from_transition) {
+    UpdateIsoTile(pred, graphreader, nodeinfo->latlng());
+  }
+  if (!costing_->Allowed(nodeinfo)) {
+    return;
+  }
+
+  // Expand from end node in forward direction.
+  GraphId edgeid = { node.tileid(), node.level(), nodeinfo->edge_index() };
+  const DirectedEdge* directededge = tile->directededge(edgeid);
+  for (uint32_t i = 0; i < nodeinfo->edge_count(); ++i, ++directededge, ++edgeid) {
+    // Handle transition edges - expand from the end node of the transition
+    // (unless this is called from a transition).
+    if (directededge->trans_up()) {
+      if (!from_transition) {
+        ExpandForward(graphreader, directededge->endnode(), pred, pred_idx, true);
+      }
+      continue;
+    }
+    if (directededge->trans_down()) {
+      if (!from_transition) {
+        ExpandForward(graphreader, directededge->endnode(), pred, pred_idx, true);
+      }
+      continue;
+    }
+
+    // Quick check to skip if no access for this mode. Also, skip shortcuts.
+    if (directededge->is_shortcut() ||
+      !(directededge->forwardaccess() & access_mode_)) {
+      continue;
+    }
+
+    // Get the current set. Skip this edge if permanently labeled (best
+    // path already found to this directed edge).
+    EdgeStatusInfo edgestatus = edgestatus_->Get(edgeid);
+    if (edgestatus.set() == EdgeSet::kPermanent) {
+      continue;
+    }
+
+    // Skip if no access is allowed to this edge (based on the costing
+    // method) or if a complex restriction exists for this path.
+    if (!costing_->Allowed(directededge, pred, tile, edgeid) ||
+         costing_->Restricted(directededge, pred, edgelabels_, tile,
+                             edgeid, true)) {
+      continue;
+    }
+
+    // Compute the cost to the end of this edge
+    Cost newcost = pred.cost() + costing_->EdgeCost(directededge) +
+         costing_->TransitionCost(directededge, nodeinfo, pred);
+
+    // Check if edge is temporarily labeled and this path has less cost. If
+    // less cost the predecessor is updated and the sort cost is decremented
+    // by the difference in real cost (A* heuristic doesn't change)
+    if (edgestatus.set() == EdgeSet::kTemporary) {
+      EdgeLabel& lab = edgelabels_[edgestatus.index()];
+      if (newcost.cost <  lab.cost().cost) {
+        float newsortcost = lab.sortcost() - (lab.cost().cost - newcost.cost);
+        adjacencylist_->decrease(edgestatus.index(), newsortcost);
+        lab.Update(pred_idx, newcost, newsortcost);
+      }
+      continue;
+    }
+
+    // Add edge label, add to the adjacency list and set edge status
+    uint32_t idx = edgelabels_.size();
+    adjacencylist_->add(idx, newcost.cost);
+    edgestatus_->Set(edgeid, EdgeSet::kTemporary, idx);
+    edgelabels_.emplace_back(pred_idx, edgeid, directededge,
+                             newcost, newcost.cost, 0.0f, mode_, 0);
+  }
+}
+
 // Compute iso-tile that we can use to generate isochrones.
 std::shared_ptr<const GriddedData<PointLL> > Isochrone::Compute(
              std::vector<PathLocation>& origin_locations,
@@ -150,15 +245,15 @@ std::shared_ptr<const GriddedData<PointLL> > Isochrone::Compute(
              const TravelMode mode) {
   // Set the mode and costing
   mode_ = mode;
-  const auto& costing = mode_costing[static_cast<uint32_t>(mode_)];
+  costing_ = mode_costing[static_cast<uint32_t>(mode_)];
 
   // Initialize and create the isotile
   auto max_seconds = max_minutes * 60;
-  Initialize(costing->UnitSize());
+  Initialize(costing_->UnitSize());
   ConstructIsoTile(false, max_minutes, origin_locations);
 
   // Set the origin locations
-  SetOriginLocations(graphreader, origin_locations, costing);
+  SetOriginLocations(graphreader, origin_locations, costing_);
 
   // Compute the isotile
   uint32_t n = 0;
@@ -175,89 +270,117 @@ std::shared_ptr<const GriddedData<PointLL> > Isochrone::Compute(
     EdgeLabel pred = edgelabels_[predindex];
     edgestatus_->Update(pred.edgeid(), EdgeSet::kPermanent);
 
-    // Get the end node of the prior directed edge. Skip if tile not found
-    // (can happen with regional data sets).
-    GraphId node = pred.endnode();
-    if ((tile = graphreader.GetGraphTile(node)) == nullptr) {
-      continue;
-    }
-
-    // Get the nodeinfo and update the isotile
-    const NodeInfo* nodeinfo = tile->node(node);
-    UpdateIsoTile(pred, graphreader, nodeinfo->latlng());
+    // Expand from the end node in forward direction.
+    ExpandForward(graphreader, pred.endnode(), pred, predindex, false);
     n++;
 
     // Return after the time interval has been met
-    if (pred.cost().secs > max_seconds) {
+    if (pred.cost().secs > max_seconds || pred.cost().cost > max_seconds * 4) {
       LOG_DEBUG("Exceed time interval: n = " + std::to_string(n));
       return isotile_;
     }
+  }
+  return isotile_;      // Should never get here
+}
 
-    // Check access at the node
-    if (!costing->Allowed(nodeinfo)) {
+// Expand from a node in reverse direction.
+void Isochrone::ExpandReverse(GraphReader& graphreader,
+         const GraphId& node, const EdgeLabel& pred, const uint32_t pred_idx,
+         const DirectedEdge* opp_pred_edge, const bool from_transition) {
+  // Get the tile and the node info. Skip if tile is null (can happen
+  // with regional data sets) or if no access at the node.
+  const GraphTile* tile = graphreader.GetGraphTile(node);
+  if (tile == nullptr) {
+    return;
+  }
+
+  // Get the nodeinfo and update the isotile
+  const NodeInfo* nodeinfo = tile->node(node);
+  if (!from_transition) {
+    UpdateIsoTile(pred, graphreader, nodeinfo->latlng());
+  }
+  if (!costing_->Allowed(nodeinfo)) {
+    return;
+  }
+
+  // Expand from end node in reverse direction.
+  GraphId edgeid = { node.tileid(), node.level(), nodeinfo->edge_index() };
+  const DirectedEdge* directededge = tile->directededge(edgeid);
+  for (uint32_t i = 0; i < nodeinfo->edge_count(); ++i, ++directededge, ++edgeid) {
+    // Handle transition edges - expand from the end not of the transition
+    // unless this is called from a transition.
+    if (directededge->trans_up()) {
+      if (!from_transition) {
+        ExpandReverse(graphreader, directededge->endnode(), pred, pred_idx,
+                      opp_pred_edge, true);
+      }
+      continue;
+    } else if (directededge->trans_down()) {
+      if (!from_transition) {
+        ExpandReverse(graphreader, directededge->endnode(), pred, pred_idx,
+                      opp_pred_edge, true);
+      }
       continue;
     }
 
-    // Expand from end node.
-    GraphId edgeid(node.tileid(), node.level(), nodeinfo->edge_index());
-    const DirectedEdge* directededge = tile->directededge(nodeinfo->edge_index());
-    for (uint32_t i = 0; i < nodeinfo->edge_count(); i++, directededge++, ++edgeid) {
-      // Skip shortcut edges
-      if (directededge->is_shortcut()) {
-        continue;
-      }
-
-      // Get the current set. Skip this edge if permanently labeled (best
-      // path already found to this directed edge).
-      EdgeStatusInfo edgestatus = edgestatus_->Get(edgeid);
-      if (edgestatus.set() == EdgeSet::kPermanent) {
-        continue;
-      }
-
-      // Handle transition edges - add to adjacency set
-      // TODO - perhaps create ExpandForward method like in bidir A*
-      if (directededge->trans_up() || directededge->trans_down()) {
-        uint32_t idx = edgelabels_.size();
-        adjacencylist_->add(idx, pred.sortcost());
-        edgestatus_->Set(edgeid, EdgeSet::kTemporary, idx);
-        edgelabels_.emplace_back(predindex, edgeid, directededge->endnode(), pred);
-        continue;
-      }
-
-      // Skip if no access is allowed to this edge (based on the costing
-      // method) or if a complex restriction exists for this path.
-      if (!costing->Allowed(directededge, pred, tile, edgeid) ||
-           costing->Restricted(directededge, pred, edgelabels_, tile,
-                               edgeid, true)) {
-        continue;
-      }
-
-      // Compute the cost to the end of this edge
-      Cost newcost = pred.cost() + costing->EdgeCost(directededge) +
-			     costing->TransitionCost(directededge, nodeinfo, pred);
-
-      // Check if edge is temporarily labeled and this path has less cost. If
-      // less cost the predecessor is updated and the sort cost is decremented
-      // by the difference in real cost (A* heuristic doesn't change)
-      if (edgestatus.set() == EdgeSet::kTemporary) {
-        EdgeLabel& lab = edgelabels_[edgestatus.index()];
-        if (newcost.cost <  lab.cost().cost) {
-          float newsortcost = lab.sortcost() - (lab.cost().cost - newcost.cost);
-          adjacencylist_->decrease(edgestatus.index(), newsortcost);
-          lab.Update(predindex, newcost, newsortcost);
-        }
-        continue;
-      }
-
-      // Add to the adjacency list and edge labels.
-      uint32_t idx = edgelabels_.size();
-      adjacencylist_->add(idx, newcost.cost);
-      edgestatus_->Set(edgeid, EdgeSet::kTemporary, idx);
-      edgelabels_.emplace_back(predindex, edgeid, directededge,
-                    newcost, newcost.cost, 0.0f, mode_, 0);
+    // Quick check to skip if no access for this mode or if edge is
+    // a shortcut
+    if (!(directededge->reverseaccess() & access_mode_) ||
+         directededge->is_shortcut()) {
+      continue;
     }
+
+    // Get the current set. Skip this edge if permanently labeled (best
+    // path already found to this directed edge).
+    EdgeStatusInfo edgestatus = edgestatus_->Get(edgeid);
+    if (edgestatus.set() == EdgeSet::kPermanent) {
+      continue;
+    }
+
+    // Get end node tile, opposing edge Id, and opposing directed edge.
+    const GraphTile* t2 = directededge->leaves_tile() ?
+        graphreader.GetGraphTile(directededge->endnode()) : tile;
+    if (t2 == nullptr) {
+      continue;
+    }
+    GraphId oppedge = t2->GetOpposingEdgeId(directededge);
+    const DirectedEdge* opp_edge = t2->directededge(oppedge);
+
+    // Skip this edge if no access is allowed (based on costing method)
+    // or if a complex restriction prevents transition onto this edge.
+    if (!costing_->AllowedReverse(directededge, pred, opp_edge, t2, oppedge) ||
+         costing_->Restricted(directededge, pred, edgelabels_, tile,
+                                     edgeid, false)) {
+      continue;
+    }
+
+    // Compute the cost to the end of this edge with separate transition cost
+    Cost tc = costing_->TransitionCostReverse(directededge->localedgeidx(),
+                               nodeinfo, opp_edge, opp_pred_edge);
+    Cost newcost = pred.cost() + costing_->EdgeCost(opp_edge);
+    newcost.cost += tc.cost;
+
+    // Check if edge is temporarily labeled and this path has less cost. If
+    // less cost the predecessor is updated and the sort cost is decremented
+    // by the difference in real cost (A* heuristic doesn't change)
+    if (edgestatus.set() == EdgeSet::kTemporary) {
+      EdgeLabel& lab = edgelabels_[edgestatus.index()];
+      if (newcost.cost < lab.cost().cost) {
+        float newsortcost = lab.sortcost() - (lab.cost().cost - newcost.cost);
+        adjacencylist_->decrease(edgestatus.index(), newsortcost);
+        lab.Update(pred_idx, newcost, newsortcost);
+      }
+      continue;
+    }
+
+    // Add edge label, add to the adjacency list and set edge status
+    uint32_t idx = edgelabels_.size();
+    adjacencylist_->add(idx, newcost.cost);
+    edgestatus_->Set(edgeid, EdgeSet::kTemporary, idx);
+    edgelabels_.emplace_back(pred_idx, edgeid, oppedge,
+                   directededge, newcost, newcost.cost, 0.0f,
+                   mode_, tc, false);
   }
-  return isotile_;      // Should never get here
 }
 
 // Compute iso-tile that we can use to generate isochrones.
@@ -269,16 +392,16 @@ std::shared_ptr<const GriddedData<PointLL> > Isochrone::ComputeReverse(
              const TravelMode mode) {
   // Set the mode and costing
   mode_ = mode;
-  const auto& costing = mode_costing[static_cast<uint32_t>(mode_)];
-  access_mode_ = costing->access_mode();
+  costing_ = mode_costing[static_cast<uint32_t>(mode_)];
+  access_mode_ = costing_->access_mode();
 
   // Initialize and create the isotile
   auto max_seconds = max_minutes * 60;
-  Initialize(costing->UnitSize());
+  Initialize(costing_->UnitSize());
   ConstructIsoTile(false, max_minutes, dest_locations);
 
   // Set the origin locations
-  SetDestinationLocations(graphreader, dest_locations, costing);
+  SetDestinationLocations(graphreader, dest_locations, costing_);
 
   // Compute the isotile
   uint32_t n = 0;
@@ -295,111 +418,19 @@ std::shared_ptr<const GriddedData<PointLL> > Isochrone::ComputeReverse(
     EdgeLabel pred = edgelabels_[predindex];
     edgestatus_->Update(pred.edgeid(), EdgeSet::kPermanent);
 
-    // Get the end node of the prior directed edge. Skip if tile not found
-    // (can happen with regional data sets).
-    GraphId node = pred.endnode();
-    if ((tile = graphreader.GetGraphTile(node)) == nullptr) {
-      continue;
-    }
+    // Get the opposing predecessor directed edge. Need to make sure we get
+    // the correct one if a transition occurred
+    const DirectedEdge* opp_pred_edge =
+      graphreader.GetGraphTile(pred.opp_edgeid())->directededge(pred.opp_edgeid());
 
-    // Get the nodeinfo and update the isotile
-    const NodeInfo* nodeinfo = tile->node(node);
-    UpdateIsoTile(pred, graphreader, nodeinfo->latlng());
+    // Expand from the end node in forward direction.
+    ExpandReverse(graphreader, pred.endnode(), pred, predindex, opp_pred_edge, false);
     n++;
 
     // Return after the time interval has been met
-    if (pred.cost().secs > max_seconds) {
+    if (pred.cost().secs > max_seconds || pred.cost().cost > max_seconds * 4) {
       LOG_DEBUG("Exceed time interval: n = " + std::to_string(n));
       return isotile_;
-    }
-
-    // Check access at the node
-    if (!costing->Allowed(nodeinfo)) {
-      continue;
-    }
-
-    // Get the opposing predecessor directed edge.
-    const DirectedEdge* opp_pred_edge =
-        (pred.opp_edgeid().Tile_Base() == tile->id().Tile_Base()) ?
-            tile->directededge(pred.opp_edgeid().id()) :
-            graphreader.GetGraphTile(pred.opp_edgeid().
-                  Tile_Base())->directededge(pred.opp_edgeid());
-
-    // Expand from end node.
-    GraphId edgeid(node.tileid(), node.level(), nodeinfo->edge_index());
-    const DirectedEdge* directededge = tile->directededge(nodeinfo->edge_index());
-    for (uint32_t i = 0; i < nodeinfo->edge_count(); i++, directededge++, ++edgeid) {
-      // Skip edges not allowed by the access mode. This allows early rejection
-      // without the opposing edge. Also skip edges shortcut edges.
-      if (!(directededge->reverseaccess() & access_mode_) ||
-            directededge->is_shortcut()) {
-        continue;
-      }
-
-      // Get the current set. Skip this edge if permanently labeled (best
-      // path already found to this directed edge).
-      EdgeStatusInfo edgestatus = edgestatus_->Get(edgeid);
-      if (edgestatus.set() == EdgeSet::kPermanent) {
-        continue;
-      }
-
-      // Handle transition edges. Add to adjacency list.
-      // TODO - perhaps create ExpandReverseMethod like in bi-dir A*
-      if (directededge->trans_up() || directededge->trans_down()) {
-        uint32_t idx = edgelabels_.size();
-        adjacencylist_->add(idx, pred.sortcost());
-        edgestatus_->Set(edgeid, EdgeSet::kTemporary, idx);
-        edgelabels_.emplace_back(predindex, edgeid, directededge->endnode(), pred);
-        continue;
-      }
-
-      // Get opposing edge Id and end node tile
-      const GraphTile* t2 = directededge->leaves_tile() ?
-           graphreader.GetGraphTile(directededge->endnode()) : tile;
-      if (t2 == nullptr) {
-        continue;
-      }
-      GraphId oppedge = t2->GetOpposingEdgeId(directededge);
-
-      // Get opposing directed edge and check if allowed.
-      const DirectedEdge* opp_edge = t2->directededge(oppedge);
-      if (!costing->AllowedReverse(directededge, pred, opp_edge,
-                                   t2, oppedge)) {
-        continue;
-      }
-
-      // Check for complex restriction
-      if (costing->Restricted(directededge, pred, edgelabels_, tile,
-                               edgeid, false)) {
-        continue;
-      }
-
-      // Compute the cost to the end of this edge with separate transition cost
-      Cost tc = costing->TransitionCostReverse(directededge->localedgeidx(),
-                                  nodeinfo, opp_edge, opp_pred_edge);
-      Cost newcost = pred.cost() + costing->EdgeCost(opp_edge);
-      newcost.cost += tc.cost;
-
-      // Check if edge is temporarily labeled and this path has less cost. If
-      // less cost the predecessor is updated and the sort cost is decremented
-      // by the difference in real cost (A* heuristic doesn't change)
-      if (edgestatus.set() == EdgeSet::kTemporary) {
-        EdgeLabel& lab = edgelabels_[edgestatus.index()];
-        if (newcost.cost < lab.cost().cost) {
-          float newsortcost = lab.sortcost() - (lab.cost().cost - newcost.cost);
-          adjacencylist_->decrease(edgestatus.index(), newsortcost);
-          lab.Update(predindex, newcost, newsortcost);
-        }
-        continue;
-      }
-
-      // Add edge label, add to the adjacency list and set edge status
-      uint32_t idx = edgelabels_.size();
-      adjacencylist_->add(idx, newcost.cost);
-      edgestatus_->Set(edgeid, EdgeSet::kTemporary, idx);
-      edgelabels_.emplace_back(predindex, edgeid, oppedge,
-                    directededge, newcost, newcost.cost, 0.0f,
-                    mode_, tc, false);
     }
   }
   return isotile_;      // Should never get here
@@ -483,7 +514,7 @@ std::shared_ptr<const GriddedData<PointLL> > Isochrone::ComputeMultiModal(
     n++;
 
     // Return after the time interval has been met
-    if (pred.cost().secs > max_seconds) {
+    if (pred.cost().secs > max_seconds || pred.cost().cost > max_seconds * 4) {
       LOG_DEBUG("Exceed time interval: n = " + std::to_string(n));
       return isotile_;
     }
@@ -748,7 +779,8 @@ std::shared_ptr<const GriddedData<PointLL> > Isochrone::ComputeMultiModal(
 void Isochrone::UpdateIsoTile(const EdgeLabel& pred, GraphReader& graphreader,
                               const PointLL& ll) {
   // Skip if the opposing edge has already been settled.
-  GraphId opp = graphreader.GetOpposingEdgeId(pred.edgeid());
+  const GraphTile* t2;
+  GraphId opp = graphreader.GetOpposingEdgeId(pred.edgeid(), t2);
   EdgeStatusInfo edgestatus = edgestatus_->Get(opp);
   if (edgestatus.set() == EdgeSet::kPermanent) {
     return;
@@ -758,36 +790,48 @@ void Isochrone::UpdateIsoTile(const EdgeLabel& pred, GraphReader& graphreader,
   const GraphTile* tile = graphreader.GetGraphTile(pred.edgeid().Tile_Base());
   const DirectedEdge* edge = tile->directededge(pred.edgeid());
 
-  // Transit lines can't really be "reached" you really just pass through
-  // those cells. TODO - also for ferries?
-  if (edge->IsTransitLine()) {
+  // Transit lines and ferries can't really be "reached" you really just
+  // pass through those cells.
+  if (edge->IsTransitLine() || edge->use() == Use::kFerry) {
     return;
   }
 
-  // Get time at the end node of the predecessor
+  // Get the time at the begin node and end node of the predecessor
+  // TODO - do we need partial shape from origin location to end of edge?
+  uint32_t idx = pred.predecessor();
+  float secs0 = (idx == kInvalidLabel) ? 0 : edgelabels_[idx].cost().secs;
   float secs1 = pred.cost().secs;
 
-  // Get the time at the end node of the predecessor
-  float secs0;
-  uint32_t predindex = pred.predecessor();
-  if (predindex == kInvalidLabel) {
-    //TODO - do we need partial shape from origin location to end of edge?
-    secs0 = 0;
-  } else {
-    secs0 = edgelabels_[predindex].cost().secs;
+  // Avoid getting the shape for short edges
+  if (edge->length() < shape_interval_) {
+    // Mark the cell at the begin node
+    const auto* de = t2->directededge(opp);
+    const auto* node = tile->node(de->endnode());
+    isotile_->SetIfLessThan(node->latlng(), secs0 * kMinPerSec);
+
+    // Mark the cell at the end node (and any intervening cells)
+    auto tiles = isotile_->Intersect(std::list<PointLL>{node->latlng(), ll});
+    for (auto t : tiles) {
+      isotile_->SetIfLessThan(t.first, secs1 * kMinPerSec);
+    }
+    return;
   }
 
-  // Get the shape and make sure shape is forward
-  // direction and resample it to the shape interval.
+  // Get the shape and make sure shape is forward direction. Resample it to
+  // the shape interval.
   auto shape = tile->edgeinfo(edge->edgeinfo_offset()).shape();
   if (!edge->forward()) {
     std::reverse(shape.begin(), shape.end());
   }
   auto resampled = resample_spherical_polyline(shape, shape_interval_);
 
-  // Mark the initial grid cell
+  // Mark the initial grid cell and iterate through the shape pairs
   float secs = secs0;
-  isotile_->SetIfLessThan(resampled.front(), secs * to_minutes);
+  isotile_->SetIfLessThan(shape.front(), secs * kMinPerSec);
+  auto tiles = isotile_->Intersect(std::list<PointLL>{shape.front(), shape.back()});
+  for (auto t : tiles) {
+    isotile_->SetIfLessThan(t.first, secs * kMinPerSec);
+  }
 
   // Mark grid cells along the shape if time is less than what is
   // already populated. Get intersection of tiles along each segment
@@ -799,7 +843,7 @@ void Isochrone::UpdateIsoTile(const EdgeLabel& pred, GraphReader& graphreader,
     secs += delta;
     auto tiles = isotile_->Intersect(std::list<PointLL>{*itr1, *itr2});
     for (auto t : tiles) {
-      isotile_->SetIfLessThan(t.first, secs * to_minutes);
+      isotile_->SetIfLessThan(t.first, secs * kMinPerSec);
     }
   }
 }

--- a/src/thor/isochrone_action.cc
+++ b/src/thor/isochrone_action.cc
@@ -33,7 +33,10 @@ namespace valhalla {
       }
       auto polygons = request.get<bool>("polygons", false);
       auto denoise = std::max(std::min(request.get<float>("denoise", 1.f), 1.f), 0.f);
-      auto generalize = request.get<float>("generalize", .2f);
+
+      // Get the generalization factor (in meters). If none is provided then
+      // an optimal factor is computed (based on the isotile grid size).
+      auto generalize = request.get<float>("generalize", kOptimalGeneralization);
 
       //get the raster
       //Extend the times in the 2-D grid to be 10 minutes beyond the highest contour time.

--- a/src/valhalla_run_isochrone.cc
+++ b/src/valhalla_run_isochrone.cc
@@ -245,10 +245,10 @@ int main(int argc, char *argv[]) {
   auto t1 = std::chrono::high_resolution_clock::now();
   Isochrone isochrone;
   auto isotile = (routetype == "multimodal") ?
-      isochrone.ComputeMultiModal(path_location, max_minutes, reader, mode_costing, mode) :
+      isochrone.ComputeMultiModal(path_location, max_minutes + 10, reader, mode_costing, mode) :
       (reverse) ?
-        isochrone.ComputeReverse(path_location, max_minutes, reader, mode_costing, mode) :
-        isochrone.Compute(path_location, max_minutes, reader, mode_costing, mode);
+        isochrone.ComputeReverse(path_location, max_minutes + 10, reader, mode_costing, mode) :
+        isochrone.Compute(path_location, max_minutes + 10, reader, mode_costing, mode);
   auto t2 = std::chrono::high_resolution_clock::now();
   uint32_t msecs = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
   LOG_INFO("Compute isotile took " + std::to_string(msecs) + " ms");

--- a/src/valhalla_run_isochrone.cc
+++ b/src/valhalla_run_isochrone.cc
@@ -280,7 +280,8 @@ int main(int argc, char *argv[]) {
   for (size_t i = 1; i <= n_contours; i++) {
     contour_times.push_back((max_minutes * i) / n_contours);
   }
-  auto contours = isotile->GenerateContours(contour_times);
+  auto contours = isotile->GenerateContours(contour_times, false, 1.0f,
+                            kOptimalGeneralization);
   auto geojson = json::to_geojson<PointLL>(contours);
 
   auto t3 = std::chrono::high_resolution_clock::now();

--- a/valhalla/midgard/constants.h
+++ b/valhalla/midgard/constants.h
@@ -21,6 +21,9 @@ constexpr float kKmPerMile          = 1.60934f;
 constexpr float kRadEarthMeters     = 6378160.187f;
 constexpr float kMetersPerDegreeLat = 110567.0f;
 
+// Speed conversion constants
+constexpr float kMPHtoMetersPerSec  = 0.44704f;
+
 // Angular measures
 constexpr float kPi        = 3.14159265f;
 constexpr float kPiOver2   = (kPi * 0.5f);

--- a/valhalla/midgard/constants.h
+++ b/valhalla/midgard/constants.h
@@ -8,8 +8,10 @@ namespace valhalla {
 namespace midgard {
 
 // Time constants
-constexpr float kSecPerHour = 3600.0f;
-constexpr float kHourPerSec = 1.0f / 3600.0f;
+constexpr float kSecPerMinute     = 60.0f;
+constexpr float kMinPerSec        = 1.0f / 60.0f;
+constexpr float kSecPerHour       = 3600.0f;
+constexpr float kHourPerSec       = 1.0f / 3600.0f;
 constexpr uint32_t kSecondsPerDay = 86400;
 
 // Distance constants

--- a/valhalla/midgard/gridded_data.h
+++ b/valhalla/midgard/gridded_data.h
@@ -9,6 +9,10 @@
 namespace valhalla {
 namespace midgard {
 
+// A special generalization value indicating that the application should
+// compute an optimal generalization factor when creating contours.
+constexpr float kOptimalGeneralization = 9999999.0f;
+
 /**
  * Class to store data in a gridded/tiled data structure. Contains methods
  * to mark each tile with data using a compare operator.
@@ -71,6 +75,9 @@ class GriddedData : public Tiles<coord_t> {
    * @param denoise              remove any contours whose size ratio is less than
    *                             this parameter with respect to the largest contour
    *                             with the same interval. by default only keep the largest
+   * @param generalize           Generalization factor in meters. A special value
+   *                             kOptimalGeneralization will let the method choose
+   *                             an optimal generalization factor based on grid size.
    *
    * @return contour line geometries with the larger intervals first (for rendering purposes)
    */

--- a/valhalla/midgard/gridded_data.h
+++ b/valhalla/midgard/gridded_data.h
@@ -4,6 +4,7 @@
 #include <valhalla/midgard/tiles.h>
 #include <vector>
 #include <map>
+#include <limits>
 #include <list>
 
 namespace valhalla {
@@ -11,7 +12,7 @@ namespace midgard {
 
 // A special generalization value indicating that the application should
 // compute an optimal generalization factor when creating contours.
-constexpr float kOptimalGeneralization = 9999999.0f;
+constexpr float kOptimalGeneralization = std::numeric_limits<float>::max();
 
 /**
  * Class to store data in a gridded/tiled data structure. Contains methods

--- a/valhalla/midgard/tiles.h
+++ b/valhalla/midgard/tiles.h
@@ -76,6 +76,13 @@ class Tiles {
   AABB2<coord_t> TileBounds() const;
 
   /**
+   * Shift the tilebounds - a special method used to nudge the tile bounds
+   * so a specific point stays centered in the grid.
+   * @param  shift  Amount to shift the bounding box.
+   */
+  void ShiftTileBounds(const coord_t& shift);
+
+  /**
    * Get the "row" based on y.
    * @param   y   y coordinate
    * @return  Returns the tile row. Returns -1 if outside the

--- a/valhalla/thor/isochrone.h
+++ b/valhalla/thor/isochrone.h
@@ -95,6 +95,9 @@ class Isochrone {
   uint32_t access_mode_;        // Access mode used by the costing method
   uint32_t tile_creation_date_; // Tile creation date
 
+  // Current costing mode
+  std::shared_ptr<sif::DynamicCost> costing_;
+
   // Vector of edge labels (requires access by index).
   std::vector<sif::EdgeLabel> edgelabels_;
 
@@ -123,6 +126,21 @@ class Isochrone {
    */
   void ConstructIsoTile(const bool multimodal, const unsigned int max_minutes,
                         std::vector<baldr::PathLocation>& origin_locations);
+
+  /**
+   * Expand from the node along the forward search path.
+   */
+  void ExpandForward(baldr::GraphReader& graphreader,
+           const baldr::GraphId& node, const sif::EdgeLabel& pred,
+           const uint32_t pred_idx, const bool from_transition);
+
+  /**
+   * Expand from the node along the forward search path.
+   */
+  void ExpandReverse(baldr::GraphReader& graphreader,
+           const baldr::GraphId& node, const sif::EdgeLabel& pred,
+           const uint32_t pred_idx, const baldr::DirectedEdge* opp_pred_edge,
+           const bool from_transition);
 
   /**
    * Updates the isotile using the edge information from the predecessor edge


### PR DESCRIPTION
As the max time changes, the isochrone boundaries change and the center location can shift within the grid. This PR tries to adjust the tile boundaries so that the center (first location in the list) remains fixed within a tile/grid cell. This helps minmize "drift" which can cause changes to the contouring.