### PR TITLE
include cmath in test/double_bucket_queue.cc

### DIFF
--- a/test/double_bucket_queue.cc
+++ b/test/double_bucket_queue.cc
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <vector>
 #include <algorithm>
+#include <cmath>
 #include "config.h"
 #include "midgard/util.h"
 #include "baldr/double_bucket_queue.h"


### PR DESCRIPTION
On Gentoo, `make test` failed with 

```
   CXX      test/test_double_bucket_queue-double_bucket_queue.o
test/double_bucket_queue.cc: In function ‘void {anonymous}::TrySimulation(valhalla::baldr::DoubleBucketQueue&, std::vector<float>&, size_t, size_t, size_t)’:
test/double_bucket_queue.cc:127:28: error: ‘floor’ is not a member of ‘std’
       const auto newcost = std::floor(min_cost + 1 + midgard::rand01() * max_increment_cost);
                            ^
make[2]: *** [Makefile:5681: test/test_double_bucket_queue-double_bucket_queue.o] Error 1
```

This fixes the issue