### PR TITLE
BicycleCost re-factor

### DIFF
--- a/src/loki/worker.cc
+++ b/src/loki/worker.cc
@@ -180,7 +180,6 @@ namespace valhalla {
       factory.Register("auto_shorter", sif::CreateAutoShorterCost);
       factory.Register("bus", sif::CreateBusCost);
       factory.Register("bicycle", sif::CreateBicycleCost);
-      factory.Register("low_stress_bicycle", sif::CreateLowStressBicycleCost);
       factory.Register("hov", sif::CreateHOVCost);
       factory.Register("pedestrian", sif::CreatePedestrianCost);
       factory.Register("truck", sif::CreateTruckCost);

--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -970,26 +970,8 @@ cost_ptr_t CreateBicycleCost(const boost::property_tree::ptree& config) {
   return std::make_shared<BicycleCost>(config);
 }
 
-////////////////////////////////////////////////////////////////////////////
-
-class LowStressBicycleCost : public BicycleCost {
- public:
-
-  LowStressBicycleCost(const boost::property_tree::ptree& config);
-
-  virtual ~LowStressBicycleCost();
-
-};
-
-LowStressBicycleCost::LowStressBicycleCost(const boost::property_tree::ptree& config)
-    : BicycleCost(config) {
-}
-
-LowStressBicycleCost::~LowStressBicycleCost() {
-}
-
 cost_ptr_t CreateLowStressBicycleCost(const boost::property_tree::ptree& config) {
-  return std::make_shared<LowStressBicycleCost>(config);
+  return std::make_shared<BicycleCost>(config);
 }
 
 }

--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -29,7 +29,7 @@ constexpr float kDefaultGatePenalty             = 300.0f; // Seconds
 constexpr float kDefaultFerryCost               = 300.0f; // Seconds
 constexpr float kDefaultCountryCrossingCost     = 600.0f; // Seconds
 constexpr float kDefaultCountryCrossingPenalty  = 0.0f;   // Seconds
-constexpr float kDefaultUseRoad                 = 0.5f;   // Factor between 0 and 1
+constexpr float kDefaultUseRoad                 = 0.25f;   // Factor between 0 and 1
 constexpr float kDefaultUseFerry                = 0.5f;   // Factor between 0 and 1
 
 // Maximum ferry penalty (when use_ferry == 0). Can't make this too large
@@ -168,7 +168,7 @@ constexpr float kGradeBasedSpeedFactor[] = {
 
 // User propensity to use "hilly" roads. Ranges from a value of 0 (avoid
 // hills) to 1 (take hills when they offer a more direct, less time, path).
-constexpr float kDefaultUseHills = 0.5f;
+constexpr float kDefaultUseHills = 0.25f;
 
 // Avoid hills "strength". How much do we want to avoid a hill. Combines
 // with the usehills factor (1.0 - usehills = avoidhills factor) to create
@@ -453,15 +453,15 @@ BicycleCost::BicycleCost(const boost::property_tree::ptree& pt)
   );
 
   // Get the bicycle type - enter as string and convert to enum
-  std::string bicycle_type = pt.get("bicycle_type", "Road");
+  std::string bicycle_type = pt.get("bicycle_type", "Hybrid");
   if (bicycle_type == "Cross") {
     type_ = BicycleType::kCross;
-  } else if (bicycle_type == "Hybrid" || bicycle_type == "City") {
-    type_ = BicycleType::kHybrid;
+  } else if (bicycle_type == "Road") {
+    type_ = BicycleType::kRoad;
   } else if (bicycle_type == "Mountain") {
     type_ = BicycleType::kMountain;
   } else {
-    type_ = BicycleType::kRoad;
+    type_ = BicycleType::kHybrid;
   }
 
   // Get default speed from the config. This is the average speed on smooth,

--- a/src/thor/worker.cc
+++ b/src/thor/worker.cc
@@ -78,7 +78,6 @@ namespace valhalla {
       factory.Register("auto_shorter", sif::CreateAutoShorterCost);
       factory.Register("bus", CreateBusCost);
       factory.Register("bicycle", sif::CreateBicycleCost);
-      factory.Register("low_stress_bicycle", sif::CreateLowStressBicycleCost);
       factory.Register("hov", sif::CreateHOVCost);
       factory.Register("pedestrian", sif::CreatePedestrianCost);
       factory.Register("transit", sif::CreateTransitCost);

--- a/valhalla/sif/bicyclecost.h
+++ b/valhalla/sif/bicyclecost.h
@@ -13,13 +13,6 @@ namespace sif {
  */
 cost_ptr_t CreateBicycleCost(const boost::property_tree::ptree& config);
 
-/**
- * Create a low-stress bicyclecost method. This is derived from bicycle costing,
- * but has a stronger preference for low-stress biking roads.
- * @param  config  Property tree with configuration / options.
- */
-cost_ptr_t CreateLowStressBicycleCost(const boost::property_tree::ptree& config);
-
 }
 }
 


### PR DESCRIPTION
LowStressBicycleCost has been emptied and is ready to be removed completely from loki, thor, etc. BicycleCost has been re-factored to have similar logic to LowStressBicycleCost in a way that use_roads=0 and use_roads=0 acts how LowStressBicycleCost acted before. The behavior won't be exactly the same as how low stress was because the changes also includes a re-balancing of how transition costing works for bicycling as well as a few other minor tweaks that affects edge costing.