### PR TITLE
For route match, check that matched edge is not too long.

### DIFF
--- a/src/thor/route_matcher.cc
+++ b/src/thor/route_matcher.cc
@@ -176,7 +176,7 @@ bool expand_from_node(const std::shared_ptr<DynamicCost>* mode_costing,
       }
 
       // Found a match if shape equals directed edge LL within tolerance
-      if (shape.at(index).ApproximatelyEqual(de_end_ll)) {
+      if (shape.at(index).ApproximatelyEqual(de_end_ll) && de->length() < length_comparison(length, true)) {
         // Update the elapsed time based on transition cost
         elapsed_time += mode_costing[static_cast<int>(mode)]->TransitionCost(
             de, node_info, prev_edge_label).secs;
@@ -260,7 +260,8 @@ bool RouteMatcher::FormPath(
     // Initialize indexes and shape
     size_t index = 0;
     float length = 0.0f;
-    float de_length = length_comparison(de->length() * (1 - edge.dist), true);
+    float de_remaining_length = de->length() * (1 - edge.dist);
+    float de_length = length_comparison(de_remaining_length, true);
     EdgeLabel prev_edge_label;
     // Loop over shape to form path from matching edges
     while (index < shape.size()) {
@@ -270,7 +271,7 @@ bool RouteMatcher::FormPath(
       }
 
       // Check if shape is within tolerance at the end node
-      if (shape.at(index).ApproximatelyEqual(de_end_ll)) {
+      if (shape.at(index).ApproximatelyEqual(de_end_ll) && de_remaining_length < length_comparison(length, true)) {
 
         // Update the elapsed time edge cost at begin edge
         elapsed_time += mode_costing[static_cast<int>(mode)]->EdgeCost(de).secs


### PR DESCRIPTION
When there are multiple edges with same start and end nodes, we used to pick the first edge that was longer than matched length. This causes wrong edge to be chosen.

Multiple edges with same start and end show up when we merge edges.