### PR TITLE
If a final transition alert is close to the corresponding pre-transition then just generate the pre-transition instruction

### DIFF
--- a/src/tyr/navigator.cc
+++ b/src/tyr/navigator.cc
@@ -105,6 +105,7 @@ NavigationStatus Navigator::OnLocationChanged(const FixLocation& fix_location) {
         && !(std::get<kPreTransition>(used_instructions_.at(next_instruction_index)))
         && (GetRemainingManeuverTime(fix_location, nav_status)
             <= GetPreTransitionThreshold(next_instruction_index))) {
+
       // Set route state
       route_state_ = NavigationStatus_RouteState_kPreTransition;
       nav_status.set_route_state(route_state_);
@@ -162,9 +163,11 @@ NavigationStatus Navigator::OnLocationChanged(const FixLocation& fix_location) {
     //////////////////////////////////////////////////////////////////////////
     // else if instruction has not been used
     // and route location is a final transition alert
+    // and alert is not close to the pre-transition
     // then set route state to kTransitionAlert
     else if (!(std::get<kFinalTransitionAlert>(used_instructions_.at(next_instruction_index)))
-        && IsFinalTransitionAlert(fix_location, nav_status, alert_length)) {
+        && IsFinalTransitionAlert(fix_location, nav_status, alert_length)
+        && !IsAlertCloseToPre(fix_location, nav_status, next_instruction_index)) {
       // Set route state
       route_state_ = NavigationStatus_RouteState_kTransitionAlert;
       nav_status.set_route_state(route_state_);
@@ -524,6 +527,18 @@ uint32_t Navigator::GetPreTransitionThreshold(size_t instruction_index) const {
       + (static_cast<uint32_t>(round(
           GetWordCount(maneuver.verbal_pre_transition_instruction())
               / kWordsPerSecond * adjustment_factor))));
+}
+
+bool Navigator::IsAlertCloseToPre(const FixLocation& fix_location,
+    const NavigationStatus& nav_status, size_t instruction_index) const {
+  const auto& maneuver = route_.trip().legs(leg_index_).maneuvers(instruction_index);
+
+  // TODO handle the transition alert pre-phrase of "In 500 feet..."
+  int remaining_time_after_alert = (GetRemainingManeuverTime(fix_location, nav_status)
+      - (static_cast<uint32_t>(round(GetWordCount(maneuver.verbal_transition_alert_instruction()) / kWordsPerSecond)))
+      - kAlertPreTimeDelta);
+
+  return (remaining_time_after_alert < GetPreTransitionThreshold(instruction_index));
 }
 
 bool Navigator::IsTimeWithinBounds(uint32_t time, uint32_t lower_bound,

--- a/test/navigator.cc
+++ b/test/navigator.cc
@@ -11773,14 +11773,14 @@ void TestAutoMiddletownRoadToLandingsDrive() {
           -76.6279602f, 40.2745819f, leg_index, 6.70793056f, 478,
           maneuver_index, 0.187824249f, 8));
   //----------------------------------------------------------------
-  // trace point = 484 | Alert 0.15 | Enter the roundabout and take the 2nd exit.
+  // trace point = 484
   maneuver_index = 7;
-  instruction_index = maneuver_index + 1;
+  instruction_index = maneuver_index;
   TryRouteOnLocationChanged(nav,
       GetFixLocation(-76.6277313f, 40.2745667f, 1489615422, 19.5209274),
-      GetNavigationStatus(NavigationStatus_RouteState_kTransitionAlert,
+      GetNavigationStatus(NavigationStatus_RouteState_kTracking,
           -76.6277313f, 40.2745628f, leg_index, 6.68837595f, 477,
-          maneuver_index, 0.168269634f, 7, instruction_index, 0.15f));
+          maneuver_index, 0.168269634f, 7));
   //----------------------------------------------------------------
   // trace point = 485
   maneuver_index = 7;
@@ -14518,14 +14518,14 @@ void TestAutoMiddletownRoadToLandingsDrive() {
           -76.5747299f, 40.2820511f, leg_index, 1.83353853f, 193,
           maneuver_index, 0.185614944f, 28));
   //----------------------------------------------------------------
-  // trace point = 789 | Alert 0.15 | Turn left onto South Forge Road.
+  // trace point = 789
   maneuver_index = 10;
-  instruction_index = maneuver_index + 1;
+  instruction_index = maneuver_index;
   TryRouteOnLocationChanged(nav,
       GetFixLocation(-76.5745697f, 40.2821312f, 1489615749, 16.4942532),
-      GetNavigationStatus(NavigationStatus_RouteState_kTransitionAlert,
+      GetNavigationStatus(NavigationStatus_RouteState_kTracking,
           -76.5745697f, 40.282135f, leg_index, 1.81703436f, 190,
-          maneuver_index, 0.169110775f, 25, instruction_index, 0.15f));
+          maneuver_index, 0.169110775f, 25));
   //----------------------------------------------------------------
   // trace point = 790
   maneuver_index = 10;

--- a/valhalla/tyr/navigator.h
+++ b/valhalla/tyr/navigator.h
@@ -24,6 +24,9 @@ constexpr uint32_t kOnRouteCloseToOriginThreshold = 20;
 // Pre-transition base threshold in seconds
 constexpr uint32_t kPreTransitionBaseThreshold = 4;
 
+// Transition alert and pre-transition time delta in seconds
+constexpr uint32_t kAlertPreTimeDelta = 2;
+
 // Number of words per second - used to calculate pre-transition threshold
 constexpr float kWordsPerSecond = 2.5f;
 
@@ -351,6 +354,19 @@ class Navigator {
      */
     uint32_t GetPreTransitionThreshold(size_t instruction_index) const;
 
+    /**
+     * Returns true if the current transition alert is close to the
+     * pre-transition; otherwise, return false.
+     *
+     * @param  fix_location  The current fix location of user.
+     * @param  nav_status  The current navigation status.
+     * @param  instruction_index  The instruction index to process.
+     *
+     * @return true if the current transition alert is close to the
+     * pre-transition; otherwise, return false.
+     */
+    bool IsAlertCloseToPre(const FixLocation& fix_location,
+        const NavigationStatus& nav_status, size_t instruction_index) const;
     /**
      * Returns true if the specified time in seconds is within the specified
      * lower and upper bounds; otherwise, returns false.


### PR DESCRIPTION
#### Changes

- Added logic to detect and simplify if final transition alert is too close to the corresponding pre-transition
- Updated tests as needed

closes #1022 