### PR TITLE
Use boost directory iterator to form tile set on a level

### DIFF
--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -503,7 +503,7 @@ std::unordered_set<GraphId> GraphReader::GetTileSet(const uint8_t level) const {
   std::unordered_set<GraphId> tiles;
   if(tile_extract_->tiles.size()) {
     for(const auto& t : tile_extract_->tiles)
-      if(t.first.level() == level)
+      if(static_cast<GraphId>(t.first).level() == level)
         tiles.emplace(t.first);
   }//or individually on disk
   else {

--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -500,17 +500,25 @@ std::unordered_set<GraphId> GraphReader::GetTileSet() const {
 // Get the set of tiles for a specified level
 std::unordered_set<GraphId> GraphReader::GetTileSet(const uint8_t level) const {
   std::unordered_set<GraphId> tiles;
-  // TODO _ support mmap
-
-  //crack open this level of tiles directory
-  boost::filesystem::path root_dir(tile_dir_ + '/' + std::to_string(level) + '/');
-  if (boost::filesystem::exists(root_dir) && boost::filesystem::is_directory(root_dir)) {
-    // iterate over all the files in the directory and turn into GraphIds
-    for (boost::filesystem::recursive_directory_iterator i(root_dir), end; i != end; ++i) {
-      if (!boost::filesystem::is_directory(i->path())) {
-        //add it if it can be parsed as a valid tile file name
-        try { tiles.emplace(GraphTile::GetTileId(i->path().string())); }
-        catch (...) { }
+  
+  //either mmap'd tiles
+  std::unordered_set<GraphId> tiles;
+  if(tile_extract_->tiles.size()) {
+    for(const auto& t : tile_extract_->tiles)
+      if(t.first.level() == level)
+        tiles.emplace(t.first);
+  }//or individually on disk
+  else {
+    //crack open this level of tiles directory
+    boost::filesystem::path root_dir(tile_dir_ + '/' + std::to_string(level) + '/');
+    if (boost::filesystem::exists(root_dir) && boost::filesystem::is_directory(root_dir)) {
+      // iterate over all the files in the directory and turn into GraphIds
+      for (boost::filesystem::recursive_directory_iterator i(root_dir), end; i != end; ++i) {
+        if (!boost::filesystem::is_directory(i->path())) {
+          //add it if it can be parsed as a valid tile file name
+          try { tiles.emplace(GraphTile::GetTileId(i->path().string())); }
+          catch (...) { }
+        }
       }
     }
   }

--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -499,8 +499,6 @@ std::unordered_set<GraphId> GraphReader::GetTileSet() const {
 
 // Get the set of tiles for a specified level
 std::unordered_set<GraphId> GraphReader::GetTileSet(const uint8_t level) const {
-  std::unordered_set<GraphId> tiles;
-  
   //either mmap'd tiles
   std::unordered_set<GraphId> tiles;
   if(tile_extract_->tiles.size()) {

--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -497,5 +497,25 @@ std::unordered_set<GraphId> GraphReader::GetTileSet() const {
   return tiles;
 }
 
+// Get the set of tiles for a specified level
+std::unordered_set<GraphId> GraphReader::GetTileSet(const uint8_t level) const {
+  std::unordered_set<GraphId> tiles;
+  // TODO _ support mmap
+
+  //crack open this level of tiles directory
+  boost::filesystem::path root_dir(tile_dir_ + '/' + std::to_string(level) + '/');
+  if (boost::filesystem::exists(root_dir) && boost::filesystem::is_directory(root_dir)) {
+    // iterate over all the files in the directory and turn into GraphIds
+    for (boost::filesystem::recursive_directory_iterator i(root_dir), end; i != end; ++i) {
+      if (!boost::filesystem::is_directory(i->path())) {
+        //add it if it can be parsed as a valid tile file name
+        try { tiles.emplace(GraphTile::GetTileId(i->path().string())); }
+        catch (...) { }
+      }
+    }
+  }
+  return tiles;
+}
+
 }
 }

--- a/src/mjolnir/graphenhancer.cc
+++ b/src/mjolnir/graphenhancer.cc
@@ -1272,15 +1272,11 @@ void GraphEnhancer::Enhance(const boost::property_tree::ptree& pt,
   // Create a randomized queue of tiles to work from
   std::deque<GraphId> tempqueue;
   boost::property_tree::ptree hierarchy_properties = pt.get_child("mjolnir");
-  GraphReader reader(hierarchy_properties);
   auto local_level = TileHierarchy::levels().rbegin()->second.level;
-  auto tiles = TileHierarchy::levels().rbegin()->second.tiles;
-  for (uint32_t id = 0; id < tiles.TileCount(); id++) {
-    // If tile exists add it to the queue
-    GraphId tile_id(id, local_level, 0);
-    if (GraphReader::DoesTileExist(hierarchy_properties, tile_id)) {
-      tempqueue.push_back(tile_id);
-    }
+  GraphReader reader(hierarchy_properties);
+  auto local_tiles = reader.GetTileSet(local_level);
+  for (const auto& tile_id : local_tiles) {
+    tempqueue.emplace_back(tile_id);
   }
   std::random_shuffle(tempqueue.begin(), tempqueue.end());
   std::queue<GraphId> tilequeue(tempqueue);

--- a/src/mjolnir/graphvalidator.cc
+++ b/src/mjolnir/graphvalidator.cc
@@ -583,33 +583,12 @@ namespace mjolnir {
     auto hierarchy_properties = pt.get_child("mjolnir");
     std::string tile_dir = hierarchy_properties.get<std::string>("tile_dir");
 
-    // Create a randomized queue of tiles to work from
+    // Create a randomized queue of tiles (at all levels) to work from
     std::deque<GraphId> tilequeue;
-    for (auto tier : TileHierarchy::levels()) {
-      auto level = tier.second.level;
-      auto tiles = tier.second.tiles;
-      for (uint32_t id = 0; id < tiles.TileCount(); id++) {
-        // If tile exists add it to the queue
-        GraphId tile_id(id, level, 0);
-        if (GraphReader::DoesTileExist(hierarchy_properties, tile_id)) {
-          tilequeue.emplace_back(std::move(tile_id));
-        }
-      }
-
-      // Check if transit level exists - add transit tiles to queue if so
-      auto transit_dir = hierarchy_properties.get_optional<std::string>("transit_dir");
-      if (transit_dir && boost::filesystem::exists(*transit_dir) && 
-          boost::filesystem::is_directory(*transit_dir) && 
-          level == TileHierarchy::levels().rbegin()->second.level) {
-        level += 1;
-        for (uint32_t id = 0; id < tiles.TileCount(); id++) {
-          // If tile exists add it to the queue
-          GraphId tile_id(id, level, 0);
-          if (GraphReader::DoesTileExist(hierarchy_properties, tile_id)) {
-            tilequeue.emplace_back(std::move(tile_id));
-          }
-        }
-      }
+    GraphReader reader(pt.get_child("mjolnir"));
+    auto tileset = reader.GetTileSet();
+    for (const auto& id : tileset) {
+      tilequeue.emplace_back(id);
     }
     std::random_shuffle(tilequeue.begin(), tilequeue.end());
 

--- a/src/mjolnir/hierarchybuilder.cc
+++ b/src/mjolnir/hierarchybuilder.cc
@@ -474,12 +474,10 @@ void UpdateTransitConnections(GraphReader& reader) {
   sequence<OldToNewNodes> old_to_new(old_to_new_file, false);
 
   auto tile_level = TileHierarchy::levels().rbegin();
-  auto& base_level = tile_level->second;
-  uint8_t transit_level = base_level.level + 1;
-  uint32_t ntiles = base_level.tiles.TileCount();
-  for (uint32_t basetileid = 0; basetileid < ntiles; basetileid++) {
-    // Get the graph tile. Skip if no tile exists (common case)
-    GraphId tile_id(basetileid, transit_level, 0);
+  uint8_t transit_level = tile_level->second.level + 1;
+  auto transit_tiles = reader.GetTileSet(transit_level);
+  for (const auto& tile_id : transit_tiles) {
+    // Skip if no nodes exist in the tile
     const GraphTile* tile = reader.GetGraphTile(tile_id);
     if (tile == nullptr || tile->header()->nodecount() == 0) {
       continue;

--- a/src/mjolnir/restrictionbuilder.cc
+++ b/src/mjolnir/restrictionbuilder.cc
@@ -542,17 +542,12 @@ void RestrictionBuilder::Build(const boost::property_tree::ptree& pt,
   GraphReader reader(hierarchy_properties);
   auto level = TileHierarchy::levels().rbegin();
   for ( ; level != TileHierarchy::levels().rend(); ++level) {
-
-    auto tile_level = level->second;
     // Create a randomized queue of tiles to work from
+    auto tile_level = level->second;
     std::deque<GraphId> tempqueue;
-
-    for (uint32_t id = 0; id < tile_level.tiles.TileCount(); id++) {
-      // If tile exists add it to the queue
-      GraphId tile_id(id, tile_level.level, 0);
-      if (GraphReader::DoesTileExist(hierarchy_properties, tile_id)) {
-        tempqueue.push_back(tile_id);
-      }
+    auto level_tiles = reader.GetTileSet(tile_level.level);
+    for (const auto& tile_id : level_tiles) {
+      tempqueue.emplace_back(tile_id);
     }
     std::random_shuffle(tempqueue.begin(), tempqueue.end());
     std::queue<GraphId> tilequeue(tempqueue);

--- a/valhalla/baldr/graphreader.h
+++ b/valhalla/baldr/graphreader.h
@@ -519,6 +519,13 @@ class GraphReader {
   std::unordered_set<GraphId> GetTileSet() const;
 
   /**
+   * Gets back a set of available tiles on the specified level
+   * @param  level  Level to get tile set.
+   * @return  returns the list of available tiles on this level
+   */
+  std::unordered_set<GraphId> GetTileSet(const uint8_t level) const;
+
+  /**
    * Returns the tile directory.
    * @return  Returns the tile directory.
    */


### PR DESCRIPTION
Use this within GraphEnhancer, HierarchyBuilder, and RestrictionsBuilder. Use the existing GetTileSet method to get all tiles inside GraphValidator. This reduces time to process very small tilesets down to almost 0 (was close to 20 seconds). Fixes #1083 