### PR TITLE
Add turn channel logic within traffic segment matcher

### DIFF
--- a/scripts/valhalla_build_config
+++ b/scripts/valhalla_build_config
@@ -73,7 +73,7 @@ config = {
     }
   },
   'meili': {
-    'mode': 'multimodal',
+    'mode': 'auto',
     'customizable': ['mode', 'search_radius', 'turn_penalty_factor', 'gps_accuracy'],
     'verbose': False,
     'default': {

--- a/src/meili/traffic_segment_matcher.cc
+++ b/src/meili/traffic_segment_matcher.cc
@@ -337,7 +337,6 @@ std::vector<traffic_segment_t> TrafficSegmentMatcher::form_segments(const std::l
     printf("\nReported Segments:\n");*/
 
     //go over the segments and move the interpolation markers accordingly
-    int idx = 0;
     float prior_start_acc_length = 0.0f;
     float prior_end_acc_length = 0.0f;
     auto left = markers.cbegin(), right = markers.cbegin();
@@ -357,7 +356,6 @@ std::vector<traffic_segment_t> TrafficSegmentMatcher::form_segments(const std::l
       //skip any segments composed entirely of transition edges (should only be one edge really)
       //they should have no valid segment id, be marked internal and also have no way ids
       if(!segment->segment_id_.Is_Valid() && segment.internal && segment.way_ids.empty()) {
-        idx++;
         continue;
       }
 
@@ -396,6 +394,7 @@ std::vector<traffic_segment_t> TrafficSegmentMatcher::form_segments(const std::l
       //   if this segment is a turn channel set the prior segment end time to
       //       the start of this turn channel segment and set the prior
       //       segment length
+      size_t idx = &segment - &merged_segments[0];
       if (segment->ends_segment_ && idx > 0 && merged_segments[idx-1].turn_channel &&
                 start_length == -1) {
         // Set the segment start time to the end time of the turn channel
@@ -434,7 +433,6 @@ std::vector<traffic_segment_t> TrafficSegmentMatcher::form_segments(const std::l
         ++right;
         left = right;
       }
-      idx++;
     }
   }
 

--- a/src/meili/traffic_segment_matcher.cc
+++ b/src/meili/traffic_segment_matcher.cc
@@ -126,9 +126,7 @@ namespace {
           merged.back()->end_percent_ = segment.end_percent_;
           merged.back()->ends_segment_ = segment.ends_segment_;
           merged.back().internal = merged.back().internal && is_internal(directed_edge);
-          // Turn off turn channel flag if any segment continuation is not a turn channel
-          if (merged.back().turn_channel && !is_turn_channel(directed_edge))
-            merged.back().turn_channel = false;
+          merged.back().turn_channel = merged.back().turn_channel && is_turn_channel(directed_edge);
           if(!directed_edge->IsTransition() && (merged.back().way_ids.size() == 0 || merged.back().way_ids.back() != way_id))
             merged.back().way_ids.push_back(way_id);
         }//new one

--- a/src/meili/traffic_segment_matcher.cc
+++ b/src/meili/traffic_segment_matcher.cc
@@ -126,7 +126,9 @@ namespace {
           merged.back()->end_percent_ = segment.end_percent_;
           merged.back()->ends_segment_ = segment.ends_segment_;
           merged.back().internal = merged.back().internal && is_internal(directed_edge);
-          merged.back().turn_channel = merged.back().internal && is_turn_channel(directed_edge);
+          // Turn off turn channel flag if any segment continuation is not a turn channel
+          if (merged.back().turn_channel && !is_turn_channel(directed_edge))
+            merged.back().turn_channel = false;
           if(!directed_edge->IsTransition() && (merged.back().way_ids.size() == 0 || merged.back().way_ids.back() != way_id))
             merged.back().way_ids.push_back(way_id);
         }//new one


### PR DESCRIPTION
Special case logic to "complete" segments before and after turn channels.
Also change default mode in meili (map-matching) to auto in the config generator script.