### PR TITLE
small update to use oneway:psv if oneway:bus does not exist.

### DIFF
--- a/lua/graph.lua
+++ b/lua/graph.lua
@@ -828,6 +828,10 @@ function filter_tags_generic(kv)
     end
   end
 
+  if kv["oneway:bus"] == nil and kv["oneway:psv"] ~= nil then
+    kv["oneway:bus"] = kv["oneway:psv"]
+  end
+
   if ((kv["oneway"] == "yes" and kv["oneway:bus"] == "no") or kv["bus:backward"] == "yes" or kv["bus:backward"] == "designated") then
     kv["bus_backward"] = "true"
   end


### PR DESCRIPTION
The following have ways with oneway:psv=no and oneway=yes. 

fixes #822 
Additional logic is needed for emergency and taxi access.

bus route before 
![screenshot from 2017-07-17 15-38-18](https://user-images.githubusercontent.com/2676277/28286782-5ddea586-6b07-11e7-9b15-63ec52805934.png)

bus route after
![screenshot from 2017-07-17 15-38-02](https://user-images.githubusercontent.com/2676277/28286795-6752c35e-6b07-11e7-91ce-5f3e59d9d25d.png)

bus route before
![screenshot from 2017-07-17 15-39-50](https://user-images.githubusercontent.com/2676277/28286812-700e030a-6b07-11e7-9e3e-4136b20d6647.png)

bus route after 
![screenshot from 2017-07-17 15-39-39](https://user-images.githubusercontent.com/2676277/28286824-793384dc-6b07-11e7-8ff3-4475cd77d73e.png)
