### PR TITLE
fix compatibilities issue with debian 8

### DIFF
--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -689,7 +689,7 @@ std::unordered_map<Location, PathLocation>
 Search(const std::vector<Location>& locations, GraphReader& reader, const EdgeFilter& edge_filter, const NodeFilter& node_filter) {
   //trivially finished already
   if(locations.empty())
-    return {};
+    return std::unordered_map<Location, PathLocation>{};
   //setup the unique list of locations
   bin_handler_t handler(locations, reader, edge_filter, node_filter);
   //search over the bins doing multiple locations per bin


### PR DESCRIPTION
With gcc 4.9.2 it isn't possible to implicitly construct a unordered_map from a initializer_list.
fix #751