### PR TITLE
Addition of some basic tests for CostMatrix and TimeDistanceMatrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,6 +180,7 @@ test/transitcost
 test/truckcost
 test/actor
 test/mapmatch
+test/matrix
 test_requests/duane_routes.txt
 run_route_scripts/results/20*
 EdgeInfoBuilder_TestWriteRead.gph

--- a/Makefile.am
+++ b/Makefile.am
@@ -893,7 +893,8 @@ check_PROGRAMS += \
 	test/graphtilebuilder \
 	test/search \
 	test/node_search \
-	test/mapmatch
+	test/mapmatch \
+	test/matrix
 test_utrecht_SOURCES = test/utrecht.cc test/test.cc
 test_utrecht_CPPFLAGS = $(DEPS_CFLAGS) $(DATA_DEPS_CFLAGS) $(SERVICE_DEPS_CFLAGS) @BOOST_CPPFLAGS@ @RAPIDJSON_CPPFLAGS@
 test_utrecht_LDADD = $(DEPS_LIBS) $(DATA_DEPS_LIBS) $(SERVICE_DEPS_LIBS) @BOOST_LDFLAGS@ $(BOOST_LIBS) libvalhalla.la
@@ -937,6 +938,10 @@ test_mapmatch_DEPENDENCIES = test/data/utrecht_tiles
 test_mapmatch_SOURCES = test/mapmatch.cc test/test.cc
 test_mapmatch_CPPFLAGS = $(DEPS_CFLAGS) $(DATA_DEPS_CFLAGS) $(SERVICE_DEPS_CFLAGS) @BOOST_CPPFLAGS@
 test_mapmatch_LDADD = $(DEPS_LIBS) $(DATA_DEPS_LIBS) $(SERVICE_DEPS_LIBS) @BOOST_LDFLAGS@ $(BOOST_LIBS) libvalhalla.la
+test_matrix_DEPENDENCIES = test/data/utrecht_tiles
+test_matrix_SOURCES = test/matrix.cc test/test.cc
+test_matrix_CPPFLAGS = $(DEPS_CFLAGS) $(DATA_DEPS_CFLAGS) $(SERVICE_DEPS_CFLAGS) @BOOST_CPPFLAGS@
+test_matrix_LDADD = $(DEPS_LIBS) $(DATA_DEPS_LIBS) $(SERVICE_DEPS_LIBS) @BOOST_LDFLAGS@ $(BOOST_LIBS) libvalhalla.la
 endif
 
 TESTS = $(check_PROGRAMS)

--- a/src/thor/timedistancematrix.cc
+++ b/src/thor/timedistancematrix.cc
@@ -629,6 +629,10 @@ bool TimeDistanceMatrix::UpdateDestinations(const PathLocation& origin,
 
     // Get the cost. The predecessor cost is cost to the end of the edge.
     // Subtract the partial remaining cost and distance along the edge.
+    // TODO - Final output of time and distance is dependent on the destinations best_cost
+    // field here but the time in seconds it takes to make a transition is not included in
+    // the final times causing discrepencies between the final times in TimeDistanceMatrix
+    // and CostMatrix. These TranstionCost times should be included.
     float remainder = dest_edge->second;
     Cost newcost = pred.cost() - (costing->EdgeCost(edge) * remainder);
     if (newcost.cost < dest.best_cost.cost) {

--- a/src/thor/timedistancematrix.cc
+++ b/src/thor/timedistancematrix.cc
@@ -629,10 +629,6 @@ bool TimeDistanceMatrix::UpdateDestinations(const PathLocation& origin,
 
     // Get the cost. The predecessor cost is cost to the end of the edge.
     // Subtract the partial remaining cost and distance along the edge.
-    // TODO - Final output of time and distance is dependent on the destinations best_cost
-    // field here but the time in seconds it takes to make a transition is not included in
-    // the final times causing discrepencies between the final times in TimeDistanceMatrix
-    // and CostMatrix. These TranstionCost times should be included.
     float remainder = dest_edge->second;
     Cost newcost = pred.cost() - (costing->EdgeCost(edge) * remainder);
     if (newcost.cost < dest.best_cost.cost) {

--- a/src/thor/worker.cc
+++ b/src/thor/worker.cc
@@ -30,33 +30,33 @@ using namespace valhalla::thor;
 namespace {
   constexpr double kMilePerMeter = 0.000621371;
 
-   std::vector<baldr::PathLocation> store_correlated_locations(const boost::property_tree::ptree& request, const std::vector<baldr::Location>& locations) {
-   //we require correlated locations
-   std::vector<baldr::PathLocation> correlated;
-   correlated.reserve(locations.size());
-   size_t i = 0;
-   do {
+  std::vector<baldr::PathLocation> store_correlated_locations(const boost::property_tree::ptree& request, const std::vector<baldr::Location>& locations) {
+    //we require correlated locations
+    std::vector<baldr::PathLocation> correlated;
+    correlated.reserve(locations.size());
+    size_t i = 0;
+    do {
      auto path_location = request.get_child_optional("correlated_" + std::to_string(i));
      if(!path_location)
        break;
-       try {
-         correlated.emplace_back(PathLocation::FromPtree(locations, *path_location));
+     try {
+       correlated.emplace_back(PathLocation::FromPtree(locations, *path_location));
 
-         auto minScoreEdge = *std::min_element (correlated.back().edges.begin(), correlated.back().edges.end(),
-            [](PathLocation::PathEdge i, PathLocation::PathEdge j)->bool {
-              return i.score < j.score;
-            });
+       auto minScoreEdge = *std::min_element (correlated.back().edges.begin(), correlated.back().edges.end(),
+          [](PathLocation::PathEdge i, PathLocation::PathEdge j)->bool {
+            return i.score < j.score;
+          });
 
-         for(auto& e : correlated.back().edges) {
-           e.score -= minScoreEdge.score;
-         }
+       for(auto& e : correlated.back().edges) {
+         e.score -= minScoreEdge.score;
        }
-       catch (...) {
-         throw valhalla_exception_t{420};
-       }
-   }while(++i);
-     return correlated;
-   }
+     }
+     catch (...) {
+       throw valhalla_exception_t{420};
+     }
+    }while(++i);
+    return correlated;
+  }
 }
 
 namespace valhalla {

--- a/test/matrix.cc
+++ b/test/matrix.cc
@@ -78,7 +78,7 @@ namespace {
       return {sec / 10.0f, sec};
     }
 
-    Cost TransitionCost(DirectedEdge* edge,
+    Cost TransitionCost(const DirectedEdge* edge,
           const NodeInfo* node,
           const EdgeLabel& pred) const {
       return {5.0f, 5.0f};
@@ -191,7 +191,8 @@ namespace {
       {"lat":52.106337,"lon":5.101728},
       {"lat":52.111276,"lon":5.089717},
       {"lat":52.103105,"lon":5.081005},
-      {"lat":52.103948,"lon":5.06813}],
+      {"lat":52.103948,"lon":5.06813}
+    ],
     "targets":[
       {"lat":52.106126,"lon":5.101497},
       {"lat":52.100469,"lon":5.087099},
@@ -203,42 +204,40 @@ namespace {
 
   std::vector<TimeDistance> cost_matrix_answers = {
       {29, 29},
-      {1858, 1803},
-      {2221, 2176},
-      {3961, 3805},
-      {1493, 1452},
-      {1689, 1639},
-      {2057, 2012},
-      {3767, 3641},
-      {2253, 2213},
-      {651, 641},
+      {1967, 1852},
+      {2329, 2225},
+      {4084, 3854},
+      {1558, 1452},
+      {1739, 1639},
+      {2102, 2012},
+      {3857, 3641},
+      {2313, 2213},
+      {686, 641},
       {0, 0},
-      {2738, 2643},
-      {5339, 5279},
-      {3757, 3707},
-      {4157, 4108},
-      {1765, 1680}
+      {2803, 2643},
+      {5529, 5279},
+      {3902, 3707},
+      {4302, 4108},
+      {1810, 1680}
   };
 
-  // TODO - when TimeDistMatrix starts to include TransitionCost in the final times it returns,
-  // these numbers below will need to be updated otherwise test will fail.
   std::vector<TimeDistance> timedist_matrix_answers = {
       {28, 28},
-      {1803, 1803},
-      {2176, 2175},
-      {3805, 3805},
-      {1398, 1397},
-      {1639, 1639},
-      {1915, 1914},
-      {3641, 3641},
-      {2098, 2097},
-      {640, 640},
+      {2027, 1837},
+      {2402, 2211},
+      {4164, 3839},
+      {1518, 1397},
+      {1809, 1639},
+      {2062, 1951},
+      {3946, 3641},
+      {2312, 2111},
+      {700, 640},
       {0,0},
-      {2627, 2626},
-      {5164, 5163},
-      {3706, 3706},
-      {4107, 4106},
-      {1680, 1679}
+      {2822, 2626},
+      {5563, 5177},
+      {3951, 3706},
+      {4367, 4106},
+      {1825, 1679}
   };
 }
 
@@ -274,7 +273,6 @@ void test_matrix() {
   CostMatrix cost_matrix;
   std::vector<TimeDistance> results;
   results = cost_matrix.SourceToTarget(correlated_s, correlated_t, reader, &costing, TravelMode::kDrive, 400000.0);
-
   for (uint32_t i = 0; i < results.size(); ++i) {
     if (results[i].dist != cost_matrix_answers[i].dist) {
       throw std::runtime_error("result " + std::to_string(i) + "'s distance is not close enough"
@@ -290,7 +288,6 @@ void test_matrix() {
 
   TimeDistanceMatrix timedist_matrix;
   results = timedist_matrix.SourceToTarget(correlated_s, correlated_t, reader, &costing, TravelMode::kDrive, 400000.0);
-
   for (uint32_t i = 0; i < results.size(); ++i) {
     if (results[i].dist != timedist_matrix_answers[i].dist) {
       throw std::runtime_error("result " + std::to_string(i) + "'s distance is not equal to"

--- a/test/matrix.cc
+++ b/test/matrix.cc
@@ -278,7 +278,7 @@ void test_matrix() {
   for (uint32_t i = 0; i < results.size(); ++i) {
     if (results[i].dist != cost_matrix_answers[i].dist) {
       throw std::runtime_error("result " + std::to_string(i) + "'s distance is not close enough"
-          " to expected value . Expected: " + std::to_string(cost_matrix_answers[i].dist)
+          " to expected value for CostMatrix. Expected: " + std::to_string(cost_matrix_answers[i].dist)
           + " Actual: " + std::to_string(results[i].dist));
     }
     if (results[i].time != cost_matrix_answers[i].time) {
@@ -293,13 +293,13 @@ void test_matrix() {
 
   for (uint32_t i = 0; i < results.size(); ++i) {
     if (results[i].dist != timedist_matrix_answers[i].dist) {
-      throw std::runtime_error("result " + std::to_string(i) + "'s distance is not close enough"
-          " to expected value . Expected: " + std::to_string(timedist_matrix_answers[i].dist)
+      throw std::runtime_error("result " + std::to_string(i) + "'s distance is not equal to"
+          " the expected value for TimeDistMatrix. Expected: " + std::to_string(timedist_matrix_answers[i].dist)
           + " Actual: " + std::to_string(results[i].dist));
     }
     if (results[i].time != timedist_matrix_answers[i].time) {
-      throw std::runtime_error("result " + std::to_string(i) + "'s time is not close enough"
-          " to expected value for CostMatrix. Expected: " + std::to_string(timedist_matrix_answers[i].time)
+      throw std::runtime_error("result " + std::to_string(i) + "'s time is not equal to"
+          " the expected value for TimeDistMatrix. Expected: " + std::to_string(timedist_matrix_answers[i].time)
           + " Actual: " + std::to_string(results[i].time));
     }
   }

--- a/test/matrix.cc
+++ b/test/matrix.cc
@@ -1,0 +1,320 @@
+#include "test.h"
+
+#include <string>
+#include <vector>
+#include <iostream>
+
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
+
+#include "thor/costmatrix.h"
+#include "thor/timedistancematrix.h"
+#include "thor/worker.h"
+#include "sif/dynamiccost.h"
+#include "loki/worker.h"
+#include "midgard/logging.h"
+
+using namespace valhalla::thor;
+using namespace valhalla::sif;
+using namespace valhalla::loki;
+using namespace valhalla::baldr;
+using namespace valhalla::midgard;
+using namespace valhalla::tyr;
+
+namespace {
+
+  // Quick costing class derived for testing so that any changes to regular costing
+  // won't change the outcome of the tests. Some of the logic for this class is just
+  // copy pasted from AutoCost as it stands when this test was written.
+  class SimpleCost final : public DynamicCost {
+  public:
+
+    SimpleCost(const boost::property_tree::ptree& pt)
+        : DynamicCost (pt, TravelMode::kDrive){}
+
+    ~SimpleCost() {}
+
+    uint32_t access_mode() const {
+      return kAutoAccess;
+    }
+
+    bool Allowed(const DirectedEdge* edge,
+          const EdgeLabel& pred,
+          const GraphTile*& tile,
+          const GraphId& edgeid) const {
+      if (!(edge->forwardaccess() & kAutoAccess) ||
+          (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
+          (pred.restrictions() & (1 << edge->localedgeidx())) ||
+           edge->surface() == Surface::kImpassable ||
+           IsUserAvoidEdge(edgeid) ||
+          (!allow_destination_only_ && !pred.destonly() && edge->destonly())) {
+        return false;
+      }
+      return true;
+    }
+
+    bool AllowedReverse(const DirectedEdge* edge,
+          const EdgeLabel& pred,
+          const DirectedEdge* opp_edge,
+          const GraphTile*& tile,
+          const GraphId& opp_edgeid) const {
+      if (!(opp_edge->forwardaccess() & kAutoAccess) ||
+           (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
+           (opp_edge->restrictions() & (1 << pred.opp_local_idx())) ||
+            opp_edge->surface() == Surface::kImpassable ||
+            IsUserAvoidEdge(opp_edgeid) ||
+           (!allow_destination_only_ && !pred.destonly() && opp_edge->destonly())) {
+        return false;
+      }
+      return true;
+    }
+
+    bool Allowed(const NodeInfo* node) const {
+      return (node->access() & kAutoAccess);
+    }
+
+    Cost EdgeCost(const DirectedEdge* edge) const {
+      float sec = static_cast<float>(edge->length());
+      return {sec / 10.0f, sec};
+    }
+
+    Cost TransitionCost(DirectedEdge* edge,
+          const NodeInfo* node,
+          const EdgeLabel& pred) const {
+      return {5.0f, 5.0f};
+    }
+
+    Cost TransitionCostReverse(const uint32_t idx,
+          const NodeInfo* node,
+          const DirectedEdge* opp_edge,
+          const DirectedEdge* opp_pred_edge) const {
+      return {5.0f, 5.0f};
+    }
+
+    float AStarCostFactor() const {
+      return 0.1f;
+    }
+
+    const EdgeFilter GetEdgeFilter() const {
+      return [](const DirectedEdge* edge) {
+        if (edge->IsTransition() || edge->is_shortcut() ||
+           !(edge->forwardaccess() & kAutoAccess))
+          return 0.0f;
+        else {
+          return 1.0f;
+        }
+      };
+    }
+
+    const NodeFilter GetNodeFilter() const {
+      return [](const NodeInfo* node){
+        return !(node->access() & kAutoAccess);
+      };
+    }
+
+  };
+
+  cost_ptr_t CreateSimpleCost (const boost::property_tree::ptree& pt) {
+    return std::make_shared<SimpleCost> (pt);
+  }
+
+
+  boost::property_tree::ptree json_to_pt(const std::string& json) {
+    std::stringstream ss; ss << json;
+    boost::property_tree::ptree pt;
+    boost::property_tree::read_json(ss, pt);
+    return pt;
+  }
+
+  rapidjson::Document to_document(const std::string& request) {
+    rapidjson::Document d;
+    auto& allocator = d.GetAllocator();
+    d.Parse(request.c_str());
+    if (d.HasParseError())
+      throw valhalla::valhalla_exception_t{100};
+    return d;
+  }
+  std::vector<PathLocation> store_correlated_locations(const boost::property_tree::ptree& request, const std::vector<Location>& locations) {
+    //we require correlated locations
+    std::vector<PathLocation> correlated;
+    correlated.reserve(locations.size());
+    size_t i = 0;
+    do {
+     auto path_location = request.get_child_optional("correlated_" + std::to_string(i));
+     if(!path_location)
+       break;
+     try {
+       correlated.emplace_back(PathLocation::FromPtree(locations, *path_location));
+
+       auto minScoreEdge = *std::min_element (correlated.back().edges.begin(), correlated.back().edges.end(),
+          [](PathLocation::PathEdge i, PathLocation::PathEdge j)->bool {
+            return i.score < j.score;
+          });
+
+       for(auto& e : correlated.back().edges) {
+         e.score -= minScoreEdge.score;
+       }
+     }
+     catch (...) {
+       throw valhalla::valhalla_exception_t{420};
+     }
+    }while(++i);
+    return correlated;
+  }
+
+  const auto config = json_to_pt(R"({
+    "mjolnir":{"tile_dir":"test/data/utrecht_tiles", "concurrency": 1},
+    "loki":{
+      "actions":["one_to_many","many_to_one","many_to_many","sources_to_targets"],
+      "logging":{"long_request": 100},
+      "service_defaults":{"minimum_reachability": 50,"radius": 0}
+    },
+    "service_limits": {
+      "auto": {"max_distance": 5000000.0, "max_locations": 20,"max_matrix_distance": 400000.0,"max_matrix_locations": 50},
+      "auto_shorter": {"max_distance": 5000000.0,"max_locations": 20,"max_matrix_distance": 400000.0,"max_matrix_locations": 50},
+      "bicycle": {"max_distance": 500000.0,"max_locations": 50,"max_matrix_distance": 200000.0,"max_matrix_locations": 50},
+      "bus": {"max_distance": 5000000.0,"max_locations": 50,"max_matrix_distance": 400000.0,"max_matrix_locations": 50},
+      "hov": {"max_distance": 5000000.0,"max_locations": 20,"max_matrix_distance": 400000.0,"max_matrix_locations": 50},
+      "isochrone": {"max_contours": 4,"max_distance": 25000.0,"max_locations": 1,"max_time": 120},
+      "max_avoid_locations": 50,"max_radius": 200,"max_reachability": 100,
+      "multimodal": {"max_distance": 500000.0,"max_locations": 50,"max_matrix_distance": 0.0,"max_matrix_locations": 0},
+      "pedestrian": {"max_distance": 250000.0,"max_locations": 50,"max_matrix_distance": 200000.0,"max_matrix_locations": 50,"max_transit_walking_distance": 10000,"min_transit_walking_distance": 1},
+      "skadi": {"max_shape": 750000,"min_resample": 10.0},
+      "trace": {"max_distance": 200000.0,"max_gps_accuracy": 100.0,"max_search_radius": 100,"max_shape": 16000,"max_best_paths":4,"max_best_paths_shape":100},
+      "transit": {"max_distance": 500000.0,"max_locations": 50,"max_matrix_distance": 200000.0,"max_matrix_locations": 50},
+      "truck": {"max_distance": 5000000.0,"max_locations": 20,"max_matrix_distance": 400000.0,"max_matrix_locations": 50}
+    }
+  })");
+
+  const auto test_request = R"({
+    "sources":[
+      {"lat":52.106337,"lon":5.101728},
+      {"lat":52.111276,"lon":5.089717},
+      {"lat":52.103105,"lon":5.081005},
+      {"lat":52.103948,"lon":5.06813}],
+    "targets":[
+      {"lat":52.106126,"lon":5.101497},
+      {"lat":52.100469,"lon":5.087099},
+      {"lat":52.103105,"lon":5.081005},
+      {"lat":52.094273,"lon":5.075254}
+    ],
+    "costing":"auto"
+  })";
+
+  std::vector<TimeDistance> cost_matrix_answers = {
+      {29, 29},
+      {1858, 1803},
+      {2221, 2176},
+      {3961, 3805},
+      {1493, 1452},
+      {1689, 1639},
+      {2057, 2012},
+      {3767, 3641},
+      {2253, 2213},
+      {651, 641},
+      {0, 0},
+      {2738, 2643},
+      {5339, 5279},
+      {3757, 3707},
+      {4157, 4108},
+      {1765, 1680}
+  };
+
+  // TODO - when TimeDistMatrix starts to include TransitionCost in the final times it returns,
+  // these numbers below will need to be updated otherwise test will fail.
+  std::vector<TimeDistance> timedist_matrix_answers = {
+      {28, 28},
+      {1803, 1803},
+      {2176, 2175},
+      {3805, 3805},
+      {1398, 1397},
+      {1639, 1639},
+      {1915, 1914},
+      {3641, 3641},
+      {2098, 2097},
+      {640, 640},
+      {0,0},
+      {2627, 2626},
+      {5164, 5163},
+      {3706, 3706},
+      {4107, 4106},
+      {1680, 1679}
+  };
+}
+
+void test_matrix() {
+  loki_worker_t loki_worker (config);
+
+  auto request_doc = to_document(test_request);
+  loki_worker.matrix (SOURCES_TO_TARGETS, request_doc);
+
+  auto request_pt = json_to_pt (rapidjson::to_string(request_doc));
+
+  auto request_sources = request_pt.get_child_optional("sources");
+  auto request_targets = request_pt.get_child_optional("targets");
+  std::vector<Location> locations;
+
+  for(const auto& s : *request_sources) {
+    try{ locations.push_back(Location::FromPtree(s.second)); }
+    catch (...) { throw valhalla::valhalla_exception_t{422}; }
+  }
+  for(const auto& t : *request_targets) {
+    try{ locations.push_back(Location::FromPtree(t.second)); }
+    catch (...) { throw valhalla::valhalla_exception_t{423}; }
+  }
+  std::vector<PathLocation> correlated = store_correlated_locations (request_pt, locations);
+
+  std::vector<PathLocation> correlated_s (correlated.begin(), correlated.begin() + request_sources->size());
+  std::vector<PathLocation> correlated_t (correlated.begin() + request_sources->size(), correlated.end());
+
+  GraphReader reader (config.get_child("mjolnir"));
+
+  cost_ptr_t costing = CreateSimpleCost(request_pt);
+
+  CostMatrix cost_matrix;
+  std::vector<TimeDistance> results;
+  results = cost_matrix.SourceToTarget(correlated_s, correlated_t, reader, &costing, TravelMode::kDrive, 400000.0);
+
+  for (uint32_t i = 0; i < results.size(); ++i) {
+    if (results[i].dist != cost_matrix_answers[i].dist) {
+      throw std::runtime_error("result " + std::to_string(i) + "'s distance is not close enough"
+          " to expected value . Expected: " + std::to_string(cost_matrix_answers[i].dist)
+          + " Actual: " + std::to_string(results[i].dist));
+    }
+    if (results[i].time != cost_matrix_answers[i].time) {
+      throw std::runtime_error("result " + std::to_string(i) + "'s time is not close enough"
+          " to expected value for CostMatrix. Expected: " + std::to_string(cost_matrix_answers[i].time)
+          + " Actual: " + std::to_string(results[i].time));
+    }
+  }
+
+  TimeDistanceMatrix timedist_matrix;
+  results = timedist_matrix.SourceToTarget(correlated_s, correlated_t, reader, &costing, TravelMode::kDrive, 400000.0);
+
+  for (uint32_t i = 0; i < results.size(); ++i) {
+    if (results[i].dist != timedist_matrix_answers[i].dist) {
+      throw std::runtime_error("result " + std::to_string(i) + "'s distance is not close enough"
+          " to expected value . Expected: " + std::to_string(timedist_matrix_answers[i].dist)
+          + " Actual: " + std::to_string(results[i].dist));
+    }
+    if (results[i].time != timedist_matrix_answers[i].time) {
+      throw std::runtime_error("result " + std::to_string(i) + "'s time is not close enough"
+          " to expected value for CostMatrix. Expected: " + std::to_string(timedist_matrix_answers[i].time)
+          + " Actual: " + std::to_string(results[i].time));
+    }
+  }
+
+}
+
+void test_timedist_matrix() {
+
+}
+
+int main(int argc, char* argv[]) {
+  test::suite suite ("matrix");
+  logging::Configure({{"type", ""}}); //silence logs
+
+  suite.test(TEST_CASE(test_matrix));
+
+  return suite.tear_down();
+}

--- a/test/matrix.cc
+++ b/test/matrix.cc
@@ -306,10 +306,6 @@ void test_matrix() {
 
 }
 
-void test_timedist_matrix() {
-
-}
-
 int main(int argc, char* argv[]) {
   test::suite suite ("matrix");
   logging::Configure({{"type", ""}}); //silence logs


### PR DESCRIPTION
Added a simple derived costing class in the test file for use in the matrix calls so that any changes in actual costing classes will not affect the tests. Uses the test utrecht tile data. This should close issue #759 (unless we want to keep it open for even more tests to be added)