### PR TITLE
Do not set length if start_time is invalid 

### DIFF
--- a/src/meili/traffic_segment_matcher.cc
+++ b/src/meili/traffic_segment_matcher.cc
@@ -398,7 +398,7 @@ std::vector<traffic_segment_t> TrafficSegmentMatcher::form_segments(const std::l
       } else  if (segment.turn_channel && traffic_segments.size() > 0 &&
                   traffic_segments.back().end_time == -1) {
         traffic_segments.back().end_time = start_time;
-        if (length > 0) {
+        if (length > 0 && traffic_segments.back().start_time > 0.0) {
           traffic_segments.back().length = (start_length - prior_start_acc_length) + length / 2;
         }
       }


### PR DESCRIPTION
(for the turn channel special case).