### PR TITLE
Increase map matcher distance outputs to 6 decimal places

### DIFF
--- a/src/thor/trace_attributes_action.cc
+++ b/src/thor/trace_attributes_action.cc
@@ -329,11 +329,11 @@ namespace {
 
       // Process matched point distance along edge
       if (controller.attributes.at(kMatchedDistanceAlongEdge) && (match_result.type != thor::MatchResult::Type::kUnmatched))
-        match_points_map->emplace("distance_along_edge", json::fp_t{match_result.distance_along,3});
+        match_points_map->emplace("distance_along_edge", json::fp_t{match_result.distance_along, 6});
 
       // Process matched point distance from trace point
       if (controller.attributes.at(kMatchedDistanceFromTracePoint) && (match_result.type != thor::MatchResult::Type::kUnmatched))
-        match_points_map->emplace("distance_from_trace_point", json::fp_t{match_result.distance_from,3});
+        match_points_map->emplace("distance_from_trace_point", json::fp_t{match_result.distance_from, 6});
 
       match_points_array->push_back(match_points_map);
     }


### PR DESCRIPTION
this PR partially addresses the issue here: https://github.com/valhalla/valhalla/issues/875 

instead of having outputs like this:

distance_along_edge | distance_from_trace_point | edge_index | lat | lon | type
-- | -- | -- | -- | -- | -- 
0.826 | 2.880 | 0 | 39.192108 | -75.544495 | matched
0.830 | 2.135 | 0 | 39.192112 | -75.544502 | interpolated
0.833 | 2.135 | 0 | 39.192116 | -75.544510 | interpolated
0.833 | 1.820 | 0 | 39.192116 | -75.544510 | interpolated
0.838 | 1.820 | 0 | 39.192123 | -75.544518 | interpolated
0.842 | 1.820 | 0 | 39.192127 | -75.544525 | interpolated
0.844 | 1.820 | 0 | 39.192131 | -75.544525 | interpolated
0.850 | 1.067 | 0 | 39.192135 | -75.544540 | interpolated
0.853 | 1.820 | 0 | 39.192142 | -75.544540 | interpolated
0.855 | 1.067 | 0 | 39.192142 | -75.544548 | interpolated
0.860 | 1.067 | 0 | 39.192150 | -75.544556 | interpolated
0.860 | 0.778 | 0 | 39.192150 | -75.544556 | interpolated
0.865 | 1.067 | 0 | 39.192158 | -75.544563 | interpolated

we'd now have:


distance_along_edge | distance_from_trace_point | edge_index | lat | lon | type
-- | -- | -- | -- | -- | --
0.825792 | 2.879994 | 0 | 39.192108 | -75.544495 | matched
0.829540 | 2.134505 | 0 | 39.192112 | -75.544502 | interpolated
0.833301 | 2.134504 | 0 | 39.192116 | -75.544510 | interpolated
0.833301 | 1.819566 | 0 | 39.192116 | -75.544510 | interpolated
0.838464 | 1.819566 | 0 | 39.192123 | -75.544518 | interpolated
0.842219 | 1.819566 | 0 | 39.192127 | -75.544525 | interpolated
0.843640 | 1.819566 | 0 | 39.192131 | -75.544525 | interpolated
0.849754 | 1.067252 | 0 | 39.192135 | -75.544540 | interpolated
0.852566 | 1.819566 | 0 | 39.192142 | -75.544540 | interpolated
0.854902 | 1.067252 | 0 | 39.192142 | -75.544548 | interpolated
0.860064 | 1.067252 | 0 | 39.192150 | -75.544556 | interpolated
0.860064 | 0.778031 | 0 | 39.192150 | -75.544556 | interpolated
0.865234 | 1.067252 | 0 | 39.192158 | -75.544563 | interpolated

