### PR TITLE
refactor global thread-safe tile cache implementation

### DIFF
--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -159,7 +159,7 @@ TileCache* TileCacheFactory::createTileCache(const boost::property_tree::ptree& 
   size_t max_cache_size = pt.get<size_t>("max_cache_size", DEFAULT_MAX_CACHE_SIZE);
 
   // wrap tile cache with thread-safe version
-  if (pt.get<bool>("memory_optimized_cache", false)) {
+  if (pt.get<bool>("global_synchronized_cache", false)) {
     if (!globalTileCache_)
       globalTileCache_.reset(new SimpleTileCache(max_cache_size));
     return new SynchronizedTileCache(*globalTileCache_, globalCacheMutex_);

--- a/test/graphreader.cc
+++ b/test/graphreader.cc
@@ -13,11 +13,11 @@ using namespace valhalla::baldr;
 
 namespace {
 
-class test_cache : public TileCache {
+class test_cache : public SimpleTileCache {
  public:
-  using TileCache::TileCache;
-  using TileCache::cache_size_;
-  using TileCache::max_cache_size_;
+  using SimpleTileCache::SimpleTileCache;
+  using SimpleTileCache::cache_size_;
+  using SimpleTileCache::max_cache_size_;
 };
 
 test_cache make_cache(size_t cache_size) {


### PR DESCRIPTION
@kevinkreiser here's a global thread-safe tile cache for use with new `tyr::actor` - basically create a single static tile cache and then give out thread-safe wrapper to all actors.
This is gated by `memory_optimized_cache` setting in `mjolnir`