### PR TITLE
Retry with filtered edges when get path failed.

### DIFF
--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -658,8 +658,23 @@ struct bin_handler_t {
         correlated.edges.erase(new_end, correlated.edges.end());
       }
 
+
+      // Store filtered edges for retry in case find path with correlated.edges failed.
+
+      // We will also add penalty to the score of filtered edges, so as to handle the
+      // case low score filtered_edges VS high score good heading edges during retry.
+      // We use max score of the correlated.edgesfor penalty.
+      float penalty = 0;
+      for (const auto &edge : correlated.edges) {
+        penalty = std::max(edge.score, penalty);
+      }
+      for (auto &filtered_edge : filtered) {
+        filtered_edge.score = filtered_edge.score + penalty;
+        correlated.filtered_edges.push_back(std::move(filtered_edge));
+      }
+
       //if we found nothing that is no good but if its batch maybe throwing makes no sense?
-      if(correlated.edges.size() != 0)
+      if(correlated.edges.size() != 0 || correlated.filtered_edges.size() != 0)
         searched.insert({pp.location, correlated});
     }
     //give back all the results

--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -640,12 +640,14 @@ struct bin_handler_t {
           correlate_edge(pp.location, candidate, correlated, filtered);
         }
       }
-
+      
       //if we have nothing because of heading we'll just ignore it
-      if(correlated.edges.size() == 0 && filtered.size())
+      if(correlated.edges.size() == 0 && filtered.size()) {
         for(auto& path_edge : filtered)
           if(correlated_edges.insert(path_edge.id).second)
             correlated.edges.push_back(std::move(path_edge));
+        filtered.clear();
+      }
 
       //if it was a through location with a heading its pretty confusing.
       //does the user want to come into and exit the location at the preferred
@@ -657,21 +659,16 @@ struct bin_handler_t {
           [](const PathLocation::PathEdge& e) { return e.end_node(); });
         correlated.edges.erase(new_end, correlated.edges.end());
       }
-
-
-      // Store filtered edges for retry in case find path with correlated.edges failed.
-
-      // We will also add penalty to the score of filtered edges, so as to handle the
-      // case low score filtered_edges VS high score good heading edges during retry.
-      // We use max score of the correlated.edgesfor penalty.
-      float penalty = 0;
-      for (const auto &edge : correlated.edges) {
-        penalty = std::max(edge.score, penalty);
-      }
-      for (auto &filtered_edge : filtered) {
-        filtered_edge.score = filtered_edge.score + penalty;
-        correlated.filtered_edges.push_back(std::move(filtered_edge));
-      }
+      
+      //keep filtered edges for retry in case we cant find a route non filtered edges
+      //use the max score of the non filtered edges as a penality increase on each of the
+      //filtered edges so that when finding a route using non filtered edges fails the
+      //use of filtered edges are always penalized higher than the non filtered ones
+      auto max = std::max_element(correlated.edges.begin(), correlated.edges.end(),
+        [](const PathLocation::PathEdge& a, const PathLocation::PathEdge& b){ return a.score < b.score; });
+      std::for_each(filtered.begin(), filtered.end(), [&max](PathLocation::PathEdge& e){ e.score += max->score;});
+      correlated.filtered_edges.insert(correlated.filtered_edges.end(), std::make_move_iterator(filtered.begin()),
+        std::make_move_iterator(filtered.end()));
 
       //if we found nothing that is no good but if its batch maybe throwing makes no sense?
       if(correlated.edges.size() != 0 || correlated.filtered_edges.size() != 0)

--- a/src/thor/route_action.cc
+++ b/src/thor/route_action.cc
@@ -66,7 +66,12 @@ namespace valhalla {
     // If path is not found try again with relaxed limits (if allowed)
     if (path.empty()) {
       if (cost->AllowMultiPass()) {
-        // 2nd pass. Less aggressive hierarchy transitioning.
+        // 2nd pass. Less aggressive hierarchy transitioning, and retry with more candidate edges(filterd by heading in loki).
+
+        // add filtered edges to candidate edges for origin and destination
+        origin.edges.insert(origin.edges.end(), origin.filtered_edges.begin(), origin.filtered_edges.end());
+        destination.edges.insert(destination.edges.end(), destination.filtered_edges.begin(), destination.filtered_edges.end());
+
         path_algorithm->Clear();
         bool using_astar = (path_algorithm == &astar);
         float relax_factor = using_astar ? 16.0f : 8.0f;

--- a/valhalla/baldr/pathlocation.h
+++ b/valhalla/baldr/pathlocation.h
@@ -54,6 +54,10 @@ struct PathLocation : public Location {
   //list of edges this location appears on within the graph
   std::vector<PathEdge> edges;
 
+  //list of edges this location appears on within the graph but are filtered because of heading or
+  //something else, used for get_path retry when thor_worker_t::get_path with PathLocation.edges failed
+  std::vector<PathEdge> filtered_edges;
+
   /**
    * Equality check
    * @return true if they are equal
@@ -61,16 +65,13 @@ struct PathLocation : public Location {
   bool operator==(const PathLocation& other) const;
 
   /**
-   * Serializes this object to ptree
-   * @return ptree
-   */
-  boost::property_tree::ptree ToPtree(size_t index) const;
-
-  /**
    * Serializes this object to rapidjson
    * @return rapidjson::Value
    */
   rapidjson::Value ToRapidJson(size_t index, rapidjson::Document::AllocatorType& allocator) const;
+
+  // Serialize this edge to rapidjson
+  rapidjson::Value PathEdgeToRapidJson(const PathEdge &edge, rapidjson::Document::AllocatorType& allocator) const;
 
   /**
    * Serializes one of these objects from a ptree and a list of locations


### PR DESCRIPTION
#### Store filtered_edges in PathLocation, and retry with filtered edges when get path failed
- add field ```filtered_edges``` to ```PathLocation``` to store edges filtered out by ```heading filter```
- add and restructure ```ptree/json (de)serialization handlers``` for ```edges & filtered_edges in PathLocation::PathEdge```
- add logic in ```loki_worker_t::bin_handler_t::finalize``` to return ```filtered_edges```(with penalty) with correlated edges result
  - add penalty to ```filtered_edges``` for the case ```original result edges``` with **high score** VS ```filtered edges``` with **low score** when retry
- add logic in ```thor_worker_t::get_path``` to **retry get_path with unfiltered edges in 2nd PASS** if first get_path attempt failed

This PR adds a retry in ```thor_worker_t::get_path``` such that when the original ```get_path``` logic failed, it would retry by searching with all ```candidate edges``` (including the ones filtered by heading). 

When finding ```correlated edges``` in ```Loki``` module, some of the ```correlated_edges``` of origin and destination would be filtered by ```heading_filter```, and thor_worker_t::get_path failed with the remaining edges. And sometimes will result in ```get_path``` failure due to **all reachable edges** are filtered by heading, while some **unreachable edges** with good heading are returned when getting candidate edges in ```loki```. By retrying again with filtered edges when 1st attempt in ```get_path``` failed, this retry reduced request failures while not breaking the original get_path logic. In addition, this retry will also make some of the previously failed requests succeed by ```get_path``` with more candidate edges(*i.e*. **starting edge of origin leads to a deadend where valhalla cannot make a legal u-turn**).