### PR TITLE
Add config values for whether to build hierarchies and shortcuts. 

### DIFF
--- a/scripts/valhalla_build_config
+++ b/scripts/valhalla_build_config
@@ -13,6 +13,8 @@ config = {
     'admin': '/data/valhalla/admin.sqlite',
     'timezone': '/data/valhalla/tz_world.sqlite',
     'transit_dir': '/data/valhalla/transit',
+    'hierarchy': True,
+    'shortcuts': True,
     'logging': {
       'type': 'std_out',
       'color': True,
@@ -220,6 +222,8 @@ help_text = {
     'admin': 'Location of sqlite file holding admin polygons created with valhalla_build_admins',
     'timezone': 'Location of sqlite file holding timezone information created with valhalla_build_timezones',
     'transit_dir': 'Location of intermediate transit tiles created with valhalla_build_transit',
+    'hierarchy': 'bool indicating whether road hierarchy is to be built - default to True',
+    'shortcuts': 'bool indicating whether shortcuts are to be builr - default to True',
     'logging': {
       'type': 'Type of logger either std_out or file',
       'color': 'User colored log level in std_out logger',

--- a/src/mjolnir/util.cc
+++ b/src/mjolnir/util.cc
@@ -101,7 +101,7 @@ void build_tile_set(const boost::property_tree::ptree& config, const std::vector
     // Build shortcuts if specified in the config file. Shortcuts can only be
     // applied if hierarchies are also generated.
     auto build_shortcuts = config.get<bool>("mjolnir.shortcuts", true);
-    if (build_hierarchy) {
+    if (build_shortcuts) {
       ShortcutBuilder::Build(config);
     } else {
       LOG_INFO("Skipping shortcut builder");

--- a/src/mjolnir/util.cc
+++ b/src/mjolnir/util.cc
@@ -92,12 +92,23 @@ void build_tile_set(const boost::property_tree::ptree& config, const std::vector
   // Add transit
   TransitBuilder::Build(config);
 
-  // Builds additional hierarchies based on the config file. Connections
+  // Builds additional hierarchies if specified within config file. Connections
   // (directed edges) are formed between nodes at adjacent levels.
-  HierarchyBuilder::Build(config);
+  auto build_hierarchy = config.get<bool>("mjolnir.hierarchy", true);
+  if (build_hierarchy) {
+    HierarchyBuilder::Build(config);
 
-  // Build shortcuts
-  ShortcutBuilder::Build(config);
+    // Build shortcuts if specified in the config file. Shortcuts can only be
+    // applied if hierarchies are also generated.
+    auto build_shortcuts = config.get<bool>("mjolnir.shortcuts", true);
+    if (build_hierarchy) {
+      ShortcutBuilder::Build(config);
+    } else {
+      LOG_INFO("Skipping shortcut builder");
+    }
+  } else {
+    LOG_INFO("Skipping hierarchy builder and shortcut builder");
+  }
 
   // Build the Complex Restrictions
   RestrictionBuilder::Build(config, bin_file_prefix + "complex_restrictions.bin", osm_data.end_map);


### PR DESCRIPTION
Someone only supporting pedestrian or bicycle routing would not want/need hierarchies and shortcuts. This saves about 10% data size.

fixes #1009 