### PR TITLE
Return edge_walk path for walk_or_snap shape_match

### DIFF
--- a/src/thor/trace_attributes_action.cc
+++ b/src/thor/trace_attributes_action.cc
@@ -509,6 +509,8 @@ json::MapPtr thor_worker_t::trace_attributes(
           } catch (const std::exception& e) {
             throw valhalla_exception_t{444, shape_match->first + " algorithm failed to snap the shape points to the correct shape."};
           }
+        } else {
+          map_match_results.emplace_back(1.0f, 0.0f, std::vector<thor::MatchResult>{}, trip_path);
         }
         break;
       }


### PR DESCRIPTION
Added missing `else`

Test url:
```
http://localhost:8002/trace_attributes?json={%22encoded_polyline%22:%22ouz|iAzr}bqCG_HFeFe@m^GeFOcF]wY?yBm@{_@?]?yBGuEEeE_@kVEgDWoSUsPe@m`@GyBGsFO}I?sFUyMO_Is@gb@W{KG{AMsGGyAGuEe@{Ve@mI]iCe@yBeAcG|EwCrAm@xBkAlJsFxGgDjFgDdd@{VzKqGpSyLjFwCjPoJlFcFrPkLxByApGeF]}I?mK?M?m@?cGG_IGuEm@_^s@kj@u@}h@e@o^WgN{@cf@cAum@_@mU]uZ{@ik@_@sQ]wXsAiu@]aSm@ia@UgNmAiv@aBwbAr_AgCzy@iCjA?bA?j`@kA%22,%22shape_match%22:%22walk_or_snap%22,%22costing%22:%22auto%22,%22directions_options%22:{%22units%22:%22miles%22}}
````

BEFORE
![bad_walk_or_snap](https://user-images.githubusercontent.com/7515853/32514248-73278bbc-c3ca-11e7-88c7-ab7ca755626e.png)

AFTER
![good_walk_or_snap](https://user-images.githubusercontent.com/7515853/32514256-77810440-c3ca-11e7-96f8-7f8e93c81ac3.png)
