### PR TITLE
Alpha version of Low-Stress Bicycle Costing

### DIFF
--- a/lua/graph.lua
+++ b/lua/graph.lua
@@ -345,13 +345,13 @@ shared = {
 }
 
 dedicated = {
-["opposite_track"] = 2,
-["track"] = 2
+["opposite_lane"] = 2,
+["lane"] = 2
 }
 
 separated = {
-["opposite_lane"] = 3,
-["lane"] = 3
+["opposite_track"] = 3,
+["track"] = 3
 }
 
 oneway = {

--- a/scripts/valhalla_build_config
+++ b/scripts/valhalla_build_config
@@ -172,6 +172,12 @@ config = {
       'max_matrix_distance': 200000.0,
       'max_matrix_locations': 50
     },
+    'low_stress_bicycle': {
+      'max_distance': 500000.0,
+      'max_locations': 50,
+      'max_matrix_distance': 200000.0,
+      'max_matrix_locations': 50
+    },
     'multimodal': {
       'max_distance': 500000.0,
       'max_locations': 50,
@@ -374,6 +380,12 @@ help_text = {
       'max_transit_walking_distance': 'Maximum distance allowed for walking when using transit'
     },
     'bicycle': {
+      'max_distance': 'Maximum b-line distance between all locations in meters',
+      'max_locations': 'Maximum number of input locations',
+      'max_matrix_distance': 'Maximum b-line distance between 2 most distant locations in meters for a matrix',
+      'max_matrix_locations': 'Maximum number of input locations for a matrix'
+    },
+    'low_stress_bicycle': {
       'max_distance': 'Maximum b-line distance between all locations in meters',
       'max_locations': 'Maximum number of input locations',
       'max_matrix_distance': 'Maximum b-line distance between 2 most distant locations in meters for a matrix',

--- a/src/baldr/directededge.cc
+++ b/src/baldr/directededge.cc
@@ -292,9 +292,9 @@ void DirectedEdge::set_reverseaccess(const uint32_t modes) {
 
 // Sets the average speed in KPH.
 void DirectedEdge::set_speed(const uint32_t speed) {
-  if (speed > kMaxSpeed) {
+  if (speed > kMaxSpeedKph) {
     LOG_WARN("Exceeding maximum.  Average speed: " + std::to_string(speed));
-    speed_ = kMaxSpeed;
+    speed_ = kMaxSpeedKph;
   } else {
     speed_ = speed;
   }
@@ -302,9 +302,9 @@ void DirectedEdge::set_speed(const uint32_t speed) {
 
 // Sets the speed limit in KPH.
 void DirectedEdge::set_speed_limit(const uint32_t speed_limit) {
-  if (speed_limit > kMaxSpeed) {
+  if (speed_limit > kMaxSpeedKph) {
     LOG_WARN("Exceeding maximum.  Speed limit: " + std::to_string(speed_limit));
-    speed_limit_ = kMaxSpeed;
+    speed_limit_ = kMaxSpeedKph;
   } else {
     speed_limit_ = speed_limit;
   }
@@ -312,9 +312,9 @@ void DirectedEdge::set_speed_limit(const uint32_t speed_limit) {
 
 // Sets the truck speed in KPH.
 void DirectedEdge::set_truck_speed(const uint32_t speed) {
-  if (speed > kMaxSpeed) {
+  if (speed > kMaxSpeedKph) {
     LOG_WARN("Exceeding maximum.  Truck speed: " + std::to_string(speed));
-    truck_speed_ = kMaxSpeed;
+    truck_speed_ = kMaxSpeedKph;
   } else {
     truck_speed_ = speed;
   }

--- a/src/loki/service.cc
+++ b/src/loki/service.cc
@@ -281,6 +281,7 @@ namespace valhalla {
       factory.Register("auto_shorter", sif::CreateAutoShorterCost);
       factory.Register("bus", sif::CreateBusCost);
       factory.Register("bicycle", sif::CreateBicycleCost);
+      factory.Register("low_stress_bicycle", sif::CreateLowStressBicycleCost);
       factory.Register("hov", sif::CreateHOVCost);
       factory.Register("pedestrian", sif::CreatePedestrianCost);
       factory.Register("truck", sif::CreateTruckCost);

--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -236,7 +236,7 @@ class AutoCost : public DynamicCost {
   // We expose it within the source file for testing purposes
  public:
   VehicleType type_;                // Vehicle type: car (default), motorcycle, etc
-  float speedfactor_[256];
+  float speedfactor_[kMaxSpeedKph + 1];
   float density_factor_[16];        // Density factor
   float maneuver_penalty_;          // Penalty (seconds) when inconsistent names
   float destination_only_penalty_;  // Penalty (seconds) using a driveway or parking aisle
@@ -332,7 +332,7 @@ AutoCost::AutoCost(const boost::property_tree::ptree& pt)
 
   // Create speed cost table
   speedfactor_[0] = kSecPerHour;  // TODO - what to make speed=0?
-  for (uint32_t s = 1; s < 255; s++) {
+  for (uint32_t s = 1; s <= kMaxSpeedKph; s++) {
     speedfactor_[s] = (kSecPerHour * 0.001f) / static_cast<float>(s);
   }
 
@@ -589,7 +589,7 @@ class AutoShorterCost : public AutoCost {
   virtual float AStarCostFactor() const;
 
  protected:
-  float adjspeedfactor_[256];
+  float adjspeedfactor_[kMaxSpeedKph + 1];
 };
 
 
@@ -598,7 +598,7 @@ AutoShorterCost::AutoShorterCost(const boost::property_tree::ptree& pt)
     : AutoCost(pt) {
   // Create speed cost table that reduces the impact of speed
   adjspeedfactor_[0] = kSecPerHour;  // TODO - what to make speed=0?
-  for (uint32_t s = 1; s < 255; s++) {
+  for (uint32_t s = 1; s <= kMaxSpeedKph; s++) {
     adjspeedfactor_[s] = (kSecPerHour * 0.001f) / sqrtf(static_cast<float>(s));
   }
 }

--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -902,12 +902,12 @@ Cost LowStressBicycleCost::EdgeCost(const baldr::DirectedEdge* edge) const {
   // Special use cases: cycleway and footway
   uint32_t road_speed = static_cast<uint32_t>(edge->speed() + 0.5f);
   if (edge->use() == Use::kCycleway) {
-    // Experienced cyclists might not favor cycleways, but most do...
-    factor = (0.5f + use_roads_ * 0.5f);
+    // Low stress bicycling will prefer cycleways even if use roads is 1.
+    factor = (0.25f + use_roads_ * 0.5f);
   } else if (edge->use() == Use::kFootway || edge->use() == Use::kPath) {
     // Cyclists who favor using roads may want to avoid paths with pedestrian
     // traffic. Most cyclists would use them though.
-    factor = 0.75f + (use_roads_ * 0.5f);
+    factor = 0.1f;
   } else if (edge->use() == Use::kMountainBike &&
              type_ == BicycleType::kMountain) {
     factor = 0.5f;
@@ -920,9 +920,9 @@ Cost LowStressBicycleCost::EdgeCost(const baldr::DirectedEdge* edge) const {
     if (edge->cyclelane() == CycleLane::kShared) {
       factor = 0.9f * speedpenalty_[road_speed];
     } else if (edge->cyclelane() == CycleLane::kDedicated) {
-      factor = 0.8f * speedpenalty_[road_speed];
+      factor = 0.5f * speedpenalty_[road_speed];
     } else if (edge->cyclelane() == CycleLane::kSeparated) {
-      factor *= 0.7f;
+      factor *= 0.25f;
     } else {
       // On a road without a bicycle lane. Set factor to include any speed
       // penalty and road class factor
@@ -938,7 +938,7 @@ Cost LowStressBicycleCost::EdgeCost(const baldr::DirectedEdge* edge) const {
     // Favor bicycle networks.
     // TODO - do we need to differentiate between types of network?
     if (edge->bike_network() > 0) {
-      factor *= kBicycleNetworkFactor;
+      factor *= kBicycleNetworkFactor * 2.0f;
     }
   }
 

--- a/src/sif/truckcost.cc
+++ b/src/sif/truckcost.cc
@@ -255,7 +255,7 @@ class TruckCost : public DynamicCost {
 
  public:
   VehicleType type_;                // Vehicle type: tractor trailer
-  float speedfactor_[256];
+  float speedfactor_[kMaxSpeedKph + 1];
   float density_factor_[16];        // Density factor
   float maneuver_penalty_;          // Penalty (seconds) when inconsistent names
   float destination_only_penalty_;  // Penalty (seconds) using a driveway or parking aisle
@@ -341,7 +341,7 @@ TruckCost::TruckCost(const boost::property_tree::ptree& pt)
 
   // Create speed cost table
   speedfactor_[0] = kSecPerHour;  // TODO - what to make speed=0?
-  for (uint32_t s = 1; s < 255; s++) {
+  for (uint32_t s = 1; s <= kMaxSpeedKph; s++) {
     speedfactor_[s] = (kSecPerHour * 0.001f) / static_cast<float>(s);
   }
   for (uint32_t d = 0; d < 16; d++) {

--- a/src/thor/service.cc
+++ b/src/thor/service.cc
@@ -81,6 +81,7 @@ namespace valhalla {
       factory.Register("auto_shorter", sif::CreateAutoShorterCost);
       factory.Register("bus", CreateBusCost);
       factory.Register("bicycle", sif::CreateBicycleCost);
+      factory.Register("low_stress_bicycle", sif::CreateLowStressBicycleCost);
       factory.Register("hov", sif::CreateHOVCost);
       factory.Register("pedestrian", sif::CreatePedestrianCost);
       factory.Register("transit", sif::CreateTransitCost);

--- a/valhalla/baldr/directededge.h
+++ b/valhalla/baldr/directededge.h
@@ -508,7 +508,7 @@ class DirectedEdge {
   void set_reverseaccess(const uint32_t modes);
 
   /**
-   * Gets the speed in KPH.
+   * Gets the average speed in KPH.
    * @return  Returns the speed in KPH.
    */
   uint32_t speed() const {
@@ -516,7 +516,7 @@ class DirectedEdge {
   }
 
   /**
-   * Sets the speed in KPH.
+   * Sets the average speed in KPH.
    * @param  speed  Speed in KPH.
    */
   void set_speed(const uint32_t speed);

--- a/valhalla/baldr/directededge.h
+++ b/valhalla/baldr/directededge.h
@@ -112,7 +112,7 @@ class DirectedEdge {
   /**
    * Get the weighted grade factor
    * @return  Returns the weighted grade factor (0-15).
-   *          where 0 is a 10% grade and 15 is 15%
+   *          where 0 is a -10% grade and 15 is 15%
    */
   uint32_t weighted_grade() const {
     return weighted_grade_;

--- a/valhalla/baldr/graphconstants.h
+++ b/valhalla/baldr/graphconstants.h
@@ -128,9 +128,6 @@ constexpr uint32_t kMaxEdgeLength = 16777215;   // 2^24 meters
 // Maximum number of edges allowed in a turn restriction mask
 constexpr uint32_t kMaxTurnRestrictionEdges = 8;
 
-// Maximum speed (kph)
-constexpr float kMaxSpeed = 255.0f;
-
 // Maximum lane count
 constexpr uint32_t kMaxLaneCount = 15;
 

--- a/valhalla/sif/bicyclecost.h
+++ b/valhalla/sif/bicyclecost.h
@@ -13,6 +13,13 @@ namespace sif {
  */
 cost_ptr_t CreateBicycleCost(const boost::property_tree::ptree& config);
 
+/**
+ * Create a low-stress bicyclecost method. This is derived from bicycle costing,
+ * but has a stronger preference for low-stress biking roads.
+ * @param  config  Property tree with configuration / options.
+ */
+cost_ptr_t CreateLowStressBicycleCost(const boost::property_tree::ptree& config);
+
 }
 }
 


### PR DESCRIPTION
Adding in a low-stress bicycle costing option to routing with the API name of "low_stress_bicycle." Still an early version of this but it is looking presentable now and needs some feedback.
## Low-Stress Bicycle Details
+ Derived from BicycleCost and overrides the EdgeCost, TransitionCost, and TransitionCostReverse functions as well as overwrites some internal data in the constructor like adjusting speed and weighted grade penalties
+ Edge and transition costing uses numbers and a slightly different algorithm that are based off of a paper submitted to the TRB (Can be found [here](http://amonline.trb.org/trb60693-2016-1.2807374/t022-1.2817530/362-1.2817851/16-1115-1.2817345/16-1115-1.2817857?qr=1))
  - New approach to costing takes deeper consideration in adding vs multiplying different values to the "factor" value used to skew the cost of a particular edge. The ordering of the multiplication and addition of these different values is also considered.
  - Some factors that were not considered in the paper that we do consider were made up to best fit low-stress biking
+ Config changes were made to make low_stress_bicycle a valid costing option
## Other Changes
+ Data issue fixed where OSM tags "track" and "lane" (and the reverses of those) were switched when being parsed meaning our bicycle costing (and the subsequent low-stress bicycle costing in this pr) were favoring the wrong kinds of cycle lanes more heavily.
+ Had two different "max speed" constants in graphconstants.h when only one of them should ever be used (Because we cap edge speeds using the other max speed constant that was kept). This then allowed us to cut back the size of the speed penalty arrays in all of the costing classes because we will never need to access values greater than the new default max speed value.
