### PR TITLE
Cyclelane data fix and addition of some more bike tags

### DIFF
--- a/lua/graph.lua
+++ b/lua/graph.lua
@@ -889,7 +889,7 @@ function filter_tags_generic(kv)
     kv["emergency_backward"] = kv["emergency_forward"]
 
     if (kv["bike_backward"] == "false" and kv["oneway:bicycle"] ~= "-1" and 
-       (kv["oneway:bicycle"] == nil or oneway[kv["oneway:bicycle"]] == false)) then
+       (kv["oneway:bicycle"] == nil or oneway[kv["oneway:bicycle"]] == false or kv["oneway:bicycle"] == "no")) then
       kv["bike_backward"] = kv["bike_forward"]
     end
 

--- a/lua/graph.lua
+++ b/lua/graph.lua
@@ -1010,12 +1010,12 @@ function filter_tags_generic(kv)
   if kv["highway"] then
      if kv["highway"] == "track" then
         use = 3
+     elseif kv["highway"] == "living_street" then
+        use = 10
      elseif kv["highway"] == "cycleway" then
         use = 20
      elseif kv["pedestrian"] == "false" and kv["auto_forward"] == "false" and kv["auto_backward"] == "false" and (kv["bike_forward"] == "true" or kv["bike_backward"] == "true") then
         use = 20
-     elseif kv["highway"] == "living_street" then
-        use = 23
      elseif (kv["highway"] == "footway" and kv["footway"] == "sidewalk") then
         use = 24
      elseif kv["highway"] == "footway" then

--- a/lua/graph.lua
+++ b/lua/graph.lua
@@ -347,6 +347,7 @@ shared = {
 dedicated = {
 ["opposite_lane"] = 2,
 ["lane"] = 2
+["buffer"] = 2
 }
 
 separated = {
@@ -994,6 +995,8 @@ function filter_tags_generic(kv)
         use = 20
      elseif kv["pedestrian"] == "false" and kv["auto_forward"] == "false" and kv["auto_backward"] == "false" and (kv["bike_forward"] == "true" or kv["bike_backward"] == "true") then
         use = 20
+     elseif kv["highway"] == "living_street" then
+        use = 23
      elseif (kv["highway"] == "footway" and kv["footway"] == "sidewalk") then
         use = 24
      elseif kv["highway"] == "footway" then

--- a/lua/graph.lua
+++ b/lua/graph.lua
@@ -1100,7 +1100,7 @@ function filter_tags_generic(kv)
       cycle_lane_left_opposite = bike_reverse[kv["cycleway:left"]] or "false"
     end
 
-    --Figure out whihc side of the road has what cyclelane
+    --Figure out which side of the road has what cyclelane
     cycle_lane_right = shared[kv["cycleway"]] or separated[kv["cycleway"]] or dedicated[kv["cycleway"]] or buffer[kv["cycleway:both:buffer"]] or 0
     cycle_lane_left = cycle_lane_right
 

--- a/lua/graph.lua
+++ b/lua/graph.lua
@@ -1043,45 +1043,67 @@ function filter_tags_generic(kv)
 
   kv["use"] = use
 
-  local cycle_lane_right_opposite = bike_reverse[kv["cycleway"]] or "false"
-  local cycle_lane_left_opposite = cycle_lane_right_opposite
+  local cycle_lane_right_opposite = "false"
+  local cycle_lane_left_opposite = "false"
 
-  if cycle_lane_right_opposite == "false" then
-    cycle_lane_right_opposite = bike_reverse[kv["cycleway:right"]] or "false"
-    cycle_lane_left_opposite = bike_reverse[kv["cycleway:left"]] or "false"
-  end
+  local cycle_lane_right
+  local cycle_lane_left
 
-  local cycle_lane_right = shared[kv["cycleway"]] or separated[kv["cycleway"]] or dedicated[kv["cycleway"]] or buffer[kv["cycleway:both:buffer"]] or 0
-  local cycle_lane_left = cycle_lane_right
+  if (use == 20 or use == 25 or use == 27) and
+     (kv["bike_forward"] == "true" or kv["bike_backward"] == "true") then
+    if kv["pedestrian"] == "false" then
+      cycle_lane_right = 3 --separated
+    elseif kv["segregated"] == "yes" then
+      cycle_lane_right = 2 --dedicated
+    elseif kv["segregated"] == "no" then
+      cycle_lane_right = 1 --shared
+    elseif use == 20 then
+      cycle_lane_right = 2 --If no segregated tag but it is tagged as a cycleway then we assume separated lanes
+    else
+      cycle_lane_right = 1 --If no segregated tag and it's tagged as a footway or path then we assume shared lanes
+    end
+    cycle_lane_left = cycle_lane_right
+  else
+    cycle_lane_right_opposite = bike_reverse[kv["cycleway"]] or "false"
+    cycle_lane_left_opposite = cycle_lane_right_opposite
 
-  if cycle_lane_right == 0 then
-    cycle_lane_right = shared[kv["cycleway:right"]] or separated[kv["cycleway:right"]] or dedicated[kv["cycleway:right"]] or buffer[kv["cycleway:right:buffer"]] or 0
-    cycle_lane_left = shared[kv["cycleway:left"]] or separated[kv["cycleway:left"]] or dedicated[kv["cycleway:left"]] or buffer[kv["cycleway:left:buffer"]] or 0
-  end
+    if cycle_lane_right_opposite == "false" then
+      cycle_lane_right_opposite = bike_reverse[kv["cycleway:right"]] or "false"
+      cycle_lane_left_opposite = bike_reverse[kv["cycleway:left"]] or "false"
+    end
 
-  --If we have the oneway:bicycle=no tag and there are not "opposite_lane/opposite_track" tags then there are certain situations where
-  --the cyclelane is considered a two-way. (Based off of some examples on wiki.openstreetmap.org/wiki/Bicycle)
-  if kv["oneway:bicycle"] == "no" and cycle_lane_right_opposite == "false" and cycle_lane_left_opposite == "false" then
-    if cycle_lane_right == 2 or cycle_lane_right == 3 then
-      --Example M1 or M2d but on the right side
-      if oneway_norm == "true" then
-        cycle_lane_left = cycle_lane_right
-        cycle_lane_left_opposite = "true"
+    cycle_lane_right = shared[kv["cycleway"]] or separated[kv["cycleway"]] or dedicated[kv["cycleway"]] or buffer[kv["cycleway:both:buffer"]] or 0
+    cycle_lane_left = cycle_lane_right
 
-      --Example L1b
-      elseif cycle_lane_left == 0 then
-        cycle_lane_left = cycle_lane_right
-      end
+    if cycle_lane_right == 0 then
+      cycle_lane_right = shared[kv["cycleway:right"]] or separated[kv["cycleway:right"]] or dedicated[kv["cycleway:right"]] or buffer[kv["cycleway:right:buffer"]] or 0
+      cycle_lane_left = shared[kv["cycleway:left"]] or separated[kv["cycleway:left"]] or dedicated[kv["cycleway:left"]] or buffer[kv["cycleway:left:buffer"]] or 0
+    end
 
-    elseif cycle_lane_left == 2 or cycle_lane_left == 3 then
-      --Example M2d
-      if oneway_norm == "true" then
-        cycle_lane_right = cycle_lane_left
-        cycle_lane_right_opposite = "true"
+    --If we have the oneway:bicycle=no tag and there are not "opposite_lane/opposite_track" tags then there are certain situations where
+    --the cyclelane is considered a two-way. (Based off of some examples on wiki.openstreetmap.org/wiki/Bicycle)
+    if kv["oneway:bicycle"] == "no" and cycle_lane_right_opposite == "false" and cycle_lane_left_opposite == "false" then
+      if cycle_lane_right == 2 or cycle_lane_right == 3 then
+        --Example M1 or M2d but on the right side
+        if oneway_norm == "true" then
+          cycle_lane_left = cycle_lane_right
+          cycle_lane_left_opposite = "true"
 
-      --Example L1b but on the left side
-      elseif cycle_lane_right == 0 then
-        cycle_lane_right = cycle_lane_left
+        --Example L1b
+        elseif cycle_lane_left == 0 then
+          cycle_lane_left = cycle_lane_right
+        end
+
+      elseif cycle_lane_left == 2 or cycle_lane_left == 3 then
+        --Example M2d
+        if oneway_norm == "true" then
+          cycle_lane_right = cycle_lane_left
+          cycle_lane_right_opposite = "true"
+
+        --Example L1b but on the left side
+        elseif cycle_lane_right == 0 then
+          cycle_lane_right = cycle_lane_left
+        end
       end
     end
   end

--- a/lua/graph.lua
+++ b/lua/graph.lua
@@ -1062,20 +1062,27 @@ function filter_tags_generic(kv)
   --If we have the oneway:bicycle=no tag and there are not "opposite_lane/opposite_track" tags then there are certain situations where
   --the cyclelane is considered a two-way. (Based off of some examples on wiki.openstreetmap.org/wiki/Bicycle)
   if kv["oneway:bicycle"] == "no" and cycle_lane_right_opposite == "false" and cycle_lane_left_opposite == "false" then
-    --Example M1 or M2d but on the right side
-    if cycle_lane_right ~= 0 and oneway_norm == "true" then
-      cycle_lane_left = cycle_lane_right
-      cycle_lane_left_opposite = "true"
-    --Example L1b
-    elseif cycle_lane_right ~= 0 and cycle_lane_left == 0 then
-      cycle_lane_left = cycle_lane_right
-    --Example M2d
-    elseif cycle_lane_left ~= 0 and oneway_norm == "true" then
-      cycle_lane_right = cycle_lane_left
-      cycle_lane_right_opposite = "true"
-    --Example L1b but on the left side
-    elseif cycle_lane_left ~= 0 and cycle_lane_right == 0 then
-      cycle_lane_right = cycle_lane_left
+    if cycle_lane_right == 2 or cycle_lane_right == 3 then
+      --Example M1 or M2d but on the right side
+      if oneway_norm == "true" then
+        cycle_lane_left = cycle_lane_right
+        cycle_lane_left_opposite = "true"
+
+      --Example L1b
+      elseif cycle_lane_left == 0 then
+        cycle_lane_left = cycle_lane_right
+      end
+
+    elseif cycle_lane_left == 2 or cycle_lane_left == 3 then
+      --Example M2d
+      if oneway_norm == "true" then
+        cycle_lane_right = cycle_lane_left
+        cycle_lane_right_opposite = "true"
+
+      --Example L1b but on the left side
+      elseif cycle_lane_right == 0 then
+        cycle_lane_right = cycle_lane_left
+      end
     end
   end
 

--- a/lua/graph.lua
+++ b/lua/graph.lua
@@ -1043,17 +1043,6 @@ function filter_tags_generic(kv)
 
   kv["use"] = use
 
-  local cycle_lane_right = shared[kv["cycleway"]] or separated[kv["cycleway"]] or dedicated[kv["cycleway"]] or buffer[kv["cycleway:both:buffer"]] or 0
-  local cycle_lane_left = cycle_lane_right
-
-  if cycle_lane_right == 0 then
-    cycle_lane_right = shared[kv["cycleway:right"]] or separated[kv["cycleway:right"]] or dedicated[kv["cycleway:right"]] or buffer[kv["cycleway:right:buffer"]] or 0
-    cycle_lane_left = shared[kv["cycleway:left"]] or separated[kv["cycleway:left"]] or dedicated[kv["cycleway:left"]] or buffer[kv["cycleway:left:buffer"]] or 0
-  end
-
-  kv["cycle_lane_right"] = cycle_lane_right
-  kv["cycle_lane_left"] = cycle_lane_left
-
   local cycle_lane_right_opposite = bike_reverse[kv["cycleway"]] or "false"
   local cycle_lane_left_opposite = cycle_lane_right_opposite
 
@@ -1061,6 +1050,31 @@ function filter_tags_generic(kv)
     cycle_lane_right_opposite = bike_reverse[kv["cycleway:right"]]
     cycle_lane_left_opposite = bike_reverse[kv["cycleway:left"]]
   end
+
+  local cycle_lane_right = shared[kv["cycleway"]] or separated[kv["cycleway"]] or dedicated[kv["cycleway"]] or buffer[kv["cycleway:both:buffer"]] or 0
+  local cycle_lane_left = cycle_lane_right
+
+  if cycle_lane_right == 0 then
+    cycle_lane_right = shared[kv["cycleway:right"]] or separated[kv["cycleway:right"]] or dedicated[kv["cycleway:right"]] or buffer[kv["cycleway:right:buffer"]] or 0
+    cycle_lane_left = shared[kv["cycleway:left"]] or separated[kv["cycleway:left"]] or dedicated[kv["cycleway:left"]] or buffer[kv["cycleway:left:buffer"]] or 0
+
+    --If there is a oneway but it is specified that bikes are not one way and that there is a bike lane on one of the sides of the road
+    --then we want that bike lane to act as a two way bike lane
+    if oneway_norm == "true" and oneway_bike == "false" and cycle_lane_right_opposite == "false" and cycle_lane_left_opposite == "false" then
+      --We have no way of storing a special "two way bicycle lane" besides just having both the left and the right lane
+      --set with one of them in an opposing direction so that is what we do here
+      if cycle_lane_right ~= 0 then
+        cycle_lane_left = cycle_lane_right
+        cycle_lane_left_opposite = "true"
+      elseif cycle_lane_left ~=0 then
+        cycle_lane_right = cycle_lane_left
+        cycle_lane_right_opposite = "true"
+      end
+    end
+  end
+
+  kv["cycle_lane_right"] = cycle_lane_right
+  kv["cycle_lane_left"] = cycle_lane_left
 
   kv["cycle_lane_right_opposite"] = cycle_lane_right_opposite
   kv["cycle_lane_left_opposite"] = cycle_lane_left_opposite

--- a/lua/graph.lua
+++ b/lua/graph.lua
@@ -1070,7 +1070,7 @@ function filter_tags_generic(kv)
     elseif cycle_lane_right ~= 0 and cycle_lane_left == 0 then
       cycle_lane_left = cycle_lane_right
     --Example M2d
-    elseif cycle_lane_left ~= 0 and oneway_norm == "true") then
+    elseif cycle_lane_left ~= 0 and oneway_norm == "true" then
       cycle_lane_right = cycle_lane_left
       cycle_lane_right_opposite = "true"
     --Example L1b but on the left side

--- a/lua/graph.lua
+++ b/lua/graph.lua
@@ -1043,6 +1043,17 @@ function filter_tags_generic(kv)
 
   kv["use"] = use
 
+  local shoulder_right = shoulder[kv["shoulder"]] or shoulder[kv["shoulder:both"]]
+  local shoulder_left = shoulder_right
+
+  if shoulder_right == false then
+    shoulder_right = shoulder[kv["shoulder:right"]] or "false"
+    shoulder_left = shoulder[kv["shoulder:left"]] or "false"
+  end
+
+  kv["shoulder_right"] = shoulder_right
+  kv["shoulder_left"] = shoulder_left
+
   local cycle_lane_right_opposite = "false"
   local cycle_lane_left_opposite = "false"
 

--- a/lua/graph.lua
+++ b/lua/graph.lua
@@ -1047,8 +1047,8 @@ function filter_tags_generic(kv)
   local cycle_lane_left_opposite = cycle_lane_right_opposite
 
   if cycle_lane_right_opposite == "false" then
-    cycle_lane_right_opposite = bike_reverse[kv["cycleway:right"]]
-    cycle_lane_left_opposite = bike_reverse[kv["cycleway:left"]]
+    cycle_lane_right_opposite = bike_reverse[kv["cycleway:right"]] or "false"
+    cycle_lane_left_opposite = bike_reverse[kv["cycleway:left"]] or "false"
   end
 
   local cycle_lane_right = shared[kv["cycleway"]] or separated[kv["cycleway"]] or dedicated[kv["cycleway"]] or buffer[kv["cycleway:both:buffer"]] or 0
@@ -1057,19 +1057,25 @@ function filter_tags_generic(kv)
   if cycle_lane_right == 0 then
     cycle_lane_right = shared[kv["cycleway:right"]] or separated[kv["cycleway:right"]] or dedicated[kv["cycleway:right"]] or buffer[kv["cycleway:right:buffer"]] or 0
     cycle_lane_left = shared[kv["cycleway:left"]] or separated[kv["cycleway:left"]] or dedicated[kv["cycleway:left"]] or buffer[kv["cycleway:left:buffer"]] or 0
+  end
 
-    --If there is a oneway but it is specified that bikes are not one way and that there is a bike lane on one of the sides of the road
-    --then we want that bike lane to act as a two way bike lane
-    if oneway_norm == "true" and oneway_bike == "false" and cycle_lane_right_opposite == "false" and cycle_lane_left_opposite == "false" then
-      --We have no way of storing a special "two way bicycle lane" besides just having both the left and the right lane
-      --set with one of them in an opposing direction so that is what we do here
-      if cycle_lane_right ~= 0 then
-        cycle_lane_left = cycle_lane_right
-        cycle_lane_left_opposite = "true"
-      elseif cycle_lane_left ~=0 then
-        cycle_lane_right = cycle_lane_left
-        cycle_lane_right_opposite = "true"
-      end
+  --If we have the oneway:bicycle=no tag and there are not "opposite_lane/opposite_track" tags then there are certain situations where
+  --the cyclelane is considered a two-way. (Based off of some examples on wiki.openstreetmap.org/wiki/Bicycle)
+  if kv["oneway:bicycle"] == "no" and cycle_lane_right_opposite == "false" and cycle_lane_left_opposite == "false" then
+    --Example M1 or M2d but on the right side
+    if cycle_lane_right ~= 0 and oneway_norm == "true" then
+      cycle_lane_left = cycle_lane_right
+      cycle_lane_left_opposite = "true"
+    --Example L1b
+    elseif cycle_lane_right ~= 0 and cycle_lane_left == 0 then
+      cycle_lane_left = cycle_lane_right
+    --Example M2d
+    elseif cycle_lane_left ~= 0 and oneway_norm == "true") then
+      cycle_lane_right = cycle_lane_left
+      cycle_lane_right_opposite = "true"
+    --Example L1b but on the left side
+    elseif cycle_lane_left ~= 0 and cycle_lane_right == 0 then
+      cycle_lane_right = cycle_lane_left
     end
   end
 

--- a/src/baldr/directededge.cc
+++ b/src/baldr/directededge.cc
@@ -123,6 +123,11 @@ void DirectedEdge::set_laneconnectivity(const bool lc) {
 
 // -------------------------- Routing attributes --------------------------- //
 
+// Set if bikers need to dismount along the edge
+void DirectedEdge::set_dismount (const bool dismount) {
+  dismount_ = dismount;
+}
+
 // Set the flag indicating driving is on the right hand side of the road
 // along this edge?
 void DirectedEdge::set_drive_on_right(const bool rsd) {

--- a/src/baldr/directededge.cc
+++ b/src/baldr/directededge.cc
@@ -123,9 +123,19 @@ void DirectedEdge::set_laneconnectivity(const bool lc) {
 
 // -------------------------- Routing attributes --------------------------- //
 
+// Set if edge has a shoulder (Beneficial to know for cycling)
+void DirectedEdge::set_shoulder (const bool shoulder) {
+  shoulder_ = shoulder;
+}
+
 // Set if bikers need to dismount along the edge
 void DirectedEdge::set_dismount (const bool dismount) {
   dismount_ = dismount;
+}
+
+// Set if a sidepath should be preffered when cycling over this one
+void DirectedEdge::set_use_sidepath (const bool use_sidepath) {
+  use_sidepath_ = use_sidepath;
 }
 
 // Set the flag indicating driving is on the right hand side of the road

--- a/src/mjolnir/directededgebuilder.cc
+++ b/src/mjolnir/directededgebuilder.cc
@@ -49,6 +49,8 @@ DirectedEdgeBuilder::DirectedEdgeBuilder(
   if (!way.destination_only())
     set_dest_only(way.no_thru_traffic());
 
+  set_dismount (way.dismount());
+  set_use_sidepath (way.use_sidepath());
   set_surface(way.surface());
   set_tunnel(way.tunnel());
   set_roundabout(way.roundabout());

--- a/src/mjolnir/directededgebuilder.cc
+++ b/src/mjolnir/directededgebuilder.cc
@@ -50,7 +50,6 @@ DirectedEdgeBuilder::DirectedEdgeBuilder(
     set_dest_only(way.no_thru_traffic());
 
   set_surface(way.surface());
-  set_cyclelane(way.cyclelane());
   set_tunnel(way.tunnel());
   set_roundabout(way.roundabout());
   set_bridge(way.bridge());

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -813,6 +813,8 @@ void BuildTileSet(const std::string& ways_file, const std::string& way_nodes_fil
           if (admin_index != 0)
             directededge.set_drive_on_right(drive_on_right[admin_index]);
 
+          // Set shoulder based on current facing direction and which
+          // side of the road is meant to be driven on.
           if (forward) {
             directededge.set_shoulder(
               drive_on_right[admin_index] ? w.shoulder_right() : w.shoulder_left());

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -813,6 +813,14 @@ void BuildTileSet(const std::string& ways_file, const std::string& way_nodes_fil
           if (admin_index != 0)
             directededge.set_drive_on_right(drive_on_right[admin_index]);
 
+          if (forward) {
+            directededge.set_shoulder(
+              drive_on_right[admin_index] ? w.shoulder_right() : w.shoulder_left());
+          } else {
+            directededge.set_shoulder(
+              drive_on_right[admin_index] ? w.shoulder_left() : w.shoulder_right());
+          }
+
           // Figure out cycle lanes
           bool right_cyclelane_forward = true;
           bool left_cyclelane_forward = false;

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -813,6 +813,62 @@ void BuildTileSet(const std::string& ways_file, const std::string& way_nodes_fil
           if (admin_index != 0)
             directededge.set_drive_on_right(drive_on_right[admin_index]);
 
+          // Figure out cycle lanes
+          bool right_cyclelane_forward = true;
+          bool left_cyclelane_forward = false;
+
+          // If we know bikes can only go in a specific direction then whatever
+          // cyclelanes there are will be in that direction
+          if (w.bike_forward() && !w.bike_backward()) {
+            right_cyclelane_forward = true;
+            left_cyclelane_forward = true;
+          } else if (!w.bike_forward() && w.bike_backward()) {
+            right_cyclelane_forward = false;
+            left_cyclelane_forward = false;
+          }
+          // If bike can go in both directions but the road is a oneway then we
+          // must check for contraflow lanes
+          else if (w.oneway()) {
+            right_cyclelane_forward = !w.cyclelane_right_opposite();
+            left_cyclelane_forward = !w.cyclelane_left_opposite();
+            // If the way has a tag of oneway=-1 then bike tags are in the reverse direction
+            if (w.oneway_reverse()) {
+              right_cyclelane_forward = !right_cyclelane_forward;
+              left_cyclelane_forward = !left_cyclelane_forward;
+            }
+          }
+          // If road is not a oneway then we must consider contraflow lanes
+          // as well as what side of the road people drive on
+          else {
+            right_cyclelane_forward = w.cyclelane_right_opposite() ?
+                !drive_on_right[admin_index] :
+                drive_on_right[admin_index];
+            left_cyclelane_forward = w.cyclelane_left_opposite() ?
+                drive_on_right[admin_index] :
+                !drive_on_right[admin_index];
+          }
+
+          directededge.set_cyclelane(CycleLane::kNone);
+          if (forward) {
+            if (right_cyclelane_forward) {
+              directededge.set_cyclelane(w.cyclelane_right());
+            }
+            if (left_cyclelane_forward &&
+                (static_cast<uint8_t>(w.cyclelane_left()) >
+                static_cast<uint8_t>(directededge.cyclelane()))) {
+              directededge.set_cyclelane(w.cyclelane_left());
+            }
+          } else {
+            if (!right_cyclelane_forward) {
+              directededge.set_cyclelane(w.cyclelane_right());
+            }
+            if (!left_cyclelane_forward &&
+                (static_cast<uint8_t>(w.cyclelane_left()) >
+                static_cast<uint8_t>(directededge.cyclelane()))) {
+              directededge.set_cyclelane(w.cyclelane_left());
+            }
+          }
+
           // Increment the directed edge index within the tile
           idx++;
           n++;

--- a/src/mjolnir/osmway.cc
+++ b/src/mjolnir/osmway.cc
@@ -450,6 +450,16 @@ bool OSMWay::oneway() const{
   return attributes_.fields.oneway;
 }
 
+// Sets if the oneway is facing the reverse direction
+void OSMWay::set_oneway_reverse(const bool oneway_reverse) {
+  attributes_.fields.oneway_reverse = oneway_reverse;
+}
+
+// Gets if the oneway is facing the reverse direction
+bool OSMWay::oneway_reverse() const {
+  return attributes_.fields.oneway_reverse;
+}
+
 // Set roundabout flag.
 void OSMWay::set_roundabout(const bool roundabout) {
   attributes_.fields.roundabout = roundabout;
@@ -490,14 +500,64 @@ Surface OSMWay::surface() const {
   return static_cast<Surface>(attributes_.fields.surface);
 }
 
-// Set the cycle lane.
-void OSMWay::set_cyclelane(const CycleLane cyclelane) {
-  attributes_.fields.cycle_lane = static_cast<uint8_t>(cyclelane);
+// Set the right cycle lane.
+void OSMWay::set_cyclelane_right(const CycleLane cyclelane) {
+  bike_info_.fields.cycle_lane_right = static_cast<uint8_t>(cyclelane);
 }
 
-// Get the cycle lane.
-CycleLane OSMWay::cyclelane() const {
-  return static_cast<CycleLane>(attributes_.fields.cycle_lane);
+// Get the right cycle lane.
+CycleLane OSMWay::cyclelane_right() const {
+  return static_cast<CycleLane>(bike_info_.fields.cycle_lane_right);
+}
+
+// Set the left cycle lane.
+void OSMWay::set_cyclelane_left(const CycleLane cyclelane) {
+  bike_info_.fields.cycle_lane_left= static_cast<uint8_t>(cyclelane);
+}
+
+// Get the left cycle lane.
+CycleLane OSMWay::cyclelane_left() const {
+  return static_cast<CycleLane>(bike_info_.fields.cycle_lane_left);
+}
+
+// Set the if the right cycle lane is facing the opposite direction.
+void OSMWay::set_cyclelane_right_opposite(const bool cyclelane_opposite) {
+  bike_info_.fields.cycle_lane_right_opposite = cyclelane_opposite;
+}
+
+// Get the if the right cycle lane is facing the opposite direction
+bool OSMWay::cyclelane_right_opposite() const {
+  return bike_info_.fields.cycle_lane_right_opposite;
+}
+
+// Set the if the left cycle lane is facing the opposite direction.
+void OSMWay::set_cyclelane_left_opposite(const bool cyclelane_opposite) {
+  bike_info_.fields.cycle_lane_left_opposite = cyclelane_opposite;
+}
+
+// Get the if the left cycle lane is facing the opposite direction
+bool OSMWay::cyclelane_left_opposite() const {
+  return bike_info_.fields.cycle_lane_left_opposite;
+}
+
+// Sets whether a bicyclist needs to dismount their bike for this way
+void OSMWay::set_dismount(const bool dismount) {
+  bike_info_.fields.dismount = dismount;
+}
+
+// Gets whether a bicyclist needs to dismount their bike for this way
+bool OSMWay::dismount() const {
+  return bike_info_.fields.dismount;
+}
+
+// Sets whether using a sidepath is preferred
+void OSMWay::set_use_sidepath(const bool use_sidepath) {
+  bike_info_.fields.use_sidepath = use_sidepath;
+}
+
+// Gets whether using a sidepath is preferred
+bool OSMWay::use_sidepath() const {
+  return bike_info_.fields.use_sidepath;
 }
 
 // Sets the number of lanes

--- a/src/mjolnir/osmway.cc
+++ b/src/mjolnir/osmway.cc
@@ -540,6 +540,26 @@ bool OSMWay::cyclelane_left_opposite() const {
   return bike_info_.fields.cycle_lane_left_opposite;
 }
 
+// Sets whether there is a shoulder to the right
+void OSMWay::set_shoulder_right(const bool shoulder_right) {
+  bike_info_.fields.shoulder_right = shoulder_right;
+}
+
+// Gets whether there is a shoulder to the right
+bool OSMWay::shoulder_right() const {
+  return bike_info_.fields.shoulder_right;
+}
+
+// Sets whether there is a shoulder to the left
+void OSMWay::set_shoulder_left(const bool shoulder_left) {
+  bike_info_.fields.shoulder_left = shoulder_left;
+}
+
+// Gets whether there is a shoulder to the left
+bool OSMWay::shoulder_left() const {
+  return bike_info_.fields.shoulder_left;
+}
+
 // Sets whether a bicyclist needs to dismount their bike for this way
 void OSMWay::set_dismount(const bool dismount) {
   bike_info_.fields.dismount = dismount;

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -423,6 +423,9 @@ struct graph_callback : public OSMPBF::Callback {
           case Use::kBridleway:
             w.set_use(Use::kBridleway);
             break;
+          case Use::kLivingStreet:
+            w.set_use(Use::kLivingStreet);
+            break;
           case Use::kParkingAisle:
             w.set_destination_only(true);
             w.set_use(Use::kParkingAisle);

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -456,6 +456,8 @@ struct graph_callback : public OSMPBF::Callback {
         w.set_no_thru_traffic(tag.second == "true" ? true : false);
       else if (tag.first == "oneway")
         w.set_oneway(tag.second == "true" ? true : false);
+      else if (tag.first == "oneway_reverse")
+        w.set_oneway_reverse(tag.second == "true" ? true : false);
       else if (tag.first == "roundabout")
         w.set_roundabout(tag.second == "true" ? true : false);
       else if (tag.first == "link")
@@ -615,23 +617,48 @@ struct graph_callback : public OSMPBF::Callback {
         } else has_surface = false;
       }
 
-      else if (tag.first == "cycle_lane") {
-        CycleLane cyclelane = (CycleLane) std::stoi(tag.second);
-        switch (cyclelane) {
+      else if (tag.first == "cycle_lane_right") {
+        CycleLane cyclelane_right = (CycleLane) std::stoi(tag.second);
+        switch (cyclelane_right) {
           case CycleLane::kDedicated:
-            w.set_cyclelane(CycleLane::kDedicated);
+            w.set_cyclelane_right(CycleLane::kDedicated);
             break;
           case CycleLane::kSeparated:
-            w.set_cyclelane(CycleLane::kSeparated);
+            w.set_cyclelane_right(CycleLane::kSeparated);
             break;
           case CycleLane::kShared:
-            w.set_cyclelane(CycleLane::kShared);
+            w.set_cyclelane_right(CycleLane::kShared);
             break;
           case CycleLane::kNone:
           default:
-            w.set_cyclelane(CycleLane::kNone);
+            w.set_cyclelane_right(CycleLane::kNone);
             break;
         }
+      }
+      else if (tag.first == "cycle_lane_left") {
+        CycleLane cyclelane_left = (CycleLane) std::stoi(tag.second);
+        switch (cyclelane_left) {
+          case CycleLane::kDedicated:
+            w.set_cyclelane_left(CycleLane::kDedicated);
+            break;
+          case CycleLane::kSeparated:
+            w.set_cyclelane_left(CycleLane::kSeparated);
+            break;
+          case CycleLane::kShared:
+            w.set_cyclelane_left(CycleLane::kShared);
+            break;
+          case CycleLane::kNone:
+          default:
+            w.set_cyclelane_left(CycleLane::kNone);
+            break;
+        }
+      }
+
+      else if (tag.first == "cycle_lane_right_opposite") {
+        w.set_cyclelane_right_opposite(tag.second == "true" ? true : false);
+      }
+      else if (tag.first == "cycle_lane_left_opposite") {
+        w.set_cyclelane_left_opposite(tag.second == "true" ? true : false);
       }
 
       else if (tag.first == "lanes") {
@@ -731,6 +758,7 @@ struct graph_callback : public OSMPBF::Callback {
           case Use::kAlley:
           case Use::kEmergencyAccess:
           case Use::kDriveThru:
+          case Use::kLivingStreet:
             w.set_surface(Surface::kPavedSmooth);
             break;
           case Use::kCycleway:

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -617,6 +617,21 @@ struct graph_callback : public OSMPBF::Callback {
         } else has_surface = false;
       }
 
+      else if (tag.first == "bicycle") {
+        if (tag.second == "dismount") {
+          w.set_dismount(true);
+        } else if (tag.second == "use_sidepath") {
+          w.set_use_sidepath(true);
+        }
+      }
+
+      else if (tag.first == "shoulder_right") {
+        w.set_shoulder_right(tag.second == "true" ? true : false);
+      }
+      else if (tag.first == "shoulder_left") {
+        w.set_shoulder_left(tag.second == "true" ? true : false);
+      }
+
       else if (tag.first == "cycle_lane_right") {
         CycleLane cyclelane_right = (CycleLane) std::stoi(tag.second);
         switch (cyclelane_right) {

--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -658,12 +658,15 @@ Cost BicycleCost::EdgeCost(const baldr::DirectedEdge* edge) const {
     return { sec * ferry_factor_, sec };
   }
 
-  // Update speed based on surface factor. Lower speed for rougher surfaces
+  // If you have to dismount on the edge then we set speed to an average walking speed
+  // Otherwise, Update speed based on surface factor. Lower speed for rougher surfaces
   // depending on the bicycle type. Modulate speed based on weighted grade
   // (relative measure of elevation change along the edge)
-  uint32_t bike_speed = static_cast<uint32_t>((speed_ *
-                surface_speed_factor_[static_cast<uint32_t>(edge->surface())] *
-		            kGradeBasedSpeedFactor[edge->weighted_grade()]) + 0.5f);
+  uint32_t bike_speed = edge->dismount () ?
+      5.1f :
+      static_cast<uint32_t>((speed_ *
+        surface_speed_factor_[static_cast<uint32_t>(edge->surface())] *
+        kGradeBasedSpeedFactor[edge->weighted_grade()]) + 0.5f);
 
   // Apply a weighting factor to the cost based on desirability of cycling
   // on this edge. Based on several factors: rider propensity to ride on roads,
@@ -982,12 +985,15 @@ Cost LowStressBicycleCost::EdgeCost(const baldr::DirectedEdge* edge) const {
     return { sec * ferry_factor_, sec };
   }
 
-  // Update speed based on surface factor. Lower speed for rougher surfaces
+  // If you have to dismount on the edge then we set speed to an average walking speed
+  // Otherwise, Update speed based on surface factor. Lower speed for rougher surfaces
   // depending on the bicycle type. Modulate speed based on weighted grade
   // (relative measure of elevation change along the edge)
-  uint32_t bike_speed = static_cast<uint32_t>((speed_ *
-                surface_speed_factor_[static_cast<uint32_t>(edge->surface())] *
-                                            kGradeBasedSpeedFactor[edge->weighted_grade()]) + 0.5f);
+  uint32_t bike_speed = edge->dismount () ?
+      5.1f :
+      static_cast<uint32_t>((speed_ *
+        surface_speed_factor_[static_cast<uint32_t>(edge->surface())] *
+        kGradeBasedSpeedFactor[edge->weighted_grade()]) + 0.5f);
 
   // Represents how stressful a roadway is without looking at grade or cycle accomodations
   float roadway_stress = 1.0f;

--- a/valhalla/baldr/directededge.h
+++ b/valhalla/baldr/directededge.h
@@ -664,6 +664,20 @@ class DirectedEdge {
   void set_part_of_complex_restriction(const bool part_of);
 
   /**
+   * Get if edge is a dismount edge.
+   * @return  Returns true if edge is a dismount edge, false if it is not.
+   */
+  bool dismount () const {
+    return dismount_;
+  }
+
+  /**
+   * Set if edge is a dismount edge.
+   * @param  dismount  true if the edge is a dismount edge, false if not.
+   */
+  void set_dismount (const bool dismount);
+
+  /**
    * Get the density along the edges.
    * @return  Returns relative density along the edge.
    */
@@ -1022,7 +1036,8 @@ class DirectedEdge {
   uint64_t reverseaccess_  : 12; // Access (bit mask) in reverse direction
   uint64_t classification_ : 3;  // Classification/importance of the road/path
   uint64_t surface_        : 3;  // representation of smoothness
-  uint64_t spare2_         : 10;
+  uint64_t spare2_         : 9;
+  uint64_t dismount_       : 1;  // Do you need to dismount when biking on this edge?
   uint64_t density_        : 4;  // Density along the edge
   uint64_t speed_limit_    : 8;  // Speed limit (kph)
   uint64_t named_          : 1;  // 1 if this edge has names, 0 if unnamed

--- a/valhalla/baldr/directededge.h
+++ b/valhalla/baldr/directededge.h
@@ -681,7 +681,7 @@ class DirectedEdge {
   void set_shoulder (const bool shoulder);
 
   /**
-   * Get if edge is a dismount edge.
+   * Get if cyclists should dismount their bikes along this edge
    * @return  Returns true if edge is a dismount edge, false if it is not.
    */
   bool dismount () const {
@@ -689,7 +689,7 @@ class DirectedEdge {
   }
 
   /**
-   * Set if edge is a dismount edge.
+   * Set if cyclists should dismount their bikes along this edge
    * @param  dismount  true if the edge is a dismount edge, false if not.
    */
   void set_dismount (const bool dismount);

--- a/valhalla/baldr/directededge.h
+++ b/valhalla/baldr/directededge.h
@@ -348,7 +348,8 @@ class DirectedEdge {
   void set_opp_index(const uint32_t opp_index);
 
   /**
-   * Get the cycle lane type along this edge.
+   * Get the cycle lane type along this edge. If the edge's use is cycleway, footway or path,
+   * then cyclelane holds information based on how separated cyclists are from pedestrians
    * @returns   Returns the type (if any) of bicycle lane along this edge.
    */
   CycleLane cyclelane() const  {
@@ -357,6 +358,8 @@ class DirectedEdge {
 
   /**
    * Sets the type of cycle lane (if any) present on this edge.
+   * If edge use is cycleway, footway or path, then cyclelane should represent
+   * segregation from pedestrians
    * @param  cyclelane   Type of cycle lane.
    */
   void set_cyclelane(const CycleLane cyclelane);
@@ -664,6 +667,20 @@ class DirectedEdge {
   void set_part_of_complex_restriction(const bool part_of);
 
   /**
+   * Get if edge has a shoulder
+   * @return  Returns if edge has a shoulder
+   */
+  bool shoulder () const {
+    return shoulder_;
+  }
+
+  /**
+   * Set if edge has a shoulder
+   * @param  shoulder  True if edge has shoulder
+   */
+  void set_shoulder (const bool shoulder);
+
+  /**
    * Get if edge is a dismount edge.
    * @return  Returns true if edge is a dismount edge, false if it is not.
    */
@@ -676,6 +693,20 @@ class DirectedEdge {
    * @param  dismount  true if the edge is a dismount edge, false if not.
    */
   void set_dismount (const bool dismount);
+
+  /**
+   * Get if a sidepath for bicycling should be preffered instead of this edge
+   * @return  Returns if a sidepath should be preffered for cycling
+   */
+  bool use_sidepath () const {
+    return use_sidepath_;
+  }
+
+  /**
+   * Set if a sidepath for bicycling should be preffered instead of this edge
+   * @param  use_sidepath  true if sidepath should be preffered for cycling over this edge
+   */
+  void set_use_sidepath (const bool use_sidepath);
 
   /**
    * Get the density along the edges.
@@ -1036,7 +1067,9 @@ class DirectedEdge {
   uint64_t reverseaccess_  : 12; // Access (bit mask) in reverse direction
   uint64_t classification_ : 3;  // Classification/importance of the road/path
   uint64_t surface_        : 3;  // representation of smoothness
-  uint64_t spare2_         : 9;
+  uint64_t shoulder_       : 1;  // Does the edge have a shoulder?
+  uint64_t spare2_         : 7;
+  uint64_t use_sidepath_   : 1;  // Is there a cycling path to the side that should be preffered?
   uint64_t dismount_       : 1;  // Do you need to dismount when biking on this edge?
   uint64_t density_        : 4;  // Density along the edge
   uint64_t speed_limit_    : 8;  // Speed limit (kph)

--- a/valhalla/baldr/graphconstants.h
+++ b/valhalla/baldr/graphconstants.h
@@ -222,6 +222,7 @@ enum class Use : uint8_t {
   kCycleway = 20,          // Dedicated bicycle path
   kMountainBike = 21,      // Mountain bike trail
 
+  kLivingStreet = 23,
   kSidewalk = 24,
 
   // Pedestrian specific uses

--- a/valhalla/baldr/graphconstants.h
+++ b/valhalla/baldr/graphconstants.h
@@ -307,12 +307,16 @@ inline std::string to_string(SpeedType s) {
 
 // Indication of the type of cycle lane (if any) present along an edge.
 // Higher values are more favorable to safe bicycling.
+// If edge is a cycleway, footway, or path, then there is an alternate meaning
 enum class CycleLane : uint8_t {
   kNone = 0,      // No specified bicycle lane
   kShared = 1,    // Shared use lane (could be shared with pedestrians)
+                  // Alternative: Shared path with pedestrians
   kDedicated = 2, // Dedicated cycle lane
+                  // Alternative: Path with segregated lanes
   kSeparated = 3  // A separate cycle lane (physical separation from the
                   // main carriageway)
+                  // Alternative: Path with no pedestrians on it
 };
 const std::unordered_map<uint8_t, std::string> CycleLaneStrings = {
   {static_cast<uint8_t>(CycleLane::kNone), "none"},

--- a/valhalla/baldr/graphconstants.h
+++ b/valhalla/baldr/graphconstants.h
@@ -217,12 +217,12 @@ enum class Use : uint8_t {
   kDriveThru = 8,         // Commercial drive-thru (banks/fast-food)
   kCuldesac = 9,          // Cul-de-sac (edge that forms a loop and is only
                           // connected at one node to another edge.
+  kLivingStreet = 10,     // Streets with preference towards bicyclists and pedestrians
 
   // Bicycle specific uses
   kCycleway = 20,          // Dedicated bicycle path
   kMountainBike = 21,      // Mountain bike trail
 
-  kLivingStreet = 23,
   kSidewalk = 24,
 
   // Pedestrian specific uses

--- a/valhalla/mjolnir/osmway.h
+++ b/valhalla/mjolnir/osmway.h
@@ -599,7 +599,7 @@ struct OSMWay {
 
   /**
    * Gets the right cycle lane.
-   * @return  Returns CycleLane.
+   * @return  Returns CycleLane on right.
    */
   baldr::CycleLane cyclelane_right() const;
 
@@ -611,7 +611,7 @@ struct OSMWay {
 
   /**
    * Gets the left cycle lane.
-   * @return  Returns CycleLane.
+   * @return  Returns CycleLane on left.
    */
   baldr::CycleLane cyclelane_left() const;
 

--- a/valhalla/mjolnir/osmway.h
+++ b/valhalla/mjolnir/osmway.h
@@ -532,6 +532,18 @@ struct OSMWay {
   bool oneway() const;
 
   /**
+   * Sets if the oneway is in the opposite direction
+   * @param  oneway_reverse
+   */
+  void set_oneway_reverse (const bool oneway_reverse);
+
+  /**
+   * Gets if the oneway is in the opposite direction
+   * @return  Returns if oneway is reversed
+   */
+  bool oneway_reverse() const;
+
+  /**
    * Sets the roundabout flag.
    * @param  roundabout   Is a roundabout?
    */
@@ -580,16 +592,78 @@ struct OSMWay {
   baldr::Surface surface() const;
 
   /**
-   * Sets the cycle lane.
+   * Sets the right cycle lane.
    * @param  cyclelane
    */
-  void set_cyclelane(const baldr::CycleLane cyclelane);
+  void set_cyclelane_right(const baldr::CycleLane cyclelane);
 
   /**
-   * Get the cycle lane.
+   * Gets the right cycle lane.
    * @return  Returns CycleLane.
    */
-  baldr::CycleLane cyclelane() const;
+  baldr::CycleLane cyclelane_right() const;
+
+  /**
+   * Sets the left cycle lane.
+   * @param  cyclelane
+   */
+  void set_cyclelane_left(const baldr::CycleLane cyclelane);
+
+  /**
+   * Gets the left cycle lane.
+   * @return  Returns CycleLane.
+   */
+  baldr::CycleLane cyclelane_left() const;
+
+  /**
+   * Sets if the right cycle lane is facing the opposite direction
+   * @param  cyclelane_opposite
+   */
+  void set_cyclelane_right_opposite(const bool cyclelane_opposite);
+
+  /**
+   * Gets if the right cycle lane is facing the opposite direction
+   * @return  Returns cycle_lane_right_opposite
+   */
+  bool cyclelane_right_opposite() const;
+
+  /**
+   * Sets if the left cycle lane is facing the opposite direction
+   * @param  cyclelane_opposite
+   */
+  void set_cyclelane_left_opposite(const bool cyclelane_opposite);
+
+  /**
+   * Gets if the left cycle lane is facing the opposite direction
+   * @return  Returns cycle_lane_left_opposite
+   */
+  bool cyclelane_left_opposite() const;
+
+  /**
+   * Sets if a bicyclist needs to dismount their bike
+   * @param  dismount  Whether a cyclist needs to dismount or not
+   */
+  void set_dismount(const bool dismount);
+
+  /**
+   * Gets if a bicyclist needs to dismount their bike
+   * @return  Returns dismount
+   */
+  bool dismount() const;
+
+  /**
+   * Sets whether a pedestrian or cyclist should have preference to use a different
+   * path to the side (A separate OSMWay completely)
+   * @param  use_sidepath
+   */
+  void set_use_sidepath(const bool use_sidepath);
+
+  /*
+   * Gets whether a pedestrian or cyclist should have preference to use a different
+   * path to the side (A separate OSMWay completely)
+   * @return  Returns if using a sidepath is preffered
+   */
+  bool use_sidepath() const;
 
   /**
    * Sets the number of lanes
@@ -938,11 +1012,11 @@ struct OSMWay {
       uint32_t destination_only       :1;
       uint32_t no_thru_traffic        :1;
       uint32_t oneway                 :1;
+      uint32_t oneway_reverse         :1;
       uint32_t roundabout             :1;
       uint32_t ferry                  :1;
       uint32_t rail                   :1;
       uint32_t surface                :3;
-      uint32_t cycle_lane             :2;
       uint32_t tunnel                 :1;
       uint32_t toll                   :1;
       uint32_t bridge                 :1;
@@ -959,7 +1033,7 @@ struct OSMWay {
       uint32_t truck_route            :1;
       uint32_t sidewalk_right         :1;
       uint32_t sidewalk_left          :1;
-      uint32_t spare                  :2;
+      uint32_t spare                  :3;
     } fields;
     uint32_t v;
   };
@@ -1007,6 +1081,21 @@ struct OSMWay {
   };
   WayAccess access_;
 
+  // Essentially just more space for attributes. Did not know what to name it.
+  union BikeInfo {
+    struct Fields {
+      uint16_t cycle_lane_right          :2;
+      uint16_t cycle_lane_left           :2;
+      uint16_t cycle_lane_right_opposite :1;
+      uint16_t cycle_lane_left_opposite  :1;
+      uint16_t dismount                  :1;
+      uint16_t use_sidepath              :1;
+      uint16_t spare                     :8;
+    } fields;
+    uint16_t v;
+  };
+  BikeInfo bike_info_;
+
   uint16_t nodecount_;
 
   // max speed limit in kilometers per hour
@@ -1024,6 +1113,8 @@ struct OSMWay {
 
   // Truck speed in kilometers per hour
   uint8_t truck_speed_;
+
+  uint8_t spare_;
 };
 
 }

--- a/valhalla/mjolnir/osmway.h
+++ b/valhalla/mjolnir/osmway.h
@@ -1081,7 +1081,7 @@ struct OSMWay {
   };
   WayAccess access_;
 
-  // Essentially just more space for attributes. Did not know what to name it.
+  // Attributes specific to biking
   union BikeInfo {
     struct Fields {
       uint16_t cycle_lane_right          :2;

--- a/valhalla/mjolnir/osmway.h
+++ b/valhalla/mjolnir/osmway.h
@@ -640,6 +640,30 @@ struct OSMWay {
   bool cyclelane_left_opposite() const;
 
   /**
+   * Set if edge has a shoulder on the right
+   * @param  shoulder  True if edge has shoulder on right
+   */
+  void set_shoulder_right(const bool shoulder_right);
+
+  /**
+   * Get if edge has a shoulder on the right
+   * @return  Returns if edge has a shoulder on right
+   */
+  bool shoulder_right() const;
+
+  /**
+   * Set if edge has a shoulder on the left
+   * @param  shoulder  True if edge has shoulder on left
+   */
+  void set_shoulder_left(const bool shoulder_left);
+
+  /**
+   * Get if edge has a shoulder on the left
+   * @return  Returns if edge has a shoulder on left
+   */
+  bool shoulder_left() const;
+
+  /**
    * Sets if a bicyclist needs to dismount their bike
    * @param  dismount  Whether a cyclist needs to dismount or not
    */
@@ -1088,9 +1112,11 @@ struct OSMWay {
       uint16_t cycle_lane_left           :2;
       uint16_t cycle_lane_right_opposite :1;
       uint16_t cycle_lane_left_opposite  :1;
+      uint16_t shoulder_right            :1;
+      uint16_t shoulder_left             :1;
       uint16_t dismount                  :1;
       uint16_t use_sidepath              :1;
-      uint16_t spare                     :8;
+      uint16_t spare                     :6;
     } fields;
     uint16_t v;
   };


### PR DESCRIPTION
## Changes
+ Fixed bug where cyclelanes were not being parsed correctly. Before, if there was any tag regarding a cyclelane at all it was just set for both sides of the road without regard to which direction it was facing or if there was only one cycle lane going in one direction. Now we look at many different factors to determine which cyclelanes go in which directions.
+ Fixed bug where having a "oneway:bicycle=no" tag on a two way road ironically caused the road to become a oneway for bikes only. (This tag isn't a mistake either. It is appropriate on two way roads sometimes because it can provide info about cycle lanes that are on one side of the road. i.e. "cycleway:right=track")
+ Added the parsing of several OSM tags:
  + "bicycle=use_sidepath" is now turned into a flag in directededge that bicycle costing uses to penalize a road in hopes of preferring a cycleway nearby.
  + "bicycle=dismount" is now turned into a flag in directededge that is used to set bike speed along the road to walking speed (because you must dismount your bike)
  + "shoulder=" and "shoulder:right/left/both=" is now turned into a flag in directededge so that we may prefer roads with shoulders over roads without them for bicycle routing (if there are no cycle lanes)
  + "highway=living_street" was already partly used but is now it's own use in graph constants and is also now favored in bicycle costing
  + "cycleway:buffer=", "cycleway:right/left/both:buffer=" and "cycleway=buffered_lane" are now parsed but are simply downgraded to a regular dedicated lane
  + "segregated=" is now parsed on edges where the use is a cycleway, footway, or path and is put into the cycle_lanes variable to be used when bike routing. If there is no pedestrian traffic then we say it is a "separated lane." If it has pedestrian traffic but segregated=yes (or it is assumed yes by being a cycleway) then we say it is a "dedicated lane." And if it has pedestrian traffic but segregated=no (or assumed no by being a footway or path) then we say it is a "shared lane."
+ All of these newly added tags are in use in both BicycleCost and LowStressBicycleCost