### PR TITLE
Protect against an empty tile

### DIFF
--- a/src/baldr/merge.cc
+++ b/src/baldr/merge.cc
@@ -165,25 +165,21 @@ GraphId edge_collapser::next_node_id(GraphId last_node_id, GraphId node_id) {
   }
 }
 
+// Get the edge Id between 2 nodes. Will return an invalid edge Id if there
+// is no "allowed" edge between the 2 nodes.
 GraphId edge_collapser::edge_between(GraphId cur, GraphId next) {
   // Get the tile of the current node, return none if the tile is not found
-  GraphId edge_id;
   const GraphTile* tile = m_reader.GetGraphTile(cur);
   if (tile == nullptr) {
-    return edge_id;
+    return { };
   }
   for (const auto &edge : iter::edges(tile, cur)) {
-    // Skip edges that are not allowed
-    if (!m_edge_allowed_predicate(edge.first)) {
-      continue;
-    }
-    if (edge.first->endnode() == next) {
-      edge_id = edge.second;
-      break;
-    }
+    // Return the edge Id if endnode matches and the edge is allowed
+     if (edge.first->endnode() == next && m_edge_allowed_predicate(edge.first)) {
+       return edge.second;
+     }
   }
-  assert(bool(edge_id));
-  return edge_id;
+  return { };
 }
 
 // explore starts walking the graph from a single node, building a forward and
@@ -197,9 +193,14 @@ void edge_collapser::explore(GraphId node_id) {
     return;
   }
 
-  // if either edge has been marked, then don't explore down either of them.
-  if (m_tracker.get(edge_between(node_id, nodes.first)) ||
-      m_tracker.get(edge_between(node_id, nodes.second))) {
+  // if either edge has been marked or is invalid (was not allowed in the
+  // edge between method) then don't explore down either of them.
+  GraphId e1 = edge_between(node_id, nodes.first);
+  if (!e1.Is_Valid() || m_tracker.get(e1)) {
+    return;
+  }
+  GraphId e2 = edge_between(node_id, nodes.second);
+  if (!e2.Is_Valid() || m_tracker.get(e2)) {
     return;
   }
 
@@ -224,9 +225,15 @@ bool edge_collapser::explore(GraphId prev, GraphId cur, path &forward, path &rev
   GraphId maybe_next;
   do {
     auto e1 = edge_between(prev, cur);
+    if (!e1.Is_Valid()) {
+      return false;
+    }
     forward.push_back(segment(prev, e1, cur));
     m_tracker.set(e1);
     auto e2 = edge_between(cur, prev);
+    if (!e2.Is_Valid()) {
+      return false;
+    }
     reverse.push_front(segment(cur, e2, prev));
     m_tracker.set(e2);
 
@@ -237,9 +244,15 @@ bool edge_collapser::explore(GraphId prev, GraphId cur, path &forward, path &rev
       if (cur == original_node_id) {
         // Loop is detected - add last edge and return true to indicate a loop
         auto e1 = edge_between(prev, cur);
+        if (!e1.Is_Valid()) {
+          return false;
+        }
         forward.push_back(segment(prev, e1, cur));
         m_tracker.set(e1);
         auto e2 = edge_between(cur, prev);
+        if (!e2.Is_Valid()) {
+          return false;
+        }
         reverse.push_front(segment(cur, e2, prev));
         m_tracker.set(e2);
         return true;


### PR DESCRIPTION
reader returns nullptr - which can happen with extracts.

fixes #914 