### PR TITLE
Add a DirectedEdge traffic segment flag

### DIFF
--- a/src/baldr/directededge.cc
+++ b/src/baldr/directededge.cc
@@ -122,6 +122,11 @@ void DirectedEdge::set_laneconnectivity(const bool lc) {
   lane_conn_ = lc;
 }
 
+// Sets the traffic segment flag.
+void DirectedEdge::set_traffic_seg(const bool seg) {
+  traffic_seg_ = seg;
+}
+
 // -------------------------- Routing attributes --------------------------- //
 
 // Set if edge has a shoulder (Beneficial to know for cycling)

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -976,7 +976,7 @@ void GraphTileBuilder::AddTrafficSegments(const baldr::GraphId& edgeid,
  * "chunks". Need to make sure the "shift" for offsets to data after the
  * traffic information are only increased by the amount of "new" segments.
  */
-void GraphTileBuilder::UpdateTrafficSegments() {
+void GraphTileBuilder::UpdateTrafficSegments(const bool update_dir_edges) {
   // Get the number of new segments and chunks added with this call.
   uint32_t new_segments = traffic_segment_builder_.size() -
                           header_->traffic_id_count();
@@ -1030,6 +1030,29 @@ void GraphTileBuilder::UpdateTrafficSegments() {
     const auto* end = reinterpret_cast<const char*>(header_) +
                 header_->end_offset();
     file.write(begin, end - begin);
+
+    // Update directed edge flags
+    if (update_dir_edges) {
+      // Copy directed edges so we can modify them
+      uint32_t n = header_->directededgecount();
+      directededges_builder_.resize(n);
+      memcpy(&directededges_builder_[0], directededges_, n * sizeof(DirectedEdge));
+
+      // Iterate through directed edges and set traffic segment flag for aby
+      // that have any traffic segments.
+      for (uint32_t i = 0; i < n; i++) {
+        auto segs = GetTrafficSegments(i);
+        if (segs.size() > 0) {
+          directededges_builder_[i].set_traffic_seg(true);
+        }
+      }
+
+      // Write the updated directed edges
+      size_t offset = sizeof(GraphTileHeader) + header_->nodecount() * sizeof(NodeInfo);
+      file.seekp(offset, std::ios_base::beg);
+      file.write(reinterpret_cast<const char*>(&directededges_builder_[0]),
+                 directededges_builder_.size() * sizeof(DirectedEdge));
+    }
 
     // Close the file
     file.close();

--- a/src/valhalla_associate_segments.cc
+++ b/src/valhalla_associate_segments.cc
@@ -829,7 +829,7 @@ void edge_association::add_tile(const std::string& file_name) {
   }
 
   // Finish this tile
-  m_tile_builder->UpdateTrafficSegments();
+  m_tile_builder->UpdateTrafficSegments(false);
   m_reader.Clear();
 }
 
@@ -887,7 +887,7 @@ void add_leftover_associations(const bpt::ptree &pt, std::unordered_map<GraphId,
     tile_builder.InitializeTrafficChunks();
     for(const auto& association : associations)
       tile_builder.AddTrafficSegment(association.first, association.second);
-    tile_builder.UpdateTrafficSegments();
+    tile_builder.UpdateTrafficSegments(false);
   }
 }
 
@@ -913,7 +913,10 @@ void add_chunks(const bpt::ptree &pt, std::unordered_map<vb::GraphId, chunks_t>&
     for(const auto& chunk : associated_chunks) {
       tile_builder.AddTrafficSegments(chunk.first, chunk.second);
     }
-    tile_builder.UpdateTrafficSegments();
+
+    // Since this is the last time UpdateTrafficSegments is called we set
+    // the flag indicating the DirectedEdge traffic flags are set.
+    tile_builder.UpdateTrafficSegments(true);
   }
 }
 

--- a/valhalla/baldr/directededge.h
+++ b/valhalla/baldr/directededge.h
@@ -96,6 +96,21 @@ class DirectedEdge {
   void set_laneconnectivity(const bool lc);
 
   /**
+   * Does this directed edge have a traffic segment?
+   * @return  Returns true if the directed edge has a traffic segment,
+   *          false if not.
+   */
+  bool traffic_seg() const {
+    return traffic_seg_;
+  }
+
+  /**
+   * Sets the traffic segment flag.
+   * @param  seg  True if this directed edge has a traffic segment.
+   */
+  void set_traffic_seg(const bool seg);
+
+  /**
    * Gets the length of the edge in meters.
    * @return  Returns the length in meters.
    */
@@ -1075,7 +1090,8 @@ class DirectedEdge {
   uint64_t speed_limit_    : 8;  // Speed limit (kph)
   uint64_t named_          : 1;  // 1 if this edge has names, 0 if unnamed
   uint64_t lane_conn_      : 1;  // 1 if has lane connectivity, 0 otherwise
-  uint64_t spare_          : 10;
+  uint64_t traffic_seg_    : 1;  // 1 if has a traffic segment, 0 otherwise
+  uint64_t spare_          : 9;
 
   // Geometric attributes: length, weighted grade, curvature factor.
   // Turn types between edges.

--- a/valhalla/baldr/directededge.h
+++ b/valhalla/baldr/directededge.h
@@ -1084,7 +1084,7 @@ class DirectedEdge {
   uint64_t surface_        : 3;  // representation of smoothness
   uint64_t shoulder_       : 1;  // Does the edge have a shoulder?
   uint64_t spare2_         : 7;
-  uint64_t use_sidepath_   : 1;  // Is there a cycling path to the side that should be preffered?
+  uint64_t use_sidepath_   : 1;  // Is there a cycling path to the side that should be prefered?
   uint64_t dismount_       : 1;  // Do you need to dismount when biking on this edge?
   uint64_t density_        : 4;  // Density along the edge
   uint64_t speed_limit_    : 8;  // Speed limit (kph)

--- a/valhalla/mjolnir/graphtilebuilder.h
+++ b/valhalla/mjolnir/graphtilebuilder.h
@@ -374,8 +374,10 @@ class GraphTileBuilder : public baldr::GraphTile {
 
   /**
    * Updates a tile with traffic segment and chunk data.
+   * @param  update_dir_edges  If true this will update directed edge flags
+   *                 indicating a traffic segment exists on the edge.
    */
-  void UpdateTrafficSegments();
+  void UpdateTrafficSegments(const bool update_dir_edges);
 
   /**
     * Gets the current list of edge elevation (builders).


### PR DESCRIPTION
Add a flag to indicate a directed edge has traffic segments associated to it.
When updating traffic chunks (last step of association) go though all directed edges and mark any that have a traffic segment. This updates (rewrites) the directed edges in the tile.