### PR TITLE
Added computation of queue length

### DIFF
--- a/src/meili/traffic_segment_matcher.cc
+++ b/src/meili/traffic_segment_matcher.cc
@@ -121,8 +121,8 @@ namespace {
 namespace valhalla {
 namespace meili {
 
-// Thereshold speed below which we assume a queue occurs (meters/sec)
-constexpr float kQueueSpeedThreshold = 3.0f;
+// Threshold speed below which we assume a queue occurs (meters/sec)
+constexpr float kQueueSpeedThreshold = 2.0f;  // approx 4.3 MPH
 
 TrafficSegmentMatcher::TrafficSegmentMatcher(const boost::property_tree::ptree& config): matcher_factory(config) {
 }
@@ -265,7 +265,7 @@ int TrafficSegmentMatcher::compute_queue_length(std::vector<interpolation_t>::co
     }
 
     // Compute speed. If it falls below threshold return the remaining length
-    // (from the midpoint between the 2 interpolations
+    // (from the midpoint between the 2 interpolations)
     if (d / (i2->epoch_time - i1->epoch_time) < threshold) {
       return static_cast<int>(right->total_distance - (i1->total_distance + i2->total_distance) * 0.5);
     }

--- a/valhalla/meili/traffic_segment_matcher.h
+++ b/valhalla/meili/traffic_segment_matcher.h
@@ -99,7 +99,7 @@ class TrafficSegmentMatcher {
    * Compute queue length. Determine where (and if) speed drops below the
    * threshold along a segment.
    * @param  left       Iterator to the start of the interpolated matches.
-   * @param  right      Iterator to the start of the interpolated matches.
+   * @param  right      Iterator to the end of the interpolated matches.
    * @param  threshold  Speed (m/s) threshold.
    * @return Returns the distance (meters) from the end of the segment where
    *          speed drops below the threshold.

--- a/valhalla/meili/traffic_segment_matcher.h
+++ b/valhalla/meili/traffic_segment_matcher.h
@@ -96,6 +96,19 @@ class TrafficSegmentMatcher {
     const std::shared_ptr<MapMatcher>& matcher) const;
 
   /**
+   * Compute queue length. Determine where (and if) speed drops below the
+   * threshold along a segment.
+   * @param  left       Iterator to the start of the interpolated matches.
+   * @param  right      Iterator to the start of the interpolated matches.
+   * @param  threshold  Speed (m/s) threshold.
+   * @return Returns the distance (meters) from the end of the segment where
+   *          speed drops below the threshold.
+   */
+  int compute_queue_length(std::vector<interpolation_t>::const_iterator left,
+                           std::vector<interpolation_t>::const_iterator right,
+                           const float threshold) const;
+
+  /**
    * Turns updated matching results with their distances into a list of segments with interpolated times
    * @param  the updated matched results including the nodes of all the edges on the path
    * @param  the distance along the entire path of each matched result


### PR DESCRIPTION
Using a speed threshold of 2 m/s (approx 4.3MPH), will return the distance to the end of the segment from the midpoint between 2 interpolations where the speed falls below the threshold.