### PR TITLE
Do not return distance_along_edge and distance_from_trace_point when trace point is unmatched

### DIFF
--- a/src/thor/trace_attributes_action.cc
+++ b/src/thor/trace_attributes_action.cc
@@ -319,11 +319,11 @@ namespace {
           match_points_map->emplace("end_route_discontinuity", static_cast<bool>(match_result.end_route_discontinuity));
 
         // Process matched point distance along edge
-        if (controller.attributes.at(kMatchedDistanceAlongEdge))
+        if (controller.attributes.at(kMatchedDistanceAlongEdge) && (match_result.type != thor::MatchResult::Type::kUnmatched))
           match_points_map->emplace("distance_along_edge", json::fp_t{match_result.distance_along,3});
 
         // Process matched point distance from trace point
-        if (controller.attributes.at(kMatchedDistanceFromTracePoint))
+        if (controller.attributes.at(kMatchedDistanceFromTracePoint) && (match_result.type != thor::MatchResult::Type::kUnmatched))
           match_points_map->emplace("distance_from_trace_point", json::fp_t{match_result.distance_from,3});
 
         match_points_array->push_back(match_points_map);


### PR DESCRIPTION
closes #684 

cleaner output for unmatched points:
![screenshot from 2017-05-10 09-47-04](https://cloud.githubusercontent.com/assets/7515853/25901891/13a1231c-3566-11e7-84d1-00a04fec0ce0.png)
