### PR TITLE
Addition of an 'avoid_bad_surfaces' tag

### DIFF
--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -110,13 +110,13 @@ constexpr float kMaxCyclingSpeed = 60.0f; // KPH
 // These values determine the percentage by which speed us reduced for
 // each surface type. (0 values indicate unusable surface types).
 constexpr float kRoadSurfaceSpeedFactors[] =
-        { 1.0f, 1.0f, 0.9f, 0.7f, 0.6f, 0.5f, 0.4f, 0.0f };
+        { 1.0f, 1.0f, 0.9f, 0.6f, 0.5f, 0.3f, 0.2f, 0.0f };
 constexpr float kHybridSurfaceSpeedFactors[] =
-        { 1.0f, 1.0f, 1.0f, 0.8f, 0.7f, 0.6f, 0.5f, 0.0f };
+        { 1.0f, 1.0f, 1.0f, 0.8f, 0.6f, 0.4f, 0.25f, 0.0f };
 constexpr float kCrossSurfaceSpeedFactors[] =
-        { 1.0f, 1.0f, 1.0f, 0.9f, 0.8f, 0.7f, 0.6f, 0.0f };
+        { 1.0f, 1.0f, 1.0f, 0.8f, 0.7f, 0.5f, 0.4f, 0.0f };
 constexpr float kMountainSurfaceSpeedFactors[] =
-        { 1.0f, 1.0f, 1.0f, 1.0f, 0.9f, 0.8f, 0.7f, 0.0f };
+        { 1.0f, 1.0f, 1.0f, 1.0f, 0.9f, 0.75f, 0.55f, 0.0f };
 
 // Worst allowed surface based on bicycle type
 constexpr Surface kWorstAllowedSurface[] =

--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -29,8 +29,9 @@ constexpr float kDefaultGatePenalty             = 300.0f; // Seconds
 constexpr float kDefaultFerryCost               = 300.0f; // Seconds
 constexpr float kDefaultCountryCrossingCost     = 600.0f; // Seconds
 constexpr float kDefaultCountryCrossingPenalty  = 0.0f;   // Seconds
-constexpr float kDefaultUseRoad                 = 0.25f;   // Factor between 0 and 1
+constexpr float kDefaultUseRoad                 = 0.25f;  // Factor between 0 and 1
 constexpr float kDefaultUseFerry                = 0.5f;   // Factor between 0 and 1
+constexpr float kDefaultAvoidBadSurfaces        = 0.25f;  // Factor between 0 and 1
 
 // Maximum ferry penalty (when use_ferry == 0). Can't make this too large
 // since a ferry is sometimes required to complete a route.
@@ -116,6 +117,16 @@ constexpr float kCrossSurfaceSpeedFactors[] =
         { 1.0f, 1.0f, 1.0f, 0.9f, 0.8f, 0.7f, 0.6f, 0.0f };
 constexpr float kMountainSurfaceSpeedFactors[] =
         { 1.0f, 1.0f, 1.0f, 1.0f, 0.9f, 0.8f, 0.7f, 0.0f };
+
+// Worst allowed surface based on bicycle type
+constexpr Surface kWorstAllowedSurface[] =
+        { Surface::kCompacted,            // Road bicycle
+          Surface::kGravel,               // Cross
+          Surface::kDirt,                 // Hybrid
+          Surface::kPath }; // Mountain
+
+constexpr float kSurfaceFactors[] =
+        { 1.0f, 2.5f, 4.5f, 7.0f };
 
 // Avoid driveways
 constexpr float kDrivewayFactor = 20.0f;
@@ -211,6 +222,7 @@ constexpr ranged_default_t<float> kCountryCrossingPenaltyRange{0.0f, kDefaultCou
 constexpr ranged_default_t<float> kUseRoadRange{0.0f, kDefaultUseRoad, 1.0f};
 constexpr ranged_default_t<float> kUseFerryRange{0.0f, kDefaultUseFerry, 1.0f};
 constexpr ranged_default_t<float> kUseHillsRange{0.0f, kDefaultUseHills, 1.0f};
+constexpr ranged_default_t<float> kAvoidBadSurfacesRange{0.0f, kDefaultAvoidBadSurfaces, 1.0f};
 }
 
 /**
@@ -345,6 +357,7 @@ class BicycleCost : public DynamicCost {
   float road_factor_;                    // Road factor based on use_roads_
   float use_ferry_;                      // Preference of using ferries between 0 and 1
   float use_hills_;                      // Preference of using hills between 0 and 1
+  float avoid_bad_surfaces_;             // Preference of avoiding bad surfaces for the bike type
 
   // Density factor used in edge transition costing
   std::vector<float> trans_density_factor_;
@@ -354,6 +367,9 @@ class BicycleCost : public DynamicCost {
 
   // Bicycle type
   BicycleType type_;
+
+  // Minimal surface type that will be penalized for costing
+  Surface minimal_surface_penalized_;
 
   // Surface speed factors (based on road surface type).
   const float* surface_speed_factor_;
@@ -378,12 +394,14 @@ protected:
    */
   virtual const EdgeFilter GetEdgeFilter() const {
     // Throw back a lambda that checks the access for this type of costing
-    uint32_t b = static_cast<uint32_t>(type_);
-    return [b](const baldr::DirectedEdge* edge) {
+    Surface s = avoid_bad_surfaces_ == 1.0f ?
+        minimal_surface_penalized_ :
+        Surface::kPath;
+    return [s](const baldr::DirectedEdge* edge) {
       if ( edge->IsTransition() || edge->is_shortcut() ||
           !(edge->forwardaccess() & kBicycleAccess) ||
            edge->use() == Use::kSteps ||
-           edge->surface() == Surface::kImpassable) {
+           edge->surface() > s) {
         return 0.0f;
       } else {
         // TODO - use classification/use to alter the factor
@@ -456,6 +474,8 @@ BicycleCost::BicycleCost(const boost::property_tree::ptree& pt)
     type_ = BicycleType::kHybrid;
   }
 
+  minimal_surface_penalized_ = kWorstAllowedSurface[static_cast<uint32_t> (type_)];
+
   // Get default speed from the config. This is the average speed on smooth,
   // flat roads. If not present or outside the valid range use a default speed
   // based on the bicycle type.
@@ -465,8 +485,13 @@ BicycleCost::BicycleCost(const boost::property_tree::ptree& pt)
     kDefaultCyclingSpeed[t],
     kMaxCyclingSpeed
   };
+
   speed_ = kCycleSpeedRange(
     pt.get<float>("cycling_speed", kDefaultCyclingSpeed[t])
+  );
+
+  avoid_bad_surfaces_ = kAvoidBadSurfacesRange (
+    pt.get<float>("avoid_bad_surfaces", kDefaultAvoidBadSurfaces)
   );
 
   // Set the surface speed factors for the bicycle type.
@@ -583,8 +608,11 @@ bool BicycleCost::Allowed(const baldr::DirectedEdge* edge,
     return false;
   }
 
+  Surface s = avoid_bad_surfaces_ == 1.0f ?
+          kWorstAllowedSurface[static_cast<uint32_t>(type_)] :
+          Surface::kPath;
   // Prohibit certain roads based on surface type and bicycle type
-  return edge->surface() != Surface::kImpassable;
+  return edge->surface() <= s;
 }
 
 // Checks if access is allowed for an edge on the reverse path (from
@@ -606,9 +634,12 @@ bool BicycleCost::AllowedReverse(const baldr::DirectedEdge* edge,
        IsUserAvoidEdge(opp_edgeid)) {
     return false;
   }
+  Surface s = avoid_bad_surfaces_ == 1.0f ?
+          kWorstAllowedSurface[static_cast<uint32_t>(type_)] :
+          Surface::kPath;
 
   // Prohibit certain roads based on surface type and bicycle type
-  return opp_edge->surface() != Surface::kImpassable;
+  return opp_edge->surface() <= s;
 }
 
 // Check if access is allowed at the specified node.
@@ -712,8 +743,15 @@ Cost BicycleCost::EdgeCost(const baldr::DirectedEdge* edge) const {
   // The stress of this road after accommodation but before grade
   float total_stress = accommodation_factor * roadway_stress;
 
+  float surface_factor = 0.0f;
+  if (edge->surface () >= minimal_surface_penalized_)
+  {
+    surface_factor = avoid_bad_surfaces_ * kSurfaceFactors[static_cast<uint32_t> (edge->surface ())
+                                   - static_cast<uint32_t> (minimal_surface_penalized_)];
+  }
+
   // Create a final edge factor based on total stress and the weighted grade penalty for the edge.
-  float factor = 1.0f + grade_penalty[edge->weighted_grade()] + total_stress;
+  float factor = 1.0f + grade_penalty[edge->weighted_grade()] + total_stress + surface_factor;
 
   // Compute elapsed time based on speed. Modulate cost with weighting factors.
   float sec = (edge->length() * speedfactor_[bike_speed]);

--- a/src/valhalla_path_comparison.cc
+++ b/src/valhalla_path_comparison.cc
@@ -178,7 +178,8 @@ int main(int argc, char *argv[]) {
         auto pred_edge = pred_tile->directededge(pred_id);
         auto predinfo = tile->edgeinfo(pred_edge->edgeinfo_offset());
         auto node_id = pred_edge->endnode();
-        auto node = tile->node(node_id);
+        auto node_tile = reader.GetGraphTile (node_id);
+        auto node = node_tile->node(node_id);
         EdgeLabel pred_label (0, pred_id, pred_edge, {}, 0.0f, 0.0f, static_cast<TravelMode>(0), 0);
         std::cout << "-------Transition-------\n";
         std::cout << "Pred GraphId: " << pred_id << std::endl;

--- a/test_requests/bicycle_routes.txt
+++ b/test_requests/bicycle_routes.txt
@@ -26,3 +26,5 @@
 -j '{"locations":[{"lat":34.417545,"lon":-119.854576,"street":""},{"lat":34.416924,"lon":-119.853531,"street":""}],"costing":"bicycle","directions_options":{"units":"miles"}}'
 -j '{"locations":[{"lat":34.417545,"lon":-119.854576,"street":""},{"lat":34.417549,"lon":-119.852890,"street":""}],"costing":"bicycle","directions_options":{"units":"miles"}}'
 -j '{"locations":[{"lat":34.417545,"lon":-119.854576,"street":""},{"lat":34.418053,"lon":-119.853683,"street":""}],"costing":"bicycle","directions_options":{"units":"miles"}}'
+-j '{"locations":[{"lat":37.94152381803029,"lon":-121.96226477622986},{"lat":37.931335857027115,"lon":-121.97398066520691}],"costing":"bicycle","costing_options":{"bicycle":{"bicycle_type":"Road","use_roads":"0.5","use_hills":"0.0"}}}
+-j '{"locations":[{"lat":37.94152381803029,"lon":-121.96226477622986},{"lat":37.931335857027115,"lon":-121.97398066520691}],"costing":"bicycle","costing_options":{"bicycle":{"bicycle_type":"Mountain","use_roads":"0.5","use_hills":"0.0"}}}

--- a/test_requests/eu_bicycle_routes.txt
+++ b/test_requests/eu_bicycle_routes.txt
@@ -1,5 +1,5 @@
--j '{"locations":[{"lat":52.066656,"lon":5.119761,"type":"break"},{"lat":52.066310,"lon":5.120238,"type":"break"}],"costing":"bicycle"}' --config ../conf/valhalla.json
--j '{"locations":[{"lat":52.117505,"lon":5.086265,"type":"break"},{"lat":52.118088,"lon":5.085493,"type":"break"}],"costing":"bicycle"}' --config ../conf/valhalla.json
--j '{"locations":[{"lat":52.08020,"lon":5.12173,"type":"break"},{"lat":52.08056,"lon":5.12140,"type":"break"}],"costing":"bicycle"}' --config ../conf/valhalla.json
--j '{"locations":[{"lat":50.300524924617285,"lon":-4.919478894153144,"type":"break"},{"lat":50.29989442975862,"lon":-4.904758931079414,"type":"break"}],"costing":"bicycle"}' --config ../conf/valhalla.json
--j '{"locations":[{"lat":50.29989442975862,"lon":-4.904758931079414,"type":"break"},{"lat":50.300524924617285,"lon":-4.919478894153144,"type":"break"}],"costing":"bicycle"}' --config ../conf/valhalla.json
+-j '{"locations":[{"lat":52.066656,"lon":5.119761,"type":"break"},{"lat":52.066310,"lon":5.120238,"type":"break"}],"costing":"bicycle"}'
+-j '{"locations":[{"lat":52.117505,"lon":5.086265,"type":"break"},{"lat":52.118088,"lon":5.085493,"type":"break"}],"costing":"bicycle"}'
+-j '{"locations":[{"lat":52.08020,"lon":5.12173,"type":"break"},{"lat":52.08056,"lon":5.12140,"type":"break"}],"costing":"bicycle"}'
+-j '{"locations":[{"lat":50.300524924617285,"lon":-4.919478894153144,"type":"break"},{"lat":50.29989442975862,"lon":-4.904758931079414,"type":"break"}],"costing":"bicycle"}'
+-j '{"locations":[{"lat":50.29989442975862,"lon":-4.904758931079414,"type":"break"},{"lat":50.300524924617285,"lon":-4.919478894153144,"type":"break"}],"costing":"bicycle"}'


### PR DESCRIPTION
All biking surfaces are allowed for all bicycle types except when the 'avoid_bad_surfaces' tag is equal to 1.0. Otherwise, from [0, 1) the tag scales how heavily bad surfaces for the particular bike type are penalized.