### PR TITLE
Added runtime_error throwing for jsonToProtoRoute

### DIFF
--- a/src/tyr/navigator.cc
+++ b/src/tyr/navigator.cc
@@ -36,9 +36,12 @@ Navigator::Navigator() {
 NavigationStatus Navigator::SetRoute(const std::string& route_json_str) {
   NavigationStatus nav_status;
 
-  // TODO: place in try catch block and return
-  //       NavigationStatus_RouteState_kInvalid if there is an issue
-  jsonToProtoRoute (route_json_str, route_);
+  try {
+    jsonToProtoRoute (route_json_str, route_);
+  } catch (const std::runtime_error& e) {
+    nav_status.set_route_state(NavigationStatus_RouteState_kInvalid);
+    return nav_status;
+  }
 
   leg_index_ = 0;
   maneuver_index_ = 0;

--- a/src/tyr/navigator.cc
+++ b/src/tyr/navigator.cc
@@ -40,6 +40,7 @@ NavigationStatus Navigator::SetRoute(const std::string& route_json_str) {
     jsonToProtoRoute (route_json_str, route_);
   } catch (const std::runtime_error& e) {
     nav_status.set_route_state(NavigationStatus_RouteState_kInvalid);
+    route_state_ = NavigationStatus_RouteState_kInvalid;
     return nav_status;
   }
 

--- a/src/tyr/serializers.cc
+++ b/src/tyr/serializers.cc
@@ -1549,9 +1549,11 @@ namespace valhalla {
         throw std::runtime_error ("String to document parsing failed.");
 
       // Grab the trip object from JSON
-      auto json_trip = GetOptionalFromRapidJson<rapidjson::Value::Object> (d, "/trip");
-      if (!json_trip) {
+      auto json_trip_iter = d.FindMember("trip");
+      if (json_trip_iter == d.MemberEnd()) {
         return;
+      } else if (!json_trip_iter->value.IsObject()) {
+        throw std::runtime_error ("trip is not an object.");
       }
 
       if (proto_route.has_trip())
@@ -1562,8 +1564,8 @@ namespace valhalla {
 
 
       // Set the locations
-      auto locations_iter = json_trip->FindMember("locations");
-      if (locations_iter != json_trip->end()) {
+      auto locations_iter = json_trip_iter->value.FindMember("locations");
+      if (locations_iter != json_trip_iter->value.MemberEnd()) {
         if (!locations_iter->value.IsArray()) {
           throw std::runtime_error ("locations is not an array.");
         }
@@ -1578,8 +1580,8 @@ namespace valhalla {
       }
 
       // Set the summary
-      auto summary_iter = json_trip->FindMember("summary");
-      if (summary_iter != json_trip->end()) {
+      auto summary_iter = json_trip_iter->value.FindMember("summary");
+      if (summary_iter != json_trip_iter->value.MemberEnd()) {
         if (!summary_iter->value.IsObject()) {
           throw std::runtime_error ("summary is not an object.");
         }
@@ -1587,8 +1589,8 @@ namespace valhalla {
       }
 
       // Set the legs
-      auto legs_iter = json_trip->FindMember("legs");
-      if (legs_iter != json_trip->end()) {
+      auto legs_iter = json_trip_iter->value.FindMember("legs");
+      if (legs_iter != json_trip_iter->value.MemberEnd()) {
         if (!legs_iter->value.IsArray()) {
           throw std::runtime_error ("legs is not an array.");
         }
@@ -1603,8 +1605,8 @@ namespace valhalla {
       }
 
       // Set the status_message
-      auto status_message_iter = json_trip->FindMember("status_message");
-      if (status_message_iter != json_trip->end()) {
+      auto status_message_iter = json_trip_iter->value.FindMember("status_message");
+      if (status_message_iter != json_trip_iter->value.MemberEnd()) {
         if (!status_message_iter->value.IsString()) {
           throw std::runtime_error ("status_message is not a string.");
         }
@@ -1612,8 +1614,8 @@ namespace valhalla {
       }
 
       // Set the status
-      auto status_iter = json_trip->FindMember("status");
-      if (status_iter != json_trip->end()) {
+      auto status_iter = json_trip_iter->value.FindMember("status");
+      if (status_iter != json_trip_iter->value.MemberEnd()) {
         if (!status_iter->value.IsUint()) {
           throw std::runtime_error ("status is not a Uint.");
         }
@@ -1621,8 +1623,8 @@ namespace valhalla {
       }
 
       // Set the units
-      auto units_iter = json_trip->FindMember("units");
-      if (units_iter != json_trip->end()) {
+      auto units_iter = json_trip_iter->value.FindMember("units");
+      if (units_iter != json_trip_iter->value.MemberEnd()) {
         if (!units_iter->value.IsString()) {
           throw std::runtime_error ("units is not a string.");
         }
@@ -1630,8 +1632,8 @@ namespace valhalla {
       }
 
       // Set the language
-      auto language_iter = json_trip->FindMember("language");
-      if (language_iter != json_trip->end()) {
+      auto language_iter = json_trip_iter->value.FindMember("language");
+      if (language_iter != json_trip_iter->value.MemberEnd()) {
         if (!language_iter->value.IsString()) {
           throw std::runtime_error ("language is not a string.");
         }
@@ -1639,8 +1641,8 @@ namespace valhalla {
       }
 
       // Set the id
-      auto id_iter = json_trip->FindMember("id");
-      if (id_iter != json_trip->end()) {
+      auto id_iter = json_trip_iter->value.FindMember("id");
+      if (id_iter != json_trip_iter->value.MemberEnd()) {
         if (!id_iter->value.IsString()) {
           throw std::runtime_error ("id is not a string.");
         }

--- a/src/tyr/serializers.cc
+++ b/src/tyr/serializers.cc
@@ -794,447 +794,731 @@ namespace {
 
 
   void jsonToProtoLocation (const rapidjson::Value& json_location, Route::Location* proto_location) {
-    for (const auto& member : json_location.GetObject()) {
-      std::string member_name = member.name.GetString();
-
-      // Set the lat
-      if (member_name == "lat") {
-        proto_location->set_lat(member.value.GetFloat());
+    // Set the lat
+    auto lat_iter = json_location.FindMember("lat");
+    if (lat_iter != json_location.MemberEnd()) {
+      if (!lat_iter->value.IsFloat()) {
+        throw std::runtime_error ("lat is not a float.");
       }
+      proto_location->set_lat(lat_iter->value.GetFloat());
+    }
 
-      // Set the lon
-      else if (member_name == "lon") {
-        proto_location->set_lon(member.value.GetFloat());
+    // Set the lon
+    auto lon_iter = json_location.FindMember("lon");
+    if (lon_iter != json_location.MemberEnd()) {
+      if (!lon_iter->value.IsFloat()) {
+        throw std::runtime_error ("lon is not a float.");
       }
+      proto_location->set_lon(lon_iter->value.GetFloat());
+    }
 
-      // Set the type
-      else if (member_name == "type") {
-        proto_location->set_type(member.value.GetString());
+    // Set the type
+    auto type_iter = json_location.FindMember("type");
+    if (type_iter != json_location.MemberEnd()) {
+      if (!type_iter->value.IsString()) {
+        throw std::runtime_error ("type is not a string.");
       }
+      proto_location->set_type(type_iter->value.GetString());
+    }
 
-      // Set the heading
-      else if (member_name == "heading") {
-        proto_location->set_heading(member.value.GetUint());
+    // Set the heading
+    auto heading_iter = json_location.FindMember("heading");
+    if (heading_iter != json_location.MemberEnd()) {
+      if (!heading_iter->value.IsUint()) {
+        throw std::runtime_error ("heading is not a Uint.");
       }
+      proto_location->set_heading(heading_iter->value.GetUint());
+    }
 
-      // Set the name
-      else if (member_name == "name") {
-        proto_location->set_name(member.value.GetString());
+    // Set the name
+    auto name_iter = json_location.FindMember("name");
+    if (name_iter != json_location.MemberEnd()) {
+      if (!name_iter->value.IsString()) {
+        throw std::runtime_error ("name is not a string.");
       }
+      proto_location->set_name(name_iter->value.GetString());
+    }
 
-      // Set the street
-      else if (member_name == "street") {
-        proto_location->set_street(member.value.GetString());
+    // Set the street
+    auto street_iter = json_location.FindMember("street");
+    if (street_iter != json_location.MemberEnd()) {
+      if (!street_iter->value.IsString()) {
+        throw std::runtime_error ("street is not a string.");
       }
+      proto_location->set_street(street_iter->value.GetString());
+    }
 
-      // Set the city
-      else if (member_name == "city") {
-        proto_location->set_city(member.value.GetString());
+    // Set the city
+    auto city_iter = json_location.FindMember("city");
+    if (city_iter != json_location.MemberEnd()) {
+      if (!city_iter->value.IsString()) {
+        throw std::runtime_error ("city is not a string.");
       }
+      proto_location->set_city(city_iter->value.GetString());
+    }
 
-      // Set the state
-      else if (member_name == "state") {
-        proto_location->set_state(member.value.GetString());
+    // Set the state
+    auto state_iter = json_location.FindMember("state");
+    if (state_iter != json_location.MemberEnd()) {
+      if (!state_iter->value.IsString()) {
+        throw std::runtime_error ("state is not a string.");
       }
+      proto_location->set_state(state_iter->value.GetString());
+    }
 
-      // Set the postal_code
-      else if (member_name == "postal_code") {
-        proto_location->set_postal_code(member.value.GetString());
+    // Set the postal_code
+    auto postal_code_iter = json_location.FindMember("postal_code");
+    if (postal_code_iter != json_location.MemberEnd()) {
+      if (!postal_code_iter->value.IsString()) {
+        throw std::runtime_error ("postal_code is not a string.");
       }
+      proto_location->set_postal_code(postal_code_iter->value.GetString());
+    }
 
-      // Set the country
-      else if (member_name == "country") {
-        proto_location->set_country(member.value.GetString());
+    // Set the country
+    auto country_iter = json_location.FindMember("country");
+    if (country_iter != json_location.MemberEnd()) {
+      if (!country_iter->value.IsString()) {
+        throw std::runtime_error ("country is not a string.");
       }
+      proto_location->set_country(country_iter->value.GetString());
+    }
 
-      // Set the date_time
-      else if (member_name == "date_time") {
-        proto_location->set_date_time(member.value.GetString());
+    // Set the date_time
+    auto date_time_iter = json_location.FindMember("date_time");
+    if (date_time_iter != json_location.MemberEnd()) {
+      if (!date_time_iter->value.IsString()) {
+        throw std::runtime_error ("date_time is not a string.");
       }
+      proto_location->set_date_time(date_time_iter->value.GetString());
+    }
 
-      // Set the side_of_street
-      else if (member_name == "side_of_street") {
-        proto_location->set_side_of_street(member.value.GetString());
+    // Set the side_of_street
+    auto side_of_street_iter = json_location.FindMember("side_of_street");
+    if (side_of_street_iter != json_location.MemberEnd()) {
+      if (!side_of_street_iter->value.IsString()) {
+        throw std::runtime_error ("side_of_street is not a string.");
       }
+      proto_location->set_side_of_street(side_of_street_iter->value.GetString());
+    }
 
-      // Set the original_index
-      else if (member_name == "original_index") {
-        proto_location->set_original_index(member.value.GetUint());
+    // Set the original_index
+    auto original_index_iter = json_location.FindMember("original_index");
+    if (original_index_iter != json_location.MemberEnd()) {
+      if (!original_index_iter->value.IsUint()) {
+        throw std::runtime_error ("original_index is not a Uint.");
       }
+      proto_location->set_original_index(original_index_iter->value.GetUint());
     }
   }
 
   void jsonToProtoSummary (const rapidjson::Value& json_summary, Route::Summary* proto_summary) {
-    for (const auto& member : json_summary.GetObject()) {
-      std::string member_name = member.name.GetString();
-
-      // Set the length
-      if (member_name == "length") {
-        proto_summary->set_length(member.value.GetFloat());
+    // Set the length
+    auto length_iter = json_summary.FindMember("length");
+    if (length_iter != json_summary.MemberEnd()) {
+      if (!length_iter->value.IsFloat()) {
+        throw std::runtime_error ("length is not a float.");
       }
+      proto_summary->set_length(length_iter->value.GetFloat());
+    }
 
-      // Set the time
-      else if (member_name == "time") {
-        proto_summary->set_time(member.value.GetUint());
+    // Set the time
+    auto time_iter = json_summary.FindMember("time");
+    if (time_iter != json_summary.MemberEnd()) {
+      if (!time_iter->value.IsUint()) {
+        throw std::runtime_error ("time is not a Uint.");
       }
+      proto_summary->set_time(time_iter->value.GetUint());
+    }
 
-      // Set the min_lat
-      else if (member_name == "min_lat") {
-        proto_summary->set_min_lat(member.value.GetFloat());
+    // Set the min_lat
+    auto min_lat_iter = json_summary.FindMember("min_lat");
+    if (min_lat_iter != json_summary.MemberEnd()) {
+      if (!min_lat_iter->value.IsFloat()) {
+        throw std::runtime_error ("min_lat is not a float.");
       }
+      proto_summary->set_min_lat(min_lat_iter->value.GetFloat());
+    }
 
-      // Set the min_lon
-      else if (member_name == "min_lon") {
-        proto_summary->set_min_lon(member.value.GetFloat());
+    // Set the min_lon
+    auto min_lon_iter = json_summary.FindMember("min_lon");
+    if (min_lon_iter != json_summary.MemberEnd()) {
+      if (!min_lon_iter->value.IsFloat()) {
+        throw std::runtime_error ("min_lon is not a float.");
       }
+      proto_summary->set_min_lon(min_lon_iter->value.GetFloat());
+    }
 
-      // Set the max_lat
-      else if (member_name == "max_lat") {
-        proto_summary->set_max_lat(member.value.GetFloat());
+    // Set the max_lat
+    auto max_lat_iter = json_summary.FindMember("max_lat");
+    if (max_lat_iter != json_summary.MemberEnd()) {
+      if (!max_lat_iter->value.IsFloat()) {
+        throw std::runtime_error ("max_lat is not a float.");
       }
+      proto_summary->set_max_lat(max_lat_iter->value.GetFloat());
+    }
 
-      // Set the max_lon
-      else if (member_name == "max_lon") {
-        proto_summary->set_max_lon(member.value.GetFloat());
+    // Set the max_lon
+    auto max_lon_iter = json_summary.FindMember("max_lon");
+    if (max_lon_iter != json_summary.MemberEnd()) {
+      if (!max_lon_iter->value.IsFloat()) {
+        throw std::runtime_error ("max_lon is not a float.");
       }
+      proto_summary->set_max_lon(max_lon_iter->value.GetFloat());
     }
   }
 
   void jsonToProtoElement (const rapidjson::Value& json_element, Route::Maneuver::Sign::Element* proto_element) {
-    for (const auto& member : json_element.GetObject()) {
-      std::string member_name = member.name.GetString();
-
-      // Set the text
-      if (member_name == "text") {
-        proto_element->set_text(member.value.GetString());
+    // Set the text
+    auto text_iter = json_element.FindMember("text");
+    if (text_iter != json_element.MemberEnd()) {
+      if (!text_iter->value.IsString()) {
+        throw std::runtime_error ("text is not a string.");
       }
+      proto_element->set_text(text_iter->value.GetString());
+    }
 
-      // Set the consecutive_count
-      else if (member_name == "consecutive_count") {
-        proto_element->set_consecutive_count(member.value.GetUint());
+    // Set the consecutive_count
+    auto consecutive_count_iter = json_element.FindMember("consecutive_count");
+    if (consecutive_count_iter != json_element.MemberEnd()) {
+      if (!consecutive_count_iter->value.IsUint()) {
+        throw std::runtime_error ("consecutive_count is not a Uint.");
       }
+      proto_element->set_consecutive_count(consecutive_count_iter->value.GetUint());
     }
   }
 
   void jsonToProtoSign (const rapidjson::Value& json_sign, Route::Maneuver::Sign* proto_sign) {
-    for (const auto& member : json_sign.GetObject()) {
-      std::string member_name = member.name.GetString();
-
-      // Set the exit_number_elements
-      if (member_name == "exit_number_elements") {
-        auto proto_exit_number_elements = proto_sign->mutable_exit_number_elements();
-        for (const auto& exit_number_element : member.value.GetArray()) {
-          auto proto_exit_number_element = proto_exit_number_elements->Add();
-          jsonToProtoElement(exit_number_element, proto_exit_number_element);
-        }
+    // Set the exit_number_elements
+    auto exit_number_elements_iter = json_sign.FindMember ("exit_number_elements");
+    if (exit_number_elements_iter != json_sign.MemberEnd()) {
+      if (!exit_number_elements_iter->value.IsArray()) {
+        throw std::runtime_error ("exit_number_elements is not an array.");
       }
-
-      // Set the exit_branch_elements
-      if (member_name == "exit_branch_elements") {
-        auto proto_exit_branch_elements = proto_sign->mutable_exit_branch_elements();
-        for (const auto& exit_branch_element : member.value.GetArray()) {
-          auto proto_exit_branch_element = proto_exit_branch_elements->Add();
-          jsonToProtoElement(exit_branch_element, proto_exit_branch_element);
+      auto proto_exit_number_elements = proto_sign->mutable_exit_number_elements();
+      for (const auto& exit_number_element : exit_number_elements_iter->value.GetArray()) {
+        if (!exit_number_element.IsObject()) {
+          throw std::runtime_error ("exit_number_element is not an object.");
         }
+        auto proto_exit_number_element = proto_exit_number_elements->Add();
+        jsonToProtoElement(exit_number_element, proto_exit_number_element);
       }
+    }
 
-      // Set the exit_toward_elements
-      if (member_name == "exit_toward_elements") {
-        auto proto_exit_toward_elements = proto_sign->mutable_exit_toward_elements();
-        for (const auto& exit_toward_element : member.value.GetArray()) {
-          auto proto_exit_toward_element = proto_exit_toward_elements->Add();
-          jsonToProtoElement(exit_toward_element, proto_exit_toward_element);
-        }
+    // Set the exit_branch_elements
+    auto exit_branch_elements_iter = json_sign.FindMember("exit_branch_elements");
+    if (exit_branch_elements_iter != json_sign.MemberEnd()) {
+      if (!exit_branch_elements_iter->value.IsArray()) {
+        throw std::runtime_error ("exit_branch_element is not an array.");
       }
-
-      // Set the exit_name_elements
-      if (member_name == "exit_name_elements") {
-        auto proto_exit_name_elements = proto_sign->mutable_exit_name_elements();
-        for (const auto& exit_name_element : member.value.GetArray()) {
-          auto proto_exit_name_element = proto_exit_name_elements->Add();
-          jsonToProtoElement(exit_name_element, proto_exit_name_element);
+      auto proto_exit_branch_elements = proto_sign->mutable_exit_branch_elements();
+      for (const auto& exit_branch_element : exit_branch_elements_iter->value.GetArray()) {
+        if (!exit_branch_element.IsObject()) {
+          throw std::runtime_error ("exit_branch_element is not an object.");
         }
+        auto proto_exit_branch_element = proto_exit_branch_elements->Add();
+        jsonToProtoElement(exit_branch_element, proto_exit_branch_element);
+      }
+    }
+
+    // Set the exit_toward_elements
+    auto exit_toward_elements_iter = json_sign.FindMember("exit_toward_elements");
+    if (exit_toward_elements_iter != json_sign.MemberEnd()) {
+      if (!exit_toward_elements_iter->value.IsArray()) {
+        throw std::runtime_error ("exit_toward_element is not an array.");
+      }
+      auto proto_exit_toward_elements = proto_sign->mutable_exit_toward_elements();
+      for (const auto& exit_toward_element : exit_toward_elements_iter->value.GetArray()) {
+        if (!exit_toward_element.IsObject()) {
+          throw std::runtime_error ("exit_toward_element is not an object.");
+        }
+        auto proto_exit_toward_element = proto_exit_toward_elements->Add();
+        jsonToProtoElement(exit_toward_element, proto_exit_toward_element);
+      }
+    }
+
+    // Set the exit_name_elements
+    auto exit_name_elements_iter = json_sign.FindMember ("exit_name_elements");
+    if (exit_name_elements_iter != json_sign.MemberEnd()) {
+      if (!exit_name_elements_iter->value.IsArray()) {
+        throw std::runtime_error ("exit_name_element is not an array.");
+      }
+      auto proto_exit_name_elements = proto_sign->mutable_exit_name_elements();
+      for (const auto& exit_name_element : exit_name_elements_iter->value.GetArray()) {
+        if (!exit_name_element.IsObject()) {
+          throw std::runtime_error ("exit_name_element is not an object.");
+        }
+        auto proto_exit_name_element = proto_exit_name_elements->Add();
+        jsonToProtoElement(exit_name_element, proto_exit_name_element);
       }
     }
   }
 
   void jsonToProtoTransitStop (const rapidjson::Value& json_transit_stop, Route::TransitStop* proto_transit_stop) {
-    for (const auto& member : json_transit_stop.GetObject()) {
-      std::string member_name = member.name.GetString();
-
-      // Set the type
-      if (member_name == "type") {
-        proto_transit_stop->set_type(member.value.GetString());
+    // Set the type
+    auto type_iter = json_transit_stop.FindMember("type");
+    if (type_iter != json_transit_stop.MemberEnd()) {
+      if (!type_iter->value.IsString()) {
+        throw std::runtime_error ("type is not a string.");
       }
+      proto_transit_stop->set_type(type_iter->value.GetString());
+    }
 
-      // Set the onestop_id
-      else if (member_name == "onestop_id") {
-        proto_transit_stop->set_onestop_id(member.value.GetString());
+    // Set the onestop_id
+    auto onestop_id_iter = json_transit_stop.FindMember("onestop_id");
+    if (onestop_id_iter != json_transit_stop.MemberEnd()) {
+      if (!onestop_id_iter->value.IsString()) {
+        throw std::runtime_error ("onestop_id is not a string.");
       }
+      proto_transit_stop->set_onestop_id(onestop_id_iter->value.GetString());
+    }
 
-      // Set the name
-      else if (member_name == "name") {
-        proto_transit_stop->set_name(member.value.GetString());
+    // Set the name
+    auto name_iter = json_transit_stop.FindMember("name");
+    if (name_iter != json_transit_stop.MemberEnd()) {
+      if (!name_iter->value.IsString()) {
+        throw std::runtime_error ("name is not a string.");
       }
+      proto_transit_stop->set_name(name_iter->value.GetString());
+    }
 
-      // Set the arrival_date_time
-      else if (member_name == "arrival_date_time") {
-        proto_transit_stop->set_arrival_date_time(member.value.GetString());
+    // Set the arrival_date_time
+    auto arrival_date_time_iter = json_transit_stop.FindMember("arrival_date_time");
+    if (arrival_date_time_iter != json_transit_stop.MemberEnd()) {
+      if (!arrival_date_time_iter->value.IsString()) {
+        throw std::runtime_error ("arrival_date_time is not a string.");
       }
+      proto_transit_stop->set_arrival_date_time(arrival_date_time_iter->value.GetString());
+    }
 
-      // Set the departure_date_time
-      else if (member_name == "departure_date_time") {
-        proto_transit_stop->set_departure_date_time(member.value.GetString());
+    // Set the departure_date_time
+    auto departure_date_time_iter = json_transit_stop.FindMember("departure_date_time");
+    if (departure_date_time_iter != json_transit_stop.MemberEnd()) {
+      if (!departure_date_time_iter->value.IsString()) {
+        throw std::runtime_error ("departure_date_time is not a string.");
       }
+      proto_transit_stop->set_departure_date_time(departure_date_time_iter->value.GetString());
+    }
 
-      // Set is_parent_stop
-      else if (member_name == "is_parent_stop") {
-        proto_transit_stop->set_is_parent_stop(member.value.GetBool());
+    // Set is_parent_stop
+    auto is_parent_stop_iter = json_transit_stop.FindMember("is_parent_stop");
+    if (is_parent_stop_iter != json_transit_stop.MemberEnd()) {
+      if (!is_parent_stop_iter->value.IsBool()) {
+        throw std::runtime_error ("is_parent_stop is not a bool.");
       }
+      proto_transit_stop->set_is_parent_stop(is_parent_stop_iter->value.GetBool());
+    }
 
-      // Set assumed_schedule
-      else if (member_name == "assumed_schedule") {
-        proto_transit_stop->set_assumed_schedule(member.value.GetBool());
+    // Set assumed_schedule
+    auto assumed_schedule_iter = json_transit_stop.FindMember("assumed_schedule");
+    if (assumed_schedule_iter != json_transit_stop.MemberEnd()) {
+      if (!assumed_schedule_iter->value.IsBool()) {
+        throw std::runtime_error ("assumed_schedule is not a bool.");
       }
+      proto_transit_stop->set_assumed_schedule(assumed_schedule_iter->value.GetBool());
+    }
 
-      // Set the lat
-      else if (member_name == "lat") {
-        proto_transit_stop->set_lat(member.value.GetFloat());
+    // Set the lat
+    auto lat_iter = json_transit_stop.FindMember("lat");
+    if (lat_iter != json_transit_stop.MemberEnd()) {
+      if (!lat_iter->value.IsFloat()) {
+        throw std::runtime_error ("lat is not a float.");
       }
+      proto_transit_stop->set_lat(lat_iter->value.GetFloat());
+    }
 
-      // Set the lon
-      else if (member_name == "lon") {
-        proto_transit_stop->set_lon(member.value.GetFloat());
+    // Set the lon
+    auto lon_iter = json_transit_stop.FindMember("lon");
+    if (lon_iter != json_transit_stop.MemberEnd()) {
+      if (!lon_iter->value.IsFloat()) {
+        throw std::runtime_error ("lon is not a float.");
       }
+      proto_transit_stop->set_lon(lon_iter->value.GetFloat());
     }
   }
 
   void jsonToProtoTransitInfo (const rapidjson::Value& json_transit_info, Route::TransitInfo* proto_transit_info) {
-    for (const auto& member : json_transit_info.GetObject()) {
-      std::string member_name = member.name.GetString();
-
-      // Set the onestop_id
-      if (member_name == "onestop_id") {
-        proto_transit_info->set_onestop_id(member.value.GetString());
+    // Set the onestop_id
+    auto onestop_id_iter = json_transit_info.FindMember("onestop_id");
+    if (onestop_id_iter != json_transit_info.MemberEnd()) {
+      if (!onestop_id_iter->value.IsString()) {
+        throw std::runtime_error ("onestop_id is not a string.");
       }
+      proto_transit_info->set_onestop_id(onestop_id_iter->value.GetString());
+    }
 
-      // Set the short_name
-      else if (member_name == "short_name") {
-        proto_transit_info->set_short_name(member.value.GetString());
+    // Set the short_name
+    auto short_name_iter = json_transit_info.FindMember("short_name");
+    if (short_name_iter != json_transit_info.MemberEnd()) {
+      if (!short_name_iter->value.IsString()) {
+        throw std::runtime_error ("short_name is not a string.");
       }
+      proto_transit_info->set_short_name(short_name_iter->value.GetString());
+    }
 
-      // Set the long_name
-      else if (member_name == "long_name") {
-        proto_transit_info->set_long_name(member.value.GetString());
+    // Set the long_name
+    auto long_name_iter = json_transit_info.FindMember("long_name");
+    if (long_name_iter != json_transit_info.MemberEnd()) {
+      if (!long_name_iter->value.IsString()) {
+        throw std::runtime_error ("long_name is not a string.");
       }
+      proto_transit_info->set_long_name(long_name_iter->value.GetString());
+    }
 
-      // Set the headsign
-      else if (member_name == "headsign") {
-        proto_transit_info->set_headsign(member.value.GetString());
+    // Set the headsign
+    auto headsign_iter = json_transit_info.FindMember("headsign");
+    if (headsign_iter != json_transit_info.MemberEnd()) {
+      if (!headsign_iter->value.IsString()) {
+        throw std::runtime_error ("headsign is not a string.");
       }
+      proto_transit_info->set_headsign(headsign_iter->value.GetString());
+    }
 
-      // Set the color
-      else if (member_name == "color") {
-        proto_transit_info->set_color(member.value.GetUint());
+    // Set the color
+    auto color_iter = json_transit_info.FindMember("color");
+    if (color_iter != json_transit_info.MemberEnd()) {
+      if (!color_iter->value.IsUint()) {
+        throw std::runtime_error ("color is not a Uint.");
       }
+      proto_transit_info->set_color(color_iter->value.GetUint());
+    }
 
-      // Set the text_color
-      else if (member_name == "text_color") {
-        proto_transit_info->set_text_color(member.value.GetUint());
+    // Set the text_color
+    auto text_color_iter = json_transit_info.FindMember("text_color");
+    if (text_color_iter != json_transit_info.MemberEnd()) {
+      if (!text_color_iter->value.IsUint()) {
+        throw std::runtime_error ("text_color is not a Uint.");
       }
+      proto_transit_info->set_text_color(text_color_iter->value.GetUint());
+    }
 
-      // Set the description
-      else if (member_name == "description") {
-        proto_transit_info->set_description(member.value.GetString());
+    // Set the description
+    auto description_iter = json_transit_info.FindMember("description");
+    if (description_iter != json_transit_info.MemberEnd()) {
+      if (!description_iter->value.IsString()) {
+        throw std::runtime_error ("description is not a string.");
       }
+      proto_transit_info->set_description(description_iter->value.GetString());
+    }
 
-      // Set the operator_onestop_id
-      else if (member_name == "operator_onestop_id") {
-        proto_transit_info->set_operator_onestop_id(member.value.GetString());
+    // Set the operator_onestop_id
+    auto operator_onestop_id_iter = json_transit_info.FindMember("operator_onestop_id");
+    if (operator_onestop_id_iter != json_transit_info.MemberEnd()) {
+      if (!operator_onestop_id_iter->value.IsString()) {
+        throw std::runtime_error ("operator_onestop_id is not a string.");
       }
+      proto_transit_info->set_operator_onestop_id(operator_onestop_id_iter->value.GetString());
+    }
 
-      // Set the operator_name
-      else if (member_name == "operator_name") {
-        proto_transit_info->set_operator_name(member.value.GetString());
+    // Set the operator_name
+    auto operator_name_iter = json_transit_info.FindMember("operator_name");
+    if (operator_name_iter != json_transit_info.MemberEnd()) {
+      if (!operator_name_iter->value.IsString()) {
+        throw std::runtime_error ("operator_name is not a string.");
       }
+      proto_transit_info->set_operator_name(operator_name_iter->value.GetString());
+    }
 
-      // Set the operator_url
-      else if (member_name == "operator_url") {
-        proto_transit_info->set_operator_url(member.value.GetString());
+    // Set the operator_url
+    auto operator_url_iter = json_transit_info.FindMember("operator_url");
+    if (operator_url_iter != json_transit_info.MemberEnd()) {
+      if (!operator_url_iter->value.IsString()) {
+        throw std::runtime_error ("operator_url is not a string.");
       }
+      proto_transit_info->set_operator_url(operator_url_iter->value.GetString());
+    }
 
-      // Set the transit_stops
-      else if (member_name == "transit_stops") {
-        auto proto_transit_stops = proto_transit_info->mutable_transit_stops();
-        for (const auto& transit_stop : member.value.GetArray()) {
-          auto proto_transit_stop = proto_transit_stops->Add();
-          jsonToProtoTransitStop(transit_stop, proto_transit_stop);
+    // Set the transit_stops
+    auto transit_stops_iter = json_transit_info.FindMember("transit_stops");
+    if (transit_stops_iter != json_transit_info.MemberEnd()) {
+      if (!transit_stops_iter->value.IsArray()) {
+        throw std::runtime_error ("transit_stops is not an array.");
+      }
+      auto proto_transit_stops = proto_transit_info->mutable_transit_stops();
+      for (const auto& transit_stop : transit_stops_iter->value.GetArray()) {
+        if (!transit_stop.IsObject()) {
+          throw std::runtime_error ("transit_stop is not an object.");
         }
+        auto proto_transit_stop = proto_transit_stops->Add();
+        jsonToProtoTransitStop(transit_stop, proto_transit_stop);
       }
     }
   }
 
   void jsonToProtoManeuver (const rapidjson::Value& json_maneuver, Route::Maneuver* proto_maneuver) {
-    for (const auto& member : json_maneuver.GetObject()) {
-      std::string member_name = member.name.GetString();
+    // Set the type
+    auto type_iter = json_maneuver.FindMember("type");
+    if (type_iter != json_maneuver.MemberEnd()) {
+              if (!type_iter->value.IsUint()) {
+                throw std::runtime_error ("type is not a Uint");
+              }
+      proto_maneuver->set_type(type_iter->value.GetUint());
+    }
 
-      // Set the type
-      if (member_name == "type") {
-        proto_maneuver->set_type(member.value.GetUint());
+    // Set the instruction
+    auto instruction_iter = json_maneuver.FindMember("instruction");
+    if (instruction_iter != json_maneuver.MemberEnd()) {
+              if (!instruction_iter->value.IsString()) {
+                throw std::runtime_error ("instruction is not a string.");
+              }
+      proto_maneuver->set_instruction(instruction_iter->value.GetString());
+    }
+
+    // Set the street_names
+    auto street_names_iter = json_maneuver.FindMember("street_names");
+    if (street_names_iter != json_maneuver.MemberEnd()) {
+      if (!street_names_iter->value.IsArray()) {
+        throw std::runtime_error ("street_names is not an array.");
       }
-
-      // Set the instruction
-      else if (member_name == "instruction") {
-        proto_maneuver->set_instruction(member.value.GetString());
-      }
-
-      // Set the street_names
-      else if (member_name == "street_names") {
-        auto proto_street_names = proto_maneuver->mutable_street_names();
-        for (const auto& street_name : member.value.GetArray()) {
-          auto proto_street_name = proto_street_names->Add();
-          *proto_street_name = street_name.GetString();
+      auto proto_street_names = proto_maneuver->mutable_street_names();
+      for (const auto& street_name : street_names_iter->value.GetArray()) {
+        if (!street_name.IsString()) {
+          throw std::runtime_error ("street_name is not a string.");
         }
+        auto proto_street_name = proto_street_names->Add();
+        *proto_street_name = street_name.GetString();
       }
+    }
 
-      // Set the length
-      else if (member_name == "length") {
-        proto_maneuver->set_length(member.value.GetFloat());
+    // Set the length
+    auto length_iter = json_maneuver.FindMember("length");
+    if (length_iter != json_maneuver.MemberEnd()) {
+      if (!length_iter->value.IsFloat()) {
+        throw std::runtime_error ("length is not a float.");
       }
+      proto_maneuver->set_length(length_iter->value.GetFloat());
+    }
 
-      // Set the time
-      else if (member_name == "time") {
-        proto_maneuver->set_time(member.value.GetUint());
+    // Set the time
+    auto time_iter = json_maneuver.FindMember("time");
+    if (time_iter != json_maneuver.MemberEnd()) {
+      if (!time_iter->value.IsUint()) {
+        throw std::runtime_error ("time is not a Uint.");
       }
+      proto_maneuver->set_time(time_iter->value.GetUint());
+    }
 
-      // Set the begin_cardinal_direction
-      else if (member_name == "begin_cardinal_direction") {
-        proto_maneuver->set_begin_cardinal_direction(member.value.GetString());
+    // Set the begin_cardinal_direction
+    auto begin_cardinal_direction_iter = json_maneuver.FindMember("begin_cardinal_direction");
+    if (begin_cardinal_direction_iter != json_maneuver.MemberEnd()) {
+      if (!begin_cardinal_direction_iter->value.IsString()) {
+        throw std::runtime_error ("begin_cardinal_direction is not a string.");
       }
+      proto_maneuver->set_begin_cardinal_direction(begin_cardinal_direction_iter->value.GetString());
+    }
 
-      // Set the begin_heading
-      else if (member_name == "begin_heading") {
-        proto_maneuver->set_begin_heading(member.value.GetUint());
+    // Set the begin_heading
+    auto begin_heading_iter = json_maneuver.FindMember("begin_heading");
+    if (begin_heading_iter != json_maneuver.MemberEnd()) {
+      if (!begin_heading_iter->value.IsUint()) {
+        throw std::runtime_error ("begin_heading is not a Uint.");
       }
+      proto_maneuver->set_begin_heading(begin_heading_iter->value.GetUint());
+    }
 
-      // Set the begin_shape_index
-      else if (member_name == "begin_shape_index") {
-        proto_maneuver->set_begin_shape_index(member.value.GetUint());
+    // Set the begin_shape_index
+    auto begin_shape_index_iter = json_maneuver.FindMember("begin_shape_index");
+    if (begin_shape_index_iter != json_maneuver.MemberEnd()) {
+      if (!begin_shape_index_iter->value.IsUint()) {
+        throw std::runtime_error ("begin_shape_index is not a Uint.");
       }
+      proto_maneuver->set_begin_shape_index(begin_shape_index_iter->value.GetUint());
+    }
 
-      // Set the end_shape_index
-      else if (member_name == "end_shape_index") {
-        proto_maneuver->set_end_shape_index(member.value.GetUint());
+    // Set the end_shape_index
+    auto end_shape_index_iter = json_maneuver.FindMember("end_shape_index");
+    if (end_shape_index_iter != json_maneuver.MemberEnd()) {
+      if (!end_shape_index_iter->value.IsUint()) {
+        throw std::runtime_error ("end_shape_index is not a Uint.");
       }
+      proto_maneuver->set_end_shape_index(end_shape_index_iter->value.GetUint());
+    }
 
-      // Set toll
-      else if (member_name == "toll") {
-        proto_maneuver->set_toll(member.value.GetBool());
+    // Set toll
+    auto toll_iter = json_maneuver.FindMember("toll");
+    if (toll_iter != json_maneuver.MemberEnd()) {
+      if (!toll_iter->value.IsBool()) {
+        throw std::runtime_error ("toll is not a bool.");
       }
+      proto_maneuver->set_toll(toll_iter->value.GetBool());
+    }
 
-      // Set rough
-      else if (member_name == "rough") {
-        proto_maneuver->set_rough(member.value.GetBool());
+    // Set rough
+    auto rough_iter = json_maneuver.FindMember("rough");
+    if (rough_iter != json_maneuver.MemberEnd()) {
+      if (!rough_iter->value.IsBool()) {
+        throw std::runtime_error ("rough is not a bool.");
       }
+      proto_maneuver->set_rough(rough_iter->value.GetBool());
+    }
 
-      // Set the verbal_transition_alert_instruction
-      else if (member_name == "verbal_transition_alert_instruction") {
-        proto_maneuver->set_verbal_transition_alert_instruction(member.value.GetString());
+    // Set the verbal_transition_alert_instruction
+    auto verbal_transition_alert_instruction_iter = json_maneuver.FindMember("verbal_transition_alert_instruction");
+    if (verbal_transition_alert_instruction_iter != json_maneuver.MemberEnd()) {
+      if (!verbal_transition_alert_instruction_iter->value.IsString()) {
+        throw std::runtime_error ("verbal_transition_alert_instruction is not a string.");
       }
+      proto_maneuver->set_verbal_transition_alert_instruction(verbal_transition_alert_instruction_iter->value.GetString());
+    }
 
-      // Set the verbal_pre_transition_instruction
-      else if (member_name == "verbal_pre_transition_instruction") {
-        proto_maneuver->set_verbal_pre_transition_instruction(member.value.GetString());
+    // Set the verbal_pre_transition_instruction
+    auto verbal_pre_transition_instruction_iter = json_maneuver.FindMember("verbal_pre_transition_instruction");
+    if (verbal_pre_transition_instruction_iter != json_maneuver.MemberEnd()) {
+      if (!verbal_pre_transition_instruction_iter->value.IsString()) {
+        throw std::runtime_error ("verbal_pre_transition_instruction is not a string.");
       }
+      proto_maneuver->set_verbal_pre_transition_instruction(verbal_pre_transition_instruction_iter->value.GetString());
+    }
 
-      // Set the verbal_post_transition_instruction
-      else if (member_name == "verbal_post_transition_instruction") {
-        proto_maneuver->set_verbal_post_transition_instruction(member.value.GetString());
+    // Set the verbal_post_transition_instruction
+    auto verbal_post_transition_instruction_iter = json_maneuver.FindMember("verbal_post_transition_instruction");
+    if (verbal_post_transition_instruction_iter != json_maneuver.MemberEnd()) {
+      if (!verbal_post_transition_instruction_iter->value.IsString()) {
+        throw std::runtime_error ("verbal_post_transition_instruction is not a string.");
       }
+      proto_maneuver->set_verbal_post_transition_instruction(verbal_post_transition_instruction_iter->value.GetString());
+    }
 
-      // Set the begin_street_names
-      else if (member_name == "begin_street_names") {
-        auto proto_begin_street_names = proto_maneuver->mutable_begin_street_names();
-        for (const auto& begin_street_name : member.value.GetArray()) {
-          auto proto_begin_street_name = proto_begin_street_names->Add();
-          *proto_begin_street_name = begin_street_name.GetString();
+    // Set the begin_street_names
+    auto begin_street_names_iter = json_maneuver.FindMember("begin_street_names");
+    if (begin_street_names_iter != json_maneuver.MemberEnd()) {
+      if (!begin_street_names_iter->value.IsArray()) {
+        throw std::runtime_error ("begin_street_names is not an array.");
+      }
+      auto proto_begin_street_names = proto_maneuver->mutable_begin_street_names();
+      for (const auto& begin_street_name : begin_street_names_iter->value.GetArray()) {
+        if (!begin_street_name.IsString()) {
+          throw std::runtime_error ("begin_street_name is not a string.");
         }
+        auto proto_begin_street_name = proto_begin_street_names->Add();
+        *proto_begin_street_name = begin_street_name.GetString();
       }
+    }
 
-      // Set the sign
-      else if (member_name == "sign") {
-        jsonToProtoSign (member.value, proto_maneuver->mutable_sign());
+    // Set the sign
+    auto sign_iter = json_maneuver.FindMember ("sign");
+    if (sign_iter != json_maneuver.MemberEnd()) {
+      if (!sign_iter->value.IsObject()) {
+        throw std::runtime_error ("sign is not an object.");
       }
+      jsonToProtoSign (sign_iter->value, proto_maneuver->mutable_sign());
+    }
 
-      // Set the roundabout_exit_count
-      else if (member_name == "roundabout_exit_count") {
-        proto_maneuver->set_roundabout_exit_count(member.value.GetUint());
+    // Set the roundabout_exit_count
+    auto roundabout_exit_count_iter = json_maneuver.FindMember("roundabout_exit_count");
+    if (roundabout_exit_count_iter != json_maneuver.MemberEnd()) {
+      if (!roundabout_exit_count_iter->value.IsUint()) {
+        throw std::runtime_error ("roundabout_exit_count is not a Uint.");
       }
+      proto_maneuver->set_roundabout_exit_count(roundabout_exit_count_iter->value.GetUint());
+    }
 
-      // Set the depart_instruction
-      else if (member_name == "depart_instruction") {
-        proto_maneuver->set_depart_instruction(member.value.GetString());
+    // Set the depart_instruction
+    auto depart_instruction_iter = json_maneuver.FindMember("depart_instruction");
+    if (depart_instruction_iter != json_maneuver.MemberEnd()) {
+      if (!depart_instruction_iter->value.IsString()) {
+        throw std::runtime_error ("depart_instruction is not a string.");
       }
+      proto_maneuver->set_depart_instruction(depart_instruction_iter->value.GetString());
+    }
 
-      // Set the verbal_depart_instruction
-      else if (member_name == "verbal_depart_instruction") {
-        proto_maneuver->set_verbal_depart_instruction(member.value.GetString());
+    // Set the verbal_depart_instruction
+    auto verbal_depart_instruction_iter = json_maneuver.FindMember("verbal_depart_instruction");
+    if (verbal_depart_instruction_iter != json_maneuver.MemberEnd()) {
+      if (!verbal_depart_instruction_iter->value.IsString()) {
+        throw std::runtime_error ("verbal_depart_instruction is not a string.");
       }
+      proto_maneuver->set_verbal_depart_instruction(verbal_depart_instruction_iter->value.GetString());
+    }
 
-      // Set the arrive_instruction
-      else if (member_name == "arrive_instruction") {
-        proto_maneuver->set_arrive_instruction(member.value.GetString());
+    // Set the arrive_instruction
+    auto arrive_instruction_iter = json_maneuver.FindMember("arrive_instruction");
+    if (arrive_instruction_iter != json_maneuver.MemberEnd()) {
+      if (!arrive_instruction_iter->value.IsString()) {
+        throw std::runtime_error ("arrive_instruction is not a string.");
       }
+      proto_maneuver->set_arrive_instruction(arrive_instruction_iter->value.GetString());
+    }
 
-      // Set the verbal_arrive_instruction
-      else if (member_name == "verbal_arrive_instruction") {
-        proto_maneuver->set_verbal_arrive_instruction(member.value.GetString());
+    // Set the verbal_arrive_instruction
+    auto verbal_arrive_instruction_iter = json_maneuver.FindMember("verbal_arrive_instruction");
+    if (verbal_arrive_instruction_iter != json_maneuver.MemberEnd()) {
+      if (!verbal_arrive_instruction_iter->value.IsString()) {
+        throw std::runtime_error ("verbal_arrive_instruction is not a string.");
       }
+      proto_maneuver->set_verbal_arrive_instruction(verbal_arrive_instruction_iter->value.GetString());
+    }
 
-      // Set the transit_info
-      else if (member_name == "transit_info") {
-        jsonToProtoTransitInfo (member.value, proto_maneuver->mutable_transit_info());
+    // Set the transit_info
+    auto transit_info_iter = json_maneuver.FindMember("transit_info");
+    if (transit_info_iter != json_maneuver.MemberEnd()) {
+      if (!transit_info_iter->value.IsObject()) {
+        throw std::runtime_error ("transit_info is not an object.");
       }
+      jsonToProtoTransitInfo (transit_info_iter->value, proto_maneuver->mutable_transit_info());
+    }
 
-      // Set verbal_multi_cue
-      else if (member_name == "verbal_multi_cue") {
-        proto_maneuver->set_verbal_multi_cue(member.value.GetBool());
+    // Set verbal_multi_cue
+    auto verbal_multi_cue_iter = json_maneuver.FindMember("verbal_multi_cue");
+    if (verbal_multi_cue_iter != json_maneuver.MemberEnd()) {
+      if (!verbal_multi_cue_iter->value.IsBool()) {
+        throw std::runtime_error ("verbal_multi_cue is not a bool.");
       }
+      proto_maneuver->set_verbal_multi_cue(verbal_multi_cue_iter->value.GetBool());
+    }
 
-      // Set the travel_mode
-      else if (member_name == "travel_mode") {
-        proto_maneuver->set_travel_mode(member.value.GetString());
+    // Set the travel_mode
+    auto travel_mode_iter = json_maneuver.FindMember("travel_mode");
+    if (travel_mode_iter != json_maneuver.MemberEnd()) {
+      if (!travel_mode_iter->value.IsString()) {
+        throw std::runtime_error ("travel_mode is not a string.");
       }
+      proto_maneuver->set_travel_mode(travel_mode_iter->value.GetString());
+    }
 
-      // Set the travel_type
-      else if (member_name == "travel_type") {
-        proto_maneuver->set_travel_type(member.value.GetString());
+    // Set the travel_type
+    auto travel_type_iter = json_maneuver.FindMember("travel_type");
+    if (travel_type_iter != json_maneuver.MemberEnd()) {
+      if (!travel_type_iter->value.IsString()) {
+        throw std::runtime_error ("travel_type is not a string.");
       }
+      proto_maneuver->set_travel_type(travel_type_iter->value.GetString());
     }
   }
 
   void jsonToProtoLeg (const rapidjson::Value& json_leg, Route::Leg* proto_leg) {
-    for (const auto& member : json_leg.GetObject()) {
-      std::string member_name = member.name.GetString();
-
-      // Set the summary
-      if (member_name == "summary") {
-        jsonToProtoSummary (member.value, proto_leg->mutable_summary());
+    // Set the summary
+    auto summary_iter = json_leg.FindMember("summary");
+    if (summary_iter != json_leg.MemberEnd()) {
+      if (!summary_iter->value.IsObject()) {
+        throw std::runtime_error ("summary is not an object.");
       }
+      jsonToProtoSummary (summary_iter->value, proto_leg->mutable_summary());
+    }
 
-      // Set the maneuvers
-      if(member_name == "maneuvers") {
-        auto proto_maneuvers = proto_leg->mutable_maneuvers();
-        for (const auto& maneuver : member.value.GetArray()) {
-          auto proto_maneuver = proto_maneuvers->Add();
-          jsonToProtoManeuver (maneuver, proto_maneuver);
+    // Set the maneuvers
+    auto maneuvers_iter = json_leg.FindMember("maneuvers");
+    if(maneuvers_iter != json_leg.MemberEnd()) {
+      if (!maneuvers_iter->value.IsArray()) {
+        throw std::runtime_error ("maneuvers is not an array.");
+      }
+      auto proto_maneuvers = proto_leg->mutable_maneuvers();
+      for (const auto& maneuver : maneuvers_iter->value.GetArray()) {
+        if (!maneuver.IsObject()) {
+          throw std::runtime_error ("maneuver is not an object.");
         }
+        auto proto_maneuver = proto_maneuvers->Add();
+        jsonToProtoManeuver (maneuver, proto_maneuver);
       }
+    }
 
-      // Set the shape
-      if (member_name == "shape") {
-        proto_leg->set_shape(member.value.GetString());
+    // Set the shape
+    auto shape_iter = json_leg.FindMember("shape");
+    if (shape_iter != json_leg.MemberEnd()) {
+      if (!shape_iter->value.IsString()) {
+        throw std::runtime_error ("shape is not a string.");
       }
+      proto_leg->set_shape(shape_iter->value.GetString());
     }
   }
 }
@@ -1261,6 +1545,8 @@ namespace valhalla {
     void jsonToProtoRoute (const std::string& json_route, Route& proto_route) {
       rapidjson::Document d;
       d.Parse (json_route.c_str());
+      if (d.HasParseError())
+        throw std::runtime_error ("String to document parsing failed.");
 
       // Grab the trip object from JSON
       auto json_trip = GetOptionalFromRapidJson<rapidjson::Value::Object> (d, "/trip");
@@ -1274,56 +1560,91 @@ namespace valhalla {
       // Get the empty trip object and start setting it's fields
       Route::Trip* proto_trip = proto_route.mutable_trip();
 
-      for (const auto& member : *json_trip) {
-        std::string member_name = member.name.GetString();
 
-        // Set the locations
-        if (member_name == "locations") {
-          auto proto_locations = proto_trip->mutable_locations();
-          for (const auto& loc : member.value.GetArray()) {
-            auto proto_loc = proto_locations->Add();
-            jsonToProtoLocation (loc, proto_loc);
+      // Set the locations
+      auto locations_iter = json_trip->FindMember("locations");
+      if (locations_iter != json_trip->end()) {
+        if (!locations_iter->value.IsArray()) {
+          throw std::runtime_error ("locations is not an array.");
+        }
+        auto proto_locations = proto_trip->mutable_locations();
+        for (const auto& loc : locations_iter->value.GetArray()) {
+          if (!loc.IsObject()) {
+            throw std::runtime_error ("location is not an object.");
           }
+          auto proto_loc = proto_locations->Add();
+          jsonToProtoLocation (loc, proto_loc);
         }
+      }
 
-        // Set the summary
-        else if (member_name == "summary") {
-          jsonToProtoSummary (member.value, proto_trip->mutable_summary());
+      // Set the summary
+      auto summary_iter = json_trip->FindMember("summary");
+      if (summary_iter != json_trip->end()) {
+        if (!summary_iter->value.IsObject()) {
+          throw std::runtime_error ("summary is not an object.");
         }
+        jsonToProtoSummary (summary_iter->value, proto_trip->mutable_summary());
+      }
 
-        // Set the legs
-        else if (member_name == "legs") {
-          auto proto_legs = proto_trip->mutable_legs();
-          for (const auto& leg: member.value.GetArray()) {
-            auto proto_leg = proto_legs->Add();
-            jsonToProtoLeg (leg, proto_leg);
+      // Set the legs
+      auto legs_iter = json_trip->FindMember("legs");
+      if (legs_iter != json_trip->end()) {
+        if (!legs_iter->value.IsArray()) {
+          throw std::runtime_error ("legs is not an array.");
+        }
+        auto proto_legs = proto_trip->mutable_legs();
+        for (const auto& leg: legs_iter->value.GetArray()) {
+          if (!leg.IsObject()) {
+            throw std::runtime_error ("leg is not an object.");
           }
+          auto proto_leg = proto_legs->Add();
+          jsonToProtoLeg (leg, proto_leg);
         }
+      }
 
-        // Set the status_message
-        else if (member_name == "status_message") {
-          proto_trip->set_status_message(member.value.GetString());
+      // Set the status_message
+      auto status_message_iter = json_trip->FindMember("status_message");
+      if (status_message_iter != json_trip->end()) {
+        if (!status_message_iter->value.IsString()) {
+          throw std::runtime_error ("status_message is not a string.");
         }
+        proto_trip->set_status_message(status_message_iter->value.GetString());
+      }
 
-        // Set the status
-        else if (member_name == "status") {
-          proto_trip->set_status(member.value.GetUint());
+      // Set the status
+      auto status_iter = json_trip->FindMember("status");
+      if (status_iter != json_trip->end()) {
+        if (!status_iter->value.IsUint()) {
+          throw std::runtime_error ("status is not a Uint.");
         }
+        proto_trip->set_status(status_iter->value.GetUint());
+      }
 
-        // Set the units
-        else if (member_name == "units") {
-          proto_trip->set_units(member.value.GetString());
+      // Set the units
+      auto units_iter = json_trip->FindMember("units");
+      if (units_iter != json_trip->end()) {
+        if (!units_iter->value.IsString()) {
+          throw std::runtime_error ("units is not a string.");
         }
+        proto_trip->set_units(units_iter->value.GetString());
+      }
 
-        // Set the language
-        else if (member_name == "language") {
-          proto_trip->set_language(member.value.GetString());
+      // Set the language
+      auto language_iter = json_trip->FindMember("language");
+      if (language_iter != json_trip->end()) {
+        if (!language_iter->value.IsString()) {
+          throw std::runtime_error ("language is not a string.");
         }
+        proto_trip->set_language(language_iter->value.GetString());
+      }
 
-        // Set the id
-        else if (member_name == "id") {
-          proto_trip->set_id(member.value.GetString());
+      // Set the id
+      auto id_iter = json_trip->FindMember("id");
+      if (id_iter != json_trip->end()) {
+        if (!id_iter->value.IsString()) {
+          throw std::runtime_error ("id is not a string.");
         }
+        proto_trip->set_id(id_iter->value.GetString());
       }
     }
 

--- a/test/navigator.cc
+++ b/test/navigator.cc
@@ -130,6 +130,10 @@ class NavigatorTest : public Navigator {
     return Navigator::used_instructions_;
   }
 
+  NavigationStatus_RouteState GetRouteState () {
+    return route_state_;
+  }
+
 };
 
 void TryTopLevelSetRoute(const std::string& route_json_str,
@@ -363,7 +367,11 @@ void TestTopLevelLegSetRoute() {
   NavigatorTest nt;
   NavigationStatus status = nt.SetRoute(runtimeErrorTest);
   if (status.route_state() != NavigationStatus_RouteState_kInvalid) {
-    throw std::runtime_error ("Invalid route did not cause an invalid state.");
+    throw std::runtime_error ("Invalid route did not return an invalid state.");
+  }
+
+  if (nt.GetRouteState() != NavigationStatus_RouteState_kInvalid) {
+    throw std::runtime_error ("Invalid route did not cause an internal invalid state.");
   }
 
 }

--- a/test/navigator.cc
+++ b/test/navigator.cc
@@ -356,6 +356,16 @@ void TestTopLevelLegSetRoute() {
 
   TryTopLevelLegSetRoute(route_json_str, expected_leg_maneuver_count,
       expected_leg_shape);
+
+  // Test runtime error
+
+  std::string runtimeErrorTest = R"({trip:20})";
+  NavigatorTest nt;
+  NavigationStatus status = nt.SetRoute(runtimeErrorTest);
+  if (status.route_state() != NavigationStatus_RouteState_kInvalid) {
+    throw std::runtime_error ("Invalid route did not cause an invalid state.");
+  }
+
 }
 
 void TryRouteLegCount(NavigatorTest& nav, int expected_leg_count) {

--- a/test/serializers.cc
+++ b/test/serializers.cc
@@ -165,6 +165,130 @@ void testTrip() {
   if (trip.status() != 1) {
     throw std::runtime_error ("status is: " + std::to_string(trip.status()) + " | Expected: 0");
   }
+
+  // Test throwing runtime errors
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  std::string tripErrorTest =
+      R"({trip:20})";
+  try {
+    jsonToProtoRoute (tripErrorTest, route);
+    throw std::runtime_error ("Did not throw parse error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw parse error") {
+      throw e;
+    }
+  }
+
+  tripErrorTest =
+      R"({"trip":20})";
+  try {
+    jsonToProtoRoute (tripErrorTest, route);
+    throw std::runtime_error ("Did not throw trip error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw trip error") {
+      throw e;
+    }
+  }
+
+  tripErrorTest =
+      R"({"trip":{"language":20}})";
+  try {
+    jsonToProtoRoute (tripErrorTest, route);
+    throw std::runtime_error ("Did not throw language error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw language error") {
+      throw e;
+    }
+  }
+
+  tripErrorTest =
+      R"({"trip":{"summary":20}})";
+  try {
+    jsonToProtoRoute (tripErrorTest, route);
+    throw std::runtime_error ("Did not throw summary error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw summary error") {
+      throw e;
+    }
+  }
+
+  tripErrorTest =
+      R"({"trip":{"locations":20}})";
+  try {
+    jsonToProtoRoute (tripErrorTest, route);
+    throw std::runtime_error ("Did not throw locations error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw locations error") {
+      throw e;
+    }
+  }
+
+  tripErrorTest =
+      R"({"trip":{"locations":[20]}})";
+  try {
+    jsonToProtoRoute (tripErrorTest, route);
+    throw std::runtime_error ("Did not throw location error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw location error") {
+      throw e;
+    }
+  }
+
+  tripErrorTest =
+      R"({"trip":{"units":20}})";
+  try {
+    jsonToProtoRoute (tripErrorTest, route);
+    throw std::runtime_error ("Did not throw units error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw units error") {
+      throw e;
+    }
+  }
+
+  tripErrorTest =
+      R"({"trip":{"legs":20}})";
+  try {
+    jsonToProtoRoute (tripErrorTest, route);
+    throw std::runtime_error ("Did not throw legs error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw legs error") {
+      throw e;
+    }
+  }
+
+  tripErrorTest =
+      R"({"trip":{"legs":[20]}})";
+  try {
+    jsonToProtoRoute (tripErrorTest, route);
+    throw std::runtime_error ("Did not throw leg error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw leg error") {
+      throw e;
+    }
+  }
+
+  tripErrorTest =
+      R"({"trip":{"status_message":20}})";
+  try {
+    jsonToProtoRoute (tripErrorTest, route);
+    throw std::runtime_error ("Did not throw status_message error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw status_message error") {
+      throw e;
+    }
+  }
+
+  tripErrorTest =
+      R"({"trip":{"status":"1"}})";
+  try {
+    jsonToProtoRoute (tripErrorTest, route);
+    throw std::runtime_error ("Did not throw status error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw status error") {
+      throw e;
+    }
+  }
 }
 
 void testLocation() {
@@ -207,7 +331,7 @@ void testLocation() {
   }
 
   if (location.type() != "break") {
-    throw std::runtime_error ("type is: " + location.type() + " | Expected: breal");
+    throw std::runtime_error ("type is: " + location.type() + " | Expected: break");
   }
 
   if (location.heading() != 25) {
@@ -248,6 +372,152 @@ void testLocation() {
 
   if (location.original_index() != 5) {
     throw std::runtime_error ("original_index is: " + std::to_string(location.original_index()) + " | Expected: 5");
+  }
+
+  // Test throwing runtime errors
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  std::string locationErrorTest =
+      R"({"trip":{"locations":[{"state":20}]}})";
+  try {
+    jsonToProtoRoute (locationErrorTest, route);
+    throw std::runtime_error ("Did not throw state error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw state error") {
+      throw e;
+    }
+  }
+
+  locationErrorTest =
+      R"({"trip":{"locations":[{"type":20}]}})";
+  try {
+    jsonToProtoRoute (locationErrorTest, route);
+    throw std::runtime_error ("Did not throw type error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw type error") {
+      throw e;
+    }
+  }
+
+  locationErrorTest =
+      R"({"trip":{"locations":[{"side_of_street":20}]}})";
+  try {
+    jsonToProtoRoute (locationErrorTest, route);
+    throw std::runtime_error ("Did not throw side_of_street error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw side_of_street error") {
+      throw e;
+    }
+  }
+
+  locationErrorTest =
+      R"({"trip":{"locations":[{"lat":"12.24153"}]}})";
+  try {
+    jsonToProtoRoute (locationErrorTest, route);
+    throw std::runtime_error ("Did not throw lat error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw lat error") {
+      throw e;
+    }
+  }
+
+  locationErrorTest =
+      R"({"trip":{"locations":[{"lon":"12.24153"}]}})";
+  try {
+    jsonToProtoRoute (locationErrorTest, route);
+    throw std::runtime_error ("Did not throw lon error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw lon error") {
+      throw e;
+    }
+  }
+
+  locationErrorTest =
+      R"({"trip":{"locations":[{"city":1}]}})";
+  try {
+    jsonToProtoRoute (locationErrorTest, route);
+    throw std::runtime_error ("Did not throw city error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw city error") {
+      throw e;
+    }
+  }
+
+  locationErrorTest =
+      R"({"trip":{"locations":[{"street":123}]}})";
+  try {
+    jsonToProtoRoute (locationErrorTest, route);
+    throw std::runtime_error ("Did not throw street error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw street error") {
+      throw e;
+    }
+  }
+
+  locationErrorTest =
+      R"({"trip":{"locations":[{"heading":"25"}]}})";
+  try {
+    jsonToProtoRoute (locationErrorTest, route);
+    throw std::runtime_error ("Did not throw heading error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw heading error") {
+      throw e;
+    }
+  }
+
+  locationErrorTest =
+      R"({"trip":{"locations":[{"name":20}]}})";
+  try {
+    jsonToProtoRoute (locationErrorTest, route);
+    throw std::runtime_error ("Did not throw name error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw name error") {
+      throw e;
+    }
+  }
+
+  locationErrorTest =
+      R"({"trip":{"locations":[{"postal_code":12345}]}})";
+  try {
+    jsonToProtoRoute (locationErrorTest, route);
+    throw std::runtime_error ("Did not throw postal_code error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw postal_code error") {
+      throw e;
+    }
+  }
+
+  locationErrorTest =
+      R"({"trip":{"locations":[{"country":20}]}})";
+  try {
+    jsonToProtoRoute (locationErrorTest, route);
+    throw std::runtime_error ("Did not throw country error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw country error") {
+      throw e;
+    }
+  }
+
+  locationErrorTest =
+      R"({"trip":{"locations":[{"date_time":20}]}})";
+  try {
+    jsonToProtoRoute (locationErrorTest, route);
+    throw std::runtime_error ("Did not throw date_time error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw date_time error") {
+      throw e;
+    }
+  }
+
+  locationErrorTest =
+      R"({"trip":{"locations":[{"original_index":"5"}]}})";
+  try {
+    jsonToProtoRoute (locationErrorTest, route);
+    throw std::runtime_error ("Did not throw original_index error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw original_index error") {
+      throw e;
+    }
   }
 }
 
@@ -296,6 +566,86 @@ void testSummary () {
   if (summary.max_lon() != -12.733452f) {
     throw std::runtime_error ("max_lon is: " + std::to_string(summary.max_lon()) + " | Expected: -12.733452");
   }
+
+  // Test throwing runtime errors
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  std::string summaryErrorTest =
+      R"({"trip":{"summary":{"max_lon":"-12.733452"}}})";
+  try {
+    jsonToProtoRoute (summaryErrorTest, route);
+    throw std::runtime_error ("Did not throw max_lon error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw max_lon error") {
+      throw e;
+    }
+  }
+
+  summaryErrorTest =
+      R"({"trip":{"summary":{"max_lat":"-12.733452"}}})";
+  try {
+    jsonToProtoRoute (summaryErrorTest, route);
+    throw std::runtime_error ("Did not throw max_lat error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw max_lat error") {
+      throw e;
+    }
+  }
+
+  summaryErrorTest =
+      R"({"trip":{"summary":{"time":"8435"}}})";
+  try {
+    jsonToProtoRoute (summaryErrorTest, route);
+    throw std::runtime_error ("Did not throw time error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw time error") {
+      throw e;
+    }
+  }
+
+  summaryErrorTest =
+      R"({"trip":{"summary":{"length":"147.371"}}})";
+  try {
+    jsonToProtoRoute (summaryErrorTest, route);
+    throw std::runtime_error ("Did not throw length error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw length error") {
+      throw e;
+    }
+  }
+
+  summaryErrorTest =
+      R"({"trip":{"summary":{"min_lat":"11.24153"}}})";
+  try {
+    jsonToProtoRoute (summaryErrorTest, route);
+    throw std::runtime_error ("Did not throw min_lat error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw min_lat error") {
+      throw e;
+    }
+  }
+
+  summaryErrorTest =
+      R"({"trip":{"summary":{"min_lat":"11.24153"}}})";
+  try {
+    jsonToProtoRoute (summaryErrorTest, route);
+    throw std::runtime_error ("Did not throw min_lat error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw min_lat error") {
+      throw e;
+    }
+  }
+
+  summaryErrorTest =
+      R"({"trip":{"summary":{"min_lon":"11.24153"}}})";
+  try {
+    jsonToProtoRoute (summaryErrorTest, route);
+    throw std::runtime_error ("Did not throw min_lon error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw min_lon error") {
+      throw e;
+    }
+  }
 }
 
 void testLeg () {
@@ -327,6 +677,53 @@ void testLeg () {
 
   if (leg.shape() != "q{ewkA|bliqC|DlJ") {
     throw std::runtime_error ("shape: " + leg.shape() + " | Expected: q{ewkA|bliqC|DlJ");
+  }
+
+  // Test throwing runtime errors
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  std::string legErrorTest =
+      R"({"trip":{"legs":[{"shape":20}]}})";
+  try {
+    jsonToProtoRoute (legErrorTest, route);
+    throw std::runtime_error ("Did not throw shape error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw shape error") {
+      throw e;
+    }
+  }
+
+  legErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":20}]}})";
+  try {
+    jsonToProtoRoute (legErrorTest, route);
+    throw std::runtime_error ("Did not throw maneuvers error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw maneuvers error") {
+      throw e;
+    }
+  }
+
+  legErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[20]}]}})";
+  try {
+    jsonToProtoRoute (legErrorTest, route);
+    throw std::runtime_error ("Did not throw maneuver error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw maneuver error") {
+      throw e;
+    }
+  }
+
+  legErrorTest =
+      R"({"trip":{"legs":[{"summary":20}]}})";
+  try {
+    jsonToProtoRoute (legErrorTest, route);
+    throw std::runtime_error ("Did not throw summary error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw summary error") {
+      throw e;
+    }
   }
 }
 
@@ -500,6 +897,306 @@ void testManeuver () {
   if (maneuver.travel_type() != "car") {
     throw std::runtime_error ("travel_type is: " + maneuver.travel_type() + " | Expected: car");
   }
+
+  // Test throwing runtime errors
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  std::string maneuverErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"travel_type":20}]}]}})";
+  try {
+    jsonToProtoRoute (maneuverErrorTest, route);
+    throw std::runtime_error ("Did not throw travel_type error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw travel_type error") {
+      throw e;
+    }
+  }
+
+  maneuverErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"travel_mode":20}]}]}})";
+  try {
+    jsonToProtoRoute (maneuverErrorTest, route);
+    throw std::runtime_error ("Did not throw travel_mode error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw travel_mode error") {
+      throw e;
+    }
+  }
+
+  maneuverErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"verbal_pre_transition_instruction":20}]}]}})";
+  try {
+    jsonToProtoRoute (maneuverErrorTest, route);
+    throw std::runtime_error ("Did not throw verbal_pre_transition_instruction error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw verbal_pre_transition_instruction error") {
+      throw e;
+    }
+  }
+
+  maneuverErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"verbal_transition_alert_instruction":20}]}]}})";
+  try {
+    jsonToProtoRoute (maneuverErrorTest, route);
+    throw std::runtime_error ("Did not throw verbal_transition_alert_instruction error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw verbal_transition_alert_instruction error") {
+      throw e;
+    }
+  }
+
+  maneuverErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"toll":"true"}]}]}})";
+  try {
+    jsonToProtoRoute (maneuverErrorTest, route);
+    throw std::runtime_error ("Did not throw toll error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw toll error") {
+      throw e;
+    }
+  }
+
+  maneuverErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"instruction":20}]}]}})";
+  try {
+    jsonToProtoRoute (maneuverErrorTest, route);
+    throw std::runtime_error ("Did not throw instruction error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw instruction error") {
+      throw e;
+    }
+  }
+
+  maneuverErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"end_shape_index":"2111"}]}]}})";
+  try {
+    jsonToProtoRoute (maneuverErrorTest, route);
+    throw std::runtime_error ("Did not throw end_shape_index error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw end_shape_index error") {
+      throw e;
+    }
+  }
+
+  maneuverErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"type":"20"}]}]}})";
+  try {
+    jsonToProtoRoute (maneuverErrorTest, route);
+    throw std::runtime_error ("Did not throw type error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw type error") {
+      throw e;
+    }
+  }
+
+  maneuverErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"time":"33"}]}]}})";
+  try {
+    jsonToProtoRoute (maneuverErrorTest, route);
+    throw std::runtime_error ("Did not throw time error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw time error") {
+      throw e;
+    }
+  }
+
+  maneuverErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"begin_shape_index":"2086"}]}]}})";
+  try {
+    jsonToProtoRoute (maneuverErrorTest, route);
+    throw std::runtime_error ("Did not throw begin_shape_index error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw begin_shape_index error") {
+      throw e;
+    }
+  }
+
+  maneuverErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"length":"0.266"}]}]}})";
+  try {
+    jsonToProtoRoute (maneuverErrorTest, route);
+    throw std::runtime_error ("Did not throw length error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw length error") {
+      throw e;
+    }
+  }
+
+  maneuverErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"sign":20}]}]}})";
+  try {
+    jsonToProtoRoute (maneuverErrorTest, route);
+    throw std::runtime_error ("Did not throw sign error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw sign error") {
+      throw e;
+    }
+  }
+
+  maneuverErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"street_names":"street"}]}]}})";
+  try {
+    jsonToProtoRoute (maneuverErrorTest, route);
+    throw std::runtime_error ("Did not throw street_names error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw street_names error") {
+      throw e;
+    }
+  }
+
+  maneuverErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"street_names":[20]}]}]}})";
+  try {
+    jsonToProtoRoute (maneuverErrorTest, route);
+    throw std::runtime_error ("Did not throw street_name error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw street_name error") {
+      throw e;
+    }
+  }
+
+  maneuverErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"begin_cardinal_direction":20}]}]}})";
+  try {
+    jsonToProtoRoute (maneuverErrorTest, route);
+    throw std::runtime_error ("Did not throw begin_cardinal_direction error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw begin_cardinal_direction error") {
+      throw e;
+    }
+  }
+
+  maneuverErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"begin_heading":"7"}]}]}})";
+  try {
+    jsonToProtoRoute (maneuverErrorTest, route);
+    throw std::runtime_error ("Did not throw begin_heading error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw begin_heading error") {
+      throw e;
+    }
+  }
+
+  maneuverErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"rough":"true"}]}]}})";
+  try {
+    jsonToProtoRoute (maneuverErrorTest, route);
+    throw std::runtime_error ("Did not throw rough error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw rough error") {
+      throw e;
+    }
+  }
+
+  maneuverErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"verbal_post_transition_instruction":20}]}]}})";
+  try {
+    jsonToProtoRoute (maneuverErrorTest, route);
+    throw std::runtime_error ("Did not throw verbal_post_transition_instruction error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw verbal_post_transition_instruction error") {
+      throw e;
+    }
+  }
+
+  maneuverErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"begin_street_names":"begin"}]}]}})";
+  try {
+    jsonToProtoRoute (maneuverErrorTest, route);
+    throw std::runtime_error ("Did not throw begin_street_names error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw begin_street_names error") {
+      throw e;
+    }
+  }
+
+  maneuverErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"begin_street_names":[20]}]}]}})";
+  try {
+    jsonToProtoRoute (maneuverErrorTest, route);
+    throw std::runtime_error ("Did not throw begin_street_name error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw begin_street_name error") {
+      throw e;
+    }
+  }
+
+  maneuverErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"roundabout_exit_count":"2"}]}]}})";
+  try {
+    jsonToProtoRoute (maneuverErrorTest, route);
+    throw std::runtime_error ("Did not throw roundabout_exit_count error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw roundabout_exit_count error") {
+      throw e;
+    }
+  }
+
+  maneuverErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"depart_instruction":20}]}]}})";
+  try {
+    jsonToProtoRoute (maneuverErrorTest, route);
+    throw std::runtime_error ("Did not throw depart_instruction error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw depart_instruction error") {
+      throw e;
+    }
+  }
+
+  maneuverErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"verbal_depart_instruction":20}]}]}})";
+  try {
+    jsonToProtoRoute (maneuverErrorTest, route);
+    throw std::runtime_error ("Did not throw verbal_depart_instruction error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw verbal_depart_instruction error") {
+      throw e;
+    }
+  }
+
+  maneuverErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"arrive_instruction":20}]}]}})";
+  try {
+    jsonToProtoRoute (maneuverErrorTest, route);
+    throw std::runtime_error ("Did not throw arrive_instruction error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw arrive_instruction error") {
+      throw e;
+    }
+  }
+
+  maneuverErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"verbal_arrive_instruction":20}]}]}})";
+  try {
+    jsonToProtoRoute (maneuverErrorTest, route);
+    throw std::runtime_error ("Did not throw verbal_arrive_instruction error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw verbal_arrive_instruction error") {
+      throw e;
+    }
+  }
+
+  maneuverErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"transit_info":"hello"}]}]}})";
+  try {
+    jsonToProtoRoute (maneuverErrorTest, route);
+    throw std::runtime_error ("Did not throw transit_info error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw transit_info error") {
+      throw e;
+    }
+  }
+
+  maneuverErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"verbal_multi_cue":"true"}]}]}})";
+  try {
+    jsonToProtoRoute (maneuverErrorTest, route);
+    throw std::runtime_error ("Did not throw verbal_multi_cue error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw verbal_multi_cue error") {
+      throw e;
+    }
+  }
 }
 
 void testTransitInfo () {
@@ -583,6 +1280,141 @@ void testTransitInfo () {
     throw std::runtime_error ("transit_stops size: " + std::to_string(transit_info.transit_stops_size()) +
                               " | Expected: 2");
   }
+
+  // Test throwing runtime errors
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  std::string transitInfoErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"transit_info":{"onestop_id":20}}]}]}})";
+  try {
+    jsonToProtoRoute (transitInfoErrorTest, route);
+    throw std::runtime_error ("Did not throw onestop_id error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw onestop_id error") {
+      throw e;
+    }
+  }
+
+  transitInfoErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"transit_info":{"short_name":20}}]}]}})";
+  try {
+    jsonToProtoRoute (transitInfoErrorTest, route);
+    throw std::runtime_error ("Did not throw short_name error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw short_name error") {
+      throw e;
+    }
+  }
+
+  transitInfoErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"transit_info":{"long_name":20}}]}]}})";
+  try {
+    jsonToProtoRoute (transitInfoErrorTest, route);
+    throw std::runtime_error ("Did not throw long_name error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw long_name error") {
+      throw e;
+    }
+  }
+
+  transitInfoErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"transit_info":{"headsign":20}}]}]}})";
+  try {
+    jsonToProtoRoute (transitInfoErrorTest, route);
+    throw std::runtime_error ("Did not throw headsign error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw headsign error") {
+      throw e;
+    }
+  }
+
+  transitInfoErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"transit_info":{"color":"255"}}]}]}})";
+  try {
+    jsonToProtoRoute (transitInfoErrorTest, route);
+    throw std::runtime_error ("Did not throw color error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw color error") {
+      throw e;
+    }
+  }
+
+  transitInfoErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"transit_info":{"text_color":"133"}}]}]}})";
+  try {
+    jsonToProtoRoute (transitInfoErrorTest, route);
+    throw std::runtime_error ("Did not throw text_color error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw text_color error") {
+      throw e;
+    }
+  }
+
+  transitInfoErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"transit_info":{"description":20}}]}]}})";
+  try {
+    jsonToProtoRoute (transitInfoErrorTest, route);
+    throw std::runtime_error ("Did not throw description error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw description error") {
+      throw e;
+    }
+  }
+
+  transitInfoErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"transit_info":{"operator_onestop_id":20}}]}]}})";
+  try {
+    jsonToProtoRoute (transitInfoErrorTest, route);
+    throw std::runtime_error ("Did not throw operator_onestop_id error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw operator_onestop_id error") {
+      throw e;
+    }
+  }
+
+  transitInfoErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"transit_info":{"operator_name":20}}]}]}})";
+  try {
+    jsonToProtoRoute (transitInfoErrorTest, route);
+    throw std::runtime_error ("Did not throw operator_name error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw operator_name error") {
+      throw e;
+    }
+  }
+
+  transitInfoErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"transit_info":{"operator_url":20}}]}]}})";
+  try {
+    jsonToProtoRoute (transitInfoErrorTest, route);
+    throw std::runtime_error ("Did not throw operator_url error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw operator_url error") {
+      throw e;
+    }
+  }
+
+  transitInfoErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"transit_info":{"transit_stops":20}}]}]}})";
+  try {
+    jsonToProtoRoute (transitInfoErrorTest, route);
+    throw std::runtime_error ("Did not throw transit_stops error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw transit_stops error") {
+      throw e;
+    }
+  }
+
+  transitInfoErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"transit_info":{"transit_stops":[20]}}]}]}})";
+  try {
+    jsonToProtoRoute (transitInfoErrorTest, route);
+    throw std::runtime_error ("Did not throw transit_stop error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw transit_stop error") {
+      throw e;
+    }
+  }
 }
 
 void testTransitStop() {
@@ -663,6 +1495,108 @@ void testTransitStop() {
   if (transit_stop.lon() != 19.12f) {
     throw std::runtime_error ("lon is: " + std::to_string(transit_stop.lon()) + " | Expected: 19.12");
   }
+
+  // Test throwing runtime errors
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  std::string transitStopErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"transit_info":{"transit_stops":[{"type":20}]}}]}]}})";
+  try {
+    jsonToProtoRoute (transitStopErrorTest, route);
+    throw std::runtime_error ("Did not throw type error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw type error") {
+      throw e;
+    }
+  }
+
+  transitStopErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"transit_info":{"transit_stops":[{"onestop_id":20}]}}]}]}})";
+  try {
+    jsonToProtoRoute (transitStopErrorTest, route);
+    throw std::runtime_error ("Did not throw onestop_id error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw onestop_id error") {
+      throw e;
+    }
+  }
+
+  transitStopErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"transit_info":{"transit_stops":[{"name":20}]}}]}]}})";
+  try {
+    jsonToProtoRoute (transitStopErrorTest, route);
+    throw std::runtime_error ("Did not throw name error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw name error") {
+      throw e;
+    }
+  }
+
+  transitStopErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"transit_info":{"transit_stops":[{"arrival_date_time":20}]}}]}]}})";
+  try {
+    jsonToProtoRoute (transitStopErrorTest, route);
+    throw std::runtime_error ("Did not throw arrival_date_time error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw arrival_date_time error") {
+      throw e;
+    }
+  }
+
+  transitStopErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"transit_info":{"transit_stops":[{"departure_date_time":20}]}}]}]}})";
+  try {
+    jsonToProtoRoute (transitStopErrorTest, route);
+    throw std::runtime_error ("Did not throw departure_date_time error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw departure_date_time error") {
+      throw e;
+    }
+  }
+
+  transitStopErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"transit_info":{"transit_stops":[{"is_parent_stop":"true"}]}}]}]}})";
+  try {
+    jsonToProtoRoute (transitStopErrorTest, route);
+    throw std::runtime_error ("Did not throw is_parent_stop error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw is_parent_stop error") {
+      throw e;
+    }
+  }
+
+  transitStopErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"transit_info":{"transit_stops":[{"assumed_schedule":"true"}]}}]}]}})";
+  try {
+    jsonToProtoRoute (transitStopErrorTest, route);
+    throw std::runtime_error ("Did not throw assumed_schedule error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw assumed_schedule error") {
+      throw e;
+    }
+  }
+
+  transitStopErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"transit_info":{"transit_stops":[{"lat":"13.892"}]}}]}]}})";
+  try {
+    jsonToProtoRoute (transitStopErrorTest, route);
+    throw std::runtime_error ("Did not throw lat error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw lat error") {
+      throw e;
+    }
+  }
+
+  transitStopErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"transit_info":{"transit_stops":[{"lon":"13.892"}]}}]}]}})";
+  try {
+    jsonToProtoRoute (transitStopErrorTest, route);
+    throw std::runtime_error ("Did not throw lon error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw lon error") {
+      throw e;
+    }
+  }
 }
 
 void testSignElements() {
@@ -723,6 +1657,120 @@ void testSignElements() {
   if (element.consecutive_count() != 2) {
     throw std::runtime_error ("consecutive_count is: " + std::to_string(element.consecutive_count()) + " | Expected: 2");
   }
+
+  // Test throwing runtime errors
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  std::string signElementsErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"sign":{"exit_number_elements":20}}]}]}})";
+  try {
+    jsonToProtoRoute (signElementsErrorTest, route);
+    throw std::runtime_error ("Did not throw exit_number_elements error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw exit_number_elements error") {
+      throw e;
+    }
+  }
+
+  signElementsErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"sign":{"exit_number_elements":[20]}}]}]}})";
+  try {
+    jsonToProtoRoute (signElementsErrorTest, route);
+    throw std::runtime_error ("Did not throw exit_number_element error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw exit_number_element error") {
+      throw e;
+    }
+  }
+
+  signElementsErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"sign":{"exit_toward_elements":20}}]}]}})";
+  try {
+    jsonToProtoRoute (signElementsErrorTest, route);
+    throw std::runtime_error ("Did not throw exit_toward_elements error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw exit_toward_elements error") {
+      throw e;
+    }
+  }
+
+  signElementsErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"sign":{"exit_toward_elements":[20]}}]}]}})";
+  try {
+    jsonToProtoRoute (signElementsErrorTest, route);
+    throw std::runtime_error ("Did not throw exit_toward_element error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw exit_toward_element error") {
+      throw e;
+    }
+  }
+
+  signElementsErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"sign":{"exit_branch_elements":20}}]}]}})";
+  try {
+    jsonToProtoRoute (signElementsErrorTest, route);
+    throw std::runtime_error ("Did not throw exit_branch_elements error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw exit_branch_elements error") {
+      throw e;
+    }
+  }
+
+  signElementsErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"sign":{"exit_branch_elements":[20]}}]}]}})";
+  try {
+    jsonToProtoRoute (signElementsErrorTest, route);
+    throw std::runtime_error ("Did not throw exit_branch_element error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw exit_branch_element error") {
+      throw e;
+    }
+  }
+
+  signElementsErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"sign":{"exit_name_elements":20}}]}]}})";
+  try {
+    jsonToProtoRoute (signElementsErrorTest, route);
+    throw std::runtime_error ("Did not throw exit_name_elements error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw exit_name_elements error") {
+      throw e;
+    }
+  }
+
+  signElementsErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"sign":{"exit_name_elements":[20]}}]}]}})";
+  try {
+    jsonToProtoRoute (signElementsErrorTest, route);
+    throw std::runtime_error ("Did not throw exit_name_element error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw exit_name_element error") {
+      throw e;
+    }
+  }
+
+  signElementsErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"sign":{"exit_name_elements":[{"consecutive_count":"2"}]}}]}]}})";
+  try {
+    jsonToProtoRoute (signElementsErrorTest, route);
+    throw std::runtime_error ("Did not throw consecutive_count error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw consecutive_count error") {
+      throw e;
+    }
+  }
+
+  signElementsErrorTest =
+      R"({"trip":{"legs":[{"maneuvers":[{"sign":{"exit_name_elements":[{"text":20}]}}]}]}})";
+  try {
+    jsonToProtoRoute (signElementsErrorTest, route);
+    throw std::runtime_error ("Did not throw text error");
+  } catch (const std::runtime_error& e) {
+    if (std::string(e.what()) == "Did not throw text error") {
+      throw e;
+    }
+  }
+
 }
 
 }


### PR DESCRIPTION
### Changes
+ runtime_errors are now thrown for any misreading inside of the jsonToProtoRoute function and is surrounded by a try catch block inside of the SetRoute function of Navigator.cc
+ A bunch of unit tests are in place to test the runtime_error throwing as well as a unit test for navigator to make sure an invalid state is returned if an error was thrown inside of jsonToProtoRoute
+ Changed the style in which json is parsed inside of jsonToProtoRoute for better efficiency and readability.

Closes #817 