### PR TITLE
Reserve 6 extra bits for admin index.

### DIFF
--- a/valhalla/baldr/nodeinfo.h
+++ b/valhalla/baldr/nodeinfo.h
@@ -352,7 +352,7 @@ class NodeInfo {
   uint32_t type_               : 4;  // NodeType, see graphconstants
   uint32_t mode_change_        : 1;  // Mode change allowed?
   uint32_t traffic_signal_     : 1;  // Traffic signal
-  uint32_t spare_1             : 6;
+  uint32_t admin_index_ext_    : 6;  // Extended admin index
 
   // Transit stop index (for transit level) / name consistency for all
   // other levels


### PR DESCRIPTION
Combined with the existing admin index this can allow 4096 unique admin records. This can be used to extend to add city or county level information. Work to add information and combine the 2 admin index parts together is TBD, for now just reserving the bits within the NodeInfo structure.

@noblige 