### PR TITLE
Decreased kRoundaboutFactor for pedestiran costing.

### DIFF
--- a/src/sif/pedestriancost.cc
+++ b/src/sif/pedestriancost.cc
@@ -59,7 +59,7 @@ constexpr uint32_t kTransitStartEndMaxDistance    = 2415;   // 1.5 miles
 constexpr uint32_t kTransitTransferMaxDistance   = 805;   // 0.5 miles
 
 // Avoid roundabouts
-constexpr float kRoundaboutFactor = 5.0f;
+constexpr float kRoundaboutFactor = 2.0f;
 
 // Maximum ferry penalty (when use_ferry == 0). Can't make this too large
 // since a ferry is sometimes required to complete a route.


### PR DESCRIPTION
Allows path to remain  on roundabout instead of getting off and back on.
Helps with #961 

BEFORE
![rb_walking](https://user-images.githubusercontent.com/7515853/31563374-c903d22c-b02c-11e7-86ba-45427f0cd46c.png)

AFTER
![rb_walking_path_after](https://user-images.githubusercontent.com/7515853/31563379-cd2b2026-b02c-11e7-8248-ec2ea364f10f.png)
