### PR TITLE
allow the lz4 tool to unpack HC files

### DIFF
--- a/src/valhalla_pack_elevation.cc
+++ b/src/valhalla_pack_elevation.cc
@@ -146,11 +146,14 @@ std::vector<char> lunzip(const std::vector<char>& in, algorithm_t algorithm) {
 int main(int argc, char** argv){
   if(argc < 2)
     return 0;
+  //TODO: add arguments to this
+
   std::string file_name(argv[1]);
   auto tile = read_file(file_name, file_size(file_name));
   //test the file for proper lz4hc encoding
   if(file_name.find(".lz4") == file_name.size() - 4) {
-    lunzip(tile, algorithm_t::HIGH);
+    tile = lunzip(tile, algorithm_t::HIGH);
+    write_file(file_name.substr(0, file_name.size() - 4), tile);
   }//compress an existing file
   else {
     //gunzip it

--- a/valhalla/valhalla.h.in
+++ b/valhalla/valhalla.h.in
@@ -3,7 +3,7 @@
 
 #define VALHALLA_VERSION_MAJOR 2
 #define VALHALLA_VERSION_MINOR 4
-#define VALHALLA_VERSION_PATCH 4
+#define VALHALLA_VERSION_PATCH 5
 
 //whether the API was configured with http service support or not
 @HAVE_HTTP_DEFINE@


### PR DESCRIPTION
so the findings in #1068 were not correct. lz4 is faster than gzip for the live service but its not as fast as raw files. it turns out that doing benchmarks at 2am is actually a very bad idea...

lz4hc is still a very beneficial format for us. it allows the data to be only 210GB total and decompresses way way faster than gzip. so we can spend a much smaller amount of network bandwidth and time and decompressing the entire dataset should only take on the order of 10 minutes where as gunzipping everything takes  around 2 hours.