### PR TITLE
fixes: edges which left a tile and came back weren't binned

### DIFF
--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -812,7 +812,7 @@ std::array<std::vector<GraphId>, kBinCount> GraphTileBuilder::BinEdges(const Gra
     //avoid duplicates and minimize leaving a tile for shape by:
     //writing the edge to the tile it originates in
     //not writing the edge to the tile it terminates in
-    //writing the edge to tweeners if originating < terminating
+    //writing the edge to tweeners if originating < terminating or the edge leaves and comes back
     auto start_id = tiles.TileId(edge->forward() ? shape.front() : shape.back());
     auto end_id = tiles.TileId(edge->forward() ? shape.back() : shape.front());
     auto intermediate = start_id < end_id;
@@ -828,7 +828,8 @@ std::array<std::vector<GraphId>, kBinCount> GraphTileBuilder::BinEdges(const Gra
       //as per the rules above about when to add intersections
       auto originating = i.first == start_id;
       auto terminating = i.first == end_id;
-      if(originating || (intermediate && !terminating)) {
+      auto loop_back = i.first != start_id && i.first != end_id && start_id == end_id;
+      if(originating || (intermediate && !terminating) || loop_back) {
         //which set of bins, either this local set or tweeners to be added later
         auto& out_bins = originating && max ? bins : tweeners.insert({GraphId(i.first, max_level, 0), {}}).first->second;
         //keep the edge id

--- a/test/graphtilebuilder.cc
+++ b/test/graphtilebuilder.cc
@@ -3,11 +3,13 @@
 #include "mjolnir/graphtilebuilder.h"
 #include "baldr/graphid.h"
 #include "midgard/pointll.h"
+#include "midgard/encoded.h"
 #include "baldr/tilehierarchy.h"
 #include <string>
 #include <vector>
 #include <fstream>
 #include <streambuf>
+#include <memory>
 using namespace std;
 using namespace valhalla::mjolnir;
 
@@ -197,6 +199,48 @@ void TestAddBins() {
   }
 }
 
+struct fake_tile : public GraphTile {
+ public:
+  fake_tile(const std::string& plyenc_shape) {
+    auto s = valhalla::midgard::decode<std::vector<PointLL> >(plyenc_shape);
+    auto e = valhalla::midgard::encode7(s);
+    auto l = TileHierarchy::levels().rbegin()->first;
+    auto tiles = TileHierarchy::levels().rbegin()->second.tiles;
+    auto id = GraphId(tiles.TileId(s.front()), l, 0);
+    auto o_id = GraphId(tiles.TileId(s.front()), l, tiles.TileId(s.back()));
+    o_id.fields.id = o_id == id;
+    header_ = new GraphTileHeader();
+    header_->set_graphid(id);
+    header_->set_directededgecount(1 + (id.tileid() == o_id.tileid()) * 1);
+
+    std::string info_backing;
+    edgeinfo_ = new char[sizeof(uint64_t) + sizeof(EdgeInfo::PackedItem) + e.size()];
+    std::memset(static_cast<void*>(edgeinfo_), 0, sizeof(uint64_t));
+    EdgeInfo::PackedItem pi{0, static_cast<uint32_t>(e.size())};
+    std::memcpy(static_cast<void*>(edgeinfo_ + sizeof(uint64_t)), static_cast<void *>(&pi), sizeof(EdgeInfo::PackedItem));
+    textlist_ = edgeinfo_;
+    textlist_size_ = 0;
+    std::memcpy(static_cast<void*>(edgeinfo_ + sizeof(uint64_t) + sizeof(EdgeInfo::PackedItem)), static_cast<void *>(&e[0]), e.size());
+
+    directededges_ = new DirectedEdge[2];
+    std::memset(static_cast<void*>(&directededges_[0]), 0, sizeof(DirectedEdge) * header_->directededgecount());
+    directededges_[0].set_forward(true);
+  }
+  ~fake_tile() {
+    delete header_;
+    delete [] edgeinfo_;
+    delete [] directededges_;
+  }
+};
+
+void TestBinEdges() {
+  fake_tile fake("gsoyLcpczmFgJOsMzAwGtDmDtEmApG|@tE|EdF~PjKlRjLbKhLrJnTdD`\\oEz`@wAlJKjVnHfMpRbQdQbRvTtNrM~ShNdZ|HjLfCbPfIbGdNxBjOyBjPOnJm@rDvD~BbFxFzA|IjAdEdFy@tOqBbPv@`HfHj`@pGxMtNbFlUjBtNvMhLbQfOxLhNzVTrFkGhMsQ|J_N{AqKkBqRxCoZpGu^jLqMz@sQwCmPmJwLgNcHePwIqG{KOoLvCsLbGeUpGm`@l@}_@jBeZmA}[aQs_@gd@gOyVosAqf@gYkLub@m@{LgCkFz@sBvDKrEjApH~Er[hOha@hIfc@i@pHaIrPyMng@mF~^kA~\\h@zVtCnHrFzAlUtE~@hBv@rFqBb\\?xVdEjV}@hM?tOvClJmAdEwCvD_b@|SuKbGiGpH_JtOsOvXyBvMbBtOlAtO}EdF}GjA_QhBiKjBsHxLoGtYkGdd@yJbf@fAxWvEtO]fCcFl@{ZlJcKnI{@lJtDpH`I|J~GbFtG|@hCz@MtEoCxB_QpGmKdE_KtPyAdO~BvNUdEyBxB_HjB{NxBwOxAuHrFwF~IXjLbDjKbKbFnIzArBvDwAdE{GtEyE|IElJ~B`H_AvCyDjBgH?mRgDy`@]{OtDaKxLiCvNiFjLgMxL_XdPgr@re@yi@vb@mWrQuFjKqHnSuH|JiGlJqAfDbAtE~A~GgBdFyKlJy[xWqMvMqTlKoPfCeKiBkHeF}E{KoD{JaLsGwSeEg~BqR");
+  GraphTileBuilder::tweeners_t tweeners;
+  auto bins = GraphTileBuilder::BinEdges(&fake, tweeners);
+  if(tweeners.size() != 1)
+    throw std::logic_error("This edge leaves a tile for 1 other tile and comes back.");
+}
+
 }
 
 int main() {
@@ -207,6 +251,9 @@ int main() {
 
   // Add bins to a tile and see if its still ok
   suite.test(TEST_CASE(TestAddBins));
+
+  // Test bin edges of some tricky edges
+  suite.test(TEST_CASE(TestBinEdges));
 
   return suite.tear_down();
 }

--- a/test/graphtilebuilder.cc
+++ b/test/graphtilebuilder.cc
@@ -9,7 +9,6 @@
 #include <vector>
 #include <fstream>
 #include <streambuf>
-#include <memory>
 using namespace std;
 using namespace valhalla::mjolnir;
 

--- a/test/graphtilebuilder.cc
+++ b/test/graphtilebuilder.cc
@@ -212,7 +212,6 @@ struct fake_tile : public GraphTile {
     header_->set_graphid(id);
     header_->set_directededgecount(1 + (id.tileid() == o_id.tileid()) * 1);
 
-    std::string info_backing;
     edgeinfo_ = new char[sizeof(uint64_t) + sizeof(EdgeInfo::PackedItem) + e.size()];
     std::memset(static_cast<void*>(edgeinfo_), 0, sizeof(uint64_t));
     EdgeInfo::PackedItem pi{0, static_cast<uint32_t>(e.size())};


### PR DESCRIPTION
thanks to @dnesbitt61 for debugging and finding out the root of the problem! basically the logic was saying if an edge leaves the tile then it will have its shape spread over some intermediate tiles and indeed those will get binned. it didnt account for the possibility that an edge may leave a tile and come back. that is, the edge has both end points in the same tile but the shape does leave the tile. those edges would only get a bin entry in the tile with the end points. other tiles in between would not get bin entries. the fix that @dnesbitt61 proposed was to simply check for that case. indeed ive created a test for this case and the test confirms his approach works.