### PR TITLE
Derive meili Label from sif EdgeLabel

### DIFF
--- a/src/meili/map_matcher.cc
+++ b/src/meili/map_matcher.cc
@@ -207,8 +207,7 @@ FindMatchResult(const MapMatching& mapmatching,
     const auto rbegin = prev_state.RouteBegin(state),
                  rend = prev_state.RouteEnd();
     if (rbegin != rend) {
-      // Use label_edgeid method so we get an invalid edge label for origins
-      edgeid = rbegin->label_edgeid();
+      edgeid = rbegin->edgeid();
     }
   }
 
@@ -218,8 +217,7 @@ FindMatchResult(const MapMatching& mapmatching,
     // It must stay on the first edge of the route
     for (auto label = state.RouteBegin(next_state); label != state.RouteEnd(); label++) {
       if (label->edgeid().Is_Valid()) {
-        // Use label_edgeid method so we get an invalid edge label for origins
-        edgeid = label->label_edgeid();
+        edgeid = label->edgeid();
       }
     }
   }

--- a/src/meili/map_matcher.cc
+++ b/src/meili/map_matcher.cc
@@ -207,7 +207,8 @@ FindMatchResult(const MapMatching& mapmatching,
     const auto rbegin = prev_state.RouteBegin(state),
                  rend = prev_state.RouteEnd();
     if (rbegin != rend) {
-      edgeid = rbegin->edgeid();
+      // Use label_edgeid method so we get an invalid edge label for origins
+      edgeid = rbegin->label_edgeid();
     }
   }
 
@@ -217,7 +218,8 @@ FindMatchResult(const MapMatching& mapmatching,
     // It must stay on the first edge of the route
     for (auto label = state.RouteBegin(next_state); label != state.RouteEnd(); label++) {
       if (label->edgeid().Is_Valid()) {
-        edgeid = label->edgeid();
+        // Use label_edgeid method so we get an invalid edge label for origins
+        edgeid = label->label_edgeid();
       }
     }
   }

--- a/src/meili/map_matcher.cc
+++ b/src/meili/map_matcher.cc
@@ -207,7 +207,7 @@ FindMatchResult(const MapMatching& mapmatching,
     const auto rbegin = prev_state.RouteBegin(state),
                  rend = prev_state.RouteEnd();
     if (rbegin != rend) {
-      edgeid = rbegin->edgeid;
+      edgeid = rbegin->edgeid();
     }
   }
 
@@ -216,8 +216,8 @@ FindMatchResult(const MapMatching& mapmatching,
     const auto& next_state = mapmatching.state(next_stateid);
     // It must stay on the first edge of the route
     for (auto label = state.RouteBegin(next_state); label != state.RouteEnd(); label++) {
-      if (label->edgeid.Is_Valid()) {
-        edgeid = label->edgeid;
+      if (label->edgeid().Is_Valid()) {
+        edgeid = label->edgeid();
       }
     }
   }

--- a/src/meili/match_route.cc
+++ b/src/meili/match_route.cc
@@ -232,11 +232,12 @@ MergeRoute(std::vector<EdgeSegment>& route, const State& source, const State& ta
 
   // Skip the first dummy edge std::prev(route_rend)
   for (; std::next(label) != route_rend; label++) {
-    segments.emplace_back(label->label_edgeid(), label->source(), label->target());
+    segments.emplace_back(label->edgeid(), label->source(), label->target());
   }
 
-  if (label->label_edgeid().Is_Valid()) {
-    throw std::logic_error("The first edge must be dummy");
+  // Make sure the first edge has an invalid predecessor
+  if (label->predecessor() != baldr::kInvalidLabel) {
+    throw std::logic_error("The first edge must be an origin (invalid predecessor)");
   }
 
   return MergeEdgeSegments(route, segments.rbegin(), segments.rend());

--- a/src/meili/match_route.cc
+++ b/src/meili/match_route.cc
@@ -232,10 +232,10 @@ MergeRoute(std::vector<EdgeSegment>& route, const State& source, const State& ta
 
   // Skip the first dummy edge std::prev(route_rend)
   for (; std::next(label) != route_rend; label++) {
-    segments.emplace_back(label->edgeid, label->source, label->target);
+    segments.emplace_back(label->edgeid(), label->source(), label->target());
   }
 
-  if (label->edgeid.Is_Valid()) {
+  if (label->edgeid().Is_Valid()) {
     throw std::logic_error("The first edge must be dummy");
   }
 
@@ -284,7 +284,6 @@ ConstructRoute(const MapMatching& mapmatching,
 
     prev_match = match;
   }
-
   return route;
 }
 

--- a/src/meili/match_route.cc
+++ b/src/meili/match_route.cc
@@ -232,10 +232,10 @@ MergeRoute(std::vector<EdgeSegment>& route, const State& source, const State& ta
 
   // Skip the first dummy edge std::prev(route_rend)
   for (; std::next(label) != route_rend; label++) {
-    segments.emplace_back(label->edgeid(), label->source(), label->target());
+    segments.emplace_back(label->label_edgeid(), label->source(), label->target());
   }
 
-  if (label->edgeid().Is_Valid()) {
+  if (label->label_edgeid().Is_Valid()) {
     throw std::logic_error("The first edge must be dummy");
   }
 

--- a/test/routing.cc
+++ b/test/routing.cc
@@ -179,6 +179,9 @@ void TestRoutePathIterator()
   // Travel mode is insignificant in the tests
   sif::TravelMode travelmode = static_cast<sif::TravelMode>(0);
 
+  // Create a dummy DirectedEdge for use in LabelSet
+  baldr::DirectedEdge de;
+
   // Construct two poor trees:
   //  0         1
   //         3     4
@@ -189,19 +192,19 @@ void TestRoutePathIterator()
   labelset.put(3, baldr::GraphId(),
                0.f, 1.f,
                {0.f, 0.0f}, 0.f, 0.f,
-               1, nullptr, travelmode, nullptr);
+               1, &de, travelmode);
   labelset.put(4, baldr::GraphId(),
                0.f, 1.f,
                {0.f, 0.0f}, 0.f, 0.f,
-               1, nullptr, travelmode, nullptr);
+               1, &de, travelmode);
   labelset.put(5, baldr::GraphId(),
                0.f, 1.f,
                {0.f, 0.0f}, 0.f, 0.f,
-               3, nullptr, travelmode, nullptr);
+               3, &de, travelmode);
   labelset.put(6, baldr::GraphId(),
                0.f, 1.f,
                {0.f, 0.0f}, 0.f, 0.f,
-               3, nullptr, travelmode, nullptr);
+               3, &de, travelmode);
 
   meili::RoutePathIterator the_end(&labelset, baldr::kInvalidLabel),
       it0(&labelset, 0),
@@ -218,7 +221,7 @@ void TestRoutePathIterator()
   test::assert_bool(&(*it0) == &labelset.label(0),
                     "TestRoutePathIterator: wrong dereferencing");
 
-  test::assert_bool(it0->predecessor == baldr::kInvalidLabel,
+  test::assert_bool(it0->predecessor() == baldr::kInvalidLabel,
                     "TestRoutePathIterator: wrong dereferencing pointer");
 
   test::assert_bool(++it0 == the_end,
@@ -236,10 +239,10 @@ void TestRoutePathIterator()
   test::assert_bool(std::next(it4, 2) == the_end,
                     "TestRoutePathIterator: wrong forwarding 4");
 
-  test::assert_bool(it4->predecessor == 1,
+  test::assert_bool(it4->predecessor() == 1,
                     "TestRoutePathIterator: wrong dereferencing pointer 2");
 
-  test::assert_bool((it5++)->predecessor == 3,
+  test::assert_bool((it5++)->predecessor() == 3,
                     "TestRoutePathIterator: wrong postfix increment");
 
   test::assert_bool(it5 == it3,

--- a/valhalla/meili/map_matching.h
+++ b/valhalla/meili/map_matching.h
@@ -45,7 +45,7 @@ class State
              const midgard::DistanceApproximator& approximator,
              const float search_radius,
              sif::cost_ptr_t costing,
-             std::shared_ptr<const sif::EdgeLabel> edgelabel,
+             const Label* edgelabel,
              const float turn_cost_table[181]) const;
 
   const Label* last_label(const State& state) const;

--- a/valhalla/meili/routing.h
+++ b/valhalla/meili/routing.h
@@ -23,107 +23,139 @@ namespace meili {
 constexpr uint16_t kInvalidDestination = std::numeric_limits<uint16_t>::max();
 
 /**
- * Labels used to mark edges in the path. Includes predecessor and cost
- * information needed to construct and recover shortest paths.
- * TODO simplify by inheriting from sif::EdgeLabel
+ * Label used to mark edges within the map-matching routing algorithm.
+ * Derived from EdgeLabel, this adds information required by map-matching
+ * which uses a one to many routing algorithm.
  */
-struct Label
-{
-  Label() = delete;
+class Label : public sif::EdgeLabel {
+ public:
 
-  Label(const baldr::GraphId& the_nodeid, const baldr::GraphId& the_edgeid,
-        float the_source, float the_target,
-        const sif::Cost& the_cost, float the_turn_cost, float the_sortcost,
-        uint32_t the_predecessor, const baldr::DirectedEdge* the_edge,
-        sif::TravelMode the_travelmode,
-        std::shared_ptr<const sif::EdgeLabel> the_edgelabel)
-      : Label(the_nodeid, kInvalidDestination, the_edgeid,
-              the_source, the_target, the_cost, the_turn_cost, the_sortcost,
-              the_predecessor, the_edge, the_travelmode, the_edgelabel) {}
-
-  /**
-   * Construct a Label without a node Id.
-   */
-  Label(uint16_t the_dest, const baldr::GraphId& the_edgeid,
-        float the_source, float the_target,
-        const sif::Cost& the_cost, float the_turn_cost, float the_sortcost,
-        uint32_t the_predecessor, const baldr::DirectedEdge* the_edge,
-        sif::TravelMode the_travelmode,
-        std::shared_ptr<const sif::EdgeLabel> the_edgelabel)
-      : Label({}, the_dest, the_edgeid, the_source, the_target,
-              the_cost, the_turn_cost, the_sortcost,
-              the_predecessor, the_edge, the_travelmode, the_edgelabel) {}
+  Label() {
+    // zero out the data but set the node Id and edge Id to invalid
+    memset(this, 0, sizeof(Label));
+    nodeid_ = baldr::GraphId();
+    edgeid_ = baldr::GraphId();
+  }
 
   /**
    * Construct a Label with all the required information.
    */
-  Label(const baldr::GraphId& the_nodeid, uint16_t the_dest,
-        const baldr::GraphId& the_edgeid,
-        float the_source, float the_target,
-        const sif::Cost& the_cost, float the_turn_cost, float the_sortcost,
-        uint32_t the_predecessor,
-        const baldr::DirectedEdge* the_edge,
-        sif::TravelMode the_travelmode,
-        std::shared_ptr<const sif::EdgeLabel> the_edgelabel)
-      : nodeid(the_nodeid), dest(the_dest), edgeid(the_edgeid),
-        source(the_source), target(the_target),
-        cost(the_cost), turn_cost(the_turn_cost), sortcost(the_sortcost),
-        predecessor(the_predecessor),
-        edgelabel(the_edgelabel) {
-    if (!((nodeid.Is_Valid() && dest == kInvalidDestination) || (!nodeid.Is_Valid() && dest != kInvalidDestination))) {
-      throw std::invalid_argument("nodeid and dest must be mutually exclusive, i.e. either nodeid is valid or dest is valid");
-    }
-
+  Label(const baldr::GraphId& nodeid, uint16_t dest,
+        const baldr::GraphId& edgeid, float source, float target,
+        const sif::Cost& cost, float turn_cost, float sortcost,
+        const uint32_t predecessor, const baldr::DirectedEdge* edge,
+        const sif::TravelMode mode)
+     : sif::EdgeLabel(predecessor, edgeid, edge, cost, sortcost, 0.0f, mode, 0),
+       nodeid_(nodeid),
+       dest_(dest),
+       source_(source),
+       target_(target),
+       turn_cost_(turn_cost) {
+    // Validate inputs
     if (!(0.f <= source && source <= target && target <= 1.f)) {
-      throw std::invalid_argument("invalid source ("
-                                  + std::to_string(source)
-                                  + ") or target ("
-                                  + std::to_string(target) + ")");
+      throw std::invalid_argument("invalid source (" + std::to_string(source)
+                   + ") or target (" + std::to_string(target) + ")");
     }
-
     if (cost.cost < 0.f) {
       throw std::invalid_argument("invalid cost = " + std::to_string(cost.cost));
     }
-
     if (turn_cost < 0.f) {
       throw std::invalid_argument("invalid turn_cost = " + std::to_string(turn_cost));
     }
-
-    if (!edgelabel && the_edge) {
-      // Populate the sif EdgeLabel. The cost within Cost is the distance.
-      edgelabel = std::make_shared<const sif::EdgeLabel>(the_predecessor,
-           the_edgeid, the_edge, the_cost, sortcost, 0.0f, the_travelmode, 0);
-    }
   }
 
-  // Must be mutually exclusive, i.e. nodeid.Is_Valid() XOR dest != kInvalidDestination
-  baldr::GraphId nodeid;
-  uint16_t dest;
+  /**
+   * Set the node Id.
+   * @param  id   Node Id.
+   */
+  void set_nodeid(const baldr::GraphId& id) {
+    nodeid_= id;
+  }
 
-  // Invalid graphid if dummy
-  baldr::GraphId edgeid;
+  /**
+   * Get the node Id.
+   * @return  Returns the node Id.
+   */
+  baldr::GraphId nodeid() const {
+    return nodeid_;
+  }
+
+  /**
+   * Get the edge Id. If the predecessor is invalid return an invalid edgeid.
+   * This is used to handle internal map matching logic that relies on the
+   * first edge having an invalid edge id, but needing the EdgeLabel edgeid to
+   * be valid for costing purposes).
+   */
+  baldr::GraphId label_edgeid() const {
+    return predecessor_ == baldr::kInvalidLabel ?  baldr::GraphId() : edgeid();
+  }
+
+  /**
+   * Set the destination index.
+   * @param  dest  Destination index.
+   */
+  void set_dest(const uint16_t dest) {
+    dest_ = dest;
+  }
+
+  /**
+   * Get the destination index.
+   * @return Returns the destination index.
+   */
+  uint16_t dest() const {
+    return dest_;
+  }
+
+  /**
+   * Get the source distance.
+   * @return  Returns the source distance (0-1).
+   */
+  float source() const {
+    return source_;
+  }
+
+  /**
+   * Get the target distance.
+   * @return  Returns the target distance (0-1).
+   */
+  float target() const {
+    return target_;
+  }
+
+  /**
+   * Get the accumulated turn cost for this label.
+   * @return  Returns the accumulated turn cost.
+   */
+  float turn_cost() const {
+    return turn_cost_;
+  }
+
+  /**
+   * Set all costs to 0. This is used when copying a prior Label to use as an
+   * origin - we want to preserve Label values except costs must be set to 0.
+   */
+  void InitAsOrigin(const sif::TravelMode mode) {
+    source_ = 0.0f;
+    target_ = 0.0f;
+    turn_cost_ = 0.0f;
+    sortcost_  = 0.0f;
+    cost_ = {};
+    predecessor_ = baldr::kInvalidLabel;
+    mode_ = static_cast<uint32_t>(mode);
+  }
+
+ private:
+  // Must be mutually exclusive, i.e. nodeid.Is_Valid() XOR dest != kInvalidDestination
+  baldr::GraphId nodeid_;
+  uint16_t dest_;
 
   // Assert: 0.f <= source <= target <= 1.f
-  float source;
-  float target;
-
-  // Cost since origin (including the cost of this edge segment). cost is the
-  // accumulate distance and secs is the elapsed time along the path
-  sif::Cost cost;
+  float source_;
+  float target_;
 
   // Turn cost since origin (including the turn cost of this edge segment)
-  float turn_cost;
-
-  // For ranking labels: sortcost = accumulated cost since origin + heuristic cost to the goal
-  float sortcost;
-
-  // baldr::kInvalidLabel if dummy
-  uint32_t predecessor;
-
-  // An EdgeLabel is needed here for passing to sif's filters later
-  std::shared_ptr<const sif::EdgeLabel> edgelabel;
+  float turn_cost_;
 };
-
 
 // Status information: label index and whether it is permanently labeled.
 struct Status{
@@ -134,7 +166,6 @@ struct Status{
         permanent(false) {}
 
   uint32_t label_idx : 31;
-
   uint32_t permanent : 1;
 };
 
@@ -148,62 +179,102 @@ class LabelSet
  public:
   LabelSet(const float max_cost, const float bucket_size = 1.0f);
 
-  bool put(const baldr::GraphId& nodeid, sif::TravelMode travelmode,
-           std::shared_ptr<const sif::EdgeLabel> edgelabel) {
-    return put(nodeid, {},                 // nodeid, (dummy) edgeid
-               0.f, 0.f,                   // source, target
-               sif::Cost(), 0.f, 0.f,      // cost, turn cost, sort cost
-               baldr::kInvalidLabel,       // predecessor
-               nullptr, travelmode, edgelabel);
+  /**
+   * Add an origin label using a destination index.
+   */
+  void put(const uint16_t dest, const sif::TravelMode mode,
+           const Label* edgelabel) {
+    // Do not add a duplicate label for the same destination index
+    if (dest_status_.find(dest) == dest_status_.end()) {
+      // If edgelabel is not null, append it to the label set otherwise append
+      // a dummy. In both cases add the label to the priority queue, set its
+      // predecessor to kInvalidLabel, and initialize costs to 0.
+      const uint32_t idx = labels_.size();
+      queue_->add(idx, 0.0f);
+      dest_status_.emplace(dest, idx);
+      labels_.emplace_back(edgelabel ? *edgelabel : Label());
+      Label& label = labels_.back();
+      label.InitAsOrigin(mode);
+      label.set_dest(dest);
+      label.set_nodeid({});
+    }
   }
 
-
-  bool put(const baldr::GraphId& nodeid,
-           const baldr::GraphId& edgeid,
-           float source, float target,
-           const sif::Cost& cost, float turn_cost, float sortcost,
-           uint32_t predecessor,
-           const baldr::DirectedEdge* edge,
-           sif::TravelMode travelmode,
-           std::shared_ptr<const sif::EdgeLabel> edgelabel);
-
-  bool put(uint16_t dest, sif::TravelMode travelmode,
-           std::shared_ptr<const sif::EdgeLabel> edgelabel) {
-    return put(dest, {},                  // dest, (dummy) edgeid
-               0.f, 0.f,                  // source, target
-               sif::Cost(), 0.f, 0.f,     // cost, turn cost, sort cost
-               baldr::kInvalidLabel,      // predecessor
-               nullptr, travelmode, edgelabel);
+  /**
+   * Add an origin label using a node id.
+   */
+  void put(const baldr::GraphId& nodeid, const sif::TravelMode mode,
+           const Label* edgelabel) {
+    // Do not add a duplicate origin label for the same node
+    if (node_status_.find(nodeid) == node_status_.end()) {
+      // If edgelabel is not null, append it to the label set otherwise append
+      // a dummy. In both cases add the label to the priority queue and set its
+      // predecessor to kInvalidLabel
+      const uint32_t idx = labels_.size();
+      queue_->add(idx, 0.0f);
+      node_status_.emplace(nodeid, idx);
+      labels_.emplace_back(edgelabel ? *edgelabel : Label());
+      Label& label = labels_.back();
+      label.InitAsOrigin(mode);
+      label.set_dest(kInvalidDestination);
+      label.set_nodeid(nodeid);
+    }
   }
 
-  bool put(uint16_t dest,
-           const baldr::GraphId& edgeid,
-           float source, float target,
-           const sif::Cost&  cost, float turn_cost, float sortcost,
-           uint32_t predecessor,
-           const baldr::DirectedEdge* edge,
-           sif::TravelMode travelmode,
-           std::shared_ptr<const sif::EdgeLabel> edgelabel);
+  /**
+   * Add a label with an edge and node Id.
+   */
+  void put(const baldr::GraphId& nodeid, const baldr::GraphId& edgeid,
+           const float source, const float target, const sif::Cost& cost,
+           const float turn_cost, const float sortcost,
+           const uint32_t predecessor, const baldr::DirectedEdge* edge,
+           const sif::TravelMode mode);
 
+  /**
+   * Add a label with an edge and a destination index.
+   */
+  void put(const uint16_t dest, const baldr::GraphId& edgeid,
+           const float source, const float target,
+           const sif::Cost& cost, const float turn_cost, const float sortcost,
+           const uint32_t predecessor, const baldr::DirectedEdge* edge,
+           const sif::TravelMode mode);
+
+  /**
+   * Get the next label from the priority queue. Marks the popped label
+   * as permanent (best path found).
+   * @return  Returns an index into the label set.
+   */
   uint32_t pop();
 
-  const Label& label(uint32_t label_idx) const
-  { return labels_[label_idx]; }
+  /**
+   * Get a reference to a Label given its index.
+   * @param label_idx  Label index.
+   * @return  Returns a const reference to the label.
+   */
+  const Label& label(uint32_t label_idx) const {
+    return labels_[label_idx];
+  }
 
-  void clear_queue()
-  { queue_->clear(); }
+  /**
+   * Clear the priority queue.
+   */
+  void clear_queue() {
+    queue_->clear();
+  }
 
-  void clear_status()
-  {
+  /**
+   * Clear the status maps.
+   */
+  void clear_status() {
     node_status_.clear();
     dest_status_.clear();
   }
 
  private:
-  std::shared_ptr<baldr::DoubleBucketQueue> queue_;
-  std::unordered_map<baldr::GraphId, Status> node_status_;
-  std::unordered_map<uint16_t, Status> dest_status_;
-  std::vector<Label> labels_;
+  std::shared_ptr<baldr::DoubleBucketQueue> queue_;         // Priority queue
+  std::unordered_map<baldr::GraphId, Status> node_status_;  // Node status
+  std::unordered_map<uint16_t, Status> dest_status_;        // Destination status
+  std::vector<Label> labels_;                               // Label list.
 };
 
 using labelset_ptr_t = std::shared_ptr<LabelSet>;
@@ -214,73 +285,69 @@ using labelset_ptr_t = std::shared_ptr<LabelSet>;
 std::unordered_map<uint16_t, uint32_t>
 find_shortest_path(baldr::GraphReader& reader,
                    const std::vector<baldr::PathLocation>& destinations,
-                   uint16_t origin_idx,
-                   labelset_ptr_t labelset,
+                   uint16_t origin_idx, labelset_ptr_t labelset,
                    const midgard::DistanceApproximator& approximator,
-                   const float search_radius,
-                   sif::cost_ptr_t costing,
-                   std::shared_ptr<const sif::EdgeLabel> edgelabel,
-                   const float turn_cost_table[181],
+                   const float search_radius, sif::cost_ptr_t costing,
+                   const Label* edgelabel, const float turn_cost_table[181],
                    const float max_dist, const float max_time);
 
+// Route path iterator. Methods to assist recovering route paths from Labels.
 class RoutePathIterator:
       public std::iterator<std::forward_iterator_tag, const Label>
 {
  public:
-  RoutePathIterator(const LabelSet* labelset,
-                    uint32_t label_idx)
+  // Construct a route path iterator.
+  RoutePathIterator(const LabelSet* labelset, const uint32_t label_idx)
       : labelset_(labelset),
         label_idx_(label_idx) {}
 
-  // Construct a tail iterator
+  // Construct a tail iterator.
   RoutePathIterator(const LabelSet* labelset)
       : labelset_(labelset),
         label_idx_(baldr::kInvalidLabel) {}
 
-  // Construct an invalid iterator
+  // Construct an invalid iterator.
   RoutePathIterator()
       : labelset_(nullptr),
         label_idx_(baldr::kInvalidLabel) {}
 
-  // Postfix increment
-  RoutePathIterator operator++(int)
-  {
+  // Postfix increment.
+  RoutePathIterator operator++(int) {
     if (label_idx_ != baldr::kInvalidLabel) {
       auto clone = *this;
-      label_idx_ = labelset_->label(label_idx_).predecessor;
+      label_idx_ = labelset_->label(label_idx_).predecessor();
       return clone;
     }
     return *this;
   }
 
-  // Prefix increment
-  RoutePathIterator& operator++()
-  {
+  // Prefix increment.
+  RoutePathIterator& operator++() {
     if (label_idx_ != baldr::kInvalidLabel) {
-      label_idx_ = labelset_->label(label_idx_).predecessor;
+      label_idx_ = labelset_->label(label_idx_).predecessor();
     }
     return *this;
   }
 
-  bool operator==(const RoutePathIterator& other) const
-  {
-    return label_idx_ == other.label_idx_
-        && labelset_ == other.labelset_;
+  // Equality operator.
+  bool operator==(const RoutePathIterator& other) const {
+    return label_idx_ == other.label_idx_ && labelset_ == other.labelset_;
   }
 
-  bool operator!=(const RoutePathIterator& other) const
-  { return !(*this == other); }
+  // Inequality operator.
+  bool operator!=(const RoutePathIterator& other) const {
+    return !(*this == other);
+  }
 
-  // Derefrencnce
-  reference operator*() const
-  { return labelset_->label(label_idx_); }
+  // Dereference
+  reference operator*() const {
+    return labelset_->label(label_idx_);
+  }
 
   // Pointer dereference
-  pointer operator->() const
-  { return &(labelset_->label(label_idx_)); }
-
-  bool is_valid() const
-  { return labelset_ != nullptr; }
+  pointer operator->() const {
+    return &(labelset_->label(label_idx_));
+  }
 
  private:
   const LabelSet* labelset_;

--- a/valhalla/meili/routing.h
+++ b/valhalla/meili/routing.h
@@ -83,8 +83,8 @@ class Label : public sif::EdgeLabel {
   /**
    * Get the edge Id. If the predecessor is invalid return an invalid edgeid.
    * This is used to handle internal map matching logic that relies on the
-   * first edge having an invalid edge id, but needing the EdgeLabel edgeid to
-   * be valid for costing purposes).
+   * first edge having an invalid edge id, but internal to routing the edgeid
+   * should be valid if passed in from a prior route state (for costing).
    */
   baldr::GraphId label_edgeid() const {
     return predecessor_ == baldr::kInvalidLabel ?  baldr::GraphId() : edgeid();

--- a/valhalla/sif/edgelabel.h
+++ b/valhalla/sif/edgelabel.h
@@ -335,7 +335,7 @@ class EdgeLabel {
   // restriction_:   Bit mask of edges (by local edge index at the end node)
   //                 that are restricted (simple turn restrictions)
   uint32_t path_distance_ : 25;
-  uint64_t restrictions_  : 7;
+  uint32_t restrictions_  : 7;
 
   /**
    * edgeid_:         Graph Id of the edge.


### PR DESCRIPTION
Update logic for adding (origins) vs. adding labels during the path expansion. One issue was that for costing purposes a valid edge Id is needed (if it comes from a prior Label) but for map-matching methods that use the Labels the initial edge Id must be invalid GraphId. A special method was created for use outside of routing to get the edge Id (will be an invalid edgeid for origin Labels).

Very nice that there are somewhat extensive map-matching tests using real data!