### PR TITLE
Fix breaking out of form_segments

### DIFF
--- a/src/meili/traffic_segment_matcher.cc
+++ b/src/meili/traffic_segment_matcher.cc
@@ -379,10 +379,6 @@ std::vector<traffic_segment_t> TrafficSegmentMatcher::form_segments(const std::l
         end_time = prev->epoch_time + (right->epoch_time - prev->epoch_time) * ratio;
       }
 
-      // start_time and end_time can both be -1 (if the merged segment does not
-      // start a segment and does not end a segment - for example by taking
-      // local roads, so do not break if this occurs...
-
       //figure out the total length of the segment
       int length = start_length != -1 && end_length != -1 ? (end_length - start_length) +.5f : -1;
 
@@ -427,8 +423,7 @@ std::vector<traffic_segment_t> TrafficSegmentMatcher::form_segments(const std::l
       //print(traffic_segments.back());
 
       // Break out of the loop once we are past where we have interpolations
-      // (e.g. for a long edge with many segments). TODO - will this break
-      // too early if there are discontinuities in the trace?
+      // (e.g. for a long edge with many segments).
       if (idx > 0 && right->epoch_time == -1) {
         break;
       }

--- a/src/meili/traffic_segment_matcher.cc
+++ b/src/meili/traffic_segment_matcher.cc
@@ -379,9 +379,9 @@ std::vector<traffic_segment_t> TrafficSegmentMatcher::form_segments(const std::l
         end_time = prev->epoch_time + (right->epoch_time - prev->epoch_time) * ratio;
       }
 
-      //if we didnt have a start or end time then we are past where we had interpolations
-      if(start_time == -1 && end_time == -1)
-        break;
+      // start_time and end_time can both be -1 (if the merged segment does not
+      // start a segment and does not end a segment - for example by taking
+      // local roads, so do not break if this occurs...
 
       //figure out the total length of the segment
       int length = start_length != -1 && end_length != -1 ? (end_length - start_length) +.5f : -1;
@@ -425,6 +425,13 @@ std::vector<traffic_segment_t> TrafficSegmentMatcher::form_segments(const std::l
                   length, queue_length, segment.internal, segment.way_ids});
 
       //print(traffic_segments.back());
+
+      // Break out of the loop once we are past where we have interpolations
+      // (e.g. for a long edge with many segments). TODO - will this break
+      // too early if there are discontinuities in the trace?
+      if (idx > 0 && right->epoch_time == -1) {
+        break;
+      }
 
       //if the right side of this was the end of this edge then at least we need to start from the next edge
       if(segment->end_percent_ == 1.f) {

--- a/src/meili/traffic_segment_matcher.cc
+++ b/src/meili/traffic_segment_matcher.cc
@@ -389,20 +389,17 @@ std::vector<traffic_segment_t> TrafficSegmentMatcher::form_segments(const std::l
       //       the start of this turn channel segment and set the prior
       //       segment length
       size_t idx = &segment - &merged_segments[0];
-      if (segment->ends_segment_ && idx > 0 && merged_segments[idx-1].turn_channel &&
-                start_length == -1) {
+      if (segment->ends_segment_ && idx > 0 && merged_segments[idx-1].turn_channel && start_length == -1) {
         // Set the segment start time to the end time of the turn channel
         if (traffic_segments.size() > 0 && end_length != -1) {
           start_time = traffic_segments.back().end_time;
-          length = (end_length - prior_end_acc_length) +
-                      traffic_segments.back().length / 2;
+          length = (end_length - prior_end_acc_length) + traffic_segments.back().length / 2;
         }
       } else  if (segment.turn_channel && traffic_segments.size() > 0 &&
                   traffic_segments.back().end_time == -1) {
         traffic_segments.back().end_time = start_time;
         if (length > 0) {
-          traffic_segments.back().length = (start_length - prior_start_acc_length) +
-                        length / 2;
+          traffic_segments.back().length = (start_length - prior_start_acc_length) + length / 2;
         }
       }
 
@@ -424,9 +421,8 @@ std::vector<traffic_segment_t> TrafficSegmentMatcher::form_segments(const std::l
 
       // Break out of the loop once we are past where we have interpolations
       // (e.g. for a long edge with many segments).
-      if (idx > 0 && right->epoch_time == -1) {
+      if (idx > 0 && right->epoch_time == -1)
         break;
-      }
 
       //if the right side of this was the end of this edge then at least we need to start from the next edge
       if(segment->end_percent_ == 1.f) {


### PR DESCRIPTION
It was invalid to break out of the form_segment loop if start time and end time are both -1 (this can occur when the path transitions part of a segment such as entering and exiting onto local roads). Instead break out at the end of the loop if the right epoch time is -1 and not the first merged segment.