### PR TITLE
add actor to python bindings

### DIFF
--- a/src/bindings/python/python.cc
+++ b/src/bindings/python/python.cc
@@ -10,6 +10,7 @@
 
 #include "midgard/logging.h"
 #include "meili/traffic_segment_matcher.h"
+#include "tyr/actor.h"
 
 namespace {
 
@@ -46,6 +47,16 @@ namespace {
   void py_configure(const std::string& config_file) {
     configure(config_file);
   }
+
+  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(route_overloads, route, 1, 1);
+  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(locate_overloads, locate, 1, 1);
+  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(optimized_route_overloads, optimized_route, 1, 1);
+  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(matrix_overloads, matrix, 1, 1);
+  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(isochrone_overloads, isochrone, 1, 1);
+  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(trace_route_overloads, trace_route, 1, 1);
+  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(trace_attributes_overloads, trace_attributes, 1, 1);
+  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(height_overloads, height, 1, 1);
+  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(transit_available_overloads, transit_available, 1, 1);
 }
 
 BOOST_PYTHON_MODULE(valhalla) {
@@ -59,4 +70,20 @@ BOOST_PYTHON_MODULE(valhalla) {
         ("SegmentMatcher", boost::python::no_init)
       .def("__init__", boost::python::make_constructor(+[](){ return boost::make_shared<valhalla::meili::TrafficSegmentMatcher>(configure()); }))
       .def("Match", &valhalla::meili::TrafficSegmentMatcher::match);
+
+  boost::python::class_<valhalla::tyr::actor_t, boost::noncopyable,
+                       boost::shared_ptr<valhalla::tyr::actor_t> >
+        ("Actor", boost::python::no_init)
+      .def("__init__", boost::python::make_constructor(+[](){ return boost::make_shared<valhalla::tyr::actor_t>(configure(), true); }))
+      .def("Route", &valhalla::tyr::actor_t::route, route_overloads())
+      .def("Locate", &valhalla::tyr::actor_t::route, locate_overloads())
+      .def("OptimizedRoute", &valhalla::tyr::actor_t::route, optimized_route_overloads())
+      .def("Matrix", &valhalla::tyr::actor_t::route, matrix_overloads())
+      .def("Isochrone", &valhalla::tyr::actor_t::route, isochrone_overloads())
+      .def("TraceRoute", &valhalla::tyr::actor_t::route, trace_route_overloads())
+      .def("TraceAttributes", &valhalla::tyr::actor_t::route, trace_attributes_overloads())
+      .def("Height", &valhalla::tyr::actor_t::route, height_overloads())
+      .def("TransitAvailable", &valhalla::tyr::actor_t::route, transit_available_overloads())
+
+  ;
 }

--- a/src/tyr/actor.cc
+++ b/src/tyr/actor.cc
@@ -76,7 +76,7 @@ namespace valhalla {
       pimpl->cleanup();
     }
 
-    std::string actor_t::route(ACTION_TYPE action, const std::string& request_str, const std::function<void ()>& interrupt) {
+    std::string actor_t::route(const std::string& request_str, const std::function<void ()>& interrupt) {
       //set the interrupts
       pimpl->set_interrupts(interrupt);
       //parse the request
@@ -90,7 +90,7 @@ namespace valhalla {
       //get some directions back from them
       auto directions = pimpl->odin_worker.narrate(request_pt, legs);
       //serialize them out to json string
-      auto json = tyr::serializeDirections(action, request_pt, directions);
+      auto json = tyr::serializeDirections(ROUTE, request_pt, directions);
       std::stringstream ss;
       ss << *json;
       //if they want you do to do the cleanup automatically
@@ -114,16 +114,16 @@ namespace valhalla {
       return ss.str();
     }
 
-    std::string actor_t::matrix(ACTION_TYPE action, const std::string& request_str, const std::function<void ()>& interrupt) {
+    std::string actor_t::matrix(const std::string& request_str, const std::function<void ()>& interrupt) {
       //set the interrupts
       pimpl->set_interrupts(interrupt);
       //parse the request
       auto request = to_document(request_str);
       //check the request and locate the locations in the graph
-      pimpl->loki_worker.matrix(action, request);
+      pimpl->loki_worker.matrix(SOURCES_TO_TARGETS, request);
       auto request_pt = to_ptree(request);
       //compute the matrix
-      auto json = pimpl->thor_worker.matrix(action, request_pt);
+      auto json = pimpl->thor_worker.matrix(SOURCES_TO_TARGETS, request_pt);
       std::stringstream ss;
       ss << *json;
       //if they want you do to do the cleanup automatically

--- a/test/actor.cc
+++ b/test/actor.cc
@@ -56,10 +56,10 @@ namespace {
     auto conf = make_conf();
     tyr::actor_t actor(conf);
 
-    actor.route(tyr::ROUTE, R"({"locations":[{"lat":40.546115,"lon":-76.385076,"type":"break"},
+    actor.route(R"({"locations":[{"lat":40.546115,"lon":-76.385076,"type":"break"},
       {"lat":40.544232,"lon":-76.385752,"type":"break"}],"costing":"auto"})");
     actor.cleanup();
-    auto route_json = actor.route(tyr::ROUTE, R"({"locations":[{"lat":40.546115,"lon":-76.385076,"type":"break"},
+    auto route_json = actor.route(R"({"locations":[{"lat":40.546115,"lon":-76.385076,"type":"break"},
           {"lat":40.544232,"lon":-76.385752,"type":"break"}],"costing":"auto"})");
     actor.cleanup();
     auto route = json_to_pt(route_json);
@@ -93,7 +93,7 @@ namespace {
     struct test_exception_t {};
 
     try {
-      actor.route(tyr::ROUTE, R"({"locations":[{"lat":40.546115,"lon":-76.385076,"type":"break"},
+      actor.route(R"({"locations":[{"lat":40.546115,"lon":-76.385076,"type":"break"},
         {"lat":40.544232,"lon":-76.385752,"type":"break"}],"costing":"auto"})", []()->void{throw test_exception_t{};});
       throw std::logic_error("this should have thrown already");
     } catch (const test_exception_t& e) { }

--- a/test/mapmatch.cc
+++ b/test/mapmatch.cc
@@ -137,7 +137,7 @@ namespace {
       auto test_case = make_test_case(start, end);
       std::cout << test_case << std::endl;
       boost::property_tree::ptree route;
-      try { route = json_to_pt(actor.route(tyr::ROUTE, test_case)); }
+      try { route = json_to_pt(actor.route(test_case)); }
       catch (...) { std::cout << "route failed" << std::endl; continue; }
       auto encoded_shape = route.get_child("trip.legs").front().second.get<std::string>("shape");
       auto shape = midgard::decode<std::vector<midgard::PointLL> >(encoded_shape);
@@ -236,7 +236,7 @@ namespace {
   void test32bit() {
     tyr::actor_t actor(conf, true);
     std::string test_case = "{\"costing\":\"auto\",\"locations\":[{\"lat\":52.096672,\"lon\":5.110825},{\"lat\":52.081371,\"lon\":5.125671}]}";
-    actor.route(tyr::ROUTE, test_case);
+    actor.route(test_case);
   }
 
   void test_topk_validate() {

--- a/valhalla/tyr/actor.h
+++ b/valhalla/tyr/actor.h
@@ -75,9 +75,9 @@ namespace valhalla {
      public:
       actor_t(const boost::property_tree::ptree& config, bool auto_cleanup = false);
       void cleanup();
-      std::string route(ACTION_TYPE action, const std::string& request_str, const std::function<void ()>& interrupt = []()->void{});
+      std::string route(const std::string& request_str, const std::function<void ()>& interrupt = []()->void{});
       std::string locate(const std::string& request_str, const std::function<void ()>& interrupt = []()->void{});
-      std::string matrix(ACTION_TYPE action, const std::string& request_str, const std::function<void ()>& interrupt = []()->void{});
+      std::string matrix(const std::string& request_str, const std::function<void ()>& interrupt = []()->void{});
       std::string optimized_route(const std::string& request_str, const std::function<void ()>& interrupt = []()->void{});
       std::string isochrone(const std::string& request_str, const std::function<void ()>& interrupt = []()->void{});
       std::string trace_route(const std::string& request_str, const std::function<void ()>& interrupt = []()->void{});


### PR DESCRIPTION
this also simplified the actor actions for route and matrix so that they both only support ROUTE and SOURCES_TO_TARGETS respectively.

here's what it looks from the python console:

```
kkreiser@HP-ZBook-15:~/sandbox/valhalla/valhalla$ PYTHONPATH=.libs/ python
Python 2.7.12 (default, Nov 20 2017, 18:23:56) 
[GCC 5.4.0 20160609] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import json
>>> import valhalla
>>> valhalla.Configure('conf.json')
>>> r={"locations":[{"lat":40.54849,"lon":-76.38312},{"lat":40.54829,"lon":-76.38190}],"costing":"auto"}
>>> a=valhalla.Actor()
2017/12/08 18:31:35.295174 [WARN] Tile extract could not be loaded
2017/12/08 18:31:35.301488 [WARN] /data/valhalla/elevation/ has no elevation tiles
>>> a.Route(json.dumps(r))
2017/12/08 18:31:44.680245 [ANALYTICS] locations_count::2
2017/12/08 18:31:44.680291 [ANALYTICS] costing_type::auto
2017/12/08 18:31:44.680393 [ANALYTICS] location_distance::0.105591km
2017/12/08 18:31:44.686978 [ANALYTICS] travel_mode::0
2017/12/08 18:31:44.696631 [ANALYTICS] admin_state_iso:: PA 
2017/12/08 18:31:44.696652 [ANALYTICS] admin_country_iso:: US 
2017/12/08 18:31:44.696757 [INFO] trip_path_->node_size()=5
2017/12/08 18:31:44.722166 [INFO] maneuver_count::4
'{"trip":{"language":"en-US","summary":{"max_lon":-76.381897,"max_lat":40.548756,"time":41,"length":0.267,"min_lat":40.548290,"min_lon":-76.383850},"locations":[{"lon":-76.383118,"lat":40.548489,"type":"break"},{"lon":-76.381897,"lat":40.548290,"type":"break"}],"units":"kilometers","legs":[{"shape":"og{ilA|v`upCcB?m@\\\\s@jAe@xBGrf@iCq\\\\wCeZ`Bk`@fDoTnDMhCkA|IuF","summary":{"max_lon":-76.381897,"max_lat":40.548756,"time":41,"length":0.267,"min_lat":40.548290,"min_lon":-76.383850},"maneuvers":[{"travel_type":"car","street_names":["Mifflin Street"],"verbal_pre_transition_instruction":"Drive northwest on Mifflin Street for 70 meters. Then Turn sharp right onto East Mill Street.","instruction":"Drive northwest on Mifflin Street.","end_shape_index":5,"type":1,"time":8,"verbal_multi_cue":true,"length":0.072,"begin_shape_index":0,"travel_mode":"drive"},{"travel_type":"car","travel_mode":"drive","verbal_pre_transition_instruction":"Turn sharp right onto East Mill Street.","verbal_transition_alert_instruction":"Turn sharp right onto East Mill Street.","length":0.154,"instruction":"Turn sharp right onto East Mill Street.","end_shape_index":9,"type":11,"time":25,"verbal_post_transition_instruction":"Continue for 200 meters.","street_names":["East Mill Street"],"begin_shape_index":5},{"travel_type":"car","travel_mode":"drive","verbal_multi_cue":true,"verbal_pre_transition_instruction":"Turn right onto Carbon Street. Then You will arrive at your destination.","verbal_transition_alert_instruction":"Turn right onto Carbon Street.","length":0.040,"instruction":"Turn right onto Carbon Street.","end_shape_index":12,"type":10,"time":8,"verbal_post_transition_instruction":"Continue for 40 meters.","street_names":["Carbon Street"],"begin_shape_index":9},{"travel_type":"car","travel_mode":"drive","begin_shape_index":12,"time":0,"type":4,"end_shape_index":12,"instruction":"You have arrived at your destination.","length":0.000,"verbal_transition_alert_instruction":"You will arrive at your destination.","verbal_pre_transition_instruction":"You have arrived at your destination."}]}],"status_message":"Found route between points","status":0}}'
```