### PR TITLE
do not add shape if it is empty

### DIFF
--- a/src/mjolnir/valhalla_build_transit.cc
+++ b/src/mjolnir/valhalla_build_transit.cc
@@ -479,7 +479,7 @@ void get_stop_patterns(Transit& tile, std::unordered_map<std::string, size_t>& s
       auto lat = geom.second.back().second.get_value<float>();
       trip_shape.emplace_back(PointLL(lon,lat));
     }
-    if (trip_shape.size()) {
+    if (trip_shape.size() > 1) {
       // encode the points to reduce size
       shape->set_encoded_shape(encode7(trip_shape));
 

--- a/src/mjolnir/valhalla_build_transit.cc
+++ b/src/mjolnir/valhalla_build_transit.cc
@@ -479,13 +479,15 @@ void get_stop_patterns(Transit& tile, std::unordered_map<std::string, size_t>& s
       auto lat = geom.second.back().second.get_value<float>();
       trip_shape.emplace_back(PointLL(lon,lat));
     }
-    // encode the points to reduce size
-    shape->set_encoded_shape(encode7(trip_shape));
+    if (trip_shape.size()) {
+      // encode the points to reduce size
+      shape->set_encoded_shape(encode7(trip_shape));
 
-    // shapes.size()+1 because we can't have a shape id of 0.
-    // 0 means shape id is not set in the transit builder.
-    shape->set_shape_id(shapes.size()+1);
-    shapes.emplace(shape_id, shape->shape_id());
+      // shapes.size()+1 because we can't have a shape id of 0.
+      // 0 means shape id is not set in the transit builder.
+      shape->set_shape_id(shapes.size()+1);
+      shapes.emplace(shape_id, shape->shape_id());
+    }
   }
 }
 

--- a/src/mjolnir/valhalla_fetch_transit.cc
+++ b/src/mjolnir/valhalla_fetch_transit.cc
@@ -332,13 +332,15 @@ void get_stop_patterns(Transit_Fetch& tile, std::unordered_map<std::string, size
       auto lat = geom.second.back().second.get_value<float>();
       trip_shape.emplace_back(PointLL(lon,lat));
     }
-    // encode the points to reduce size
-    shape->set_encoded_shape(encode7(trip_shape));
+    if (trip_shape.size()) {
+      // encode the points to reduce size
+      shape->set_encoded_shape(encode7(trip_shape));
 
-    // shapes.size()+1 because we can't have a shape id of 0.
-    // 0 means shape id is not set in the transit builder.
-    shape->set_shape_id(shapes.size()+1);
-    shapes.emplace(shape_id, shape->shape_id());
+      // shapes.size()+1 because we can't have a shape id of 0.
+      // 0 means shape id is not set in the transit builder.
+      shape->set_shape_id(shapes.size()+1);
+      shapes.emplace(shape_id, shape->shape_id());
+    }
   }
 }
 

--- a/src/mjolnir/valhalla_fetch_transit.cc
+++ b/src/mjolnir/valhalla_fetch_transit.cc
@@ -332,7 +332,7 @@ void get_stop_patterns(Transit_Fetch& tile, std::unordered_map<std::string, size
       auto lat = geom.second.back().second.get_value<float>();
       trip_shape.emplace_back(PointLL(lon,lat));
     }
-    if (trip_shape.size()) {
+    if (trip_shape.size() > 1) {
       // encode the points to reduce size
       shape->set_encoded_shape(encode7(trip_shape));
 


### PR DESCRIPTION
protect against empty shape in stop_patterns. 

terminate called after throwing an instance of 'std::runtime_error'
  what():  Bad encoded polyline
Aborted (core dumped)

@irees not sure if new transit was added, but you should scan the data for empty stop_patterns.

