### PR TITLE
Loops can create overlapping edges in the path

### DIFF
--- a/src/baldr/merge.cc
+++ b/src/baldr/merge.cc
@@ -189,7 +189,6 @@ void edge_collapser::explore(GraphId node_id) {
     return;
   }
 
-
   // if either edge has been marked, then don't explore down either of them.
   if (m_tracker.get(edge_between(node_id, nodes.first)) ||
       m_tracker.get(edge_between(node_id, nodes.second))) {

--- a/src/baldr/merge.cc
+++ b/src/baldr/merge.cc
@@ -229,7 +229,6 @@ bool edge_collapser::explore(GraphId prev, GraphId cur, path &forward, path &rev
       cur = maybe_next;
       if (cur == original_node_id) {
         // Loop is detected - add last edge and return true to indicate a loop
-        printf("Loop!\n");
         auto e1 = edge_between(prev, cur);
         forward.push_back(segment(prev, e1, cur));
         m_tracker.set(e1);

--- a/valhalla/baldr/merge.h
+++ b/valhalla/baldr/merge.h
@@ -45,7 +45,9 @@ struct edge_collapser {
   GraphId next_node_id(GraphId last_node_id, GraphId node_id);
   GraphId edge_between(GraphId cur, GraphId next);
   void explore(GraphId node_id);
-  void explore(GraphId prev, GraphId cur, path &forward, path &reverse);
+
+  // return true if a loop is detected
+  bool explore(GraphId prev, GraphId cur, path &forward, path &reverse);
 
 private:
   GraphReader &m_reader;


### PR DESCRIPTION
If a loop is detected, finish the last edge on the 2 paths and return true. Do not call explore a second time if the first call detects a loop (otherwise the overlapping path is created).

@zerebubuth - does this make sense?