### PR TITLE
Add max label limit to AStarPathAlgorithm

### DIFF
--- a/src/thor/astar.cc
+++ b/src/thor/astar.cc
@@ -23,7 +23,6 @@ AStarPathAlgorithm::AStarPathAlgorithm()
       travel_type_(0),
       adjacencylist_(nullptr),
       edgestatus_(nullptr),
-      tile_creation_date_(0),
       max_label_count_(std::numeric_limits<uint32_t>::max()) {
 }
 
@@ -350,9 +349,6 @@ void AStarPathAlgorithm::SetOrigin(GraphReader& graphreader,
     GraphId edgeid = edge.id;
     const GraphTile* tile = graphreader.GetGraphTile(edgeid);
     const DirectedEdge* directededge = tile->directededge(edgeid);
-
-    // Set the tile creation date
-    tile_creation_date_ = tile->header()->date_created();
 
     // Get the tile at the end node. Skip if tile not found as we won't be
     // able to expand from this origin edge.

--- a/src/thor/astar.cc
+++ b/src/thor/astar.cc
@@ -18,11 +18,13 @@ constexpr uint64_t kInitialEdgeLabelCount = 500000;
 
 // Default constructor
 AStarPathAlgorithm::AStarPathAlgorithm()
-    : PathAlgorithm(), mode_(TravelMode::kDrive),
+    : PathAlgorithm(),
+      mode_(TravelMode::kDrive),
       travel_type_(0),
       adjacencylist_(nullptr),
       edgestatus_(nullptr),
-      tile_creation_date_(0) {
+      tile_creation_date_(0),
+      max_label_count_(std::numeric_limits<uint32_t>::max()) {
 }
 
 // Destructor
@@ -141,6 +143,11 @@ std::vector<PathInfo> AStarPathAlgorithm::GetBestPath(PathLocation& origin,
     if(interrupt && total_labels/kInterruptIterationsInterval < current_labels/kInterruptIterationsInterval)
       (*interrupt)();
     total_labels = current_labels;
+
+    // Abort if max label count is exceeded
+    if (total_labels > max_label_count_) {
+      return { };
+    }
 
     // Get next element from adjacency list. Check that it is valid. An
     // invalid label indicates there are no edges that can be expanded.

--- a/src/thor/isochrone.cc
+++ b/src/thor/isochrone.cc
@@ -46,7 +46,6 @@ constexpr uint64_t kInitialEdgeLabelCount = 500000;
 // Default constructor
 Isochrone::Isochrone()
     : access_mode_(kAutoAccess),
-      tile_creation_date_(0),
       shape_interval_(50.0f),
       mode_(TravelMode::kDrive),
       adjacencylist_(nullptr),
@@ -882,9 +881,6 @@ void Isochrone::SetOriginLocations(GraphReader& graphreader,
       GraphId edgeid = edge.id;
       const GraphTile* tile = graphreader.GetGraphTile(edgeid);
       const DirectedEdge* directededge = tile->directededge(edgeid);
-
-      // Set the tile creation date
-      tile_creation_date_ = tile->header()->date_created();
 
       // Get the tile at the end node. Skip if tile not found as we won't be
       // able to expand from this origin edge.

--- a/src/valhalla_associate_segments.cc
+++ b/src/valhalla_associate_segments.cc
@@ -185,7 +185,7 @@ private:
 
   vb::GraphReader m_reader;
   vs::TravelMode m_travel_mode;
-  std::shared_ptr<vt::PathAlgorithm> m_path_algo;
+  std::shared_ptr<vt::AStarPathAlgorithm> m_path_algo;
   std::shared_ptr<vs::DynamicCost> m_costing;
   std::shared_ptr<vj::GraphTileBuilder> m_tile_builder;
 
@@ -670,6 +670,7 @@ std::vector<EdgeMatch> edge_association::match_edges(const pbf::Segment& segment
 
     // make sure there's no state left over from previous paths
     m_path_algo->Clear();
+    m_path_algo->set_max_label_count(100);
     auto path = m_path_algo->GetBestPath(origin, dest, m_reader, &m_costing, m_travel_mode);
 
     if (path.empty()) {

--- a/valhalla/thor/astar.h
+++ b/valhalla/thor/astar.h
@@ -74,7 +74,6 @@ class AStarPathAlgorithm : public PathAlgorithm {
   uint32_t max_label_count_;    // Max label count to allow
   sif::TravelMode mode_;        // Current travel mode
   uint8_t travel_type_;         // Current travel type
-  uint32_t tile_creation_date_; // Tile creation date
 
   // Hierarchy limits.
   std::vector<sif::HierarchyLimits> hierarchy_limits_;

--- a/valhalla/thor/astar.h
+++ b/valhalla/thor/astar.h
@@ -46,7 +46,7 @@ class AStarPathAlgorithm : public PathAlgorithm {
    * @param  origin       Origin location
    * @param  dest         Destination location
    * @param  graphreader  Graph reader for accessing routing graph.
-   * @param  costing      Costing methods.
+   * @param  mode_costing Costing methods for each mode.
    * @param  mode         Travel mode to use.
    * @return Returns the path edges (and elapsed time/modes at end of
    *          each edge).
@@ -61,15 +61,20 @@ class AStarPathAlgorithm : public PathAlgorithm {
    */
   virtual void Clear();
 
+  /**
+   * Set a maximum label count. The path algorithm terminates if this
+   * is exceeded.
+   * @param  max_count  Maximum number of labels to allow.
+   */
+  void set_max_label_count(const uint32_t max_count) {
+    max_label_count_ = max_count;
+  }
+
  protected:
-  // Current travel mode
-  sif::TravelMode mode_;
-
-  // Current travel type
-  uint8_t travel_type_;
-
-  // Tile creation date
-  uint32_t tile_creation_date_;
+  uint32_t max_label_count_;    // Max label count to allow
+  sif::TravelMode mode_;        // Current travel mode
+  uint8_t travel_type_;         // Current travel type
+  uint32_t tile_creation_date_; // Tile creation date
 
   // Hierarchy limits.
   std::vector<sif::HierarchyLimits> hierarchy_limits_;
@@ -146,7 +151,7 @@ class AStarPathAlgorithm : public PathAlgorithm {
    * direction from the origin to the destination.
    * @param  edgeid   Edge where path completion occurs.
    * @param  orig     Location information of the origin.
-   * @param  origin   Location information of the destination
+   * @param  dest     Location information of the destination
    * @return Returns true if the path is trivial.
    */
   bool IsTrivial(const baldr::GraphId& edgeid,

--- a/valhalla/thor/isochrone.h
+++ b/valhalla/thor/isochrone.h
@@ -93,7 +93,6 @@ class Isochrone {
   float shape_interval_;        // Interval along shape to mark time
   sif::TravelMode mode_;        // Current travel mode
   uint32_t access_mode_;        // Access mode used by the costing method
-  uint32_t tile_creation_date_; // Tile creation date
 
   // Current costing mode
   std::shared_ptr<sif::DynamicCost> costing_;

--- a/valhalla/thor/pathalgorithm.h
+++ b/valhalla/thor/pathalgorithm.h
@@ -29,7 +29,9 @@ class PathAlgorithm {
   /**
    * Constructor
    */
-  PathAlgorithm():interrupt(nullptr) { }
+  PathAlgorithm()
+     : interrupt(nullptr) {
+  }
 
   /**
    * Destructor
@@ -59,10 +61,12 @@ class PathAlgorithm {
 
   /**
    * Set a callback that will throw when the path computation should be aborted
-   *
-   * @param interrupt_callback  the function to periodically call to see if we should abort
+   * @param interrupt_callback  the function to periodically call to see if
+   *                            we should abort
    */
-  void set_interrupt(const std::function<void ()>* interrupt_callback) { interrupt = interrupt_callback; }
+  void set_interrupt(const std::function<void ()>* interrupt_callback) {
+    interrupt = interrupt_callback;
+  }
 
  protected:
   const std::function<void()>* interrupt;


### PR DESCRIPTION
Add a max label limit to AStarPathAlgorithm. Abort (with no result) if this is exceeded. Used for valhalla_associate_segments to prevent long searches that ultimately fail. Within valhalla_associate_segments add a max label limit of 100 to the AStarPathAlgorithm (which is used as a fallback if edge walking fails).