### PR TITLE
Shuffle list of OSMLR tiles 

### DIFF
--- a/src/valhalla_associate_segments.cc
+++ b/src/valhalla_associate_segments.cc
@@ -1012,7 +1012,10 @@ int main(int argc, char** argv) {
       }
     }
   }
-  //std::random_shuffle(osmlr_tiles.begin(), osmlr_tiles.end());
+
+  // Shuffle the list to minimize the chance of adjacent tiles being access
+  // by different threads at the same time
+  std::random_shuffle(osmlr_tiles.begin(), osmlr_tiles.end());
 
   //configure logging
   vm::logging::Configure({{"type","std_err"},{"color","true"}});


### PR DESCRIPTION
so there is less chance of adjacent tiles being worked on simultaneously.