### PR TITLE
Fixes for valhalla_associate_segments

### DIFF
--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -215,6 +215,9 @@ GraphReader::GraphReader(const boost::property_tree::ptree& pt)
 
 // Method to test if tile exists
 bool GraphReader::DoesTileExist(const GraphId& graphid) const {
+  if (!graphid.Is_Valid() || graphid.level() > TileHierarchy::get_max_level()) {
+    return false;
+  }
   //if you are using an extract only check that
   if(!tile_extract_->tiles.empty())
     return tile_extract_->tiles.find(graphid) != tile_extract_->tiles.cend();
@@ -228,6 +231,9 @@ bool GraphReader::DoesTileExist(const GraphId& graphid) const {
 }
 
 bool GraphReader::DoesTileExist(const boost::property_tree::ptree& pt, const GraphId& graphid) {
+  if (!graphid.Is_Valid() || graphid.level() > TileHierarchy::get_max_level()) {
+    return false;
+  }
   //if you are using an extract only check that
   auto extract = get_extract_instance(pt);
   if(!extract->tiles.empty())

--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -73,7 +73,7 @@ GraphTile::GraphTile(const std::string& tile_dir, const GraphId& graphid)
       : header_(nullptr) {
 
   // Don't bother with invalid ids
-  if (!graphid.Is_Valid())
+  if (!graphid.Is_Valid() || graphid.level() > TileHierarchy::get_max_level())
     return;
 
   // Open to the end of the file so we can immediately get size;
@@ -276,7 +276,8 @@ std::string GraphTile::FileSuffix(const GraphId& graphid) {
   //figure the largest id for this level
   auto found = TileHierarchy::levels().find(graphid.level());
   if(found == TileHierarchy::levels().cend() && graphid.level() != TileHierarchy::GetTransitLevel().level)
-    throw std::runtime_error("Could not compute FileSuffix for non-existent level");
+    throw std::runtime_error("Could not compute FileSuffix for non-existent level: " +
+                             std::to_string(graphid.level()));
 
   //get the level info
   const auto& level = graphid.level() == TileHierarchy::GetTransitLevel().level ?

--- a/src/baldr/tilehierarchy.cc
+++ b/src/baldr/tilehierarchy.cc
@@ -45,6 +45,11 @@ uint8_t TileHierarchy::get_level(const RoadClass roadclass) {
   }
 }
 
+// Get the max hierarchy level.
+uint8_t TileHierarchy::get_max_level() {
+  return transit_level_.level;
+}
+
 // Returns all the GraphIds of the tiles which intersect the given bounding
 // box at that level.
 std::vector<GraphId> TileHierarchy::GetGraphIds(

--- a/src/valhalla_associate_segments.cc
+++ b/src/valhalla_associate_segments.cc
@@ -101,7 +101,8 @@ struct CandidateEdge {
 uint16_t bearing(const std::vector<vm::PointLL> &shape) {
   // OpenLR says to use 20m along the edge, but we could use the
   // GetOffsetForHeading function, which adapts it to the road class.
-  float heading = vm::PointLL::HeadingAlongPolyline(shape, 20);
+  float heading = shape.size() >= 2 ?
+      vm::PointLL::HeadingAlongPolyline(shape, 20) : 0.0f;
   assert(heading >= 0.0);
   assert(heading < 360.0);
   return uint16_t(std::round(heading));
@@ -641,13 +642,11 @@ std::vector<EdgeMatch> edge_association::match_edges(const pbf::Segment& segment
     return edges;
   }
 
-  return { };
-
   // TODO - this should not happen if both are at nodes! Does not happen
   // with low node tolerance, but as node search tolerance is raised we get
   // fallback cases where we shouldn't
   if (segment.lrps(0).at_node() && segment.lrps(size-1).at_node()) {
-    LOG_INFO("Fall back to A*: " + std::to_string(segment_id) + " value = " +
+    LOG_DEBUG("Fall back to A*: " + std::to_string(segment_id) + " value = " +
                   std::to_string(segment_id.value));
   }
 
@@ -787,10 +786,10 @@ bool edge_association::match_segment(vb::GraphId segment_id, const pbf::Segment 
   if (edges.empty()) {
     size_t n = segment.lrps_size();
     if (segment.lrps(0).at_node() && segment.lrps(n-1).at_node()) {
-      LOG_INFO("No match from nodes: " + std::to_string(segment_id) + " value = " +
+      LOG_DEBUG("No match from nodes: " + std::to_string(segment_id) + " value = " +
                     std::to_string(segment_id.value));
     } else {
-      LOG_INFO("No match along edge: " + std::to_string(segment_id) + " value = " +
+      LOG_DEBUG("No match along edge: " + std::to_string(segment_id) + " value = " +
               std::to_string(segment_id.value));
     }
     return false;

--- a/valhalla/baldr/tilehierarchy.h
+++ b/valhalla/baldr/tilehierarchy.h
@@ -82,6 +82,12 @@ class TileHierarchy {
    */
   static uint8_t get_level(const RoadClass roadclass);
 
+  /**
+   * Gets the maximum level supported in the hierarchy.
+   * @return  Returns the max. level.
+   */
+  static uint8_t get_max_level();
+
  private:
   static std::map<uint8_t, TileLevel> levels_;
   static TileLevel transit_level_;


### PR DESCRIPTION
Make sure we fall back to A* if edge walking fails (was checked in with the fallback disabled). Lower some log statements to debug level.
Add some protection in GraphReader and GraphTile to make sure the level is valid.