### PR TITLE
Fix ViterbiSearch clears search states too early

### DIFF
--- a/src/meili/viterbi_search.cc
+++ b/src/meili/viterbi_search.cc
@@ -35,8 +35,8 @@ template <bool Maximize>
 void NaiveViterbiSearch<Maximize>::Clear()
 {
   IViterbiSearch::Clear();
-  ClearSearch();
   states_.clear();
+  ClearSearch();
 }
 
 template <bool Maximize>
@@ -284,8 +284,8 @@ double ViterbiSearch::AccumulatedCost(const StateId& stateid) const
 void ViterbiSearch::Clear()
 {
   IViterbiSearch::Clear();
-  ClearSearch();
   states_.clear();
+  ClearSearch();
 }
 
 void ViterbiSearch::ClearSearch()


### PR DESCRIPTION
In `ViterbiSearch::ClearSearch` `states_` is copied to `unreached_states_`, so `states_` needs to be cleared before clearing search.