### PR TITLE
Explicitly convert unsigned long to uint64_t

### DIFF
--- a/src/loki/transit_available_action.cc
+++ b/src/loki/transit_available_action.cc
@@ -18,7 +18,7 @@ namespace {
     ({
       {"input_lat", json::fp_t{location.latlng_.lat(), 6}},
       {"input_lon", json::fp_t{location.latlng_.lng(), 6}},
-      {"radius", location.radius_}
+      {"radius", static_cast<uint64_t>(location.radius_)}
     });
     json->emplace("istransit", istransit);
     return json;


### PR DESCRIPTION
On macOS, the radius of type `unsigned long` doesn't work with the `Value` type in `baldr/json.h`, and will report

```
/usr/local/include/boost/variant/variant.hpp:1768:9: note: in instantiation of function template specialization 'boost::variant<std::__1::basic_string<char>,
      unsigned long long, long long, valhalla::baldr::json::fp_t, bool, nullptr_t, std::__1::shared_ptr<valhalla::baldr::json::Jmap>,
      std::__1::shared_ptr<valhalla::baldr::json::Jarray> >::convert_construct<const unsigned long>' requested here                           
        convert_construct(operand, 1L);
```

Explicitly conversion to `uint64_t` fixed the problem.
