### PR TITLE
Fix penalty being ignored when max score of correlatedEdges too small

### DIFF
--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -640,7 +640,7 @@ struct bin_handler_t {
           correlate_edge(pp.location, candidate, correlated, filtered);
         }
       }
-      
+
       //if we have nothing because of heading we'll just ignore it
       if(correlated.edges.size() == 0 && filtered.size()) {
         for(auto& path_edge : filtered)
@@ -659,14 +659,14 @@ struct bin_handler_t {
           [](const PathLocation::PathEdge& e) { return e.end_node(); });
         correlated.edges.erase(new_end, correlated.edges.end());
       }
-      
+
       //keep filtered edges for retry in case we cant find a route non filtered edges
       //use the max score of the non filtered edges as a penality increase on each of the
       //filtered edges so that when finding a route using non filtered edges fails the
       //use of filtered edges are always penalized higher than the non filtered ones
       auto max = std::max_element(correlated.edges.begin(), correlated.edges.end(),
         [](const PathLocation::PathEdge& a, const PathLocation::PathEdge& b){ return a.score < b.score; });
-      std::for_each(filtered.begin(), filtered.end(), [&max](PathLocation::PathEdge& e){ e.score += max->score;});
+      std::for_each(filtered.begin(), filtered.end(), [&max](PathLocation::PathEdge& e){ e.score += (3600.0f + max->score);});
       correlated.filtered_edges.insert(correlated.filtered_edges.end(), std::make_move_iterator(filtered.begin()),
         std::make_move_iterator(filtered.end()));
 


### PR DESCRIPTION
@noblige @smWork @yzadik @kevinkreiser @dnesbitt61  
This PR is to fix ```penalty``` being ignored when ```max score``` of ```correlated edges``` is **too small** comparing to the ```difference in edge cost and distance```, causing ```filtered_edges``` being chosen before ```correlated_edges```, so as to improve the start edge used in 2nd pass.

<img width="792" alt="screen shot 2017-08-24 at 10 41 21 pm" src="https://user-images.githubusercontent.com/31260061/29700965-7c420f34-891d-11e7-90a6-5e39739effc0.png">

As shown above, when sorting the ```PathEdge``` of origin and destination, the cost of an candidate is a combination of their ```edgecost, distance and score```. In the case when the ```penalty```(max score of correlated edges) added to ```filtered_edges``` is too small, this would still result in ```filtered_edges``` still be chosen before ```correlated edges```, because the ```penalty``` added to the ```filtered_edges``` is too small comparing to the difference in edgecost and distance. Therefore we need to add some number like ```3600``` to the max score of correlated edges for penalty to offset the difference, and below is an example demonstrated the difference.

On a horizontal road, a start point is used to get route with heading 119, in this case for the edges to its left(```filtered_edge```) and the edges to its right(```correlated_edge```), it should choose the ```correlated edge``` to start.

With only max score(1.778) of the correlated edges added to the penalty, the ```getBestPath``` chose the ```filtered_edge``` instead of the ```correlated edge```
![screen shot 2017-08-24 at 5 13 38 pm](https://user-images.githubusercontent.com/31260061/29695011-e9d64e9e-88f4-11e7-9771-ba5bb5acaac8.png)

With (max score + 3600) added to the penalty, the ```getBestPath``` chose the correlated_edge to start as expected.
![screen shot 2017-08-24 at 5 10 09 pm](https://user-images.githubusercontent.com/31260061/29695019-f3915bae-88f4-11e7-8d59-e30aeb85e656.png)
