### PR TITLE
Fix bug where leftover associations were overwritten

### DIFF
--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -897,17 +897,24 @@ void GraphTileBuilder::AddBins(const std::string& tile_dir,
     throw std::runtime_error("Failed to open file " + filename.string());
 }
 
-/**
- * Initialize traffic segment association. Sizes the traffic segment Id list
- * and sets them all to Invalid.
- */
+// Initialize traffic segment association. Sizes the traffic segment Id list
+// and sets them all to Invalid.
 void GraphTileBuilder::InitializeTrafficSegments() {
-  if(header_->traffic_id_count())
+  if(header_->traffic_id_count()) {
     traffic_segment_builder_.assign(traffic_segments_, traffic_segments_ + header_->traffic_id_count());
-  else
+  } else {
     traffic_segment_builder_.resize(header_builder_.directededgecount());
+  }
+}
 
-  //TODO: assign the chunks to its builder counterpart
+// Initialize traffic chunks. Copies existing chunks into the chunk builder.
+// This is executed before adding "leftovers" and again before adding chunks.
+void GraphTileBuilder::InitializeTrafficChunks() {
+  // Assign the chunks to its builder counterpart
+  if (traffic_chunk_size_ > 0) {
+    size_t count = traffic_chunk_size_ / sizeof(TrafficChunk);
+    traffic_chunk_builder_.assign(traffic_chunks_, traffic_chunks_ + count);
+  }
 }
 
 // Add a traffic segment association - used when an edge associates to

--- a/src/valhalla_associate_segments.cc
+++ b/src/valhalla_associate_segments.cc
@@ -916,6 +916,7 @@ void add_leftover_associations(const bpt::ptree &pt, std::unordered_map<GraphId,
     // Write leftovers
     vj::GraphTileBuilder tile_builder(tile_dir, associations.front().first.Tile_Base(), false);
     tile_builder.InitializeTrafficSegments();
+    tile_builder.InitializeTrafficChunks();
     for(const auto& association : associations)
       tile_builder.AddTrafficSegment(association.first, association.second);
     tile_builder.UpdateTrafficSegments();
@@ -940,6 +941,7 @@ void add_chunks(const bpt::ptree &pt, std::unordered_map<vb::GraphId, chunks_t>&
     // Write chunks
     vj::GraphTileBuilder tile_builder(tile_dir, associated_chunks.front().first.Tile_Base(), false);
     tile_builder.InitializeTrafficSegments();
+    tile_builder.InitializeTrafficChunks();
     for(const auto& chunk : associated_chunks) {
       tile_builder.AddTrafficSegments(chunk.first, chunk.second);
     }

--- a/valhalla/mjolnir/graphtilebuilder.h
+++ b/valhalla/mjolnir/graphtilebuilder.h
@@ -349,6 +349,12 @@ class GraphTileBuilder : public baldr::GraphTile {
   void InitializeTrafficSegments();
 
   /**
+   * Initialize traffic chunks. Copies existing chunks into the chunk builder.
+   * This is executed before adding "leftovers" and again before adding chunks.
+   */
+  void InitializeTrafficChunks();
+
+  /**
    * Add a traffic segment association - used when an edge associates to
    * a single traffic segment.
    * @param  edgeid  Edge Id to which traffic segment is associated.


### PR DESCRIPTION
Add a method to initialize the traffic chunk builder by copying in any current chunks. Add this to valhalla_associate_segments so that leftovers are not overwritten by chunks.

This fixes a bug where edges are assigned a "leftover" chunk (an OSMLR segment in another tile) but then when chunks are written the builder size is 0 (rather than the true size of any leftover chunks written in the prior stage) and the chunk is overwritten (but edges that point to the chunk offset now point to different segments).