### PR TITLE
allow actor actions to be interrupted, also make them cleanup

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -68,10 +68,18 @@ valhalla/proto/tripdirections.pb.h: src/proto/tripdirections.pb.cc
 	-mkdir -p valhalla/proto && mv src/proto/tripdirections.pb.h valhalla/proto
 src/proto/tripdirections.pb.cc:
 	@echo " PROTOC tripdirections.proto" && mkdir -p src/proto && @PROTOC_BIN@ -Iproto --cpp_out=src/proto proto/tripdirections.proto
+valhalla/proto/route.pb.h: src/proto/route.pb.cc
+	-mkdir -p valhalla/proto && mv src/proto/route.pb.h valhalla/proto
+src/proto/route.pb.cc:
+	@echo " PROTOC route.proto" && mkdir -p src/proto && @PROTOC_BIN@ -Iproto --cpp_out=src/proto proto/route.proto
+valhalla/proto/navigator.pb.h: src/proto/navigator.pb.cc
+	-mkdir -p valhalla/proto && mv src/proto/navigator.pb.h valhalla/proto
+src/proto/navigator.pb.cc:
+	@echo " PROTOC navigator.proto" && mkdir -p src/proto && @PROTOC_BIN@ -Iproto --cpp_out=src/proto proto/navigator.proto
 
-BUILT_SOURCES = genfiles/date_time_zonespec.h genfiles/graph_lua_proc.h genfiles/admin_lua_proc.h genfiles/locales.h valhalla/proto/tripcommon.pb.h valhalla/proto/trippath.pb.h valhalla/proto/directions_options.pb.h valhalla/proto/tripdirections.pb.h src/proto/tripcommon.pb.cc src/proto/trippath.pb.cc src/proto/directions_options.pb.cc src/proto/tripdirections.pb.cc
+BUILT_SOURCES = genfiles/date_time_zonespec.h genfiles/graph_lua_proc.h genfiles/admin_lua_proc.h genfiles/locales.h valhalla/proto/tripcommon.pb.h valhalla/proto/trippath.pb.h valhalla/proto/directions_options.pb.h valhalla/proto/tripdirections.pb.h valhalla/proto/route.pb.h valhalla/proto/navigator.pb.h src/proto/tripcommon.pb.cc src/proto/trippath.pb.cc src/proto/directions_options.pb.cc src/proto/tripdirections.pb.cc src/proto/route.pb.cc src/proto/navigator.pb.cc
 nodist_libvalhalla_la_SOURCES = genfiles/date_time_zonespec.h genfiles/graph_lua_proc.h genfiles/admin_lua_proc.h genfiles/locales.h
-CLEANFILES = $(EXTRA_PROGRAMS) genfiles/date_time_zonespec.h genfiles/graph_lua_proc.h genfiles/admin_lua_proc.h genfiles/locales.h valhalla/proto/tripcommon.pb.h valhalla/proto/trippath.pb.h valhalla/proto/directions_options.pb.h valhalla/proto/tripdirections.pb.h src/proto/tripcommon.pb.cc src/proto/trippath.pb.cc src/proto/directions_options.pb.cc src/proto/tripdirections.pb.cc
+CLEANFILES = $(EXTRA_PROGRAMS) genfiles/date_time_zonespec.h genfiles/graph_lua_proc.h genfiles/admin_lua_proc.h genfiles/locales.h valhalla/proto/tripcommon.pb.h valhalla/proto/trippath.pb.h valhalla/proto/directions_options.pb.h valhalla/proto/tripdirections.pb.h valhalla/proto/route.pb.h valhalla/proto/navigator.pb.h src/proto/tripcommon.pb.cc src/proto/trippath.pb.cc src/proto/directions_options.pb.cc src/proto/tripdirections.pb.cc src/proto/route.pb.cc src/proto/navigator.pb.cc
 
 #data tools protobuffs
 if DATA_TOOLS
@@ -99,20 +107,6 @@ BUILT_SOURCES += valhalla/proto/osmformat.pb.h valhalla/proto/fileformat.pb.h va
 nodist_libvalhalla_la_SOURCES += valhalla/proto/osmformat.pb.h valhalla/proto/fileformat.pb.h valhalla/proto/transit.pb.h valhalla/proto/tile.pb.h valhalla/proto/segment.pb.h
 CLEANFILES += valhalla/proto/osmformat.pb.h valhalla/proto/fileformat.pb.h valhalla/proto/transit.pb.h valhalla/proto/tile.pb.h valhalla/proto/segment.pb.h src/proto/tripcommon.pb.cc src/proto/trippath.pb.cc src/proto/directions_options.pb.cc src/proto/tripdirections.pb.cc src/proto/osmformat.pb.cc src/proto/fileformat.pb.cc src/proto/transit.pb.cc src/proto/tile.pb.cc src/proto/segment.pb.cc
 endif
-
-#embedded device protobuffs
-#if EMBEDDED
-valhalla/proto/route.pb.h: src/proto/route.pb.cc
-	-mkdir -p valhalla/proto && mv src/proto/route.pb.h valhalla/proto
-src/proto/route.pb.cc:
-	@echo " PROTOC route.proto" && mkdir -p src/proto && @PROTOC_BIN@ -Iproto --cpp_out=src/proto proto/route.proto
-valhalla/proto/navigator.pb.h: src/proto/navigator.pb.cc
-	-mkdir -p valhalla/proto && mv src/proto/navigator.pb.h valhalla/proto
-src/proto/navigator.pb.cc:
-	@echo " PROTOC navigator.proto" && mkdir -p src/proto && @PROTOC_BIN@ -Iproto --cpp_out=src/proto proto/navigator.proto
-BUILT_SOURCES += valhalla/proto/route.pb.h valhalla/proto/navigator.pb.h
-CLEANFILES += valhalla/proto/route.pb.h valhalla/proto/navigator.pb.h src/proto/route.pb.cc src/proto/navigator.pb.cc
-#endif
 
 lib_LTLIBRARIES = libvalhalla.la
 nobase_include_HEADERS = \

--- a/src/loki/worker.cc
+++ b/src/loki/worker.cc
@@ -195,7 +195,7 @@ namespace valhalla {
     }
 
 #ifdef HAVE_HTTP
-    worker_t::result_t loki_worker_t::work(const std::list<zmq::message_t>& job, void* request_info, const worker_t::interrupt_function_t&) {
+    worker_t::result_t loki_worker_t::work(const std::list<zmq::message_t>& job, void* request_info, const std::function<void ()>& interrupt_function) {
       //get time for start of request
       auto s = std::chrono::system_clock::now();
       auto& info = *static_cast<http_request_info_t*>(request_info);
@@ -220,6 +220,9 @@ namespace valhalla {
         //let further processes know about tracking
         auto do_not_track = request.headers.find("DNT");
         info.spare = do_not_track != request.headers.cend() && do_not_track->second == "1";
+
+        // Set the interrupt function
+        service_worker_t::set_interrupt(interrupt_function);
 
         worker_t::result_t result{true};
         //do request specific processing

--- a/src/odin/worker.cc
+++ b/src/odin/worker.cc
@@ -61,7 +61,7 @@ namespace valhalla {
     }
 
 #ifdef HAVE_HTTP
-    worker_t::result_t odin_worker_t::work(const std::list<zmq::message_t>& job, void* request_info, const worker_t::interrupt_function_t&) {
+    worker_t::result_t odin_worker_t::work(const std::list<zmq::message_t>& job, void* request_info, const std::function<void ()>& interrupt_function) {
       auto& info = *static_cast<http_request_info_t*>(request_info);
       LOG_INFO("Got Odin Request " + std::to_string(info.id));
       boost::optional<std::string> jsonp;
@@ -77,6 +77,9 @@ namespace valhalla {
         catch(...) {
           return jsonify_error({200}, info, jsonp);
         }
+
+        // Set the interrupt function
+        service_worker_t::set_interrupt(interrupt_function);
 
         //parse each leg
         std::list<TripPath> legs;

--- a/src/skadi/worker.cc
+++ b/src/skadi/worker.cc
@@ -183,7 +183,7 @@ namespace valhalla {
     }
 
 #ifdef HAVE_HTTP
-    worker_t::result_t skadi_worker_t::work(const std::list<zmq::message_t>& job, void* request_info, const worker_t::interrupt_function_t&) {
+    worker_t::result_t skadi_worker_t::work(const std::list<zmq::message_t>& job, void* request_info, const std::function<void ()>& interrupt_function) {
       //get time for start of request
       auto s = std::chrono::system_clock::now();
       auto& info = *static_cast<http_request_info_t*>(request_info);
@@ -197,6 +197,9 @@ namespace valhalla {
         auto action = PATH_TO_ACTION.find(request.path);
         if(action == PATH_TO_ACTION.cend())
           return jsonify_error(valhalla_exception_t{304, action_str}, info, jsonp);
+
+        // Set the interrupt function
+        service_worker_t::set_interrupt(interrupt_function);
 
         //parse the query's json
         auto request_rj = from_request(request);

--- a/src/thor/trace_attributes_action.cc
+++ b/src/thor/trace_attributes_action.cc
@@ -428,8 +428,8 @@ json::MapPtr thor_worker_t::trace_attributes(
         try {
           trip_path = route_match(controller);
           if (trip_path.node().size() == 0)
-            throw;
-        } catch (...) {
+            throw std::exception{};
+        } catch (const std::exception& e) {
           throw valhalla_exception_t{443, shape_match->first + " algorithm failed to find exact route match.  Try using shape_match:'walk_or_snap' to fallback to map-matching algorithm"};
         }
         break;
@@ -440,7 +440,7 @@ json::MapPtr thor_worker_t::trace_attributes(
           trip_match = map_match(controller, true);
           trip_path = std::move(trip_match.first);
           match_results = std::move(trip_match.second);
-        } catch (...) {
+        } catch (const std::exception& e) {
           throw valhalla_exception_t{444, shape_match->first + " algorithm failed to snap the shape points to the correct shape."};
         }
         break;
@@ -455,7 +455,7 @@ json::MapPtr thor_worker_t::trace_attributes(
             trip_match = map_match(controller, true);
             trip_path = std::move(trip_match.first);
             match_results = std::move(trip_match.second);
-          } catch (...) {
+          } catch (const std::exception& e) {
             throw valhalla_exception_t{444, shape_match->first + " algorithm failed to snap the shape points to the correct shape."};
           }
         }

--- a/src/thor/trace_route_action.cc
+++ b/src/thor/trace_route_action.cc
@@ -128,7 +128,7 @@ odin::TripPath thor_worker_t::route_match(const AttributesController& controller
     trip_path = thor::TripPathBuilder::Build(controller, reader, mode_costing,
                                              path_infos, correlated.front(),
                                              correlated.back(), std::list<PathLocation>{},
-                                             interrupt_callback);
+                                             interrupt);
   }
 
   return trip_path;
@@ -153,7 +153,7 @@ std::pair<odin::TripPath, std::vector<thor::MatchResult>> thor_worker_t::map_mat
     throw std::runtime_error(std::string(ex.what()));
   }
 
-  matcher->set_interrupt(interrupt_callback);
+  matcher->set_interrupt(interrupt);
   std::vector<meili::Measurement> sequence;
   for (const auto& coord : shape) {
     sequence.emplace_back(coord,
@@ -407,7 +407,7 @@ std::pair<odin::TripPath, std::vector<thor::MatchResult>> thor_worker_t::map_mat
     trip_path = thor::TripPathBuilder::Build(controller, matcher->graphreader(),
                                              mode_costing, path_edges, origin,
                                              destination, std::list<PathLocation>{},
-                                             interrupt_callback, &route_discontinuities);
+                                             interrupt, &route_discontinuities);
   } else {
     throw;
   }

--- a/src/thor/worker.cc
+++ b/src/thor/worker.cc
@@ -107,14 +107,12 @@ namespace valhalla {
       } else {
         source_to_target_algorithm = SELECT_OPTIMAL;
       }
-
-      interrupt_callback = nullptr;
     }
 
     thor_worker_t::~thor_worker_t(){}
 
 #ifdef HAVE_HTTP
-    worker_t::result_t thor_worker_t::work(const std::list<zmq::message_t>& job, void* request_info, const worker_t::interrupt_function_t& interrupt) {
+    worker_t::result_t thor_worker_t::work(const std::list<zmq::message_t>& job, void* request_info, const std::function<void ()>& interrupt_function) {
       //get time for start of request
       auto s = std::chrono::system_clock::now();
       auto& info = *static_cast<http_request_info_t*>(request_info);
@@ -140,7 +138,7 @@ namespace valhalla {
         }
 
         // Set the interrupt function
-        interrupt_callback = &interrupt;
+        service_worker_t::set_interrupt(interrupt_function);
 
         //flag healthcheck requests; do not send to logstash
         healthcheck = request.get<bool>("healthcheck", false);
@@ -148,9 +146,9 @@ namespace valhalla {
         ACTION_TYPE action = static_cast<ACTION_TYPE>(request.get<int>("action"));
         boost::optional<int> date_time_type = request.get_optional<int>("date_time.type");
         // Allow the request to be aborted
-        astar.set_interrupt(&interrupt);
-        bidir_astar.set_interrupt(&interrupt);
-        multi_modal_astar.set_interrupt(&interrupt);
+        astar.set_interrupt(interrupt);
+        bidir_astar.set_interrupt(interrupt);
+        multi_modal_astar.set_interrupt(interrupt);
 
         worker_t::result_t result{true};
         double denominator = 0;

--- a/src/thor/worker.cc
+++ b/src/thor/worker.cc
@@ -145,10 +145,6 @@ namespace valhalla {
         // Initialize request - get the PathALgorithm to use
         ACTION_TYPE action = static_cast<ACTION_TYPE>(request.get<int>("action"));
         boost::optional<int> date_time_type = request.get_optional<int>("date_time.type");
-        // Allow the request to be aborted
-        astar.set_interrupt(interrupt);
-        bidir_astar.set_interrupt(interrupt);
-        multi_modal_astar.set_interrupt(interrupt);
 
         worker_t::result_t result{true};
         double denominator = 0;

--- a/src/tyr/actor.cc
+++ b/src/tyr/actor.cc
@@ -72,6 +72,10 @@ namespace valhalla {
     actor_t::actor_t(const boost::property_tree::ptree& config): pimpl(new pimpl_t(config)) {
     }
 
+    void actor_t::cleanup() {
+      pimpl->cleanup();
+    }
+
     std::string actor_t::route(ACTION_TYPE action, const std::string& request_str, const std::function<void ()>& interrupt) {
       //set the interrupts
       pimpl->set_interrupts(interrupt);
@@ -89,8 +93,6 @@ namespace valhalla {
       auto json = tyr::serializeDirections(action, request_pt, directions);
       std::stringstream ss;
       ss << *json;
-      //cleanup
-      pimpl->cleanup();
       return ss.str();
     }
 
@@ -103,8 +105,6 @@ namespace valhalla {
       auto json = pimpl->loki_worker.locate(request);
       std::stringstream ss;
       ss << *json;
-      //cleanup
-      pimpl->cleanup();
       return ss.str();
     }
 
@@ -120,8 +120,6 @@ namespace valhalla {
       auto json = pimpl->thor_worker.matrix(action, request_pt);
       std::stringstream ss;
       ss << *json;
-      //cleanup
-      pimpl->cleanup();
       return ss.str();
     }
 
@@ -141,8 +139,6 @@ namespace valhalla {
       auto json = tyr::serializeDirections(ROUTE, request_pt, directions);
       std::stringstream ss;
       ss << *json;
-      //cleanup
-      pimpl->cleanup();
       return ss.str();
     }
 
@@ -158,8 +154,6 @@ namespace valhalla {
       auto json = pimpl->thor_worker.isochrones(request_pt);
       std::stringstream ss;
       ss << *json;
-      //cleanup
-      pimpl->cleanup();
       return ss.str();
     }
 
@@ -179,8 +173,6 @@ namespace valhalla {
       auto json = tyr::serializeDirections(ROUTE, request_pt, directions);
       std::stringstream ss;
       ss << *json;
-      //cleanup
-      pimpl->cleanup();
       return ss.str();
     }
 
@@ -196,8 +188,6 @@ namespace valhalla {
       auto json = pimpl->thor_worker.trace_attributes(request_pt);
       std::stringstream ss;
       ss << *json;
-      //cleanup
-      pimpl->cleanup();
       return ss.str();
     }
 
@@ -210,8 +200,6 @@ namespace valhalla {
       auto json = pimpl->skadi_worker.height(request_rj);
       std::stringstream ss;
       ss << *json;
-      //cleanup
-      pimpl->cleanup();
       return ss.str();
     }
 

--- a/src/tyr/actor.cc
+++ b/src/tyr/actor.cc
@@ -51,6 +51,18 @@ namespace valhalla {
       pimpl_t(const boost::property_tree::ptree& config):
         loki_worker(config), thor_worker(config), odin_worker(config), skadi_worker(config) {
       }
+      void set_interrupts(const std::function<void ()>& interrupt_function) {
+        loki_worker.set_interrupt(interrupt_function);
+        thor_worker.set_interrupt(interrupt_function);
+        odin_worker.set_interrupt(interrupt_function);
+        skadi_worker.set_interrupt(interrupt_function);
+      }
+      void cleanup() {
+        loki_worker.cleanup();
+        thor_worker.cleanup();
+        odin_worker.cleanup();
+        skadi_worker.cleanup();
+      }
       loki::loki_worker_t loki_worker;
       thor::thor_worker_t thor_worker;
       odin::odin_worker_t odin_worker;
@@ -60,7 +72,9 @@ namespace valhalla {
     actor_t::actor_t(const boost::property_tree::ptree& config): pimpl(new pimpl_t(config)) {
     }
 
-    std::string actor_t::route(ACTION_TYPE action, const std::string& request_str) {
+    std::string actor_t::route(ACTION_TYPE action, const std::string& request_str, const std::function<void ()>& interrupt) {
+      //set the interrupts
+      pimpl->set_interrupts(interrupt);
       //parse the request
       auto request = to_document(request_str);
       //check the request and locate the locations in the graph
@@ -75,20 +89,28 @@ namespace valhalla {
       auto json = tyr::serializeDirections(action, request_pt, directions);
       std::stringstream ss;
       ss << *json;
+      //cleanup
+      pimpl->cleanup();
       return ss.str();
     }
 
-    std::string actor_t::locate(const std::string& request_str) {
+    std::string actor_t::locate(const std::string& request_str, const std::function<void ()>& interrupt) {
+      //set the interrupts
+      pimpl->set_interrupts(interrupt);
       //parse the request
       auto request = to_document(request_str);
       //check the request and locate the locations in the graph
       auto json = pimpl->loki_worker.locate(request);
       std::stringstream ss;
       ss << *json;
+      //cleanup
+      pimpl->cleanup();
       return ss.str();
     }
 
-    std::string actor_t::matrix(ACTION_TYPE action, const std::string& request_str) {
+    std::string actor_t::matrix(ACTION_TYPE action, const std::string& request_str, const std::function<void ()>& interrupt) {
+      //set the interrupts
+      pimpl->set_interrupts(interrupt);
       //parse the request
       auto request = to_document(request_str);
       //check the request and locate the locations in the graph
@@ -98,10 +120,14 @@ namespace valhalla {
       auto json = pimpl->thor_worker.matrix(action, request_pt);
       std::stringstream ss;
       ss << *json;
+      //cleanup
+      pimpl->cleanup();
       return ss.str();
     }
 
-    std::string actor_t::optimized_route(const std::string& request_str) {
+    std::string actor_t::optimized_route(const std::string& request_str, const std::function<void ()>& interrupt) {
+      //set the interrupts
+      pimpl->set_interrupts(interrupt);
       //parse the request
       auto request = to_document(request_str);
       //check the request and locate the locations in the graph
@@ -115,10 +141,14 @@ namespace valhalla {
       auto json = tyr::serializeDirections(ROUTE, request_pt, directions);
       std::stringstream ss;
       ss << *json;
+      //cleanup
+      pimpl->cleanup();
       return ss.str();
     }
 
-    std::string actor_t::isochrone(const std::string& request_str) {
+    std::string actor_t::isochrone(const std::string& request_str, const std::function<void ()>& interrupt) {
+      //set the interrupts
+      pimpl->set_interrupts(interrupt);
       //parse the request
       auto request = to_document(request_str);
       //check the request and locate the locations in the graph
@@ -128,10 +158,14 @@ namespace valhalla {
       auto json = pimpl->thor_worker.isochrones(request_pt);
       std::stringstream ss;
       ss << *json;
+      //cleanup
+      pimpl->cleanup();
       return ss.str();
     }
 
-    std::string actor_t::trace_route(const std::string& request_str) {
+    std::string actor_t::trace_route(const std::string& request_str, const std::function<void ()>& interrupt) {
+      //set the interrupts
+      pimpl->set_interrupts(interrupt);
       //parse the request
       auto request = to_document(request_str);
       //check the request and locate the locations in the graph
@@ -145,10 +179,14 @@ namespace valhalla {
       auto json = tyr::serializeDirections(ROUTE, request_pt, directions);
       std::stringstream ss;
       ss << *json;
+      //cleanup
+      pimpl->cleanup();
       return ss.str();
     }
 
-    std::string actor_t::trace_attributes(const std::string& request_str) {
+    std::string actor_t::trace_attributes(const std::string& request_str, const std::function<void ()>& interrupt) {
+      //set the interrupts
+      pimpl->set_interrupts(interrupt);
       //parse the request
       auto request = to_document(request_str);
       //check the request and locate the locations in the graph
@@ -158,16 +196,22 @@ namespace valhalla {
       auto json = pimpl->thor_worker.trace_attributes(request_pt);
       std::stringstream ss;
       ss << *json;
+      //cleanup
+      pimpl->cleanup();
       return ss.str();
     }
 
-    std::string actor_t::height(const std::string& request_str) {
+    std::string actor_t::height(const std::string& request_str, const std::function<void ()>& interrupt) {
+      //set the interrupts
+      pimpl->set_interrupts(interrupt);
       //parse the request
       auto request_rj = to_document(request_str);
       //get the height at each point
       auto json = pimpl->skadi_worker.height(request_rj);
       std::stringstream ss;
       ss << *json;
+      //cleanup
+      pimpl->cleanup();
       return ss.str();
     }
 

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -307,4 +307,10 @@ namespace valhalla {
 
 #endif
 
+  service_worker_t::service_worker_t(): interrupt(nullptr) {}
+  service_worker_t::~service_worker_t() {}
+  void service_worker_t::set_interrupt(const std::function<void ()>& interrupt_function) {
+    interrupt = &interrupt_function;
+  };
+
 }

--- a/test/actor.cc
+++ b/test/actor.cc
@@ -56,13 +56,21 @@ namespace {
     auto conf = make_conf();
     tyr::actor_t actor(conf);
 
-    auto route_json = actor.route(tyr::ROUTE, R"({"locations":[{"lat":40.546115,"lon":-76.385076,"type":"break"},
+    actor.route(tyr::ROUTE, R"({"locations":[{"lat":40.546115,"lon":-76.385076,"type":"break"},
       {"lat":40.544232,"lon":-76.385752,"type":"break"}],"costing":"auto"})");
+    actor.cleanup();
+    auto route_json = actor.route(tyr::ROUTE, R"({"locations":[{"lat":40.546115,"lon":-76.385076,"type":"break"},
+          {"lat":40.544232,"lon":-76.385752,"type":"break"}],"costing":"auto"})");
+    actor.cleanup();
     auto route = json_to_pt(route_json);
     route_json.find("Tulpehocken");
 
+    actor.trace_attributes(R"({"shape":[{"lat":40.546115,"lon":-76.385076},
+      {"lat":40.544232,"lon":-76.385752}],"costing":"auto","shape_match":"map_snap"})");
+    actor.cleanup();
     auto attributes_json = actor.trace_attributes(R"({"shape":[{"lat":40.546115,"lon":-76.385076},
       {"lat":40.544232,"lon":-76.385752}],"costing":"auto","shape_match":"map_snap"})");
+    actor.cleanup();
     auto attributes = json_to_pt(attributes_json);
     attributes_json.find("Tulpehocken");
 

--- a/test/admin.cc
+++ b/test/admin.cc
@@ -5,7 +5,6 @@
 #include <fstream>
 
 #include "baldr/admin.h"
-#include <boost/shared_array.hpp>
 #include <memory>
 
 using namespace std;

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -23,8 +23,6 @@
 #include <valhalla/midgard/util.h>
 #include <valhalla/midgard/aabb2.h>
 
-#include <boost/shared_ptr.hpp>
-#include <boost/shared_array.hpp>
 #include <memory>
 #include "signinfo.h"
 
@@ -405,7 +403,7 @@ class GraphTile {
  protected:
 
   // Graph tile memory, this must be shared so that we can put it into cache
-  boost::shared_ptr<std::vector<char>> graphtile_;
+  std::shared_ptr<std::vector<char>> graphtile_;
 
   // Header information for the tile
   GraphTileHeader* header_;

--- a/valhalla/loki/worker.h
+++ b/valhalla/loki/worker.h
@@ -26,7 +26,7 @@ namespace valhalla {
      public:
       loki_worker_t(const boost::property_tree::ptree& config);
 #ifdef HAVE_HTTP
-      virtual worker_t::result_t work(const std::list<zmq::message_t>& job, void* request_info, const worker_t::interrupt_function_t& interrupt) override;
+      virtual worker_t::result_t work(const std::list<zmq::message_t>& job, void* request_info, const std::function<void ()>& interrupt) override;
 #endif
       virtual void cleanup() override;
 

--- a/valhalla/odin/worker.h
+++ b/valhalla/odin/worker.h
@@ -17,7 +17,7 @@ namespace valhalla {
       odin_worker_t(const boost::property_tree::ptree& config);
       virtual ~odin_worker_t();
 #ifdef HAVE_HTTP
-      virtual worker_t::result_t work(const std::list<zmq::message_t>& job, void* request_info, const worker_t::interrupt_function_t& interupt) override;
+      virtual worker_t::result_t work(const std::list<zmq::message_t>& job, void* request_info, const std::function<void ()>& interupt) override;
 #endif
       virtual void cleanup() override;
 

--- a/valhalla/skadi/worker.h
+++ b/valhalla/skadi/worker.h
@@ -5,8 +5,6 @@
 #include <list>
 #include <string>
 #include <boost/property_tree/ptree.hpp>
-#include <prime_server/prime_server.hpp>
-#include <prime_server/http_protocol.hpp>
 
 #include <valhalla/baldr/json.h>
 #include <valhalla/midgard/pointll.h>
@@ -25,7 +23,7 @@ namespace valhalla {
       skadi_worker_t(const boost::property_tree::ptree& config);
       virtual ~skadi_worker_t();
 #ifdef HAVE_HTTP
-      virtual prime_server::worker_t::result_t work(const std::list<zmq::message_t>& job, void* request_info, const prime_server::worker_t::interrupt_function_t& interrupt) override;
+      virtual worker_t::result_t work(const std::list<zmq::message_t>& job, void* request_info, const std::function<void ()>& interrupt) override;
 #endif
       virtual void cleanup() override;
 

--- a/valhalla/thor/worker.h
+++ b/valhalla/thor/worker.h
@@ -50,7 +50,7 @@ class thor_worker_t : public service_worker_t{
   thor_worker_t(const boost::property_tree::ptree& config);
   virtual ~thor_worker_t();
 #ifdef HAVE_HTTP
-  virtual prime_server::worker_t::result_t work(const std::list<zmq::message_t>& job, void* request_info, const prime_server::worker_t::interrupt_function_t& interrupt) override;
+  virtual worker_t::result_t work(const std::list<zmq::message_t>& job, void* request_info, const std::function<void ()>& interrupt) override;
 #endif
   virtual void cleanup() override;
 
@@ -110,7 +110,6 @@ class thor_worker_t : public service_worker_t{
   std::unordered_set<std::string> trace_customizable;
   boost::property_tree::ptree trace_config;
 
-  const std::function<void ()>* interrupt_callback;
   bool healthcheck;
   std::vector<uint32_t> optimal_order;
 };

--- a/valhalla/tyr/actor.h
+++ b/valhalla/tyr/actor.h
@@ -70,6 +70,7 @@ namespace valhalla {
     class actor_t {
      public:
       actor_t(const boost::property_tree::ptree& config);
+      void cleanup();
       std::string route(ACTION_TYPE action, const std::string& request_str, const std::function<void ()>& interrupt = []()->void{});
       std::string locate(const std::string& request_str, const std::function<void ()>& interrupt = []()->void{});
       std::string matrix(ACTION_TYPE action, const std::string& request_str, const std::function<void ()>& interrupt = []()->void{});

--- a/valhalla/tyr/actor.h
+++ b/valhalla/tyr/actor.h
@@ -70,14 +70,14 @@ namespace valhalla {
     class actor_t {
      public:
       actor_t(const boost::property_tree::ptree& config);
-      std::string route(ACTION_TYPE action, const std::string& request_str);
-      std::string locate(const std::string& request_str);
-      std::string matrix(ACTION_TYPE action, const std::string& request_str);
-      std::string optimized_route(const std::string& request_str);
-      std::string isochrone(const std::string& request_str);
-      std::string trace_route(const std::string& request_str);
-      std::string trace_attributes(const std::string& request_str);
-      std::string height(const std::string& request_str);
+      std::string route(ACTION_TYPE action, const std::string& request_str, const std::function<void ()>& interrupt = []()->void{});
+      std::string locate(const std::string& request_str, const std::function<void ()>& interrupt = []()->void{});
+      std::string matrix(ACTION_TYPE action, const std::string& request_str, const std::function<void ()>& interrupt = []()->void{});
+      std::string optimized_route(const std::string& request_str, const std::function<void ()>& interrupt = []()->void{});
+      std::string isochrone(const std::string& request_str, const std::function<void ()>& interrupt = []()->void{});
+      std::string trace_route(const std::string& request_str, const std::function<void ()>& interrupt = []()->void{});
+      std::string trace_attributes(const std::string& request_str, const std::function<void ()>& interrupt = []()->void{});
+      std::string height(const std::string& request_str, const std::function<void ()>& interrupt = []()->void{});
      protected:
       struct pimpl_t;
       std::shared_ptr<pimpl_t> pimpl;

--- a/valhalla/worker.h
+++ b/valhalla/worker.h
@@ -29,7 +29,9 @@ namespace valhalla {
 
   class service_worker_t {
    public:
-    virtual ~service_worker_t(){};
+    service_worker_t();
+
+    virtual ~service_worker_t();
 
 #ifdef HAVE_HTTP
     /**
@@ -40,13 +42,23 @@ namespace valhalla {
      * @param  interrupt     a function that may be called periodically and will throw when processing should be interrupted
      * @return result_t      the finished bit of work to be either send back to the client or forwarded on to the next pipeline stage
      */
-    virtual worker_t::result_t work(const std::list<zmq::message_t>& job, void* request_info, const worker_t::interrupt_function_t& interrupt) = 0;
+    virtual worker_t::result_t work(const std::list<zmq::message_t>& job, void* request_info, const std::function<void ()>& interrupt) = 0;
 #endif
 
     /**
      * After forwarding the completed work on this is called to reset any internal state or reclaim any memory
      */
     virtual void cleanup() = 0;
+
+    /**
+     * A function which may or may not be called periodically and show throw if computation is supposed to be halted
+     * @param  interrupt    the function to be called which should throw
+     */
+    virtual void set_interrupt(const std::function<void ()>& interrupt) final;
+
+   protected:
+    const std::function<void ()>* interrupt;
+
   };
 }
 


### PR DESCRIPTION
this publicizes a final virtual member in the base worker class to set the interrupt function. this allows the actor actions to take an interrupt function and set them on each worker just as the service does when it gets work (a request). there's also a test added to confirm that the interrupts are getting called through the actor actions.

i also realized that i forgot to hookup the cleanup functions to the actor. so the actor also has a cleanup function that should be called after the actor does any action. the actor doesnt call it automatically its up to the calling code to do so. this allows the calling code to do so after its send on the result (ie async).

@noblige what do you think?