### PR TITLE
Astar fix for unreachable edges

### DIFF
--- a/src/thor/astar.cc
+++ b/src/thor/astar.cc
@@ -270,7 +270,8 @@ std::vector<PathInfo> AStarPathAlgorithm::GetBestPath(PathLocation& origin,
       // (cost from the dest. location to the end of the edge).
       auto p = destinations_.find(edgeid);
       if (p != destinations_.end()) {
-        newcost -= p->second;
+        newcost.secs -= p->second.secs;  // Should properly handle elapsed time
+        newcost.cost += p->second.cost;  // Need this to handle the edge score
       }
 
       // Check if edge is temporarily labeled and this path has less cost. If
@@ -361,7 +362,7 @@ void AStarPathAlgorithm::SetOrigin(GraphReader& graphreader,
     // We need to penalize this location based on its score (distance in meters from input)
     // We assume the slowest speed you could travel to cover that distance to start/end the route
     // TODO: assumes 1m/s which is a maximum penalty this could vary per costing model
-    cost.cost += edge.score;
+    cost.cost += edge.score * 10;
 
     // If this edge is a destination, subtract the partial/remainder cost
     // (cost from the dest. location to the end of the edge) if the
@@ -373,7 +374,7 @@ void AStarPathAlgorithm::SetOrigin(GraphReader& graphreader,
         // a trivial route passes along a single edge, meaning that the
         // destination point must be on this edge, and so the distance
         // remaining must be zero.
-        cost -= p->second;
+        cost.secs -= p->second.secs;
         dist = 0.0;
       }
     }
@@ -430,7 +431,7 @@ uint32_t AStarPathAlgorithm::SetDestination(GraphReader& graphreader,
     // We need to penalize this location based on its score (distance in meters from input)
     // We assume the slowest speed you could travel to cover that distance to start/end the route
     // TODO: assumes 1m/s which is a maximum penalty this could vary per costing model
-    destinations_[edge.id].cost += edge.score;
+    destinations_[edge.id].cost += edge.score * 10;
 
     // Get the tile relative density
     density = tile->header()->density();

--- a/src/thor/astar.cc
+++ b/src/thor/astar.cc
@@ -362,6 +362,7 @@ void AStarPathAlgorithm::SetOrigin(GraphReader& graphreader,
     // We need to penalize this location based on its score (distance in meters from input)
     // We assume the slowest speed you could travel to cover that distance to start/end the route
     // TODO: assumes 1m/s which is a maximum penalty this could vary per costing model
+    // Perhaps need to adjust score?
     cost.cost += edge.score * 10;
 
     // If this edge is a destination, subtract the partial/remainder cost


### PR DESCRIPTION
Fix an issue where an unreachable region projects to a single edge and selects the A* algorithm. Increase the penalties and adjust the trivial cases to make sure the edge score penalty is properly applied to the destination.

fixes #716 