### PR TITLE
Add dummy queue length to return.

### DIFF
--- a/src/meili/traffic_segment_matcher.cc
+++ b/src/meili/traffic_segment_matcher.cc
@@ -319,8 +319,11 @@ std::vector<traffic_segment_t> TrafficSegmentMatcher::form_segments(const std::l
 
       //this is what we know so far
       //NOTE: in both cases we take the left most value for the shape index in an effort to be conservative
+      int queue_length = 0; // TODO - compute queue length (based on interpolations - where speed falls
+                            // below some threshold
       traffic_segments.emplace_back(
-        traffic_segment_t{segment->segment_id_, start_time, left->original_index, end_time, prev->original_index, length, segment.internal, segment.way_ids});
+        traffic_segment_t{segment->segment_id_, start_time, left->original_index, end_time, prev->original_index,
+                  length, queue_length, segment.internal, segment.way_ids});
 
       //if the right side of this was the end of this edge then at least we need to start from the next edge
       if(segment->end_percent_ == 1.f) {
@@ -382,6 +385,7 @@ std::string TrafficSegmentMatcher::serialize(const std::vector<traffic_segment_t
       {"length", static_cast<int64_t>(seg.length)},
       {"begin_shape_index", static_cast<uint64_t>(seg.begin_shape_index)},
       {"end_shape_index", static_cast<uint64_t>(seg.end_shape_index)},
+      {"queue_length", static_cast<int64_t>(seg.queue_length)},
       {"internal", static_cast<bool>(seg.internal)}
     });
     //some of the segments are just sections of the path with no ots's

--- a/valhalla/meili/traffic_segment_matcher.h
+++ b/valhalla/meili/traffic_segment_matcher.h
@@ -34,6 +34,7 @@ struct traffic_segment_t {
   double end_time;               // End time along this segment, if < 0 then no end match
   size_t end_shape_index;        // Ends at this index of original input
   int length;                    // Length in meters along this segment, if < 0 then no match
+  int queue_length;              // Length of any queue from the end of the segment
   bool internal;                 // Is the set of edges making up this segment internal edge types
   std::vector<uint64_t> way_ids; // A list of way ids from the directed edge
 };


### PR DESCRIPTION
Will fill in logic for computing queue length later, just wanted this in the return so we can start seeing it being reported.