### PR TITLE
Update bidirectional connection cost computation

### DIFF
--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -477,9 +477,6 @@ std::vector<PathInfo> BidirectionalAStar::GetBestPath(PathLocation& origin,
 // search tree. Check if this is the best connection so far and set the
 // search threshold.
 void BidirectionalAStar::SetForwardConnection(const BDEdgeLabel& pred) {
-  GraphId oppedge = pred.opp_edgeid();
-  EdgeStatusInfo oppedgestatus = edgestatus_reverse_->Get(oppedge);
-
   // Disallow connections that are part of a complex restriction.
   // TODO - validate that we do not need to "walk" the paths forward
   // and backward to see if they match a restriction.
@@ -491,26 +488,40 @@ void BidirectionalAStar::SetForwardConnection(const BDEdgeLabel& pred) {
   if (threshold_ == 0) {
     threshold_ = GetThreshold(mode_, edgelabels_forward_.size() + edgelabels_reverse_.size());
   }
-  uint32_t predidx = edgelabels_reverse_[oppedgestatus.index()].predecessor();
-  float oppcost = (predidx == kInvalidLabel) ?
-        0 : edgelabels_reverse_[predidx].cost().cost;
-  float c = pred.cost().cost + oppcost +
-      edgelabels_reverse_[oppedgestatus.index()].transition_cost();
-  if (c < best_connection_.cost) {
-    best_connection_ = { pred.edgeid(), oppedge, c };
-  }
+
+  // Get the opposing edge - a candidate shortest path has been found to the
+  // end node of this directed edge. Get total cost.
+  float c;
+  GraphId oppedge = pred.opp_edgeid();
+  EdgeStatusInfo oppedgestatus = edgestatus_reverse_->Get(oppedge);
+  if (pred.predecessor() != kInvalidLabel) {
+    // Get the start of the predecessor edge on the forward path. Cost is to
+    // the end this edge, plus the cost to the end of the reverse predecessor,
+    // plus the transition cost.
+    c = edgelabels_forward_[pred.predecessor()].cost().cost +
+        edgelabels_reverse_[oppedgestatus.index()].cost().cost +
+        pred.transition_cost();
+    } else {
+     // If no predecessor on the forward path get the predecessor on
+     // the reverse path to form the cost.
+     uint32_t predidx = edgelabels_reverse_[oppedgestatus.index()].predecessor();
+     float oppcost = (predidx == kInvalidLabel) ?
+           0 : edgelabels_reverse_[predidx].cost().cost;
+     c = pred.cost().cost + oppcost +
+         edgelabels_reverse_[oppedgestatus.index()].transition_cost();
+    }
+
+    // Set best_connection if cost is less than the best cost so far.
+    if (c < best_connection_.cost) {
+      best_connection_ = { pred.edgeid(), oppedge, c };
+    }
 }
 
 // The edge on the reverse search connects to a reached edge on the forward
 // search tree. Check if this is the best connection so far and set the
 // search threshold.
 void BidirectionalAStar::SetReverseConnection(const BDEdgeLabel& pred) {
-  // Get the opposing edge - if this edge has been reached then a shortest
-  // path has been found to the end node of this directed edge.
-  GraphId oppedge = pred.opp_edgeid();
-  EdgeStatusInfo oppedgestatus = edgestatus_forward_->Get(oppedge);
-
-  // Disallow connections that are part of a cmplex restriction.
+  // Disallow connections that are part of a complex restriction.
   // TODO - validate that we do not need to "walk" the paths forward
   // and backward to see if they match a restriction.
   if (pred.on_complex_rest()) {
@@ -521,11 +532,30 @@ void BidirectionalAStar::SetReverseConnection(const BDEdgeLabel& pred) {
   if (threshold_ == 0) {
     threshold_ = GetThreshold(mode_, edgelabels_forward_.size() + edgelabels_reverse_.size());
   }
-  uint32_t predidx = edgelabels_forward_[oppedgestatus.index()].predecessor();
-  float oppcost = (predidx == kInvalidLabel) ?
-        0 : edgelabels_forward_[predidx].cost().cost;
-  float c = pred.cost().cost + oppcost +
+
+  // Get the opposing edge - a candidate shortest path has been found to the
+  // end node of this directed edge. Get total cost.
+  float c;
+  GraphId oppedge = pred.opp_edgeid();
+  EdgeStatusInfo oppedgestatus = edgestatus_forward_->Get(oppedge);
+  if (pred.predecessor() != kInvalidLabel) {
+    // Get the start of the predecessor edge on the reverse path. Cost is to
+    // the end this edge, plus the cost to the end of the forward predecessor,
+    // plus the transition cost.
+    c = edgelabels_reverse_[pred.predecessor()].cost().cost +
+        edgelabels_forward_[oppedgestatus.index()].cost().cost +
+        pred.transition_cost();
+  } else {
+    // If no predecessor on the reverse path get the predecessor on
+    // the forward path to form the cost.
+    uint32_t predidx = edgelabels_forward_[oppedgestatus.index()].predecessor();
+    float oppcost = (predidx == kInvalidLabel) ?
+          0 : edgelabels_forward_[predidx].cost().cost;
+    c = pred.cost().cost + oppcost +
         edgelabels_forward_[oppedgestatus.index()].transition_cost();
+  }
+
+  // Set best_connection if cost is less than the best cost so far.
   if (c < best_connection_.cost) {
     best_connection_ = { oppedge, pred.edgeid(), c };
   }

--- a/test_requests/pedestrian_routes.txt
+++ b/test_requests/pedestrian_routes.txt
@@ -13,3 +13,4 @@
 -j '{"locations":[{"lat":40.062997,"lon":-76.3139319},{"lat":40.064705,"lon":-76.314608}],"costing":"pedestrian"}'
 -j '{"locations":[{"lat":42.02104,"lon":-80.27232},{"lat":42.020613,"lon":-80.273290}],"costing":"pedestrian"}'
 -j '{"locations":[{"lat":39.379583,"lon":-76.461485},{"lat":39.379571,"lon":-76.462858}],"costing":"pedestrian"}'
+-j '{"locations":[{"lat":37.12759,"lon":-118.43134},{"lat":37.12765,"lon":-118.43104}],"costing":"pedestrian"}'


### PR DESCRIPTION
Update bidirectional connections to handle cases where the connecting edge is one of the origin (or destination) edges and the cost is high. A better method is to use the cost to the start node of the connection edge and only fall back to prior logic if the connection edge is one of the origin or destination edges (and thus has no predecessor).

fixes #918 