### PR TITLE
fix precision issue with doublebucket queue get bucket

### DIFF
--- a/src/baldr/double_bucket_queue.cc
+++ b/src/baldr/double_bucket_queue.cc
@@ -9,6 +9,10 @@ namespace baldr {
 // stored in an "overflow" bucket.
 DoubleBucketQueue::DoubleBucketQueue(const float mincost, const float range,
           const uint32_t bucketsize, const LabelCost& labelcost) {
+  // We need at least a bucketsize of 1 or more
+  if(bucketsize < 1)
+    throw std::runtime_error("Bucketsize must be 1 or greater");
+
   // Adjust min cost to be the start of a bucket
   uint32_t c = static_cast<uint32_t>(mincost);
   currentcost_ = (c - (c % bucketsize));

--- a/src/meili/routing.cc
+++ b/src/meili/routing.cc
@@ -37,12 +37,12 @@ bool LabelSet::put(const baldr::GraphId& nodeid, const baldr::GraphId& edgeid,
   // Create a new label and push it to the queue
   if (it == node_status_.end()) {
     const uint32_t idx = labels_.size();
-    queue_->add(idx, sortcost);
     labels_.emplace_back(nodeid, edgeid,
                        source, target,
                        cost, turn_cost, sortcost,
                        predecessor,
                        edge, travelmode, edgelabel);
+    queue_->add(idx);
     node_status_.emplace(nodeid, idx);
     return true;
   }
@@ -81,12 +81,12 @@ bool LabelSet::put(uint16_t dest,
   // Create a new label and push it to the queue
   if (it == dest_status_.end()) {
     const uint32_t idx = labels_.size();
-    queue_->add(idx, sortcost);
     labels_.emplace_back(dest, edgeid,
                        source, target,
                        cost, turn_cost, sortcost,
                        predecessor,
                        edge, travelmode, edgelabel);
+    queue_->add(idx);
     dest_status_.emplace(dest, idx);
     return true;
   }

--- a/src/thor/astar.cc
+++ b/src/thor/astar.cc
@@ -232,8 +232,8 @@ std::vector<PathInfo> AStarPathAlgorithm::GetBestPath(PathLocation& origin,
         if (!hierarchy_limits_[directededge->endnode().level()].StopExpanding(dist2dest)) {
           // Allow the transition edge. Add it to the adjacency list and edge labels
           // using the predecessor information. Transition edges have no length.
-          AddToAdjacencyList(edgeid, pred.sortcost());
           edgelabels_.emplace_back(predindex, edgeid, directededge->endnode(), pred);
+          AddToAdjacencyList(edgeid, pred.sortcost());
           if (directededge->trans_up()) {
             hierarchy_limits_[node.level()].up_transition_count++;
           }
@@ -309,9 +309,9 @@ std::vector<PathInfo> AStarPathAlgorithm::GetBestPath(PathLocation& origin,
       }
 
       // Add to the adjacency list and edge labels.
-      AddToAdjacencyList(edgeid, sortcost);
       edgelabels_.emplace_back(predindex, edgeid, directededge,
                                newcost, sortcost, dist, mode_, 0);
+      AddToAdjacencyList(edgeid, sortcost);
     }
   }
   return {};      // Should never get here
@@ -321,8 +321,8 @@ std::vector<PathInfo> AStarPathAlgorithm::GetBestPath(PathLocation& origin,
 // label it.
 void AStarPathAlgorithm::AddToAdjacencyList(const GraphId& edgeid,
                                        const float sortcost) {
-  uint32_t idx = edgelabels_.size();
-  adjacencylist_->add(idx, sortcost);
+  uint32_t idx = edgelabels_.size() - 1;
+  adjacencylist_->add(idx);
   edgestatus_->Set(edgeid, EdgeSet::kTemporary, idx);
 }
 
@@ -401,13 +401,14 @@ void AStarPathAlgorithm::SetOrigin(GraphReader& graphreader,
     // Set the predecessor edge index to invalid to indicate the origin
     // of the path.
     uint32_t d = static_cast<uint32_t>(directededge->length() * (1.0f - edge.dist));
-    adjacencylist_->add(edgelabels_.size(), sortcost);
     EdgeLabel edge_label(kInvalidLabel, edgeid, directededge, cost,
                          sortcost, dist, mode_, d);
+    // Set the origin flag
     edge_label.set_origin();
 
-    // Set the origin flag
+    // Add EdgeLabel to the adjeacency list
     edgelabels_.push_back(std::move(edge_label));
+    adjacencylist_->add(edgelabels_.size() - 1);
   }
 
   // Set the origin timezone

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -204,11 +204,11 @@ void BidirectionalAStar::ExpandForward(GraphReader& graphreader,
 
     // Add edge label, add to the adjacency list and set edge status
     uint32_t idx = edgelabels_forward_.size();
-    adjacencylist_forward_->add(idx, sortcost);
     edgestatus_forward_->Set(edgeid, EdgeSet::kTemporary, idx);
     edgelabels_forward_.emplace_back(pred_idx, edgeid, oppedge, directededge,
                   newcost, sortcost, dist, mode_, tc,
                   (pred.not_thru_pruning() || !directededge->not_thru()));
+    adjacencylist_forward_->add(idx);
   }
 }
 
@@ -316,11 +316,11 @@ void BidirectionalAStar::ExpandReverse(GraphReader& graphreader,
 
     // Add edge label, add to the adjacency list and set edge status
     uint32_t idx = edgelabels_reverse_.size();
-    adjacencylist_reverse_->add(idx, sortcost);
     edgestatus_reverse_->Set(edgeid, EdgeSet::kTemporary, idx);
     edgelabels_reverse_.emplace_back(pred_idx, edgeid, oppedge,
                  directededge, newcost, sortcost, dist, mode_, tc,
                  (pred.not_thru_pruning() || !directededge->not_thru()));
+    adjacencylist_reverse_->add(idx);
   }
 }
 
@@ -572,10 +572,10 @@ void BidirectionalAStar::SetOrigin(GraphReader& graphreader,
     // Add EdgeLabel to the adjacency list. Set the predecessor edge index
     // to invalid to indicate the origin of the path.
     uint32_t idx = edgelabels_forward_.size();
-    adjacencylist_forward_->add(idx, sortcost);
     edgestatus_forward_->Set(edgeid, EdgeSet::kTemporary, idx);
     edgelabels_forward_.emplace_back(kInvalidLabel, edgeid, directededge, cost,
                                      sortcost, dist, mode_);
+    adjacencylist_forward_->add(idx);
 
     // Set the initial not_thru flag to false. There is an issue with not_thru
     // flags on small loops. Set this to false here to override this for now.
@@ -639,10 +639,10 @@ void BidirectionalAStar::SetDestination(GraphReader& graphreader,
     // to invalid to indicate the origin of the path. Make sure the opposing
     // edge (edgeid) is set.
     uint32_t idx = edgelabels_reverse_.size();
-    adjacencylist_reverse_->add(idx, sortcost);
     edgestatus_reverse_->Set(opp_edge_id, EdgeSet::kTemporary, idx);
     edgelabels_reverse_.emplace_back(kInvalidLabel, opp_edge_id, edgeid,
              opp_dir_edge, cost, sortcost, dist, mode_, c, false);
+    adjacencylist_reverse_->add(idx);
 
     // Set the initial not_thru flag to false. There is an issue with not_thru
     // flags on small loops. Set this to false here to override this for now.

--- a/src/thor/isochrone.cc
+++ b/src/thor/isochrone.cc
@@ -276,10 +276,10 @@ void Isochrone::ExpandForward(GraphReader& graphreader, const GraphId& node,
 
     // Add edge label, add to the adjacency list and set edge status
     uint32_t idx = edgelabels_.size();
-    adjacencylist_->add(idx, newcost.cost);
     edgestatus_->Set(edgeid, EdgeSet::kTemporary, idx);
     edgelabels_.emplace_back(pred_idx, edgeid, directededge,
                              newcost, newcost.cost, 0.0f, mode_, 0);
+    adjacencylist_->add(idx);
   }
 }
 
@@ -423,11 +423,11 @@ void Isochrone::ExpandReverse(GraphReader& graphreader,
 
     // Add edge label, add to the adjacency list and set edge status
     uint32_t idx = bdedgelabels_.size();
-    adjacencylist_->add(idx, newcost.cost);
     edgestatus_->Set(edgeid, EdgeSet::kTemporary, idx);
     bdedgelabels_.emplace_back(pred_idx, edgeid, oppedge,
                    directededge, newcost, newcost.cost, 0.0f,
                    mode_, tc, false);
+    adjacencylist_->add(idx);
   }
 }
 
@@ -657,9 +657,9 @@ std::shared_ptr<const GriddedData<PointLL> > Isochrone::ComputeMultiModal(
       // information.
       if (directededge->IsTransition()) {
         uint32_t idx = mmedgelabels_.size();
-        adjacencylist_->add(idx, pred.sortcost());
         edgestatus_->Set(edgeid, EdgeSet::kTemporary, idx);
         mmedgelabels_.emplace_back(predindex, edgeid, directededge->endnode(), pred);
+        adjacencylist_->add(idx);
         continue;
       }
 
@@ -818,11 +818,11 @@ std::shared_ptr<const GriddedData<PointLL> > Isochrone::ComputeMultiModal(
 
       // Add edge label, add to the adjacency list and set edge status
       uint32_t idx = mmedgelabels_.size();
-      adjacencylist_->add(idx, newcost.cost);
       edgestatus_->Set(edgeid, EdgeSet::kTemporary, idx);
       mmedgelabels_.emplace_back(predindex, edgeid, directededge,
                     newcost, newcost.cost, 0.0f, mode_, walking_distance,
                     tripid, prior_stop, blockid, operator_id, has_transit);
+      adjacencylist_->add(idx);
     }
   }
   return isotile_;      // Should never get here
@@ -950,14 +950,15 @@ void Isochrone::SetOriginLocations(GraphReader& graphreader,
       // of the path.
       uint32_t idx = edgelabels_.size();
       uint32_t d = static_cast<uint32_t>(directededge->length() * (1.0f - edge.dist));
-      adjacencylist_->add(idx, cost.cost);
       edgestatus_->Set(edgeid, EdgeSet::kTemporary, idx);
       EdgeLabel edge_label(kInvalidLabel, edgeid, directededge, cost,
                            cost.cost, 0.0f, mode_, d);
+      // Set the origin flag
       edge_label.set_origin();
 
-      // Set the origin flag
+      // Add EdgeLabel to the adjacency list
       edgelabels_.push_back(std::move(edge_label));
+      adjacencylist_->add(idx);
     }
 
     // Set the origin timezone
@@ -1021,10 +1022,10 @@ void Isochrone::SetDestinationLocations(GraphReader& graphreader,
       // to invalid to indicate the origin of the path. Make sure the opposing
       // edge (edgeid) is set.
       uint32_t idx = bdedgelabels_.size();
-      adjacencylist_->add(idx, cost.cost);
       edgestatus_->Set(opp_edge_id, EdgeSet::kTemporary, idx);
       bdedgelabels_.emplace_back(kInvalidLabel, opp_edge_id, edgeid,
                   opp_dir_edge, cost, cost.cost, 0.0f, mode_, c, false);
+      adjacencylist_->add(idx);
     }
   }
 }

--- a/src/thor/multimodal.cc
+++ b/src/thor/multimodal.cc
@@ -332,8 +332,8 @@ std::vector<PathInfo> MultiModalPathAlgorithm::GetBestPath(
         // Add the transition edge to the adjacency list and edge labels
         // using the predecessor information. Transition edges have
         // no length.
-        AddToAdjacencyList(edgeid, pred.sortcost());
         edgelabels_.emplace_back(predindex, edgeid, directededge->endnode(), pred);
+        AddToAdjacencyList(edgeid, pred.sortcost());
         continue;
       }
 
@@ -510,10 +510,10 @@ std::vector<PathInfo> MultiModalPathAlgorithm::GetBestPath(
       }
 
       // Add edge label, add to the adjacency list and set edge status
-      AddToAdjacencyList(edgeid, sortcost);
       edgelabels_.emplace_back(predindex, edgeid, directededge,
                     newcost, sortcost, dist, mode_, walking_distance_,
                     tripid, prior_stop, blockid, operator_id, has_transit);
+      AddToAdjacencyList(edgeid, sortcost);
     }
   }
   return {};      // Should never get here
@@ -523,8 +523,8 @@ std::vector<PathInfo> MultiModalPathAlgorithm::GetBestPath(
 // label it.
 void MultiModalPathAlgorithm::AddToAdjacencyList(const GraphId& edgeid,
                                        const float sortcost) {
-  uint32_t idx = edgelabels_.size();
-  adjacencylist_->add(idx, sortcost);
+  uint32_t idx = edgelabels_.size() - 1;
+  adjacencylist_->add(idx);
   edgestatus_->Set(edgeid, EdgeSet::kTemporary, idx);
 }
 
@@ -603,13 +603,14 @@ void MultiModalPathAlgorithm::SetOrigin(GraphReader& graphreader,
     // Set the predecessor edge index to invalid to indicate the origin
     // of the path.
     uint32_t d = static_cast<uint32_t>(directededge->length() * (1.0f - edge.dist));
-    adjacencylist_->add(edgelabels_.size(), sortcost);
     MMEdgeLabel edge_label(kInvalidLabel, edgeid, directededge, cost,
                          sortcost, dist, mode_, d, 0, GraphId(), 0, 0, false);
+    // Set the origin flag
     edge_label.set_origin();
 
-    // Set the origin flag
+    // Add EdgeLabel to the adjacency list
     edgelabels_.push_back(std::move(edge_label));
+    adjacencylist_->add(edgelabels_.size() - 1);
   }
 
   // Set the origin timezone
@@ -695,7 +696,7 @@ bool MultiModalPathAlgorithm::CanReachDestination(const PathLocation& destinatio
     Cost cost = costing->EdgeCost(diredge) * ratio;
     edgelabels.emplace_back(kInvalidLabel, oppedge,
             diredge, cost, cost.cost, 0.0f, mode_, length);
-    adjlist.add(label_idx, cost.cost);
+    adjlist.add(label_idx);
     edgestatus.Set(oppedge, EdgeSet::kTemporary, label_idx);
     label_idx++;
   }
@@ -748,7 +749,7 @@ bool MultiModalPathAlgorithm::CanReachDestination(const PathLocation& destinatio
         // Add the transition edge to the adjacency list and edge labels
         // using the predecessor information.
         edgelabels.emplace_back(predindex, edgeid, directededge->endnode(), pred);
-        adjlist.add(label_idx, pred.sortcost());
+        adjlist.add(label_idx);
         edgestatus.Set(edgeid, EdgeSet::kTemporary, label_idx);
         label_idx++;
         continue;
@@ -778,7 +779,7 @@ bool MultiModalPathAlgorithm::CanReachDestination(const PathLocation& destinatio
       // Add edge label, add to the adjacency list and set edge status
       edgelabels.emplace_back(predindex, edgeid, directededge,
                     newcost, newcost.cost, 0.0f, mode_, walking_distance);
-      adjlist.add(label_idx, newcost.cost);
+      adjlist.add(label_idx);
       edgestatus.Set(edgeid, EdgeSet::kTemporary, label_idx);
       label_idx++;
     }

--- a/src/thor/timedistancematrix.cc
+++ b/src/thor/timedistancematrix.cc
@@ -167,8 +167,8 @@ std::vector<TimeDistance> TimeDistanceMatrix::OneToMany(
 
       // Handle transition edges - add to adjacency set.
       if (directededge->IsTransition()) {
-        AddToAdjacencyList(edgeid, pred.sortcost());
         edgelabels_.emplace_back(predindex, edgeid, directededge->endnode(), pred);
+        AddToAdjacencyList(edgeid, pred.sortcost());
         continue;
       }
 
@@ -200,9 +200,9 @@ std::vector<TimeDistance> TimeDistanceMatrix::OneToMany(
       }
 
       // Add to the adjacency list and edge labels.
-      AddToAdjacencyList(edgeid, newcost.cost);
       edgelabels_.emplace_back(predindex, edgeid, directededge,
                     newcost, newcost.cost, 0.0f, mode_, distance);
+      AddToAdjacencyList(edgeid, newcost.cost);
     }
   }
   return {};      // Should never get here
@@ -210,8 +210,8 @@ std::vector<TimeDistance> TimeDistanceMatrix::OneToMany(
 
 void TimeDistanceMatrix::AddToAdjacencyList(const baldr::GraphId& edgeid,
                                             const float sortcost) {
-  uint32_t idx = edgelabels_.size();
-  adjacencylist_->add(idx, sortcost);
+  uint32_t idx = edgelabels_.size() - 1;
+  adjacencylist_->add(idx);
   edgestatus_->Set(edgeid, EdgeSet::kTemporary, idx);
 }
 
@@ -323,8 +323,8 @@ std::vector<TimeDistance> TimeDistanceMatrix::ManyToOne(
 
       // Handle transition edges. Add to adjacency list.
       if (directededge->IsTransition()) {
-        AddToAdjacencyList(edgeid, pred.sortcost());
         edgelabels_.emplace_back(predindex, edgeid, directededge->endnode(), pred);
+        AddToAdjacencyList(edgeid, pred.sortcost());
         continue;
       }
 
@@ -364,9 +364,9 @@ std::vector<TimeDistance> TimeDistanceMatrix::ManyToOne(
       }
 
       // Add to the adjacency list and edge labels.
-      AddToAdjacencyList(edgeid, newcost.cost);
       edgelabels_.emplace_back(predindex, edgeid, directededge,
                     newcost, newcost.cost, 0.0f, mode_, distance);
+      AddToAdjacencyList(edgeid, newcost.cost);
     }
   }
   return {};      // Should never get here
@@ -453,11 +453,11 @@ void TimeDistanceMatrix::SetOriginOneToMany(GraphReader& graphreader,
     // Add EdgeLabel to the adjacency list (but do not set its status).
     // Set the predecessor edge index to invalid to indicate the origin
     // of the path. Set the origin flag
-    adjacencylist_->add(edgelabels_.size(), cost.cost);
     EdgeLabel edge_label(kInvalidLabel, edgeid, directededge, cost,
                          cost.cost, 0.0f, mode_, d);
     edge_label.set_origin();
     edgelabels_.push_back(std::move(edge_label));
+    adjacencylist_->add(edgelabels_.size() - 1);
   }
 }
 
@@ -500,11 +500,11 @@ void TimeDistanceMatrix::SetOriginManyToOne(GraphReader& graphreader,
     // Set the predecessor edge index to invalid to indicate the origin
     // of the path. Set the origin flag.
     // TODO - restrictions?
-    adjacencylist_->add(edgelabels_.size(), cost.cost);
     EdgeLabel edge_label(kInvalidLabel, opp_edge_id, opp_dir_edge, cost,
                          cost.cost, 0.0f, mode_, d);
     edge_label.set_origin();
     edgelabels_.push_back(std::move(edge_label));
+    adjacencylist_->add(edgelabels_.size() - 1);
   }
 }
 

--- a/src/valhalla_benchmark_adjacency_list.cc
+++ b/src/valhalla_benchmark_adjacency_list.cc
@@ -78,7 +78,7 @@ int Benchmark(const uint32_t n, const float maxcost,
     EdgeLabel el;
     el.SetSortCost(costs[i]);
     edgelabels.push_back(std::move(el));
-    adjlist.add(i, costs[i]);
+    adjlist.add(i);
   }
 
   // Get edge label indexes from the adj list. Accumulate total cost to make

--- a/test/double_bucket_queue.cc
+++ b/test/double_bucket_queue.cc
@@ -26,7 +26,7 @@ void TryAddRemove(const std::vector<uint32_t>& costs,
   DoubleBucketQueue adjlist(0, 10000, 5, edgecost);
   for (auto cost : costs) {
     edgelabels.emplace_back(cost);
-    adjlist.add(i, cost);
+    adjlist.add(i);
     i++;
   }
   for (auto expected : expectedorder) {
@@ -55,7 +55,7 @@ void TryClear(const std::vector<uint32_t>& costs) {
   DoubleBucketQueue adjlist(0, 10000, 50, edgecost);
   for (auto cost : costs) {
     edgelabels.emplace_back(cost);
-    adjlist.add(i, cost);
+    adjlist.add(i);
     i++;
   }
   adjlist.clear();
@@ -109,7 +109,7 @@ void TrySimulation(DoubleBucketQueue& dbqueue,
 
   const uint32_t idx = costs.size();
   costs.push_back(10.f);
-  dbqueue.add(idx, 10.f);
+  dbqueue.add(idx);
   std::random_device rd;
   std::mt19937 gen(rd());
   for (size_t i = 0; i < loop_count; i++) {
@@ -144,7 +144,7 @@ void TrySimulation(DoubleBucketQueue& dbqueue,
         // Add new label
         const uint32_t idx = costs.size();
         costs.push_back(newcost);
-        dbqueue.add(idx, newcost);
+        dbqueue.add(idx);
         addedLabels.insert(idx);
       }
     }

--- a/test/json.cc
+++ b/test/json.cc
@@ -62,6 +62,8 @@ void TestJsonSerialize() {
   boost::property_tree::ptree res,ans;
   boost::property_tree::read_json(result, res);
   boost::property_tree::read_json(answer, ans);
+  res.sort();
+  ans.sort();
 
   stringstream res_formatted,ans_formatted;
   boost::property_tree::write_json(res_formatted, res);

--- a/test/mapmatch.cc
+++ b/test/mapmatch.cc
@@ -312,6 +312,12 @@ namespace {
       std::logic_error("Using time it should not take a small detour");
   }
 
+  void test32bit() {
+    tyr::actor_t actor(conf, true);
+    std::string test_case = "{\"costing\":\"auto\",\"locations\":[{\"lat\":52.096672,\"lon\":5.110825},{\"lat\":52.081371,\"lon\":5.125671}]}";
+    actor.route(tyr::ROUTE, test_case);
+  }
+
 }
 
 int main(int argc, char* argv[]) {
@@ -321,6 +327,8 @@ int main(int argc, char* argv[]) {
     seed = std::stoi(argv[1]);
   if(argc > 2)
     bound = std::stoi(argv[2]);
+
+  suite.test(TEST_CASE(test32bit));
 
   suite.test(TEST_CASE(test_matcher));
 

--- a/test/routing.cc
+++ b/test/routing.cc
@@ -10,7 +10,7 @@ void Add(baldr::DoubleBucketQueue &adjlist, const std::vector<float>& costs)
 {
   uint32_t idx = 0;
   for (const auto cost : costs) {
-    adjlist.add(idx++, cost);
+    adjlist.add(idx++);
   }
 }
 
@@ -67,11 +67,11 @@ void TestAddRemove()
   costs[4] = 5;
   baldr::DoubleBucketQueue adjlist3(0, 10, 1, labelcost);
 
-  adjlist3.add(0, 1000);
-  adjlist3.add(1, 100);
-  adjlist3.add(2, 10);
-  adjlist3.add(3, 9);
-  adjlist3.add(4, 5);
+  adjlist3.add(0);
+  adjlist3.add(1);
+  adjlist3.add(2);
+  adjlist3.add(3);
+  adjlist3.add(4);
 
   // Decrease cost of label 3 to 3 - pop the lowest cost element - it should be label 3
   adjlist3.decrease(3, 3);
@@ -96,7 +96,7 @@ void TrySimulation(size_t loop_count, size_t expansion_size, size_t max_incremen
 
   const uint32_t idx = costs.size();
   costs.push_back(10.f);
-  adjlist.add(idx, 10.f);
+  adjlist.add(idx);
   track.insert(idx);
 
   std::random_device rd;
@@ -130,7 +130,7 @@ void TrySimulation(size_t loop_count, size_t expansion_size, size_t max_incremen
         // Add new label
         const uint32_t idx = costs.size();
         costs.push_back(newcost);
-        adjlist.add(idx, newcost);
+        adjlist.add(idx);
         track.insert(idx);
       }
     }

--- a/valhalla/baldr/double_bucket_queue.h
+++ b/valhalla/baldr/double_bucket_queue.h
@@ -61,8 +61,8 @@ class DoubleBucketQueue {
    * @param   label  Label index to add to the queue.
    * @param   cost   Cost for this label.
    */
-  void add(const uint32_t label, const float cost) {
-    get_bucket(cost).push_back(label);
+  void add(const uint32_t label) {
+    get_bucket(labelcost_(label)).push_back(label);
   }
 
   /**
@@ -107,10 +107,7 @@ class DoubleBucketQueue {
    * @param  cost  Cost.
    * @return Returns the bucket that the cost lies within.
    */
-  bucket_t& get_bucket(float cost) {
-    //shift the cost to the middle of the bucket so as to avoid precision issues
-    //since minimum bucketsize is 1 this shouldnt be a problem
-    cost = std::floor(cost) + (bucketsize_ *.5f);
+  bucket_t& get_bucket(const float cost) {
     return (cost < currentcost_) ? *currentbucket_ :
              (cost < maxcost_) ?
                buckets_[static_cast<uint32_t>((cost - mincost_) * inv_)] :

--- a/valhalla/baldr/double_bucket_queue.h
+++ b/valhalla/baldr/double_bucket_queue.h
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <vector>
+#include <cmath>
 #include <valhalla/midgard/util.h>
 
 namespace valhalla {
@@ -106,7 +107,10 @@ class DoubleBucketQueue {
    * @param  cost  Cost.
    * @return Returns the bucket that the cost lies within.
    */
-  bucket_t& get_bucket(const float cost) {
+  bucket_t& get_bucket(float cost) {
+    //shift the cost to the middle of the bucket so as to avoid precision issues
+    //since minimum bucketsize is 1 this shouldnt be a problem
+    cost = std::floor(cost) + (bucketsize_ *.5f);
     return (cost < currentcost_) ? *currentbucket_ :
              (cost < maxcost_) ?
                buckets_[static_cast<uint32_t>((cost - mincost_) * inv_)] :

--- a/valhalla/valhalla.h.in
+++ b/valhalla/valhalla.h.in
@@ -3,7 +3,7 @@
 
 #define VALHALLA_VERSION_MAJOR 2
 #define VALHALLA_VERSION_MINOR 3
-#define VALHALLA_VERSION_PATCH 1
+#define VALHALLA_VERSION_PATCH 2
 
 //whether the API was configured with http service support or not
 @HAVE_HTTP_DEFINE@


### PR DESCRIPTION
this new test failed on 32bit architectures. the crux of the matter is that for some reason when the label gets added it goes into one bucket but then when it gets decreased the bucket look up looks in the wrong (but adjacent) bucket to find the label. it fails to find it and then does an erase on a vector::end because it hasnt found the label in the bucket it was expecting it to. i've found that adding anything mundane to the inlined doublebucketqueue::add function causes the situation to rectify itself...

the fix ive employed here was to move the cost to the middle of the bucket before computing the bucket index as an integer. this avoid that computation being near a bucket boundary