### PR TITLE
Allow multiple locations in a single isochrone query

### DIFF
--- a/scripts/valhalla_build_config
+++ b/scripts/valhalla_build_config
@@ -197,7 +197,7 @@ config = {
     'isochrone': {
       'max_contours': 4,
       'max_time': 120,
-      'max_distance': 50000.0
+      'max_distance': 25000.0,
       'max_locations': 25
     },
     'trace': {
@@ -404,6 +404,7 @@ help_text = {
     'isochrone': {
       'max_contours': 'Maximum number of input contours to allow',
       'max_time': 'Maximum time value for any one contour',
+      'max_distance':'Maximum b-line distance between all locations in meters',
       'max_locations': 'Maximum number of input locations'
     },
     'trace': {

--- a/scripts/valhalla_build_config
+++ b/scripts/valhalla_build_config
@@ -197,7 +197,8 @@ config = {
     'isochrone': {
       'max_contours': 4,
       'max_time': 120,
-      'max_locations': 1
+      'max_distance': 50000.0
+      'max_locations': 25
     },
     'trace': {
       'max_distance': 200000.0,

--- a/scripts/valhalla_build_config
+++ b/scripts/valhalla_build_config
@@ -198,7 +198,7 @@ config = {
       'max_contours': 4,
       'max_time': 120,
       'max_distance': 25000.0,
-      'max_locations': 25
+      'max_locations': 1
     },
     'trace': {
       'max_distance': 200000.0,

--- a/src/loki/isochrone_action.cc
+++ b/src/loki/isochrone_action.cc
@@ -8,7 +8,24 @@ using namespace prime_server;
 using namespace valhalla::baldr;
 
 namespace {
-const headers_t::value_type CORS{"Access-Control-Allow-Origin", "*"};
+  const headers_t::value_type CORS{"Access-Control-Allow-Origin", "*"};
+
+  void check_distance(const std::vector<Location>& locations, float matrix_max_distance, float& max_location_distance) {
+    //see if any locations pairs are unreachable or too far apart
+    for(const auto& source = locations.begin(); source != locations.end() - 1; ++source){
+      for(const auto& target = source + 1; target != locations.end(); ++target){
+        //check if distance between latlngs exceed max distance limit
+        auto path_distance = source->latlng_.Distance(target->latlng_);
+
+        if (path_distance >= max_location_distance) {
+          max_location_distance = path_distance;
+        }
+
+        if (path_distance > matrix_max_distance)
+          throw valhalla_exception_t{400, 154};
+      }
+    }
+  }
 }
 
 namespace valhalla {
@@ -45,6 +62,12 @@ namespace valhalla {
       //check that location size does not exceed max
       if (locations.size() > max_locations.find("isochrone")->second)
         throw valhalla_exception_t{400, 150, std::to_string(max_locations.find("isochrone")->second)};
+
+      //check the distances
+      auto max_location_distance = std::numeric_limits<float>::min();
+      check_distance(locations, max_distance.find("isochrone")->second, max_location_distance);
+      if (!healthcheck)
+        valhalla::midgard::logging::Log("max_location_distance::" + std::to_string(max_location_distance * kKmPerMeter) + "km", " [ANALYTICS] ");
 
       auto costing = GetOptionalFromRapidJson<std::string>(request, "/costing").get_value_or("");
       auto date_type = GetOptionalFromRapidJson<int>(request, "/date_time/type");

--- a/src/loki/isochrone_action.cc
+++ b/src/loki/isochrone_action.cc
@@ -2,6 +2,7 @@
 #include "loki/search.h"
 #include "baldr/datetime.h"
 #include "baldr/rapidjson_utils.h"
+#include "midgard/logging.h"
 #include <boost/property_tree/json_parser.hpp>
 
 using namespace prime_server;
@@ -12,8 +13,8 @@ namespace {
 
   void check_distance(const std::vector<Location>& locations, float matrix_max_distance, float& max_location_distance) {
     //see if any locations pairs are unreachable or too far apart
-    for(const auto& source = locations.begin(); source != locations.end() - 1; ++source){
-      for(const auto& target = source + 1; target != locations.end(); ++target){
+    for(auto source = locations.begin(); source != locations.end() - 1; ++source){
+      for(auto target = source + 1; target != locations.end(); ++target){
         //check if distance between latlngs exceed max distance limit
         auto path_distance = source->latlng_.Distance(target->latlng_);
 

--- a/src/loki/service.cc
+++ b/src/loki/service.cc
@@ -241,7 +241,7 @@ namespace valhalla {
           continue;
         if (kv.first != "skadi" && kv.first != "trace")
           max_locations.emplace(kv.first, config.get<size_t>("service_limits." + kv.first + ".max_locations"));
-        if (kv.first != "skadi" && kv.first != "isochrone")
+        if (kv.first != "skadi")
           max_distance.emplace(kv.first, config.get<float>("service_limits." + kv.first + ".max_distance"));
         if (kv.first != "skadi" && kv.first != "trace" && kv.first != "isochrone") {
           max_matrix_distance.emplace(kv.first, config.get<float>("service_limits." + kv.first + ".max_matrix_distance"));

--- a/src/midgard/aabb2.cc
+++ b/src/midgard/aabb2.cc
@@ -274,6 +274,19 @@ void AABB2<coord_t>::Expand(const AABB2<coord_t>& r2) {
     maxy_ = r2.maxy();
 }
 
+// Expands (if necessary) the bounding box to include the specified point.
+template <class coord_t>
+void AABB2<coord_t>::Expand(const coord_t& point) {
+  if (point.x() < minx_)
+    minx_ = point.x();
+  if (point.y() < miny_)
+    miny_ = point.y();
+  if (point.x() > maxx_)
+    maxx_ = point.x();
+  if (point.y() > maxy_)
+    maxy_ = point.y();
+}
+
 // Explicit instantiation
 template class AABB2<Point2>;
 template class AABB2<PointLL>;

--- a/test/loki_service.cc
+++ b/test/loki_service.cc
@@ -132,7 +132,7 @@ namespace {
         "pedestrian": { "max_distance": 250000.0, "max_locations": 50,
                         "max_matrix_distance": 200000.0, "max_matrix_locations": 50,
                         "min_transit_walking_distance": 1, "max_transit_walking_distance": 10000 },
-        "isochrone": { "max_contours": 4, "max_time": 120, "max_locations": 1},
+        "isochrone": { "max_contours": 4, "max_time": 120, "max_distance": 25000, "max_locations": 1},
         "trace": { "max_distance": 65000.0, "max_gps_accuracy": 100.0, "max_shape": 16000, "max_search_radius": 100 },
         "max_avoid_locations": 0,
         "max_reachability": 100,

--- a/valhalla/midgard/aabb2.h
+++ b/valhalla/midgard/aabb2.h
@@ -262,6 +262,12 @@ class AABB2 {
    */
   void Expand(const AABB2& r2);
 
+  /**
+   * Expands (if necessary) the bounding box to include the specified point.
+   * @param  point  Point to "add" to this bounding box.
+   */
+  void Expand(const coord_t& r2);
+
  protected:
   // Edge to clip against
   enum ClipEdge { kLeft, kRight, kBottom, kTop };


### PR DESCRIPTION
# Changes
+ Config changes have been made to allow up to 25 locations in a single request.
+ A new max_distance parameter has been added to isochrone under service_limits in valhalla_build_config. The default is set to 25 km. This may be increased in the future.
+ Minor tweak to the ConstructIsoTile function in isochrone where the grid is shifted to center around the center most location in the request instead of the first location in the request.