### PR TITLE
Add dummy Admin in GraphTileBuilder constructor

### DIFF
--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -424,10 +424,6 @@ void BuildTileSet(const std::string& ways_file, const std::string& way_nodes_fil
       graphtile.AddTileCreationDate(tile_creation_date);
       graphtile.header_builder().set_dataset_id(osmdata.max_changeset_id_);
 
-      // Create a dummy admin record at index 0. Used if admin records
-      // are not used/created or if none is found.
-      graphtile.AddAdmin("None","None","","");
-
       // Get the admin polygons. If only one exists for the tile check if the
       // tile is entirely inside the polygon
       bool tile_within_one_admin = false;

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -28,11 +28,6 @@ GraphTileBuilder::GraphTileBuilder(const std::string& tile_dir,
   // Copy tile header to a builder (if tile exists). Always set the tileid
   if (header_) {
     header_builder_ = *header_;
-  } else {
-    // Tile does not yet exist. We are creating a new one. Add a dummy admin
-    // record at index 0 to be used if admin records are not used/created or
-    //if none is found.
-    AddAdmin("None","None","","");
   }
   header_builder_.set_graphid(graphid);
 
@@ -41,6 +36,10 @@ GraphTileBuilder::GraphTileBuilder(const std::string& tile_dir,
     textlistbuilder_.emplace_back("");
     text_offset_map_.emplace("", 0);
     text_list_offset_ = 1;
+
+    // Add a dummy admin record at index 0 to be used if admin records are
+    // not used/created or if none is found.
+    AddAdmin("None","None","","");
     return;
   }
 

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -28,6 +28,11 @@ GraphTileBuilder::GraphTileBuilder(const std::string& tile_dir,
   // Copy tile header to a builder (if tile exists). Always set the tileid
   if (header_) {
     header_builder_ = *header_;
+  } else {
+    // Tile does not yet exist. We are creating a new one. Add a dummy admin
+    // record at index 0 to be used if admin records are not used/created or
+    //if none is found.
+    AddAdmin("None","None","","");
   }
   header_builder_.set_graphid(graphid);
 

--- a/src/mjolnir/hierarchybuilder.cc
+++ b/src/mjolnir/hierarchybuilder.cc
@@ -179,9 +179,6 @@ void FormTilesInNewLevel(GraphReader& reader, bool has_elevation) {
       tilebuilder = new GraphTileBuilder(reader.tile_dir(), tile_id, false);
       current_level = nodea.level();
 
-      // Create a dummy admin at index 0. Used if admins are not used/created.
-      tilebuilder->AddAdmin("None", "None", "", "");
-
       // Check if we need to clear the base/local tile cache
       if (reader.OverCommitted()) {
         reader.Clear();

--- a/src/mjolnir/shortcutbuilder.cc
+++ b/src/mjolnir/shortcutbuilder.cc
@@ -566,9 +566,6 @@ uint32_t FormShortcuts(GraphReader& reader,
     GraphId new_tile(tileid, tile_level, 0);
     GraphTileBuilder tilebuilder(reader.tile_dir(), new_tile, false);
 
-    // Create a dummy admin at index 0.  Used if admins are not used/created.
-    tilebuilder.AddAdmin("None", "None", "", "");
-
     // Iterate through the nodes in the tile
     GraphId node_id(tileid, tile_level, 0);
     for (uint32_t n = 0; n < tile->header()->nodecount(); n++, ++node_id) {

--- a/src/mjolnir/valhalla_build_transit.cc
+++ b/src/mjolnir/valhalla_build_transit.cc
@@ -1440,8 +1440,6 @@ void AddToGraph(GraphTileBuilder& tilebuilder_transit,
   std::set<uint64_t> added_stations;
   std::set<uint64_t> added_egress;
 
-  tilebuilder_transit.AddAdmin("None","None","","");
-
   // Data looks like the following.
   // Egress1_for_Station_A
   // Egress2_for_Station_A

--- a/test/node_search.cc
+++ b/test/node_search.cc
@@ -54,10 +54,6 @@ vj::GraphTileBuilder &graph_writer::builder(vb::GraphId tile_id) {
     bool inserted = false;
     auto builder = std::make_shared<vj::GraphTileBuilder>(test_tile_dir, tile_id, false);
 
-    // Create a dummy admin record at index 0. Used if admin records
-    // are not used/created or if none is
-    builder->AddAdmin("None","None","","");
-
     std::tie(itr, inserted) = m_builders.emplace(tile_id, builder);
     // should be new, since itr == end.
     assert(inserted);


### PR DESCRIPTION
Add a dummy Admin record in GraphTileBuilder if the tile is newly created. This ensures the dummy record exists (rather than relying on each place a new tile is created to remember to add one).

fixes #76 