### PR TITLE
Fixes for building on MacOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,11 @@ AX_BOOST_IOSTREAMS
 AC_SUBST(BOOST_CPPFLAGS, "$BOOST_CPPFLAGS -DBOOST_SPIRIT_THREADSAFE -DBOOST_NO_CXX11_SCOPED_ENUMS")
 AC_SUBST(RAPIDJSON_CPPFLAGS, "$RAPIDJSON_CPPFLAGS -DRAPIDJSON_HAS_STDSTRING")
 
-PKG_CHECK_MODULES([DEPS], [protobuf >= 2.4.0 libcurl >= 7.35.0 zlib >= 1.2.8 liblz4 >= 131])
+# Note - because libz4 changed it's versioning scheme, we need to check for both >131, and if
+#        that fails, try >= 1.7.3
+PKG_CHECK_MODULES([DEPS], [protobuf >= 2.4.0 libcurl >= 7.35.0 zlib >= 1.2.8 liblz4 >= 131],, [
+  PKG_CHECK_MODULES([DEPS], [protobuf >= 2.4.0 libcurl >= 7.35.0 zlib >= 1.2.8 liblz4 >= 1.7.3])
+])
 
 # if we wanted services
 AC_ARG_ENABLE([services],

--- a/src/skadi/sample.cc
+++ b/src/skadi/sample.cc
@@ -117,7 +117,7 @@ namespace skadi {
           continue;
         }
         mapped_cache[index].first = format;
-        mapped_cache[index].second.map(f, size, POSIX_FADV_SEQUENTIAL);
+        mapped_cache[index].second.map(f, size, POSIX_MADV_SEQUENTIAL);
       }
     }
   }

--- a/src/valhalla_pack_elevation.cc
+++ b/src/valhalla_pack_elevation.cc
@@ -25,7 +25,9 @@ std::vector<char> read_file(const std::string& file_name, long size) {
   int fd = open(file_name.c_str(), O_RDONLY);
   if(fd == -1)
     throw std::runtime_error("Could not open: " + file_name);
+#ifndef __APPLE__
   posix_fadvise(fd, 0, 0, POSIX_FADV_SEQUENTIAL);
+#endif
   std::vector<char> in(size);
   if(read(fd, in.data(), size) != size)
     throw std::runtime_error("Could not open: " + file_name);

--- a/valhalla/midgard/sequence.h
+++ b/valhalla/midgard/sequence.h
@@ -44,7 +44,7 @@ class mem_map {
   mem_map(): ptr(nullptr), count(0), file_name("") { }
 
   //construct with file
-  mem_map(const std::string& file_name, size_t size, int advice = POSIX_FADV_NORMAL): ptr(nullptr), count(0), file_name("") {
+  mem_map(const std::string& file_name, size_t size, int advice = POSIX_MADV_NORMAL): ptr(nullptr), count(0), file_name("") {
     map(file_name, size, advice);
   }
 
@@ -54,7 +54,7 @@ class mem_map {
   }
 
   //reset to another file or another size
-  void map(const std::string& new_file_name, size_t new_count, int advice = POSIX_FADV_NORMAL) {
+  void map(const std::string& new_file_name, size_t new_count, int advice = POSIX_MADV_NORMAL) {
     //just in case there was already something
     unmap();
 
@@ -63,11 +63,11 @@ class mem_map {
       auto fd = open(new_file_name.c_str(), O_RDWR, 0);
       if(fd == -1)
         throw std::runtime_error(new_file_name + "(open): " + strerror(errno));
-      posix_fadvise(fd, 0, 0, advice);
       ptr = mmap(nullptr, new_count * sizeof(T), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
       if(ptr == MAP_FAILED)
         throw std::runtime_error(new_file_name + "(mmap): " + strerror(errno));
       auto cl = close(fd);
+      posix_madvise(ptr, new_count * sizeof(T), advice);
       if(cl == -1)
         throw std::runtime_error(new_file_name + "(close): " + strerror(errno));
       count = new_count;


### PR DESCRIPTION
Various fixes needed to get things building on MacOS.

  - liblz4 moved to a different version numbering scheme - this PR now checks for minimum versions in both schemes (at least one check must pass)
  - MacOS doesn't have `posix_fadvise` (that I could find).  For places where read-ahead hints were for `mmap`-ed files, I've switched to `posix_madvise`, which is available on both platforms.  There's only one spot where I've `#ifndef`-ed out the `posix_fadvise` call.