### PR TITLE
 Update/added kMotorScooter VehicleType 

### DIFF
--- a/proto/tripdirections.proto
+++ b/proto/tripdirections.proto
@@ -36,6 +36,7 @@ message TripDirections {
     kMotorcycle = 1;
     kAutoBus = 2;
     kTractorTrailer = 3;
+    kMotorScooter = 4;
   }
 
   // TODO: review and update as needed

--- a/proto/trippath.proto
+++ b/proto/trippath.proto
@@ -93,6 +93,7 @@ message TripPath {
     kMotorcycle = 1;
     kAutoBus = 2;
     kTractorTrailer = 3;
+    kMotorScooter = 4;
   }
 
   // TODO: review and update as needed

--- a/src/odin/directionsbuilder.cc
+++ b/src/odin/directionsbuilder.cc
@@ -24,6 +24,7 @@ const std::unordered_map<int, TripDirections_VehicleType> translate_vehicle_type
   { static_cast<int>(TripPath_VehicleType_kMotorcycle), TripDirections_VehicleType_kMotorcycle },
   { static_cast<int>(TripPath_VehicleType_kAutoBus), TripDirections_VehicleType_kAutoBus },
   { static_cast<int>(TripPath_VehicleType_kTractorTrailer), TripDirections_VehicleType_kTractorTrailer },
+  { static_cast<int>(TripPath_VehicleType_kMotorScooter), TripDirections_VehicleType_kMotorScooter },
 };
 
 const std::unordered_map<int, TripDirections_PedestrianType> translate_pedestrian_type {

--- a/src/sif/motorscootercost.cc
+++ b/src/sif/motorscootercost.cc
@@ -618,7 +618,7 @@ float MotorScooterCost::AStarCostFactor() const {
 
 // Returns the current travel type.
 uint8_t MotorScooterCost::travel_type() const {
-  return static_cast<uint8_t>(VehicleType::kMoped);
+  return static_cast<uint8_t>(VehicleType::kMotorScooter);
 }
 
 cost_ptr_t CreateMotorScooterCost(const boost::property_tree::ptree& config) {

--- a/src/thor/trippathbuilder.cc
+++ b/src/thor/trippathbuilder.cc
@@ -200,9 +200,10 @@ constexpr odin::TripPath_VehicleType kTripPathVehicleType[] = {
     odin::TripPath_VehicleType::TripPath_VehicleType_kCar,
     odin::TripPath_VehicleType::TripPath_VehicleType_kMotorcycle,
     odin::TripPath_VehicleType::TripPath_VehicleType_kAutoBus,
-    odin::TripPath_VehicleType::TripPath_VehicleType_kTractorTrailer };
+    odin::TripPath_VehicleType::TripPath_VehicleType_kTractorTrailer,
+    odin::TripPath_VehicleType::TripPath_VehicleType_kMotorScooter };
 TripPath_VehicleType GetTripPathVehicleType(const uint8_t type) {
-  return (type <= static_cast<uint8_t>(VehicleType::kTractorTrailer)) ?
+  return (type <= static_cast<uint8_t>(VehicleType::kMotorScooter)) ?
       kTripPathVehicleType[type] : kTripPathVehicleType[0];
 }
 

--- a/src/tyr/serializers.cc
+++ b/src/tyr/serializers.cc
@@ -402,6 +402,7 @@ namespace {
       { static_cast<int>(TripDirections_VehicleType_kMotorcycle), "motorcycle" },
       { static_cast<int>(TripDirections_VehicleType_kAutoBus), "bus" },
       { static_cast<int>(TripDirections_VehicleType_kTractorTrailer), "tractor_trailer" },
+      { static_cast<int>(TripDirections_VehicleType_kMotorScooter), "motor_scooter" },
     };
 
     std::unordered_map<int, std::string> pedestrian_to_string {

--- a/test_requests/na_motor_scooter_routes.txt
+++ b/test_requests/na_motor_scooter_routes.txt
@@ -1,0 +1,1 @@
+-j '{"locations":[{"lat":37.76502442709533,"lon":-122.48050747693708},{"lat":37.77335383395655,"lon":-122.48206102238441}],"costing":"motor_scooter","directions_options":{"units":"miles"}}'

--- a/valhalla/sif/costconstants.h
+++ b/valhalla/sif/costconstants.h
@@ -19,7 +19,7 @@ enum class VehicleType : uint8_t {
   kMotorcycle = 1,
   kBus = 2,
   kTractorTrailer = 3,
-  kMoped = 4
+  kMotorScooter = 4
 };
 
 // Pedestrian travel type


### PR DESCRIPTION
Fixes #968 

Passes back proper travel_type now, for example:
![motor_scooter_example](https://user-images.githubusercontent.com/7515853/31676656-4bb7864e-b336-11e7-91a4-1ca777ab0ee2.png)

