### PR TITLE
Add ViterbiSearch::RemoveStateId

### DIFF
--- a/valhalla/meili/viterbi_search.h
+++ b/valhalla/meili/viterbi_search.h
@@ -172,6 +172,16 @@ class IViterbiSearch
   virtual bool AddStateId(const StateId& stateid)
   { return added_states_.insert(stateid).second; }
 
+  /**
+   * Remove a state ID. Note that if an ID is removed, client must call ClearSearch before new search.
+   *
+   * @return true if it's removed
+   */
+  virtual bool RemoveStateId(const StateId& stateid)
+  {
+    return 0 < added_states_.erase(stateid);
+  }
+
   virtual bool HasStateId(const StateId& stateid) const
   { return added_states_.find(stateid) != added_states_.end(); }
 
@@ -245,6 +255,21 @@ class NaiveViterbiSearch: public IViterbiSearch
 
   bool AddStateId(const StateId& stateid) override;
 
+  bool RemoveStateId(const StateId& stateid) override
+  {
+    const auto removed = IViterbiSearch::RemoveStateId(stateid);
+    if (!removed) {
+      return false;
+    }
+    // remove it from columns
+    auto& column = states_[stateid.time()];
+    const auto it = std::find(column.begin(), column.end(), stateid);
+    column.earse(it);
+    return true;
+
+    // TODO should we call ClearSearch here or ask user to call ClearSearch after removing stateid
+  }
+
   StateId SearchWinner(StateId::Time time, bool force_continuous) override;
 
   StateId Predecessor(const StateId& stateid) const override;
@@ -291,6 +316,21 @@ class ViterbiSearch: public IViterbiSearch
   void ClearSearch() override;
 
   bool AddStateId(const StateId& stateid) override;
+
+  bool RemoveStateId(const StateId& stateid) override
+  {
+    const auto removed = IViterbiSearch::RemoveStateId(stateid);
+    if (!removed) {
+      return false;
+    }
+    // remove it from columns
+    auto& column = states_[stateid.time()];
+    const auto it = std::find(column.begin(), column.end(), stateid);
+    column.erase(it);
+    return true;
+
+    // TODO should we call ClearSearch here or ask user to call ClearSearch after removing stateid
+  }
 
   StateId SearchWinner(StateId::Time time, bool force_continuous) override;
 

--- a/valhalla/meili/viterbi_search.h
+++ b/valhalla/meili/viterbi_search.h
@@ -264,7 +264,7 @@ class NaiveViterbiSearch: public IViterbiSearch
     // remove it from columns
     auto& column = states_[stateid.time()];
     const auto it = std::find(column.begin(), column.end(), stateid);
-    column.earse(it);
+    column.erase(it);
     return true;
 
     // TODO should we call ClearSearch here or ask user to call ClearSearch after removing stateid

--- a/valhalla/meili/viterbi_search.h
+++ b/valhalla/meili/viterbi_search.h
@@ -265,9 +265,9 @@ class NaiveViterbiSearch: public IViterbiSearch
     auto& column = states_[stateid.time()];
     const auto it = std::find(column.begin(), column.end(), stateid);
     column.erase(it);
+    // clear current search status to remove possible uses of the removed state ID
+    ClearSearch();
     return true;
-
-    // TODO should we call ClearSearch here or ask user to call ClearSearch after removing stateid
   }
 
   StateId SearchWinner(StateId::Time time, bool force_continuous) override;
@@ -327,9 +327,9 @@ class ViterbiSearch: public IViterbiSearch
     auto& column = states_[stateid.time()];
     const auto it = std::find(column.begin(), column.end(), stateid);
     column.erase(it);
+    // clear current search status to remove possible uses of the removed state ID
+    ClearSearch();
     return true;
-
-    // TODO should we call ClearSearch here or ask user to call ClearSearch after removing stateid
   }
 
   StateId SearchWinner(StateId::Time time, bool force_continuous) override;


### PR DESCRIPTION
This PR adds an method to remove a stateid from a viterbisearch instance.

Discussed  @kevinkreiser that if we should remove stateid like we did in this PR, or we should just mark them as removed. I think it might be easier and straightforward to remove stateids from viterbisearch directly if we can make sure that we don't need them anymore.

@kevinkreiser Could you help fix the removing from the vector `states_[time]` here?