### PR TITLE
add @dgearhart 's test exposing segfault with topk

### DIFF
--- a/test/mapmatch.cc
+++ b/test/mapmatch.cc
@@ -268,6 +268,15 @@ namespace {
         streets += n + " ";
       throw std::logic_error("The second most obvious result is stay right but got: " + streets);
     }
+
+    matched = json_to_pt(actor.trace_attributes(
+      R"({"costing":"auto","best_paths":2,"shape_match":"map_snap","shape":[
+         {"lat":52.088548,"lon":5.15357,"accuracy":30},
+         {"lat":52.088627,"lon":5.153269,"accuracy":30},
+         {"lat":52.08864,"lon":5.15298,"accuracy":30},
+         {"lat":52.08861,"lon":5.15272,"accuracy":30},
+         {"lat":52.08863,"lon":5.15253,"accuracy":30},
+         {"lat":52.08851,"lon":5.15249,"accuracy":30}]})"));
   }
 
 }


### PR DESCRIPTION
for some traces with `k > 1` the topk logic will segfault.

the stack looks like this at the time of segfault:

```c++
              test_distance_only  [PASS]
             test_time_rejection  [PASS]
                       test_topk
Program received signal SIGSEGV, Segmentation fault.
0x00007ffff739e6ba in std::__shared_ptr<valhalla::meili::LabelSet, (__gnu_cxx::_Lock_policy)2>::operator bool (this=0x1b800d9fd08)
    at /usr/include/c++/5/bits/shared_ptr_base.h:1063
1063	      { return _M_ptr == 0 ? false : true; }
(gdb) where
#0  0x00007ffff739e6ba in std::__shared_ptr<valhalla::meili::LabelSet, (__gnu_cxx::_Lock_policy)2>::operator bool (this=0x1b800d9fd08)
    at /usr/include/c++/5/bits/shared_ptr_base.h:1063
#1  0x00007ffff739e6ab in std::operator!=<valhalla::meili::LabelSet>(std::shared_ptr<valhalla::meili::LabelSet> const&, decltype(nullptr)) (__a=<Fehler beim Lesen der Variable: Cannot access memory at address 0x1b800d9fd10>) at /usr/include/c++/5/bits/shared_ptr.h:359
#2  0x00007ffff739e0b9 in valhalla::meili::State::routed (this=0x1b800d9fb98) at ./valhalla/meili/state.h:32
#3  0x00007ffff739c078 in valhalla::meili::TransitionCostModel::UpdateRoute (this=0xc22f20, lhs=..., rhs=...)
    at src/meili/transition_cost_model.cc:111
#4  0x00007ffff739be11 in valhalla::meili::TransitionCostModel::operator() (this=0xc22f20, lhs=..., rhs=...)
    at src/meili/transition_cost_model.cc:79
#5  0x00007ffff73ab1c6 in std::_Function_handler<float (valhalla::meili::StateId const&, valhalla::meili::StateId const&), valhalla::meili::TransitionCostModel>::_M_invoke(std::_Any_data const&, valhalla::meili::StateId const&, valhalla::meili::StateId const&) (
    __functor=..., __args#0=..., __args#1=...) at /usr/include/c++/5/functional:1857
#6  0x00007ffff736bb3f in std::function<float (valhalla::meili::StateId const&, valhalla::meili::StateId const&)>::operator()(valhalla::meili::StateId const&, valhalla::meili::StateId const&) const (this=0xc22e78, __args#0=..., __args#1=...)
    at /usr/include/c++/5/functional:2267
#7  0x00007ffff737a20a in valhalla::meili::EnlargedTransitionCostModel::operator() (this=0xda6dc0, lhs=..., rhs=...)
    at src/meili/topk_search.cc:50
#8  0x00007ffff737c417 in std::_Function_handler<float (valhalla::meili::StateId const&, valhalla::meili::StateId const&), valhalla::meili::EnlargedTransitionCostModel>::_M_invoke(std::_Any_data const&, valhalla::meili::StateId const&, valhalla::meili::StateId const&) (
    __functor=..., __args#0=..., __args#1=...) at /usr/include/c++/5/functional:1857
#9  0x00007ffff736bb3f in std::function<float (valhalla::meili::StateId const&, valhalla::meili::StateId const&)>::operator()(valhalla::meili::StateId const&, valhalla::meili::StateId const&) const (this=0xda6dc0, __args#0=..., __args#1=...)
    at /usr/include/c++/5/functional:2267
#10 0x00007ffff7369fe3 in valhalla::meili::IViterbiSearch::TransitionCost (this=0xda6d60, lhs=..., rhs=...)
    at ./valhalla/meili/viterbi_search.h:200
#11 0x00007ffff7369185 in valhalla::meili::ViterbiSearch::AddSuccessorsToQueue (this=0xda6d60, stateid=...)
    at src/meili/viterbi_search.cc:337
#12 0x00007ffff736999e in valhalla::meili::ViterbiSearch::IterativeSearch (this=0xda6d60, target=5, request_new_start=false)
    at src/meili/viterbi_search.cc:442
#13 0x00007ffff7368a47 in valhalla::meili::ViterbiSearch::SearchWinner (this=0xda6d60, time=5) at src/meili/viterbi_search.cc:247
#14 0x00007ffff737b09a in valhalla::meili::IViterbiSearch::SearchPath (this=0xda6d60, time=5) at ./valhalla/meili/viterbi_search.h:176
#15 0x00007ffff73a377c in valhalla::meili::MapMatcher::OfflineMatch (this=0xda6d10, measurements=
    std::vector of length 6, capacity 8 = {...}, k=2) at src/meili/map_matcher.cc:379
#16 0x00007ffff75fbfd0 in valhalla::thor::thor_worker_t::map_match (this=0xe199d8, controller=..., trace_attributes_action=true, 
    best_paths=2) at src/thor/trace_route_action.cc:150
#17 0x00007ffff75deb33 in valhalla::thor::thor_worker_t::trace_attributes (this=0xe199d8, request=...)
    at src/thor/trace_attributes_action.cc:500
#18 0x00007ffff762d915 in valhalla::tyr::actor_t::trace_attributes(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::function<void ()> const&) (this=0x7fffffffd2a0, 
    request_str="{\"costing\":\"auto\",\"best_paths\":2,\"shape_match\":\"map_snap\",\"shape\":[\n         {\"lat\":52.088548,\"lon\":5.15357,\"accuracy\":30},\n         {\"lat\":52.088627,\"lon\":5.153269,\"accuracy\":30},\n         {\"lat\":52."..., interrupt=...)
    at src/tyr/actor.cc:206
#19 0x0000000000580e25 in (anonymous namespace)::test_topk () at test/mapmatch.cc:272
#20 0x00000000005c41e8 in test::suite::test (this=0x7fffffffd760, test_name="test_topk", 
    function=0x5803d7 <(anonymous namespace)::test_topk()>) at test/test.cc:19
#21 0x0000000000581628 in main (argc=1, argv=0x7fffffffd908) at test/mapmatch.cc:300
```

notice that the last bit of our code that it sees is:

    #3  0x00007ffff739c078 in valhalla::meili::TransitionCostModel::UpdateRoute (this=0xc22f20, lhs=..., rhs=...)

Its trying to call `State::routed` on `prev_state`. But what is the value of `prev_state`, it got from a call to `StateContainer::State()` with `prev_stateid`. Sadly `prev_stateid` is one of the claimed state ids:

```c++
#3  0x00007ffff739c078 in valhalla::meili::TransitionCostModel::UpdateRoute (this=0xc22f20, lhs=..., rhs=...)
    at src/meili/transition_cost_model.cc:111
111	    if (!prev_state.routed()) {
(gdb) p prev_stateid
$1 = (const valhalla::meili::StateId &) @0x7fffffffb8a0: {fields_ = {time = 0, id = 4294967295}, value_ = 18446744069414584320}
```

We tried removing the claimed state ids but its clear that they are used to mark the previous paths already generated from the viterbi search. we just arent clear on the mechanism in place for not actually using these claimed states twice or using the original state that they claim so as to get the proper `id` and not the `maxint based ids`.

@ptpt any pointers would be greatly appreciated!