### PR TITLE
restriction and transit update

### DIFF
--- a/src/mjolnir/valhalla_build_transit.cc
+++ b/src/mjolnir/valhalla_build_transit.cc
@@ -418,13 +418,14 @@ void get_routes(Transit& tile, std::unordered_map<std::string, size_t>& routes,
       type = Transit_VehicleType::Transit_VehicleType_kTram;
     else if (vehicle_type == "metro")
       type = Transit_VehicleType::Transit_VehicleType_kMetro;
-    else if (vehicle_type == "rail" || vehicle_type == "suburban_railway")
+    else if (vehicle_type == "rail" || vehicle_type == "suburban_railway" ||
+             vehicle_type == "railway_service")
       type = Transit_VehicleType::Transit_VehicleType_kRail;
     else if (vehicle_type == "bus" || vehicle_type == "trolleybus_service" ||
              vehicle_type == "express_bus_service" || vehicle_type == "local_bus_service" ||
              vehicle_type == "bus_service" || vehicle_type == "shuttle_bus" ||
              vehicle_type == "demand_and_response_bus_service" ||
-             vehicle_type == "regional_bus_service")
+             vehicle_type == "regional_bus_service" || vehicle_type == "coach_service")
       type = Transit_VehicleType::Transit_VehicleType_kBus;
     else if (vehicle_type == "ferry")
       type = Transit_VehicleType::Transit_VehicleType_kFerry;

--- a/src/mjolnir/valhalla_fetch_transit.cc
+++ b/src/mjolnir/valhalla_fetch_transit.cc
@@ -271,13 +271,14 @@ void get_routes(Transit_Fetch& tile, std::unordered_map<std::string, size_t>& ro
       type = Transit_Fetch_VehicleType::Transit_Fetch_VehicleType_kTram;
     else if (vehicle_type == "metro")
       type = Transit_Fetch_VehicleType::Transit_Fetch_VehicleType_kMetro;
-    else if (vehicle_type == "rail" || vehicle_type == "suburban_railway")
+    else if (vehicle_type == "rail" || vehicle_type == "suburban_railway" ||
+             vehicle_type == "railway_service")
       type = Transit_Fetch_VehicleType::Transit_Fetch_VehicleType_kRail;
     else if (vehicle_type == "bus" || vehicle_type == "trolleybus_service" ||
              vehicle_type == "express_bus_service" || vehicle_type == "local_bus_service" ||
              vehicle_type == "bus_service" || vehicle_type == "shuttle_bus" ||
              vehicle_type == "demand_and_response_bus_service" ||
-             vehicle_type == "regional_bus_service")
+             vehicle_type == "regional_bus_service" || vehicle_type == "coach_service")
       type = Transit_Fetch_VehicleType::Transit_Fetch_VehicleType_kBus;
     else if (vehicle_type == "ferry")
       type = Transit_Fetch_VehicleType::Transit_Fetch_VehicleType_kFerry;


### PR DESCRIPTION
added logic to support restriction = x but has exceptions; therefore, apply restriction to everything except for modes in the except key.
Example://  http://www.openstreetmap.org/relation/1310163  Restrictions exist for everything except bus and taxi/psv.

Auto:  goes around the block as it should.
```
   "legs": [
      {
        "shape": "cfs`gApaunhFjKgNnY{`@hv@rdA`CdEyH|JuO|Skz@yiAoSwXcQ}UeTuYeKgNsFqH",
        "summary": {
          "max_lon": -122.414322,
          "max_lat": 37.77655,
          "time": 161,
          "length": 0.663,
          "min_lat": 37.773903,
          "min_lon": -122.417122
        },
        "maneuvers": [
          {
            "travel_type": "car",
            "street_names": [
              "10th Street"
            ],
            "verbal_pre_transition_instruction": "Drive southeast on 10th Street for 100 meters. Then Turn right onto Minna Street.",
            "instruction": "Drive southeast on 10th Street.",
            "end_shape_index": 2,
            "type": 1,
            "time": 21,
            "verbal_multi_cue": true,
            "length": 0.098,
            "begin_shape_index": 0,
            "travel_mode": "drive"
          },
          {
            "travel_type": "car",
            "travel_mode": "drive",
            "verbal_pre_transition_instruction": "Turn right onto Minna Street.",
            "verbal_transition_alert_instruction": "Turn right onto Minna Street.",
            "length": 0.15,
            "instruction": "Turn right onto Minna Street.",
            "end_shape_index": 4,
            "type": 10,
            "time": 15,
            "verbal_post_transition_instruction": "Continue for 200 meters.",
            "street_names": [
              "Minna Street"
            ],
            "begin_shape_index": 2
          },
          {
            "travel_type": "car",
            "travel_mode": "drive",
            "verbal_multi_cue": true,
            "verbal_pre_transition_instruction": "Turn right onto 11th Street. Then Turn right onto Mission Street.",
            "verbal_transition_alert_instruction": "Turn right onto 11th Street.",
            "length": 0.066,
            "instruction": "Turn right onto 11th Street.",
            "end_shape_index": 6,
            "type": 10,
            "time": 24,
            "verbal_post_transition_instruction": "Continue for 70 meters.",
            "street_names": [
              "11th Street"
            ],
            "begin_shape_index": 4
          },
          {
            "travel_type": "car",
            "travel_mode": "drive",
            "verbal_pre_transition_instruction": "Turn right onto Mission Street.",
            "verbal_transition_alert_instruction": "Turn right onto Mission Street.",
            "length": 0.349,
            "instruction": "Turn right onto Mission Street.",
            "end_shape_index": 12,
            "type": 10,
            "time": 101,
            "verbal_post_transition_instruction": "Continue for 300 meters.",
            "street_names": [
              "Mission Street"
            ],
            "begin_shape_index": 6
          },
          {
            "travel_type": "car",
            "travel_mode": "drive",
            "begin_shape_index": 12,
            "time": 0,
            "type": 4,
            "end_shape_index": 12,
            "instruction": "You have arrived at your destination.",
            "length": 0,
            "verbal_transition_alert_instruction": "You will arrive at your destination.",
            "verbal_pre_transition_instruction": "You have arrived at your destination."
          }
        ]
      }
    ],
```
Bus:  makes the left
```
    "legs": [
      {
        "shape": "cfs`gApaunhFjKgNoSwXcQ}UeTuYeKgNsFqH",
        "summary": {
          "max_lon": -122.414322,
          "max_lat": 37.77655,
          "time": 67,
          "length": 0.231,
          "min_lat": 37.775276,
          "min_lon": -122.416168
        },
        "maneuvers": [
          {
            "travel_type": "bus",
            "street_names": [
              "10th Street"
            ],
            "verbal_pre_transition_instruction": "Drive southeast on 10th Street for 30 meters. Then Turn left onto Mission Street.",
            "instruction": "Drive southeast on 10th Street.",
            "end_shape_index": 1,
            "type": 1,
            "time": 2,
            "verbal_multi_cue": true,
            "length": 0.031,
            "begin_shape_index": 0,
            "travel_mode": "drive"
          },
          {
            "travel_type": "bus",
            "travel_mode": "drive",
            "verbal_pre_transition_instruction": "Turn left onto Mission Street.",
            "verbal_transition_alert_instruction": "Turn left onto Mission Street.",
            "length": 0.2,
            "instruction": "Turn left onto Mission Street.",
            "end_shape_index": 6,
            "type": 15,
            "time": 65,
            "verbal_post_transition_instruction": "Continue for 200 meters.",
            "street_names": [
              "Mission Street"
            ],
            "begin_shape_index": 1
          },
          {
            "travel_type": "bus",
            "travel_mode": "drive",
            "begin_shape_index": 6,
            "time": 0,
            "type": 4,
            "end_shape_index": 6,
            "instruction": "You have arrived at your destination.",
            "length": 0,
            "verbal_transition_alert_instruction": "You will arrive at your destination.",
            "verbal_pre_transition_instruction": "You have arrived at your destination."
          }
        ]
      }
    ],```
```

Note:  Tested current restrictions and they are good.
Example:// 
Truck
![image](https://user-images.githubusercontent.com/2676277/32561998-9a10e190-c47b-11e7-8325-df8a614479b0.png)

Auto
![image](https://user-images.githubusercontent.com/2676277/32562016-aa50b22e-c47b-11e7-9fd3-c6a78668af7d.png)

Also, added logic coach and rail service support.