### PR TITLE
Pedestrian A* fix

### DIFF
--- a/src/sif/dynamiccost.cc
+++ b/src/sif/dynamiccost.cc
@@ -7,7 +7,8 @@ namespace sif {
 
 DynamicCost::DynamicCost(const boost::property_tree::ptree& pt,
                          const TravelMode mode)
-    : allow_transit_connections_(false),
+    : pass_(0),
+      allow_transit_connections_(false),
       allow_destination_only_(true),
       travel_mode_(mode) {
   // Parse property tree to get hierarchy limits

--- a/src/thor/astar.cc
+++ b/src/thor/astar.cc
@@ -42,6 +42,9 @@ void AStarPathAlgorithm::Clear() {
 
   // Clear the edge status flags
   edgestatus_.reset();
+
+  // Set the ferry flag to false
+  has_ferry_ = false;
 }
 
 // Initialize prior to finding best path
@@ -468,6 +471,11 @@ std::vector<PathInfo> AStarPathAlgorithm::FormPath(const uint32_t dest) {
     const EdgeLabel& edgelabel = edgelabels_[edgelabel_index];
     path.emplace_back(edgelabel.mode(), edgelabel.cost().secs,
                       edgelabel.edgeid(), 0);
+
+    // Check if this is a ferry
+    if (edgelabel.use() == Use::kFerry) {
+      has_ferry_ = true;
+    }
   }
 
   // Reverse the list and return

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -50,6 +50,9 @@ void BidirectionalAStar::Clear() {
   adjacencylist_reverse_.reset();
   edgestatus_forward_.reset();
   edgestatus_reverse_.reset();
+
+  // Set the ferry flag to false
+  has_ferry_ = false;
 }
 
 // Initialize the A* heuristic and adjacency lists for both the forward
@@ -670,6 +673,11 @@ std::vector<PathInfo> BidirectionalAStar::FormPath(GraphReader& graphreader) {
     const BDEdgeLabel& edgelabel = edgelabels_forward_[edgelabel_index];
     path.emplace_back(edgelabel.mode(), edgelabel.cost().secs,
                       edgelabel.edgeid(), 0);
+
+    // Check if this is a ferry
+    if (edgelabel.use() == Use::kFerry) {
+      has_ferry_ = true;
+    }
   }
 
   // Reverse the list
@@ -714,6 +722,11 @@ std::vector<PathInfo> BidirectionalAStar::FormPath(GraphReader& graphreader) {
     }
     secs += tc;
     path.emplace_back(edgelabel.mode(), secs, oppedge, 0);
+
+    // Check if this is a ferry
+    if (edgelabel.use() == Use::kFerry) {
+      has_ferry_ = true;
+    }
 
     // Update edgelabel_index and transition cost to apply at next iteration
     edgelabel_index = predidx;

--- a/src/thor/multimodal.cc
+++ b/src/thor/multimodal.cc
@@ -95,6 +95,9 @@ void MultiModalPathAlgorithm::Clear() {
 
   // Clear the edge status flags
   edgestatus_.reset();
+
+  // Set the ferry flag to false
+  has_ferry_ = false;
 }
 
 
@@ -800,6 +803,11 @@ std::vector<PathInfo> MultiModalPathAlgorithm::FormPath(const uint32_t dest) {
     const MMEdgeLabel& edgelabel = edgelabels_[edgelabel_index];
     path.emplace_back(edgelabel.mode(), edgelabel.cost().secs,
                       edgelabel.edgeid(), edgelabel.tripid());
+
+    // Check if this is a ferry
+    if (edgelabel.use() == Use::kFerry) {
+      has_ferry_ = true;
+    }
   }
 
   // Reverse the list and return

--- a/src/thor/route_action.cc
+++ b/src/thor/route_action.cc
@@ -53,7 +53,7 @@ namespace valhalla {
   }
 
   std::vector<thor::PathInfo> thor_worker_t::get_path(PathAlgorithm* path_algorithm, baldr::PathLocation& origin,
-      baldr::PathLocation& destination) {
+      baldr::PathLocation& destination, const std::string& costing) {
     // Find the path. If bidirectional A* disable use of destination only
     // edges on the first pass. If there is a failure, we allow them on the
     // second pass.
@@ -61,13 +61,17 @@ namespace valhalla {
     if (path_algorithm == &bidir_astar) {
       cost->set_allow_destination_only(false);
     }
+    cost->set_pass(0);
     auto path = path_algorithm->GetBestPath(origin, destination, reader,
                                              mode_costing, mode);
+
     // If path is not found try again with relaxed limits (if allowed)
-    if (path.empty()) {
+    if (path.empty() ||
+        (costing == "pedestrian" && path_algorithm->has_ferry())) {
       if (cost->AllowMultiPass()) {
         // 2nd pass. Less aggressive hierarchy transitioning.
         path_algorithm->Clear();
+        cost->set_pass(1);
         bool using_astar = (path_algorithm == &astar);
         float relax_factor = using_astar ? 16.0f : 8.0f;
         float expansion_within_factor = using_astar ? 4.0f : 2.0f;
@@ -108,7 +112,7 @@ namespace valhalla {
       }
 
       // Get best path and keep it
-      auto temp_path = get_path(path_algorithm, *origin, *destination);
+      auto temp_path = get_path(path_algorithm, *origin, *destination, costing);
       temp_path.swap(path);
 
       // Merge through legs by updating the time and splicing the lists
@@ -173,7 +177,7 @@ namespace valhalla {
       }
 
       // Get best path and keep it
-      auto temp_path = get_path(path_algorithm, *origin, *destination);
+      auto temp_path = get_path(path_algorithm, *origin, *destination, costing);
 
       // Merge through legs by updating the time and splicing the lists
       if(!path.empty()) {

--- a/src/valhalla_run_route.cc
+++ b/src/valhalla_run_route.cc
@@ -87,15 +87,19 @@ TripPath PathTest(GraphReader& reader, PathLocation& origin,
                   const std::shared_ptr<DynamicCost>* mode_costing,
                   const TravelMode mode, PathStatistics& data,
                   bool multi_run, uint32_t iterations,
-                  bool using_astar, bool match_test) {
+                  bool using_astar, bool match_test,
+                  const std::string& routetype) {
   auto t1 = std::chrono::high_resolution_clock::now();
   std::vector<PathInfo> pathedges;
   pathedges = pathalgorithm->GetBestPath(origin, dest, reader, mode_costing, mode);
   cost_ptr_t cost = mode_costing[static_cast<uint32_t>(mode)];
+  cost->set_pass(0);
   data.incPasses();
-  if (pathedges.size() == 0) {
+  if (pathedges.size() == 0 ||
+      (routetype == "pedestrian" && pathalgorithm->has_ferry())) {
     if (cost->AllowMultiPass()) {
       LOG_INFO("Try again with relaxed hierarchy limits");
+      cost->set_pass(1);
       pathalgorithm->Clear();
       float relax_factor = (using_astar) ? 16.0f : 8.0f;
       float expansion_within_factor = (using_astar) ? 4.0f : 2.0f;
@@ -705,7 +709,7 @@ int main(int argc, char *argv[]) {
     try {
       trip_path = PathTest(reader, path_location[i], path_location[i + 1],
                            pathalgorithm, mode_costing, mode, data, multi_run,
-                           iterations, using_astar, match_test);
+                           iterations, using_astar, match_test, routetype);
     } catch (std::runtime_error& rte) {
       LOG_ERROR("trip_path not found");
     }

--- a/valhalla/baldr/graphconstants.h
+++ b/valhalla/baldr/graphconstants.h
@@ -71,6 +71,9 @@ constexpr uint32_t kMaxDensity = 15;
 // clamped to this maximum value.
 constexpr uint32_t kMaxSpeedKph = 140;      // ~85 MPH
 
+// Maximum ferry speed
+constexpr uint32_t kMaxFerrySpeedKph = 40;  // 21 knots
+
 // Road class or importance of an edge
 enum class RoadClass : uint8_t {
   kMotorway = 0,

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -71,6 +71,22 @@ class DynamicCost {
   virtual bool AllowMultiPass() const;
 
   /**
+   * Get the pass number.
+   * @return  Returns the pass through the algorithm.
+   */
+  uint32_t pass() const {
+    return pass_;
+  }
+
+  /**
+   * Set the pass number.
+   * @param  pass  Pass number (incremental).
+   */
+  void set_pass(const uint32_t pass) {
+    pass_ = pass;
+  }
+
+  /**
    * Returns the maximum transfer distance between stops that you are willing
    * to travel for this mode.  It is the max distance you are willing to
    * travel between transfers.
@@ -409,6 +425,9 @@ class DynamicCost {
   }
 
  protected:
+  // Algorithm pass
+  uint32_t pass_;
+
   // Flag indicating whether transit connections are allowed.
   bool allow_transit_connections_;
 

--- a/valhalla/sif/hierarchylimits.h
+++ b/valhalla/sif/hierarchylimits.h
@@ -91,10 +91,14 @@ struct HierarchyLimits {
 
   /**
    * Relax hierarchy limits to try to find a route when initial attempt fails.
+   * Do not relax limits if they are unlimited (bicycle and pedestrian for
+   * example).
    */
   void Relax(const float factor, const float expansion_within_factor) {
-    max_up_transitions *= factor;
-    expansion_within_dist *= expansion_within_factor;
+    if (max_up_transitions != kUnlimitedTransitions) {
+      max_up_transitions *= factor;
+      expansion_within_dist *= expansion_within_factor;
+    }
   }
 };
 

--- a/valhalla/thor/pathalgorithm.h
+++ b/valhalla/thor/pathalgorithm.h
@@ -30,7 +30,8 @@ class PathAlgorithm {
    * Constructor
    */
   PathAlgorithm()
-     : interrupt(nullptr) {
+     : interrupt(nullptr),
+       has_ferry_(false) {
   }
 
   /**
@@ -68,8 +69,18 @@ class PathAlgorithm {
     interrupt = interrupt_callback;
   }
 
+  /**
+   * Does the path include a ferry?
+   * @return  Returns true if the path includes a ferry.
+   */
+  bool has_ferry() const {
+    return has_ferry_;
+  }
+
  protected:
   const std::function<void()>* interrupt;
+
+  bool has_ferry_;    // Indicates whether the path has a ferry
 
   /**
    * Check for path completion along the same edge. Edge ID in question

--- a/valhalla/thor/worker.h
+++ b/valhalla/thor/worker.h
@@ -70,7 +70,7 @@ class thor_worker_t : public service_worker_t{
  protected:
 
   std::vector<thor::PathInfo> get_path(PathAlgorithm* path_algorithm, baldr::PathLocation& origin,
-                baldr::PathLocation& destination);
+                baldr::PathLocation& destination, const std::string& costing);
   void log_admin(odin::TripPath&);
   valhalla::sif::cost_ptr_t get_costing(
       const boost::property_tree::ptree& request, const std::string& costing);


### PR DESCRIPTION
Pedestrian routes that included a ferry often have strange paths. This is due to the A* factor being set such that it underestimates the true time to get to the destination if a ferry is taken. Unfortunately, setting the A* factor based on the max. ferry speed leads to a large performance drop (by 5-10x) for pedestrian routes. Since most pedestrian routes do not use ferries, an approach was taken where the first pass uses an A* factor based on the pedestrian speed and if a ferry exists on the path then a second pass is made with A* based on ferry speed. This allow most cases to complete the path quickly and in a small percentage of cases the path is redone properly to account for the presence of a ferry.

fixes #906