### PR TITLE
Check for transit tiles before iterating through tile set

### DIFF
--- a/src/mjolnir/graphenhancer.cc
+++ b/src/mjolnir/graphenhancer.cc
@@ -1259,6 +1259,8 @@ namespace mjolnir {
 // Enhance the local level of the graph
 void GraphEnhancer::Enhance(const boost::property_tree::ptree& pt,
                             const std::string& access_file) {
+  LOG_INFO("Enhancing local graph...");
+
   // A place to hold worker threads and their results, exceptions or otherwise
   std::vector<std::shared_ptr<std::thread> > threads(
     std::max(static_cast<unsigned int>(1),
@@ -1287,7 +1289,6 @@ void GraphEnhancer::Enhance(const boost::property_tree::ptree& pt,
   std::mutex lock;
 
   // Start the threads
-  LOG_INFO("Enhancing local graph...");
   for (auto& thread : threads) {
     results.emplace_back();
     thread.reset(new std::thread(enhance,

--- a/src/mjolnir/hierarchybuilder.cc
+++ b/src/mjolnir/hierarchybuilder.cc
@@ -8,6 +8,7 @@
 #include <map>
 #include <utility>
 #include <boost/property_tree/ptree.hpp>
+#include <boost/filesystem/operations.hpp>
 
 #include "midgard/pointll.h"
 #include "midgard/logging.h"
@@ -585,7 +586,12 @@ void HierarchyBuilder::Build(const boost::property_tree::ptree& pt) {
   RemoveUnusedLocalTiles(reader.tile_dir());
 
   // Update the end nodes to all transit connections in the transit hierarchy
-  UpdateTransitConnections(reader);
+  auto hierarchy_properties = pt.get_child("mjolnir");
+  auto transit_dir = hierarchy_properties.get_optional<std::string>("transit_dir");
+  if (transit_dir && boost::filesystem::exists(*transit_dir) && boost::filesystem::is_directory(*transit_dir)) {
+    UpdateTransitConnections(reader);
+  }
+
   LOG_INFO("Done HierarchyBuilder");
 }
 


### PR DESCRIPTION
When trying to process a very small graph it turns out that iterating through all tiles and checking for presence of a tile on disk takes a couple of seconds. So even a very small graph takes some time (18 seconds in this test). Checking for transit tiles before iterating through the tile list (done in GraphValidator and HierarchyBuilder) can save several seconds for cases where transit does not exist (down to 12 seconds in this test). 

Also moves log statements to the start of methods to make timing more accurate (now catches the setup time for the tile queues).