### PR TITLE
Graphid - change from union to struct

### DIFF
--- a/src/baldr/graphid.cc
+++ b/src/baldr/graphid.cc
@@ -1,36 +1,17 @@
 #include <limits>
 
 #include "baldr/graphid.h"
-#include "baldr/graphconstants.h"
 
 namespace valhalla {
 namespace baldr {
-
-// Constructor with values for each field of the GraphId.
-GraphId::GraphId(const uint32_t tileid, const uint32_t level,
-                 const uint32_t id) {
-  Set(tileid, level, id);
-}
-
-// Set the fields of the GraphId
-void GraphId::Set(const uint32_t tileid, const uint32_t level,
-                  const uint32_t id) {
-  if(tileid <= kMaxGraphTileId) fields.tileid = tileid;
-  else throw std::logic_error("Tile id out of valid range");
-  if(level <= kMaxGraphHierarchy) fields.level = level;
-  else throw std::logic_error("Level out of valid range");
-  if(id <= kMaxGraphId) fields.id = id;
-  else throw std::logic_error("Id out of valid range");
-  fields.spare = 0;
-}
 
 // The json representation of the Id
 json::Value GraphId::json() const {
   if(Is_Valid())
     return json::map({
-      {"level", static_cast<uint64_t>(fields.level)},
-      {"tile_id", static_cast<uint64_t>(fields.tileid)},
-      {"id", static_cast<uint64_t>(fields.id)},
+      {"level", static_cast<uint64_t>(level())},
+      {"tile_id", static_cast<uint64_t>(tileid())},
+      {"id", static_cast<uint64_t>(id())},
       {"value", value},
     });
   return static_cast<std::nullptr_t>(nullptr);
@@ -38,7 +19,7 @@ json::Value GraphId::json() const {
 
 // Stream output
 std::ostream& operator<<(std::ostream& os, const GraphId& id) {
-  return os << id.fields.level << '/' << id.fields.tileid << '/' << id.fields.id;
+  return os << id.level() << '/' << id.tileid() << '/' << id.id();
 }
 
 }

--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -274,7 +274,7 @@ GraphId GraphReader::GetOpposingEdgeId(const GraphId& edgeid, const GraphTile*& 
     return {};
 
   // Get the opposing edge
-  id.fields.id = tile->node(id)->edge_index() + directededge->opp_index();
+  id.set_id(tile->node(id)->edge_index() + directededge->opp_index());
   return id;
 }
 

--- a/src/baldr/tilehierarchy.cc
+++ b/src/baldr/tilehierarchy.cc
@@ -28,7 +28,7 @@ GraphId TileHierarchy::GetGraphId(const midgard::PointLL& pointll, const uint8_t
   if(tl != levels_.end()) {
     auto tile_id = tl->second.tiles.TileId(pointll);
     if (tile_id >= 0) {
-      id.Set(tile_id, level, 0);
+      id = { static_cast<uint32_t>(tile_id), level, 0 };
     }
   }
   return id;

--- a/src/loki/node_search.cc
+++ b/src/loki/node_search.cc
@@ -205,11 +205,11 @@ struct sort_by_tile {
   sort_by_tile() {}
 
   inline bool operator()(vb::GraphId a, vb::GraphId b) const {
-    return ((a.fields.level < b.fields.level) ||
-            ((a.fields.level == b.fields.level) &&
-             ((a.fields.tileid < b.fields.tileid) ||
-              ((a.fields.tileid == b.fields.tileid) &&
-               (a.fields.id < b.fields.id)))));
+    return ((a.level() < b.level()) ||
+            ((a.level() == b.level()) &&
+             ((a.tileid() < b.tileid()) ||
+              ((a.tileid() == b.tileid()) &&
+               (a.id() < b.id())))));
   }
 };
 

--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -325,7 +325,7 @@ struct bin_handler_t {
 
         //get some info about this edge and the opposing
         GraphId id = tile->id();
-        id.fields.id = node->edge_index() + (edge - start_edge);
+        id.set_id(node->edge_index() + (edge - start_edge));
         auto info = tile->edgeinfo(edge->edgeinfo_offset());
 
         //do we want this edge

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -77,17 +77,17 @@ std::map<GraphId, size_t> SortGraph(const std::string& nodes_file,
       //remember if this was a new tile
       if(node_index == 0 || node.graph_id != (--tiles.end())->first) {
         tiles.insert({node.graph_id, node_index});
-        node.graph_id.fields.id = 0;
+        node.graph_id.set_id(0);
         run_index = node_index;
         ++node_count;
       }//but is it a new node
       else if(last_node.node.osmid != node.node.osmid) {
-        node.graph_id.fields.id = last_node.graph_id.fields.id + 1;
+        node.graph_id.set_id(last_node.graph_id.id() + 1);
         run_index = node_index;
         ++node_count;
       }//not new keep the same graphid
       else
-        node.graph_id.fields.id = last_node.graph_id.fields.id;
+        node.graph_id.set_id(last_node.graph_id.id());
 
       //if this node marks the start of an edge, go tell the edge where the first node in the series is
       if(node.is_start()) {

--- a/src/mjolnir/transitbuilder.cc
+++ b/src/mjolnir/transitbuilder.cc
@@ -442,8 +442,8 @@ void FindOSMConnection(const PointLL& stop_ll, GraphReader& reader_local_level,
             // use the new wayid
 
             wayid = edgeinfo.wayid();
-            startnode.Set(newtile->header()->graphid().tileid(),
-                          newtile->header()->graphid().level(), i);
+            startnode = { newtile->header()->graphid().tileid(),
+                          newtile->header()->graphid().level(), i };
             endnode = directededge->endnode();
             mindist = std::get<1>(this_closest);
             closest = this_closest;
@@ -493,8 +493,8 @@ void AddOSMConnection(const GraphId& transit_stop_node,
         names = edgeinfo.GetNames();
 
         if (std::get<1>(this_closest) < mindist) {
-          startnode.Set(tile->header()->graphid().tileid(),
-                        tile->header()->graphid().level(), i);
+          startnode = { tile->header()->graphid().tileid(),
+                        tile->header()->graphid().level(), i };
           endnode = directededge->endnode();
           mindist = std::get<1>(this_closest);
           closest = this_closest;
@@ -693,8 +693,7 @@ void TransitBuilder::Build(const boost::property_tree::ptree& pt) {
     for(; transit_file_itr != end_file_itr; ++transit_file_itr) {
       if(boost::filesystem::is_regular(transit_file_itr->path()) && transit_file_itr->path().extension() == ".gph") {
         auto graph_id = GraphTile::GetTileId(transit_file_itr->path().string());
-        auto local_graph_id = graph_id;
-        local_graph_id.fields.level -= 1;
+        GraphId local_graph_id(graph_id.tileid(), graph_id.level() -1, graph_id.id());
         if(GraphReader::DoesTileExist(hierarchy_properties, local_graph_id)) {
           const GraphTile* tile = reader.GetGraphTile(local_graph_id);
           tiles.emplace(local_graph_id);

--- a/src/mjolnir/valhalla_build_transit.cc
+++ b/src/mjolnir/valhalla_build_transit.cc
@@ -325,8 +325,7 @@ void get_stop_stations(Transit& tile, std::unordered_map<std::string, uint64_t>&
       else if (traversability == "exit")
         node->set_traversability(static_cast<uint32_t>(Traversability::kBackward));
 
-      GraphId egress_id = tile_id;
-      egress_id.fields.id = nodes.size();
+      GraphId egress_id(tile_id.tileid(), tile_id.level(), nodes.size());
       node->set_graphid(egress_id);
 
       // we want to set the previous id to the first egress in the
@@ -354,8 +353,7 @@ void get_stop_stations(Transit& tile, std::unordered_map<std::string, uint64_t>&
     node->set_type(static_cast<uint32_t>(NodeType::kTransitStation));
     set_no_null(std::string, station_pt.second, "name", "null", node->set_name);
     node->set_wheelchair_boarding(station_pt.second.get<bool>("wheelchair_boarding", true));
-    GraphId station_id = tile_id;
-    station_id.fields.id = nodes.size();
+    GraphId station_id(tile_id.tileid(), tile_id.level(), nodes.size());
     node->set_graphid(station_id);
 
     auto tz = station_pt.second.get<std::string>("timezone", "null");
@@ -382,8 +380,7 @@ void get_stop_stations(Transit& tile, std::unordered_map<std::string, uint64_t>&
       node->set_type(static_cast<uint32_t>(NodeType::kMultiUseTransitPlatform));
       set_no_null(std::string, platforms_pt.second, "name", "null", node->set_name);
       node->set_wheelchair_boarding(platforms_pt.second.get<bool>("wheelchair_boarding", true));
-      GraphId platform_id = tile_id;
-      platform_id.fields.id = nodes.size();
+      GraphId platform_id(tile_id.tileid(), tile_id.level(), nodes.size());
       node->set_graphid(platform_id);
 
       auto tz = platforms_pt.second.get<std::string>("timezone", "null");

--- a/src/mjolnir/valhalla_fetch_transit.cc
+++ b/src/mjolnir/valhalla_fetch_transit.cc
@@ -243,8 +243,7 @@ void get_stops(Transit_Fetch& tile, std::unordered_map<std::string, uint64_t>& s
     set_no_null(std::string, stop_pt.second, "name", "null", stop->set_name);
     stop->set_wheelchair_boarding(stop_pt.second.get<bool>("wheelchair_boarding", true));
     set_no_null(uint64_t, stop_pt.second, "tags.osm_way_id", 0, stop->set_osm_way_id);
-    GraphId stop_id = tile_id;
-    stop_id.fields.id = stops.size();
+    GraphId stop_id(tile_id.tileid(), tile_id.level(), stops.size());
     stop->set_graphid(stop_id);
 
     auto tz = stop_pt.second.get<std::string>("timezone", "null");

--- a/src/valhalla_export_edges.cc
+++ b/src/valhalla_export_edges.cc
@@ -59,7 +59,7 @@ struct edge_t {
 edge_t opposing(GraphReader& reader, const GraphTile* tile, const DirectedEdge* edge) {
   const GraphTile* t = edge->leaves_tile() ? reader.GetGraphTile(edge->endnode()) : tile;
   auto id = edge->endnode();
-  id.fields.id = t->node(id)->edge_index() + edge->opp_index();
+  id.set_id(t->node(id)->edge_index() + edge->opp_index());
 
   // Check for invalid opposing index
   if (edge->opp_index() == kMaxEdgesPerNode) {
@@ -84,7 +84,7 @@ edge_t next(const std::unordered_map<GraphId, uint64_t>& tile_set, const bitset_
   for(size_t i = 0; i < node->edge_count(); ++i) {
     //get the edge
     GraphId id = tile->id();
-    id.fields.id = node->edge_index() + i;
+    id.set_id(node->edge_index() + i);
     //already used
     if(edge_set.get(tile_set.find(tile->id())->second + id.id()))
       continue;
@@ -225,7 +225,7 @@ int main(int argc, char *argv[]) {
 
       //make sure we dont ever look at this again
       edge_t edge{tile_count_pair.first, tile->directededge(i)};
-      edge.i.fields.id = i;
+      edge.i.set_id(i);
       edge_set.set(tile_count_pair.second + i);
       ++set;
 

--- a/test/graphid.cc
+++ b/test/graphid.cc
@@ -8,6 +8,32 @@ using namespace valhalla::baldr;
 
 namespace {
 
+void TestValues() {
+  GraphId target(123, 2, 8);
+  if (target.tileid() != 123)
+    throw runtime_error("Tile Id does not match value set");
+  if (target.level() != 2)
+    throw runtime_error("Level does not match value set");
+  if (target.id() != 8) {
+    printf("id = %d\n", target.id());
+    throw runtime_error("Id does not match value set");
+  }
+
+  GraphId target2(5689, 1, 1234567);
+  if (target2.tileid() != 5689)
+    throw runtime_error("Target 2: Tile Id does not match value set");
+  if (target2.level() != 1)
+    throw runtime_error("Target 2: Level does not match value set");
+  if (target2.id() != 1234567) {
+    printf("id = %d\n", target.id());
+    throw runtime_error("Target 2:  Id does not match value set");
+  }
+
+  target.set_id(5678);
+  if (target.id() != 5678 || target.tileid() != 123 || target.level() != 2)
+    throw runtime_error("Values do not match after set_id");
+}
+
 void TestCtorDefault() {
   GraphId target;
   if (target.Is_Valid())
@@ -67,19 +93,6 @@ void TestGet_id() {
   TryGet_id(GraphId(5, 1, 50), 50);
 }
 
-void TrySetUintUintUint(const unsigned int tileid, const unsigned int level,
-                        const unsigned int id, const GraphId& expected) {
-  GraphId result;
-  result.Set(tileid, level, id);
-  if (!(expected == result))
-    throw runtime_error("SetUintUintUint test failed");
-}
-
-void TestSetUintUintUint() {
-  TrySetUintUintUint(10, 2, 1, GraphId(10, 2, 1));
-  TrySetUintUintUint(5, 1, 50, GraphId(5, 1, 50));
-}
-
 void TestIsValid() {
   GraphId id(1,2,3);
   if(!id.Is_Valid())
@@ -136,6 +149,9 @@ void TestOpEqualTo() {
 int main() {
   test::suite suite("graphid");
 
+  // Make sure set and get produce correct values
+  suite.test(TEST_CASE(TestValues));
+
   // Ctor default
   suite.test(TEST_CASE(TestCtorDefault));
 
@@ -153,9 +169,6 @@ int main() {
 
   // Get id
   suite.test(TEST_CASE(TestGet_id));
-
-  // Set uint, uint, uint
-  suite.test(TEST_CASE(TestSetUintUintUint));
 
   // Is Valid
   suite.test(TEST_CASE(TestIsValid));

--- a/test/graphtilebuilder.cc
+++ b/test/graphtilebuilder.cc
@@ -207,7 +207,7 @@ struct fake_tile : public GraphTile {
     auto tiles = TileHierarchy::levels().rbegin()->second.tiles;
     auto id = GraphId(tiles.TileId(s.front()), l, 0);
     auto o_id = GraphId(tiles.TileId(s.front()), l, tiles.TileId(s.back()));
-    o_id.fields.id = o_id == id;
+    o_id.set_id(o_id == id);
     header_ = new GraphTileHeader();
     header_->set_graphid(id);
     header_->set_directededgecount(1 + (id.tileid() == o_id.tileid()) * 1);

--- a/test/node_search.cc
+++ b/test/node_search.cc
@@ -126,11 +126,11 @@ private:
 // functor to sort GraphId objects by level, tile then id within the tile.
 struct sort_by_tile {
   inline bool operator()(vb::GraphId a, vb::GraphId b) const {
-    return ((a.fields.level < b.fields.level) ||
-            ((a.fields.level == b.fields.level) &&
-             ((a.fields.tileid < b.fields.tileid) ||
-              ((a.fields.tileid == b.fields.tileid) &&
-               (a.fields.id < b.fields.id)))));
+    return ((a.level() < b.level()) ||
+            ((a.level() == b.level()) &&
+             ((a.tileid() < b.tileid()) ||
+              ((a.tileid() == b.tileid()) &&
+               (a.id() < b.id())))));
   }
 };
 


### PR DESCRIPTION
Seeing about a 10-15% improvement in pathfinding performance with this change. Internally GraphId now uses bit operations to form the individual fields for return in the access methods and set methods. Externally, places where the prior fields data member was accessed directly now access either the constructor, access methods, or set methods.