### PR TITLE
Isochrone fix

### DIFF
--- a/src/thor/isochrone.cc
+++ b/src/thor/isochrone.cc
@@ -942,8 +942,9 @@ void Isochrone::SetOriginLocations(GraphReader& graphreader,
 
       // We need to penalize this location based on its score (distance in meters from input)
       // We assume the slowest speed you could travel to cover that distance to start/end the route
-      // TODO: assumes 1m/s which is a maximum penalty this could vary per costing model
-      cost.cost += edge.score;
+      // TODO: high edge scores cause issues as there is code to limit cost so
+      // that large penalties (e.g., ferries) are excluded.
+      cost.cost += edge.score * 0.005f;
 
       // Add EdgeLabel to the adjacency list (but do not set its status).
       // Set the predecessor edge index to invalid to indicate the origin

--- a/src/thor/worker.cc
+++ b/src/thor/worker.cc
@@ -53,7 +53,6 @@ namespace {
        for(auto& e : correlated.back().edges) {
          e.score -= minScoreEdge.score;
          if (e.score > kMaxScore) {
-           printf("Exceeds max score: %f\n", e.score);
            e.score = kMaxScore;
          }
        }

--- a/valhalla/thor/isochrone.h
+++ b/valhalla/thor/isochrone.h
@@ -163,11 +163,11 @@ class Isochrone {
    * @param  pred         Predecessor edge label (edge being settled).
    * @param  graphreader  Graph reader
    * @param  ll           Lat,lon at the end of the edge.
-   *
+   * @param  secs0        Seconds at start of the edge.
    */
   void UpdateIsoTile(const sif::EdgeLabel& pred,
                      baldr::GraphReader& graphreader,
-                     const midgard::PointLL& ll);
+                     const midgard::PointLL& ll, const float secs0);
 
   /**
    * Add edge(s) at each origin location to the adjacency list.
@@ -176,6 +176,16 @@ class Isochrone {
    * @param  costing           Dynamic costing.
    */
   void SetOriginLocations(baldr::GraphReader& graphreader,
+                  std::vector<baldr::PathLocation>& origin_locations,
+                  const std::shared_ptr<sif::DynamicCost>& costing);
+
+  /**
+   * Add edge(s) at each origin location to the adjacency list.
+   * @param  graphreader       Graph tile reader.
+   * @param  origin_locations  Location information for origins.
+   * @param  costing           Dynamic costing.
+   */
+  void SetOriginLocationsMM(baldr::GraphReader& graphreader,
                   std::vector<baldr::PathLocation>& origin_locations,
                   const std::shared_ptr<sif::DynamicCost>& costing);
 


### PR DESCRIPTION
High edge scores were triggering the code that limits highly penalized edges. This resulted in small, rectangular isochrones when the closest edge does not connect with the rest of the network.