### PR TITLE
sqlite fix

### DIFF
--- a/src/mjolnir/valhalla_build_admins.cc
+++ b/src/mjolnir/valhalla_build_admins.cc
@@ -459,6 +459,8 @@ void BuildAdminFromPBF(const boost::property_tree::ptree& pt,
         std::unique_ptr<Geometry> mline (gf->createMultiLineString(lines.release()));
         std::vector<std::string> wkts = GetWkts(mline);
         std::string name;
+        std::string name_en;
+        std::string iso;
 
         for (const auto& wkt : wkts) {
 
@@ -468,8 +470,8 @@ void BuildAdminFromPBF(const boost::property_tree::ptree& pt,
           sqlite3_bind_int (stmt, 1, admin.admin_level());
 
           if (admin.iso_code_index()) {
-            name = osmdata.name_offset_map.name(admin.iso_code_index());
-            sqlite3_bind_text (stmt, 2, name.c_str(), name.length(), SQLITE_STATIC);
+            iso = osmdata.name_offset_map.name(admin.iso_code_index());
+            sqlite3_bind_text (stmt, 2, iso.c_str(), iso.length(), SQLITE_STATIC);
           }
           else
             sqlite3_bind_null(stmt,2);
@@ -480,8 +482,8 @@ void BuildAdminFromPBF(const boost::property_tree::ptree& pt,
           sqlite3_bind_text (stmt, 4, name.c_str(), name.length(), SQLITE_STATIC);
 
           if (admin.name_en_index()) {
-            name = osmdata.name_offset_map.name(admin.name_en_index());
-            sqlite3_bind_text (stmt, 5, name.c_str(), name.length(), SQLITE_STATIC);
+            name_en = osmdata.name_offset_map.name(admin.name_en_index());
+            sqlite3_bind_text (stmt, 5, name_en.c_str(), name_en.length(), SQLITE_STATIC);
           }
           else
             sqlite3_bind_null(stmt,5);


### PR DESCRIPTION
Can not reuse var for multiple binds unless you use sqlite_transient vs sqlite_static for bind function; otherwise, the string object will be updated before the query gets called and finalized.  This can cause garbage in the database.

Fixes #877 via the latest planet file.

Testing with Belgium
Before:
spatialite> select * from admins;
4|>||Brussels-Capital|Brussels-Capital|1|
4|Wal||Wallonia|Wallonia|1|
spatialite> 

After:
spatialite> select * from admins;
4|BRU||Région de Bruxelles-Capitale - Brussels Hoofdstedelijk Gewest|Brussels-Capital|1|
4|WAL||Wallonie|Wallonia|1|
spatialite> 

