### PR TITLE
Addition of sac_scale

### DIFF
--- a/src/baldr/directededge.cc
+++ b/src/baldr/directededge.cc
@@ -350,6 +350,13 @@ void DirectedEdge::set_classification(const RoadClass roadclass) {
   classification_= static_cast<uint32_t>(roadclass);
 }
 
+// Sets the sac scale. Shows if edge is meant for hiking, and if so how difficult
+// of a hike it is.
+void DirectedEdge::set_sac_scale(const SacScale sac_scale)
+{
+  sac_scale_ = static_cast<uint64_t>(sac_scale);
+}
+
 // Sets the surface type (see baldr/graphconstants.h). This is a general
 // indication of smoothness.
 void DirectedEdge::set_surface(const Surface surface) {

--- a/src/mjolnir/directededgebuilder.cc
+++ b/src/mjolnir/directededgebuilder.cc
@@ -51,6 +51,7 @@ DirectedEdgeBuilder::DirectedEdgeBuilder(
 
   set_dismount (way.dismount());
   set_use_sidepath (way.use_sidepath());
+  set_sac_scale (way.sac_scale());
   set_surface(way.surface());
   set_tunnel(way.tunnel());
   set_roundabout(way.roundabout());

--- a/src/mjolnir/osmway.cc
+++ b/src/mjolnir/osmway.cc
@@ -530,6 +530,18 @@ Surface OSMWay::surface() const {
   return static_cast<Surface>(attributes_.fields.surface);
 }
 
+// Set the sac scale.
+void OSMWay::set_sac_scale(const SacScale sac_scale)
+{
+  attributes_.fields.sac_scale = static_cast<uint8_t>(sac_scale);
+}
+
+// Get the sac scale.
+SacScale OSMWay::sac_scale() const
+{
+  return static_cast<SacScale>(attributes_.fields.sac_scale);
+}
+
 // Set the right cycle lane.
 void OSMWay::set_cyclelane_right(const CycleLane cyclelane) {
   bike_info_.fields.cycle_lane_right = static_cast<uint8_t>(cyclelane);

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -618,8 +618,17 @@ struct graph_callback : public OSMPBF::Callback {
         std::string value = tag.second;
         boost::algorithm::to_lower(value);
 
-        if (value.find("alpine_hiking") != std::string::npos)
+        if (value.find("difficult_alpine_hiking") != std::string::npos)
+          w.set_sac_scale(SacScale::kDifficultAlpineHiking);
+
+        else if (value.find("demanding_alpine_hiking") != std::string::npos)
+          w.set_sac_scale(SacScale::kDemandingAlpineHiking);
+
+        else if (value.find("alpine_hiking") != std::string::npos)
           w.set_sac_scale(SacScale::kAlpineHiking);
+
+        else if (value.find("demanding_mountain_hiking") != std::string::npos)
+          w.set_sac_scale(SacScale::kDemandingMountainHiking);
 
         else if (value.find("mountain_hiking") != std::string::npos)
           w.set_sac_scale(SacScale::kMountainHiking);

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -614,6 +614,23 @@ struct graph_callback : public OSMPBF::Callback {
       else if (tag.first == "int_ref" && !tag.second.empty())
         w.set_int_ref_index(osmdata_.ref_offset_map.index(tag.second));
 
+      else if (tag.first == "sac_scale") {
+        std::string value = tag.second;
+        boost::algorithm::to_lower(value);
+
+        if (value.find("alpine_hiking") != std::string::npos)
+          w.set_sac_scale(SacScale::kAlpineHiking);
+
+        else if (value.find("mountain_hiking") != std::string::npos)
+          w.set_sac_scale(SacScale::kMountainHiking);
+
+        else if (value.find("hiking") != std::string::npos)
+          w.set_sac_scale(SacScale::kHiking);
+
+        else
+          w.set_sac_scale(SacScale::kNone);
+      }
+
       else if (tag.first == "surface") {
         std::string value = tag.second;
         boost::algorithm::to_lower(value);

--- a/src/sif/pedestriancost.cc
+++ b/src/sif/pedestriancost.cc
@@ -110,11 +110,21 @@ constexpr ranged_default_t<uint32_t> kTransitTransferMaxDistanceRange{0, kTransi
                                                                       50000}; // Max 50k
 constexpr ranged_default_t<float> kUseFerryRange{0, kDefaultUseFerry, 1.0f};
 
-constexpr float kSacScaleFactor[] = {
+constexpr float kSacScaleSpeedFactor[] = {
+    1.0f,   // kNone
+    1.11f,  // kHiking (~90% speed)
+    1.25f,  // kMountainHiking (80% speed)
+    1.54f,  // kDemandingMountainHiking (~65% speed)
+    2.5f,   // kAlpineHiking (40% speed)
+    4.0f,   // kDemandingAlpineHiking (25% speed)
+    6.67f   // kDifficultAlpineHiking (~15% speed)
+};
+
+constexpr float kSacScaleCostFactor[] = {
     0.0f,   // kNone
-    0.5f,   // kHiking
-    1.0f,   // kMountainHiking
-    1.5f,   // kDemandingMountainHiking
+    0.25f,  // kHiking
+    0.75f,  // kMountainHiking
+    1.25f,  // kDemandingMountainHiking
     2.0f,   // kAlpineHiking
     2.5f,   // kDemandingAlpineHiking
     3.0f    // kDifficultAlpineHiking
@@ -560,7 +570,7 @@ Cost PedestrianCost::EdgeCost(const baldr::DirectedEdge* edge) const {
     return { sec * ferry_factor_, sec };
   }
 
-  float factor = 1.0f + kSacScaleFactor[static_cast<uint8_t>(edge->sac_scale())];
+  float factor = 1.0f + kSacScaleCostFactor[static_cast<uint8_t>(edge->sac_scale())];
 
   if (edge->use() == Use::kFootway) {
     factor *= walkway_factor_;
@@ -575,7 +585,8 @@ Cost PedestrianCost::EdgeCost(const baldr::DirectedEdge* edge) const {
   }
 
   // Slightly favor walkways/paths and penalize alleys and driveways.
-  float sec = edge->length() * speedfactor_;
+  float sec = edge->length() * speedfactor_
+      * kSacScaleSpeedFactor[static_cast<uint8_t>(edge->sac_scale())];
   return { sec * factor, sec };
 }
 

--- a/src/sif/pedestriancost.cc
+++ b/src/sif/pedestriancost.cc
@@ -36,6 +36,7 @@ constexpr uint32_t kDefaultMaxGradeFoot = 90;
 constexpr uint32_t kDefaultMaxGradeWheelchair = 12; // Conservative for now...
 
 // Other defaults (not dependent on type)
+constexpr uint8_t kDefaultMaxHikingDifficulty = 1; // T1 (kHiking)
 constexpr float kModeFactor             = 1.5f;   // Favor this mode?
 constexpr float kDefaultManeuverPenalty = 5.0f;   // Seconds
 constexpr float kDefaultGatePenalty     = 10.0f;  // Seconds
@@ -94,6 +95,7 @@ constexpr ranged_default_t<uint32_t> kMaxGradeWheelchairRange{0, kDefaultMaxGrad
 constexpr ranged_default_t<uint32_t> kMaxGradeFootRange{0, kDefaultMaxGradeFoot, kDefaultMaxGradeFoot};
 
 // Other valid ranges and defaults (not dependent on type)
+constexpr ranged_default_t<uint8_t> kMaxHikingDifficultyRange{0, kDefaultMaxHikingDifficulty, 6};
 constexpr ranged_default_t<float> kModeFactorRange{kMinFactor, kModeFactor, kMaxFactor};
 constexpr ranged_default_t<float> kManeuverPenaltyRange{kMinFactor, kDefaultManeuverPenalty, kMaxSeconds};
 constexpr ranged_default_t<float> kGatePenaltyRange{kMinFactor, kDefaultGatePenalty, kMaxSeconds};
@@ -286,9 +288,10 @@ class PedestrianCost : public DynamicCost {
    virtual const EdgeFilter GetEdgeFilter() const {
      // Throw back a lambda that checks the access for this type of costing
      auto access_mask = access_mask_;
-     return [access_mask](const baldr::DirectedEdge* edge) {
+     auto max_sac_scale = max_hiking_difficulty_;
+     return [access_mask, max_sac_scale](const baldr::DirectedEdge* edge) {
        return !(edge->IsTransition() || edge->is_shortcut() ||
-           edge->use() >= Use::kRail ||
+           edge->use() >= Use::kRail || edge->sac_scale() > max_sac_scale ||
           !(edge->forwardaccess() & access_mask));
      };
    }
@@ -336,6 +339,7 @@ class PedestrianCost : public DynamicCost {
   Surface minimal_allowed_surface_;
 
   uint32_t max_grade_;    // Maximum grade (percent).
+  SacScale max_hiking_difficulty_;  // Max sac_scale (0 - 6)
   float speed_;           // Pedestrian speed.
   float speedfactor_;     // Speed factor for costing. Based on speed.
   float walkway_factor_;  // Factor for favoring walkways and paths.
@@ -408,6 +412,14 @@ PedestrianCost::PedestrianCost(const boost::property_tree::ptree& pt)
     minimal_allowed_surface_ = Surface::kPath;
   }
 
+  if (type == "foot")
+  {
+    max_hiking_difficulty_ = static_cast<SacScale> (kMaxHikingDifficultyRange(
+      pt.get<uint8_t>("max_hiking_difficulty", kDefaultMaxHikingDifficulty)
+    ));
+  } else {
+    max_hiking_difficulty_ = SacScale::kNone;
+  }
 
   mode_factor_ = kModeFactorRange(
     pt.get<float>("mode_factor", kModeFactor)
@@ -517,6 +529,7 @@ bool PedestrianCost::Allowed(const baldr::DirectedEdge* edge,
   if (!(edge->forwardaccess() & access_mask_) ||
        (edge->surface() > minimal_allowed_surface_) ||
         edge->is_shortcut() || IsUserAvoidEdge(edgeid) ||
+        edge->sac_scale() > max_hiking_difficulty_ ||
  //      (edge->max_up_slope() > max_grade_ || edge->max_down_slope() > max_grade_) ||
       ((pred.path_distance() + edge->length()) > max_distance_)) {
     return false;
@@ -546,6 +559,7 @@ bool PedestrianCost::AllowedReverse(const baldr::DirectedEdge* edge,
   if (!(opp_edge->forwardaccess() & access_mask_) ||
        (opp_edge->surface() > minimal_allowed_surface_) ||
         opp_edge->is_shortcut() || IsUserAvoidEdge(opp_edgeid) ||
+        edge->sac_scale() > max_hiking_difficulty_ ||
  //      (opp_edge->max_up_slope() > max_grade_ || opp_edge->max_down_slope() > max_grade_) ||
         opp_edge->use() == Use::kTransitConnection || opp_edge->use() == Use::kEgressConnection ||
         opp_edge->use() == Use::kPlatformConnection) {

--- a/src/sif/pedestriancost.cc
+++ b/src/sif/pedestriancost.cc
@@ -112,9 +112,12 @@ constexpr ranged_default_t<float> kUseFerryRange{0, kDefaultUseFerry, 1.0f};
 
 constexpr float kSacScaleFactor[] = {
     0.0f,   // kNone
-    1.0f,   // kHiking
-    2.0f,   // kMountainHiking
-    3.0f    // kAlpineHiking
+    0.5f,   // kHiking
+    1.0f,   // kMountainHiking
+    1.5f,   // kDemandingMountainHiking
+    2.0f,   // kAlpineHiking
+    2.5f,   // kDemandingAlpineHiking
+    3.0f    // kDifficultAlpineHiking
 };
 
 }

--- a/valhalla/baldr/directededge.h
+++ b/valhalla/baldr/directededge.h
@@ -1107,9 +1107,8 @@ class DirectedEdge {
   uint64_t named_          : 1;  // 1 if this edge has names, 0 if unnamed
   uint64_t lane_conn_      : 1;  // 1 if has lane connectivity, 0 otherwise
   uint64_t traffic_seg_    : 1;  // 1 if has a traffic segment, 0 otherwise
-  uint64_t sac_scale_      : 2;  // Is this edge for hiking and if so how difficult is the hike?
-                                 // WARNING: MAY INCREASE BY 1 BIT. KEEP ONE BIT OPEN IN FRONT.
-  uint64_t spare_          : 7;
+  uint64_t sac_scale_      : 3;  // Is this edge for hiking and if so how difficult is the hike?
+  uint64_t spare_          : 6;
 
   // Geometric attributes: length, weighted grade, curvature factor.
   // Turn types between edges.

--- a/valhalla/baldr/directededge.h
+++ b/valhalla/baldr/directededge.h
@@ -582,6 +582,22 @@ class DirectedEdge {
   void set_classification(const RoadClass roadclass);
 
   /**
+   * Gets the sac scale. Shows if edge is meant for hiking, and if so how difficult
+   * of a hike it is.
+   * @return  sac_scale
+   */
+  SacScale sac_scale() const {
+    return static_cast<SacScale>(sac_scale_);
+  }
+
+  /**
+   * Sets the sac scale. Shows if edge is meant for hiking, and if so how difficult
+   * of a hike it is.
+   * @param  sac_scale SacScale type
+   */
+  void set_sac_scale(const SacScale sac_scale);
+
+  /**
    * Is this edge unpaved or bad surface?
    */
   bool unpaved() const {
@@ -1091,7 +1107,9 @@ class DirectedEdge {
   uint64_t named_          : 1;  // 1 if this edge has names, 0 if unnamed
   uint64_t lane_conn_      : 1;  // 1 if has lane connectivity, 0 otherwise
   uint64_t traffic_seg_    : 1;  // 1 if has a traffic segment, 0 otherwise
-  uint64_t spare_          : 9;
+  uint64_t sac_scale_      : 2;  // Is this edge for hiking and if so how difficult is the hike?
+                                 // WARNING: MAY INCREASE BY 1 BIT. KEEP ONE BIT OPEN IN FRONT.
+  uint64_t spare_          : 7;
 
   // Geometric attributes: length, weighted grade, curvature factor.
   // Turn types between edges.

--- a/valhalla/baldr/graphconstants.h
+++ b/valhalla/baldr/graphconstants.h
@@ -339,6 +339,13 @@ inline std::string to_string(CycleLane c) {
   return i->second;
 }
 
+enum class SacScale : uint8_t {
+  kNoSacScale = 0,
+  kHiking = 1,
+  kMountainHiking = 2,
+  kAlpineHiking = 3
+};
+
 // Generalized representation of surface types. Lower values indicate smoother
 // surfaces. Vehicle or bicycle type can use this to avoid or disallow edges
 // that are "too rough" or inappropriate for the vehicle to travel on.

--- a/valhalla/baldr/graphconstants.h
+++ b/valhalla/baldr/graphconstants.h
@@ -340,7 +340,7 @@ inline std::string to_string(CycleLane c) {
 }
 
 enum class SacScale : uint8_t {
-  kNoSacScale = 0,
+  kNone = 0,
   kHiking = 1,
   kMountainHiking = 2,
   kAlpineHiking = 3

--- a/valhalla/baldr/graphconstants.h
+++ b/valhalla/baldr/graphconstants.h
@@ -343,7 +343,10 @@ enum class SacScale : uint8_t {
   kNone = 0,
   kHiking = 1,
   kMountainHiking = 2,
-  kAlpineHiking = 3
+  kDemandingMountainHiking = 3,
+  kAlpineHiking = 4,
+  kDemandingAlpineHiking = 5,
+  kDifficultAlpineHiking = 6
 };
 
 // Generalized representation of surface types. Lower values indicate smoother

--- a/valhalla/mjolnir/osmway.h
+++ b/valhalla/mjolnir/osmway.h
@@ -630,6 +630,18 @@ struct OSMWay {
   baldr::Surface surface() const;
 
   /**
+   * Sets the sac scale.
+   * @param  sac_scale
+   */
+  void set_sac_scale(const baldr::SacScale sac_scale);
+
+  /**
+   * Gets the sac scale.
+   * @return  Returns sac_scale
+   */
+  baldr::SacScale sac_scale() const;
+
+  /**
    * Sets the right cycle lane.
    * @param  cyclelane
    */
@@ -1098,7 +1110,8 @@ struct OSMWay {
       uint32_t truck_route            :1;
       uint32_t sidewalk_right         :1;
       uint32_t sidewalk_left          :1;
-      uint32_t spare                  :3;
+      uint32_t sac_scale              :2;
+      uint32_t spare                  :1;
     } fields;
     uint32_t v;
   };

--- a/valhalla/mjolnir/osmway.h
+++ b/valhalla/mjolnir/osmway.h
@@ -1110,8 +1110,7 @@ struct OSMWay {
       uint32_t truck_route            :1;
       uint32_t sidewalk_right         :1;
       uint32_t sidewalk_left          :1;
-      uint32_t sac_scale              :2;
-      uint32_t spare                  :1;
+      uint32_t sac_scale              :3;
     } fields;
     uint32_t v;
   };


### PR DESCRIPTION
sac_scale now added to DE and is used by pedestrian.
Pedestrian also now has a "max_hiking_difficulty" parameter that takes an integer from 0 to 6 to represent the sac scales of (no sac_scale and) T1- T6. Any sac_scale above the specified max_hiking_difficulty is disallowed from routing. The default is 1.