### PR TITLE
Use threshold to stop checking for lower cost. 

### DIFF
--- a/src/thor/costmatrix.cc
+++ b/src/thor/costmatrix.cc
@@ -137,7 +137,7 @@ std::vector<TimeDistance> CostMatrix::SourceToTarget(
 
     // Break out when remaining sources and targets to expand are both 0
     if (remaining_sources_ == 0 && remaining_targets_ == 0) {
-      LOG_INFO("SourceToTarget iterations: n = " + std::to_string(n));
+      LOG_DEBUG("SourceToTarget iterations: n = " + std::to_string(n));
       break;
     }
 

--- a/valhalla/thor/costmatrix.h
+++ b/valhalla/thor/costmatrix.h
@@ -217,7 +217,7 @@ class CostMatrix {
    * on the reverse search tree.
    * @param  source  Source index.
    * @param  pred    Edge label of the predecessor.
-   * @param  n            Iteration counter.
+   * @param  n       Iteration counter.
    */
   void CheckForwardConnections(const uint32_t source,
                                const sif::EdgeLabel& pred, const uint32_t n);


### PR DESCRIPTION
Found cases where paths to edges marked as disconnected ended up with lower cost - but these should have been filtered out since they were above the threshold of extra iterations to run after the initial connection has been found.