### PR TITLE
Adjust bicycle travel mode if roundabout is a road

### DIFF
--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -944,11 +944,18 @@ void ManeuversBuilder::UpdateManeuver(Maneuver& maneuver, int node_index) {
 
   // Roundabouts
   if (prev_edge->roundabout()) {
+    TripPath_TravelMode mode = prev_edge->travel_mode();
+
+    // Adjust bicycle travel mode if roundabout is a road
+    if ((mode == TripPath_TravelMode_kBicycle)
+        && (prev_edge->IsRoadUse())) {
+      mode = TripPath_TravelMode_kDrive;
+    }
+    // TODO might have to adjust for pedestrian too
+
     IntersectingEdgeCounts xedge_counts;
-    trip_path_->GetEnhancedNode(node_index)
-        ->CalculateRightLeftIntersectingEdgeCounts(prev_edge->end_heading(),
-                                                   prev_edge->travel_mode(),
-                                                   xedge_counts);
+    trip_path_->GetEnhancedNode(node_index)->CalculateRightLeftIntersectingEdgeCounts(
+        prev_edge->end_heading(), mode, xedge_counts);
     if (prev_edge->drive_on_right()) {
       maneuver.set_roundabout_exit_count(
           maneuver.roundabout_exit_count()


### PR DESCRIPTION
Fixes the bicycle roundabout count when the roundabout is a road. This update does not negatively impact cycleway roundabouts

Closes #947 

BEFORE
![rb_before](https://user-images.githubusercontent.com/7515853/31555902-cb40660c-b010-11e7-979a-a1be158a5e5c.png)

AFTER
![rb_after](https://user-images.githubusercontent.com/7515853/31555907-ceea0344-b010-11e7-9f79-7b1f5ce127c6.png)

Cycleway roundabout still works properly
![rb_cycleway](https://user-images.githubusercontent.com/7515853/31556008-2ed2c138-b011-11e7-9aac-f10b36509ce8.png)
