### PR TITLE
Revert back to prior order of locations and update costs 

### DIFF
--- a/test/optimizer.cc
+++ b/test/optimizer.cc
@@ -16,10 +16,8 @@ void TryOptimizer(const uint32_t nlocs, const std::vector<float>& costs,
   Optimizer optimizer;
   optimizer.Seed(111111);
   auto order = optimizer.Solve(nlocs, costs);
-  for (uint32_t n = 0; n < nlocs; n++) {
-    if (order[n] != expected_order[n]) {
-      throw runtime_error("TryOptimizer: expected order failed");
-    }
+  if (order != expected_order) {
+    throw runtime_error("TryOptimizer: expected order failed");
   }
 }
 
@@ -32,11 +30,11 @@ void TestOptimizer() {
       357, 3037, 708, 637, 0, 1935, 47, 851, 1286, 3171, 2133,
       1839, 2004, 1525, 2480, 1963, 0, 2000, 2713, 690, 2578, 1100,
       387, 3066, 737, 715, 77, 1964, 0, 928, 1316, 3201, 2163,
-      1129, 3803, 1537, 682, 771, 2707, 819, 0, 2052, 3230, 2899,
+      1129, 3803, 1537, 682, 769, 2707, 819, 0, 2052, 3230, 2899,
       1214, 1750, 900, 1849, 1338, 634, 1375, 2082, 0, 1907, 846,
       3128, 2036, 2814, 3763, 3252, 2549, 3290, 3228, 1914, 0, 2010,
       2068, 1133, 1754, 2704, 2193, 1102, 2230, 2937, 854, 2000, 0 };
-  std::vector<uint32_t> expected_order = { 0, 4, 3, 7, 6, 2, 8, 5, 9, 1, 10 };
+  std::vector<uint32_t> expected_order = { 0, 3, 7, 4, 6, 2, 8, 5, 9, 1, 10 };
   TryOptimizer(11, costs, expected_order);
 }
 


### PR DESCRIPTION
Verified that there was another path with exact same total cost (the one from the last version). Reduced one of the costs by 2 seconds to (hopefully) make sure this path is lowest cost.

@noblige @smWork @kevinkreiser 