### PR TITLE
Added extra valhalla_run_isochrone functionality and fixed color bug in isochrone queries

### DIFF
--- a/src/baldr/geojson.cc
+++ b/src/baldr/geojson.cc
@@ -78,6 +78,7 @@ MapPtr to_geojson(const typename midgard::GriddedData<coord_t>::contours_t& grid
       );
     }
   }
+  // Add original locations to the geojson
   for (const auto& location : locations) {
     features->emplace_back(
       map({

--- a/src/baldr/geojson.cc
+++ b/src/baldr/geojson.cc
@@ -19,14 +19,13 @@ template <class coord_t>
 MapPtr to_geojson(const typename midgard::GriddedData<coord_t>::contours_t& grid_contours, bool polygons, const std::vector<std::string>& colors) {
   //for each contour interval
   int i = 0;
-  auto color_itr = colors.cbegin();
+  auto color_itr = colors.crbegin();
   auto features = array({});
   for(const auto& interval : grid_contours) {
     //color was supplied
     std::stringstream hex;
-    if(color_itr != colors.cend() && !color_itr->empty()) {
-      hex << *color_itr;
-      color_itr++;
+    if(color_itr != colors.crend() && !color_itr->empty()) {
+      hex << "#" << *color_itr;
     }//or we computed it..
     else {
       auto h = i * (150.f / grid_contours.size());
@@ -37,6 +36,9 @@ MapPtr to_geojson(const typename midgard::GriddedData<coord_t>::contours_t& grid
       hex << "#" << std::hex << static_cast<int>(std::get<0>(color)*255 + .5f) <<
                     std::hex << static_cast<int>(std::get<1>(color)*255 + .5f) <<
                     std::hex << static_cast<int>(std::get<2>(color)*255 + .5f);
+    }
+    if (color_itr != colors.crend()) {
+      color_itr++;
     }
     ++i;
 

--- a/src/thor/isochrone_action.cc
+++ b/src/thor/isochrone_action.cc
@@ -55,12 +55,6 @@ namespace valhalla {
                                      : baldr::json::to_geojson<PointLL>(isolines, polygons, colors);
 
       auto id = request.get_optional<std::string>("id");
-      /*baldr::json::ArrayPtr features = geojson->at("features");
-      features->emplace_back(
-        baldr::json::map({
-          {"type", std::string}
-        })
-      );*/
       if(id)
         geojson->emplace("id", *id);
       std::stringstream stream; stream << *geojson;

--- a/src/thor/service.cc
+++ b/src/thor/service.cc
@@ -251,7 +251,7 @@ namespace valhalla {
           catch (...) { throw valhalla_exception_t{400, 421}; }
         }
         correlated = store_correlated_locations(request, locations);
-      }//if we have a sources and targets request here we will divvy up the correlated amongst them
+      }//if we have a sources and targets request here we will divy up the correlated amongst them
       else if(request_sources && request_targets) {
         for(const auto& s : *request_sources) {
           try{ locations.push_back(baldr::Location::FromPtree(s.second)); }

--- a/src/valhalla_run_isochrone.cc
+++ b/src/valhalla_run_isochrone.cc
@@ -1,5 +1,6 @@
 #include <cstdint>
 #include <iostream>
+#include <fstream>
 #include <string>
 #include <vector>
 #include <queue>
@@ -64,7 +65,7 @@ int main(int argc, char *argv[]) {
   bool reverse = false;
   size_t n_contours = 4;
   unsigned int max_minutes = 60;
-  std::string origin, routetype, json, config;
+  std::string origin, routetype, json, config, filename;
   options.add_options()("help,h", "Print this help message.")(
       "version,v", "Print the version of this software.")(
       "origin,o",boost::program_options::value<std::string>(&origin),
@@ -78,7 +79,8 @@ int main(int argc, char *argv[]) {
       ("reverse,r", bpo::value<bool>(&reverse), "Reverse direction.")
       ("ncontours,n", bpo::value<size_t>(&n_contours), "Number of contours.")
       ("minutes,m", bpo::value<unsigned int>(&max_minutes), "Maximum minutes.")
-      ("config", bpo::value<std::string>(&config), "Valhalla configuration file");
+      ("config", bpo::value<std::string>(&config), "Valhalla configuration file")
+      ("file,f", bpo::value<std::string>(&filename), "Geojson output file name.");
 
   bpo::positional_options_description pos_options;
   pos_options.add("config", 1);
@@ -290,7 +292,14 @@ int main(int argc, char *argv[]) {
   msecs = std::chrono::duration_cast<std::chrono::milliseconds>(t3 - t1).count();
   LOG_INFO("Isochrone took " + std::to_string(msecs) + " ms");
 
-  std::cout << std::endl << *geojson;
+  std::cout << std::endl;
+  if (vm.count("file")) {
+    std::ofstream geojsonOut (filename, std::ofstream::out);
+    geojsonOut << *geojson;
+    geojsonOut.close();
+  } else {
+    std::cout << *geojson << std::endl;
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/valhalla_run_isochrone.cc
+++ b/src/valhalla_run_isochrone.cc
@@ -119,7 +119,7 @@ int main(int argc, char *argv[]) {
   std::vector<Location> avoid_locations;
 
   // Isochrone parameters
-  std::vector<std::string> colors {};
+  std::unordered_map<float, std::string> colors {};
   std::vector<float> contour_times;
 
   // argument checking and verification
@@ -208,7 +208,7 @@ int main(int argc, char *argv[]) {
     try {
       for (const auto& contour : json_ptree.get_child("contours")) {
         contour_times.push_back(contour.second.get<float>("time"));
-        colors.push_back(contour.second.get<std::string>("color", ""));
+        colors[contour_times.back()] = contour.second.get<std::string>("color", "");
       }
     } catch (...) {
       throw std::runtime_error("Contours failed to parse.");

--- a/valhalla/baldr/geojson.h
+++ b/valhalla/baldr/geojson.h
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <valhalla/baldr/json.h>
+#include <valhalla/baldr/pathlocation.h>
 #include <valhalla/midgard/gridded_data.h>
 
 #include <vector>
@@ -18,7 +19,8 @@ namespace json {
  * @param colors           the #ABC123 hex string color used in geojson fill color
  */
 template <class coord_t>
-MapPtr to_geojson(const typename midgard::GriddedData<coord_t>::contours_t& grid_contours, bool polygons = true, const std::vector<std::string>& colors = {});
+MapPtr to_geojson(const typename midgard::GriddedData<coord_t>::contours_t& grid_contours, bool polygons = true,
+    const std::unordered_map<float, std::string>& colors = {}, const std::vector<PathLocation>& locations = {});
 
 }
 }


### PR DESCRIPTION
# Changes
+ Added a "show_locations" parameter to the isochrone service (false by default). If set to true, the final geojson output will include all of the "locations" points as geojson points. That way (especially once multiple locations are allowed) you can see exactly where the isochrones are expanding from if you are visualizing the geojson output.
+ Fixed color issue with isochrones where colors would be placed in reverse order for contours and would be parsed incorrectly if only some contours specified colors while others didn't. Now if a contour has a color specified to it, that specific contour gets that color. All other contours with no color specified get a default color.
+ Added more functionality to valhalla_run_isochrone for better testing. It will now actually read json contour parameters (they were ignored before), and also the polygons, show_locations, generalize, and denoise parameters as described in the isochrone service api.
+ A command line argument has also been added for the polygons (-p), show_locations (-l), generalize (-g), and denoise (-d) parameters if you wanted to use those instead of in the json. (If both are used, a warning is displayed and the json overwrites the command line option)
+ The polygons default in valhalla_run_isochrone is now false to match the default value of polygons for the actual isochrone service.
+ Added a file command line parameter (-f) to valhalla_run_isochrone which will dump the geojson data into the specified file instead of onto the console.
