### PR TITLE
midgard util updates (move some methods from meili)

### DIFF
--- a/src/meili/candidate_search.cc
+++ b/src/meili/candidate_search.cc
@@ -227,7 +227,7 @@ CandidateGridQuery::Query(const midgard::PointLL& location,
     throw std::invalid_argument("Expect a valid location");
   }
 
-  const auto range = helpers::ExpandMeters(location, std::sqrt(sq_search_radius));
+  const auto range = midgard::ExpandMeters(location, std::sqrt(sq_search_radius));
   const auto edgeids = RangeQuery(range);
   return WithinSquaredDistance(location, sq_search_radius,
                                edgeids.begin(), edgeids.end(), filter);

--- a/src/meili/routing.cc
+++ b/src/meili/routing.cc
@@ -485,10 +485,9 @@ find_shortest_path(baldr::GraphReader& reader,
         continue;
       }
 
-      // Need the graphreader to get the tile of edgelabel
+      // Get the inbound edge heading (clamped to range [0,360])
       const auto inbound_heading = (pred_edgelabel && turn_cost_table)?
                                    get_inbound_edgelabel_heading(reader, tile, *pred_edgelabel, *nodeinfo) : 0;
-      // TODO: test it assert(0 <= inbound_heading && inbound_heading < 360);
 
       // Expand current node
       baldr::GraphId other_edgeid(nodeid.tileid(), nodeid.level(), nodeinfo->edge_index());
@@ -502,12 +501,12 @@ find_shortest_path(baldr::GraphReader& reader,
         if (!IsEdgeAllowed(other_edge, other_edgeid, costing, pred_edgelabel, other_tile)) continue;
 
         // Turn cost only for non transition edges
+        // TODO - need to properly handle turn costs across transition edges.
         float turn_cost = label_turn_cost;
         if (pred_edgelabel && turn_cost_table && !other_edge->IsTransition()) {
-          const auto other_heading = get_outbound_edge_heading(other_tile, other_edge, *nodeinfo);
-          // TODO: test it assert(0 <= other_heading && other_heading < 360);
-          const auto turn_degree = helpers::get_turn_degree180(inbound_heading, other_heading);
-          // TODO: test it assert(0 <= turn_degree && turn_degree <= 180);
+          // Get outbound heading (clamped to range [0,360])
+          const auto outbound_heading = get_outbound_edge_heading(other_tile, other_edge, *nodeinfo);
+          const auto turn_degree = midgard::get_turn_degree180(inbound_heading, outbound_heading);
           turn_cost += turn_cost_table[turn_degree];
         }
 

--- a/src/midgard/util.cc
+++ b/src/midgard/util.cc
@@ -1,5 +1,4 @@
 #include <cmath>
-#include <random>
 #include "valhalla/midgard/util.h"
 #include "valhalla/midgard/constants.h"
 #include "valhalla/midgard/point2.h"
@@ -24,14 +23,6 @@ constexpr double DEG_PER_RAD = 180.0 / valhalla::midgard::kPiDouble;
 
 namespace valhalla {
 namespace midgard {
-
-// Return a random number between 0 and 1
-float rand01() {
-  std::random_device rd;
-  std::mt19937 gen(rd());
-  std::uniform_real_distribution<> dis(0, 1);
-  return static_cast<float>(dis(gen));
-}
 
 // Trim the front of a polyline (represented as a list or vector of Point2).
 // Returns the trimmed portion of the polyline. The supplied polyline is

--- a/src/midgard/util.cc
+++ b/src/midgard/util.cc
@@ -1,4 +1,5 @@
 #include <cmath>
+#include <random>
 #include "valhalla/midgard/util.h"
 #include "valhalla/midgard/constants.h"
 #include "valhalla/midgard/point2.h"
@@ -24,27 +25,12 @@ constexpr double DEG_PER_RAD = 180.0 / valhalla::midgard::kPiDouble;
 namespace valhalla {
 namespace midgard {
 
-int GetTime(const float length, const float speed) {
-  if (speed > 0.0f)
-    return (int)(length / (speed * kHourPerSec) + 0.5f);
-  return 0;
-}
-
-uint32_t GetTurnDegree(const uint32_t from_heading, const uint32_t to_heading) {
-  return (((to_heading - from_heading) + 360) % 360);
-}
-
+// Return a random number between 0 and 1
 float rand01() {
-  return (float)rand() / (float)RAND_MAX;
-}
-
-float FastInvSqrt(float x) {
-  float xhalf = 0.5f * x;
-  int i = *(int*)&x;                 // get bits for floating value
-  i = 0x5f3759df - (i >> 1);         // give initial guess y0
-  x = *(float*)&i;                   // convert bits back to float
-  return x * (1.5f - xhalf * x * x); // newton step
-  // x *= 1.5f - xhalf*x*x;          // repeating step increases accuracy
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<> dis(0, 1);
+  return static_cast<float>(dis(gen));
 }
 
 // Trim the front of a polyline (represented as a list or vector of Point2).

--- a/src/valhalla_benchmark_adjacency_list.cc
+++ b/src/valhalla_benchmark_adjacency_list.cc
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 #include <queue>
+#include <random>
 #include <boost/program_options.hpp>
 
 #include "midgard/util.h"
@@ -18,10 +19,6 @@ using namespace valhalla::sif;
 
 namespace bpo = boost::program_options;
 
-uint32_t GetRandom(const uint32_t maxcost) {
-  return (uint32_t)(rand01() * maxcost);
-}
-
 /**
  * Benchmark of adjacency list. Constructs a large number of random numbers,
  * adds EdgeLabels to the AdjacencyList with those as the sortcost. Then
@@ -32,9 +29,12 @@ uint32_t GetRandom(const uint32_t maxcost) {
 int Benchmark(const uint32_t n, const float maxcost,
               const float bucketsize) {
   // Create a set of random costs
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<> dis(0, 1);
   std::vector<uint32_t> costs(n);
   for (uint32_t i = 0; i < n; i++) {
-    costs[i] = (uint32_t)GetRandom(maxcost);
+    costs[i] = static_cast<uint32_t>(dis(gen) * maxcost);
   }
 
   // Test performance of STL priority queue. Construct labels

--- a/test/double_bucket_queue.cc
+++ b/test/double_bucket_queue.cc
@@ -110,7 +110,8 @@ void TrySimulation(DoubleBucketQueue& dbqueue,
   const uint32_t idx = costs.size();
   costs.push_back(10.f);
   dbqueue.add(idx, 10.f);
-
+  std::random_device rd;
+  std::mt19937 gen(rd());
   for (size_t i = 0; i < loop_count; i++) {
     const auto key = dbqueue.pop();
     if (key == kInvalidLabel) {
@@ -125,10 +126,10 @@ void TrySimulation(DoubleBucketQueue& dbqueue,
     addedLabels.erase(key);
 
     for (size_t i = 0; i < expansion_size; i++) {
-      const auto newcost = std::floor(min_cost + 1 + midgard::rand01() * max_increment_cost);
+      const auto newcost = std::floor(min_cost + 1 + test::rand01(gen) * max_increment_cost);
       if (i % 2 == 0 && !addedLabels.empty()) {
         // Decrease cost
-        const auto idx = *std::next(addedLabels.begin(), midgard::rand01() * addedLabels.size());
+        const auto idx = *std::next(addedLabels.begin(), test::rand01(gen) * addedLabels.size());
         if (newcost < costs[idx]) {
           dbqueue.decrease(idx, newcost);
           costs[idx] = newcost;

--- a/test/routing.cc
+++ b/test/routing.cc
@@ -46,8 +46,10 @@ void TestAddRemove()
 
   // Test add randomly and remove
   costs.clear();
+  std::random_device rd;
+  std::mt19937 gen(rd());
   for (size_t i = 0; i < 10000; i++) {
-    const auto cost = std::floor(rand01() * 100000);
+    const auto cost = std::floor(test::rand01(gen) * 100000);
     costs.push_back(cost);
   }
 
@@ -97,6 +99,8 @@ void TrySimulation(size_t loop_count, size_t expansion_size, size_t max_incremen
   adjlist.add(idx, 10.f);
   track.insert(idx);
 
+  std::random_device rd;
+  std::mt19937 gen(rd());
   for (size_t i = 0; i < loop_count; i++) {
     const auto key = adjlist.pop();
     const auto min_cost = costs[key];
@@ -107,10 +111,10 @@ void TrySimulation(size_t loop_count, size_t expansion_size, size_t max_incremen
     track.erase(key);
 
     for (size_t i = 0; i < expansion_size; i++) {
-      const auto newcost = std::floor(min_cost + 1 + rand01() * max_increment_cost);
+      const auto newcost = std::floor(min_cost + 1 + test::rand01(gen) * max_increment_cost);
       if (i % 2 == 0 && !track.empty()) {
         // Decrease cost
-        const auto idx = *std::next(track.begin(), rand01() * track.size());
+        const auto idx = *std::next(track.begin(), test::rand01(gen) * track.size());
         if (newcost < costs[idx]) {
           adjlist.decrease(idx, newcost);
           costs[idx] = newcost;
@@ -148,10 +152,12 @@ void TestSimulation()
 
 void Benchmark()
 {
+  std::random_device rd;
+  std::mt19937 gen(rd());
   std::vector<float> costs;
   size_t N = 1000000;
   for (size_t i = 0; i < N; ++i) {
-    costs.push_back(std::floor(rand01() * N));
+    costs.push_back(std::floor(test::rand01(gen) * N));
   }
 
   const auto labelcost = [&costs](const uint32_t label) {

--- a/test/test.h
+++ b/test/test.h
@@ -5,6 +5,7 @@
 
 #include <string>
 #include <stdexcept>
+#include <random>
 
 #define TEST_CASE(x) #x, x
 
@@ -48,6 +49,12 @@ void assert_throw(function_t func, const std::string& message)
   if (!thrown) {
     throw std::runtime_error(message);
   }
+}
+
+// Return a random number between 0 and 1
+inline float rand01(std::mt19937& gen) {
+  std::uniform_real_distribution<> dis(0, 1);
+  return static_cast<float>(dis(gen));
 }
 
 }

--- a/valhalla/meili/geometry_helpers.h
+++ b/valhalla/meili/geometry_helpers.h
@@ -118,69 +118,6 @@ ClipLineString(const iterator_t& begin, const iterator_t& end,
   return clip;
 }
 
-
-inline uint8_t
-get_turn_degree180(uint16_t left, uint16_t right)
-{
-  if (!(left < 360 && right < 360)) {
-    throw std::invalid_argument("expect angles to be within [0, 360)");
-  }
-  const auto turn = std::abs(left - right);
-  return 180 < turn? 360 - turn : turn;
-}
-
-
-inline float
-TranslateLatitudeInMeters(float lat, float meters)
-{
-  const float offset = meters / midgard::kMetersPerDegreeLat;
-  return lat + offset;
-}
-
-
-inline float
-TranslateLatitudeInMeters(const midgard::PointLL& lnglat, float meters)
-{ return TranslateLatitudeInMeters(lnglat.lat(), meters); }
-
-
-inline float
-TranslateLongitudeInMeters(const midgard::PointLL& lnglat, float meters)
-{
-  const float offset = meters / midgard::DistanceApproximator::MetersPerLngDegree(lnglat.lat());
-  return lnglat.lng() + offset;
-}
-
-
-inline midgard::AABB2<midgard::PointLL>
-ExpandMeters(const midgard::AABB2<midgard::PointLL>& bbox, float meters)
-{
-  if (meters < 0.f) {
-    throw std::invalid_argument("expect non-negative meters");
-  }
-
-  midgard::PointLL minpt(TranslateLongitudeInMeters(bbox.minpt(), -meters),
-                         TranslateLatitudeInMeters(bbox.minpt(), -meters));
-  midgard::PointLL maxpt(TranslateLongitudeInMeters(bbox.maxpt(), meters),
-                         TranslateLatitudeInMeters(bbox.maxpt(), meters));
-  return {minpt, maxpt};
-}
-
-
-inline midgard::AABB2<midgard::PointLL>
-ExpandMeters(const midgard::PointLL& pt, float meters)
-{
-  if (meters < 0.f) {
-    throw std::invalid_argument("expect non-negative meters");
-  }
-
-  midgard::PointLL minpt(TranslateLongitudeInMeters(pt, -meters),
-                         TranslateLatitudeInMeters(pt, -meters));
-  midgard::PointLL maxpt(TranslateLongitudeInMeters(pt, meters),
-                         TranslateLatitudeInMeters(pt, meters));
-  return {minpt, maxpt};
-}
-
-
 // snapped point, sqaured distance, segment index, offset
 template <typename coord_t>
 std::tuple<coord_t, float, typename std::vector<coord_t>::size_type, float>

--- a/valhalla/midgard/util.h
+++ b/valhalla/midgard/util.h
@@ -85,12 +85,6 @@ inline uint8_t get_turn_degree180(const uint16_t inbound, const uint16_t outboun
 }
 
 /**
- * Get a random number between 0 and 1
- * @return  Returns a random floating point number between 0.0f and 1.0f.
- */
-float rand01();
-
-/**
  * Expand an input lat,lon bounding box by the specified distance in meters.
  * @param   box     Bounding box.
  * @param   meters  Meters to expand the bounds

--- a/valhalla/midgard/util.h
+++ b/valhalla/midgard/util.h
@@ -124,8 +124,8 @@ inline AABB2<PointLL> ExpandMeters(const PointLL& pt, const float meters) {
 
   float dlat = meters / kMetersPerDegreeLat;
   float dlng = meters / DistanceApproximator::MetersPerLngDegree(pt.lat());
-  midgard::PointLL minpt(pt.lng() - dlng, pt.lat() - dlat);
-  midgard::PointLL maxpt(pt.lng() - dlng, pt.lat() + dlat);
+  PointLL minpt(pt.lng() - dlng, pt.lat() - dlat);
+  PointLL maxpt(pt.lng() - dlng, pt.lat() + dlat);
   return { minpt, maxpt };
 }
 


### PR DESCRIPTION
Move a few geometry_helpers methods into midgard (util). 
Move some util methods to be inline and remove FastSqrt (unused).
Update rand01 to use new C++ 11 random number generation
Be more explicit about inbound and outbound edge headings in meili routing.