### PR TITLE
GPX output for routes

### DIFF
--- a/proto/directions_options.proto
+++ b/proto/directions_options.proto
@@ -6,8 +6,14 @@ message DirectionsOptions {
     kKilometers = 0;
     kMiles = 1;
   }
+  
+  enum Format {
+    json = 0;
+    gpx = 1;
+  }
 
   optional Units units = 1;                         // kKilometers or kMiles
   optional string language = 2 [default = "en-US"]; // Based on IETF BCP 47 language tag string
   optional bool narrative = 3 [default = true];     // Enable/disable narrative production
+  optional Format format = 4 [default = json];     // What the response format should be
 }

--- a/src/odin/util.cc
+++ b/src/odin/util.cc
@@ -75,7 +75,7 @@ bool IsSimilarTurnDegree(uint32_t path_turn_degree,
 }
 
 DirectionsOptions GetDirectionsOptions(const boost::property_tree::ptree& pt) {
-  valhalla::odin::DirectionsOptions directions_options;
+  DirectionsOptions directions_options;
 
   // TODO: validate values coming soon...
 
@@ -90,13 +90,19 @@ DirectionsOptions GetDirectionsOptions(const boost::property_tree::ptree& pt) {
   }
 
   auto lang_ptr = pt.get_optional<std::string>("language");
-  if (lang_ptr) {
+  if (lang_ptr && odin::get_locales().find(*lang_ptr) == odin::get_locales().end()) {
     directions_options.set_language(*lang_ptr);
   }
 
   auto narr_ptr = pt.get_optional<bool>("narrative");
   if (narr_ptr) {
     directions_options.set_narrative(*narr_ptr);
+  }
+
+  auto form_ptr = pt.get_optional<std::string>("format");
+  DirectionsOptions::Format format;
+  if (form_ptr && DirectionsOptions::Format_Parse(*form_ptr, &format)) {
+    directions_options.set_format(format);
   }
 
   return directions_options;

--- a/src/odin/util.cc
+++ b/src/odin/util.cc
@@ -90,7 +90,7 @@ DirectionsOptions GetDirectionsOptions(const boost::property_tree::ptree& pt) {
   }
 
   auto lang_ptr = pt.get_optional<std::string>("language");
-  if (lang_ptr && odin::get_locales().find(*lang_ptr) == odin::get_locales().end()) {
+  if (lang_ptr && odin::get_locales().find(*lang_ptr) != odin::get_locales().end()) {
     directions_options.set_language(*lang_ptr);
   }
 

--- a/src/odin/worker.cc
+++ b/src/odin/worker.cc
@@ -34,10 +34,10 @@ namespace valhalla {
 
     DirectionsOptions odin_worker_t::parse_options(boost::property_tree::ptree& request) const {
       //see if we can get some options
-      auto directions_options = DirectionsOptions::default_instance();
+      DirectionsOptions directions_options;
       auto options = request.get_child_optional("directions_options");
       if(options)
-        directions_options = valhalla::odin::GetDirectionsOptions(*options);
+        directions_options = odin::GetDirectionsOptions(*options);
 
       // Grab language from options and set
       request.put<std::string>("directions_options.language", directions_options.language());

--- a/src/tyr/actor.cc
+++ b/src/tyr/actor.cc
@@ -89,6 +89,9 @@ namespace valhalla {
       auto legs = pimpl->thor_worker.route(request_pt, date_time_type);
       //parse the options for directions
       auto directions_options = pimpl->odin_worker.parse_options(request_pt);
+      //gpx output
+      if(directions_options.format() == DirectionsOptions::Format::DirectionsOptions_Format_gpx)
+        return pathToGPX(legs);
       //get some directions back from them
       auto directions = pimpl->odin_worker.narrate(directions_options, legs);
       //serialize them out to json string
@@ -146,6 +149,9 @@ namespace valhalla {
       auto legs = pimpl->thor_worker.optimized_route(request_pt);
       //parse the options for directions
       auto directions_options = pimpl->odin_worker.parse_options(request_pt);
+      //gpx output
+      if(directions_options.format() == DirectionsOptions::Format::DirectionsOptions_Format_gpx)
+        return pathToGPX(legs);
       //get some directions back from them
       auto directions = pimpl->odin_worker.narrate(directions_options, legs);
       //serialize them out to json string
@@ -188,6 +194,9 @@ namespace valhalla {
       std::list<TripPath> legs{pimpl->thor_worker.trace_route(request_pt)};
       //parse the options for directions
       auto directions_options = pimpl->odin_worker.parse_options(request_pt);
+      //gpx output
+      if(directions_options.format() == DirectionsOptions::Format::DirectionsOptions_Format_gpx)
+        return pathToGPX(legs);
       //get some directions back from them
       auto directions = pimpl->odin_worker.narrate(directions_options, legs);
       //serialize them out to json string

--- a/src/tyr/actor.cc
+++ b/src/tyr/actor.cc
@@ -87,8 +87,10 @@ namespace valhalla {
       auto date_time_type = GetOptionalFromRapidJson<int>(request, "/date_time.type");
       auto request_pt = to_ptree(request);
       auto legs = pimpl->thor_worker.route(request_pt, date_time_type);
+      //parse the options for directions
+      auto directions_options = pimpl->odin_worker.parse_options(request_pt);
       //get some directions back from them
-      auto directions = pimpl->odin_worker.narrate(request_pt, legs);
+      auto directions = pimpl->odin_worker.narrate(directions_options, legs);
       //serialize them out to json string
       auto json = tyr::serializeDirections(action, request_pt, directions);
       std::stringstream ss;
@@ -142,8 +144,10 @@ namespace valhalla {
       auto request_pt = to_ptree(request);
       //compute compute all pairs and then the shortest path through them all
       auto legs = pimpl->thor_worker.optimized_route(request_pt);
+      //parse the options for directions
+      auto directions_options = pimpl->odin_worker.parse_options(request_pt);
       //get some directions back from them
-      auto directions = pimpl->odin_worker.narrate(request_pt, legs);
+      auto directions = pimpl->odin_worker.narrate(directions_options, legs);
       //serialize them out to json string
       auto json = tyr::serializeDirections(ROUTE, request_pt, directions);
       std::stringstream ss;
@@ -182,8 +186,10 @@ namespace valhalla {
       //route between the locations in the graph to find the best path
       auto request_pt = to_ptree(request);
       std::list<TripPath> legs{pimpl->thor_worker.trace_route(request_pt)};
+      //parse the options for directions
+      auto directions_options = pimpl->odin_worker.parse_options(request_pt);
       //get some directions back from them
-      auto directions = pimpl->odin_worker.narrate(request_pt, legs);
+      auto directions = pimpl->odin_worker.narrate(directions_options, legs);
       //serialize them out to json string
       auto json = tyr::serializeDirections(ROUTE, request_pt, directions);
       std::stringstream ss;

--- a/src/tyr/serializers.cc
+++ b/src/tyr/serializers.cc
@@ -1646,5 +1646,48 @@ namespace valhalla {
       }
     }
 
+    std::string pathToGPX(const std::list<odin::TripPath>& legs) {
+      //start the gpx, we'll use 6 digits of precision
+      std::stringstream gpx;
+      gpx << std::setprecision(6) << std::fixed;
+      gpx << R"(<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gpx version="1.1" creator="libvalhalla">
+<metadata></metadata>)";
+
+      //for each leg
+      for(const auto& leg : legs) {
+        //decode the shape for this leg
+        auto wpts = midgard::decode<std::vector<std::pair<float, float> > >(leg.shape());
+
+        //throw the shape points in as way points
+        //TODO: add time to each, need transition time at nodes
+        for(const auto& wpt : wpts)
+          gpx << R"(<wpt lon=")" << wpt.first << R"(" lat=")" << wpt.second << R"("></wpt>)";
+
+        //throw the intersections in as route points
+        //TODO: add time to each, need transition time at nodes
+        gpx << "<rte>";
+        uint64_t last_id = -1;
+        for(const auto& node : leg.node()) {
+          //if this isnt the last node we want the begin shape index of the edge
+          size_t shape_idx = wpts.size() - 1;
+          if(node.has_edge()) {
+            last_id = node.edge().way_id();
+            shape_idx = node.edge().begin_shape_index();
+          }
+
+          //output this intersection (note that begin and end points may not be intersections)
+          const auto& rtept = wpts[shape_idx];
+          gpx << R"(<rtept lon=")" << rtept.first << R"(" lat=")" << rtept.second << R"(">)"
+              << "<name>" << last_id << "</name></rtept>";
+        }
+        gpx << "</rte>";
+      }
+
+      //give it back as a string
+      gpx << "</gpx>";
+      return gpx.str();
+    }
+
   }
 }

--- a/src/tyr/serializers.cc
+++ b/src/tyr/serializers.cc
@@ -1650,9 +1650,7 @@ namespace valhalla {
       //start the gpx, we'll use 6 digits of precision
       std::stringstream gpx;
       gpx << std::setprecision(6) << std::fixed;
-      gpx << R"(<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
-<gpx version="1.1" creator="libvalhalla">
-<metadata></metadata>)";
+      gpx << R"(<?xml version="1.0" encoding="UTF-8" standalone="no"?><gpx version="1.1" creator="libvalhalla"><metadata/>)";
 
       //for each leg
       for(const auto& leg : legs) {

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -243,6 +243,7 @@ namespace valhalla {
   const headers_t::value_type CORS{"Access-Control-Allow-Origin", "*"};
   const headers_t::value_type JSON_MIME{"Content-type", "application/json;charset=utf-8"};
   const headers_t::value_type JS_MIME{"Content-type", "application/javascript;charset=utf-8"};
+  const headers_t::value_type XML_MIME{"Content-type", "text/xml;charset=utf-8"};
 
   worker_t::result_t jsonify_error(const valhalla_exception_t& exception, http_request_info_t& request_info, const boost::optional<std::string>& jsonp) {
     //get the http status
@@ -304,6 +305,15 @@ namespace valhalla {
     result.messages.emplace_back(response.to_string());
     return result;
   }
+
+  worker_t::result_t to_response_xml(const std::string& xml, http_request_info_t& request_info) {
+    worker_t::result_t result{false};
+    http_response_t response(200, "OK", xml, headers_t{CORS, XML_MIME});
+    response.from_info(request_info);
+    result.messages.emplace_back(response.to_string());
+    return result;
+  }
+
 
 #endif
 

--- a/valhalla/odin/worker.h
+++ b/valhalla/odin/worker.h
@@ -2,6 +2,7 @@
 #define __VALHALLA_ODIN_SERVICE_H__
 
 #include <valhalla/worker.h>
+#include <valhalla/proto/directions_options.pb.h>
 #include <valhalla/proto/tripdirections.pb.h>
 #include <valhalla/proto/trippath.pb.h>
 
@@ -21,7 +22,10 @@ namespace valhalla {
 #endif
       virtual void cleanup() override;
 
-      std::list<TripDirections> narrate(boost::property_tree::ptree& request, std::list<TripPath>& legs) const;
+      std::list<TripDirections> narrate(const DirectionsOptions& directions_options,
+          std::list<TripPath>& legs) const;
+
+      DirectionsOptions parse_options(boost::property_tree::ptree& request) const;
     };
   }
 }

--- a/valhalla/tyr/serializers.h
+++ b/valhalla/tyr/serializers.h
@@ -8,6 +8,7 @@
 
 #include <valhalla/worker.h>
 #include <valhalla/proto/tripdirections.pb.h>
+#include <valhalla/proto/trippath.pb.h>
 #include <valhalla/proto/route.pb.h>
 #include <valhalla/tyr/actor.h>
 
@@ -25,6 +26,12 @@ namespace valhalla {
      */
     void jsonToProtoRoute (const std::string& json_route, Route& proto_route);
 
+    /**
+     * Returns GPX formatted route responses given the legs of the route
+     * @param  legs  The legs of the route
+     * @return the gpx string
+     */
+    std::string pathToGPX(const std::list<odin::TripPath>& legs);
   }
 }
 

--- a/valhalla/worker.h
+++ b/valhalla/worker.h
@@ -25,6 +25,7 @@ namespace valhalla {
   worker_t::result_t jsonify_error(const valhalla_exception_t& exception, http_request_info_t& request_info, const boost::optional<std::string>& jsonp = boost::none);
   worker_t::result_t to_response(baldr::json::ArrayPtr array, const boost::optional<std::string>& jsonp, http_request_info_t& request_info);
   worker_t::result_t to_response(baldr::json::MapPtr map, const boost::optional<std::string>& jsonp, http_request_info_t& request_info);
+  worker_t::result_t to_response_xml(const std::string& xml, http_request_info_t& request_info);
 #endif
 
   class service_worker_t {


### PR DESCRIPTION
This pr enables GPX output for routes. Right now the output is very basic. Each waypoint is just the shape from the original underlying data. Each route will be a leg of the trip. Each route point will be the intersection (graph node) except when the route begins or ends not at a graph node those route points will be along a graph edge. Each route point also contains a name which is the way id (underlying data id) for the edge in the graph. The last two route points will likely have the same name. Here's an example:

```
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<gpx version="1.1" creator="libvalhalla">
  <metadata/>
  <wpt lon="-76.383102" lat="40.548489"/>
  <wpt lon="-76.383102" lat="40.548538"/>
  <wpt lon="-76.383118" lat="40.548561"/>
  <wpt lon="-76.383156" lat="40.548588"/>
  <wpt lon="-76.383217" lat="40.548607"/>
  <wpt lon="-76.383850" lat="40.548611"/>
  <wpt lon="-76.383377" lat="40.548679"/>
  <wpt lon="-76.382942" lat="40.548756"/>
  <wpt lon="-76.382408" lat="40.548706"/>
  <wpt lon="-76.382065" lat="40.548622"/>
  <wpt lon="-76.382057" lat="40.548534"/>
  <wpt lon="-76.382019" lat="40.548466"/>
  <wpt lon="-76.381897" lat="40.548290"/>
  <rte>
    <rtept lon="-76.383102" lat="40.548489">
      <name>15014175</name>
    </rtept>
    <rtept lon="-76.383850" lat="40.548611">
      <name>241011982</name>
    </rtept>
    <rtept lon="-76.382942" lat="40.548756">
      <name>241011982</name>
    </rtept>
    <rtept lon="-76.382065" lat="40.548622">
      <name>15007730</name>
    </rtept>
    <rtept lon="-76.381897" lat="40.548290">
      <name>15007730</name>
    </rtept>
  </rte>
</gpx>
```