### PR TITLE
Clean up #include-s for missing/superfluous headers

### DIFF
--- a/src/midgard/util.cc
+++ b/src/midgard/util.cc
@@ -4,6 +4,7 @@
 #include "valhalla/midgard/point2.h"
 #include "valhalla/midgard/distanceapproximator.h"
 
+#include <cctype>
 #include <cstdint>
 #include <stdlib.h>
 #include <sstream>

--- a/src/mjolnir/admin.cc
+++ b/src/mjolnir/admin.cc
@@ -1,7 +1,10 @@
 #include "mjolnir/admin.h"
 #include "baldr/datetime.h"
 #include "midgard/logging.h"
+#include <unordered_map>
 #include <boost/filesystem/operations.hpp>
+#include <sqlite3.h>
+#include <spatialite.h>
 
 namespace valhalla {
 namespace mjolnir {

--- a/src/mjolnir/graphvalidator.cc
+++ b/src/mjolnir/graphvalidator.cc
@@ -13,6 +13,7 @@
 #include <utility>
 #include <queue>
 #include <list>
+#include <set>
 #include <thread>
 #include <future>
 #include <mutex>

--- a/src/mjolnir/restrictionbuilder.cc
+++ b/src/mjolnir/restrictionbuilder.cc
@@ -7,6 +7,7 @@
 #include <future>
 #include <thread>
 #include <queue>
+#include <set>
 
 #include <boost/filesystem/operations.hpp>
 

--- a/src/mjolnir/transitbuilder.cc
+++ b/src/mjolnir/transitbuilder.cc
@@ -10,8 +10,6 @@
 #include <unordered_map>
 #include <tuple>
 #include <set>
-#include <sqlite3.h>
-#include <spatialite.h>
 #include <fstream>
 #include <iostream>
 #include <boost/filesystem/operations.hpp>

--- a/src/skadi/util.cc
+++ b/src/skadi/util.cc
@@ -1,4 +1,5 @@
 #include "skadi/util.h"
+#include <algorithm>
 
 namespace {
 

--- a/src/tyr/navigator.cc
+++ b/src/tyr/navigator.cc
@@ -1,4 +1,5 @@
 #include <cmath>
+#include <cctype>
 #include <iomanip>
 #include <iostream>
 #include <locale>

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -1,4 +1,6 @@
+#include <iostream>
 #include <sstream>
+#include <unordered_map>
 #include <boost/property_tree/json_parser.hpp>
 
 #include "worker.h"

--- a/valhalla/mjolnir/admin.h
+++ b/valhalla/mjolnir/admin.h
@@ -11,7 +11,6 @@
 #include <boost/geometry/multi/geometries/multi_polygon.hpp>
 #include <boost/geometry/io/wkt/wkt.hpp>
 #include <sqlite3.h>
-#include <spatialite.h>
 #include <unordered_map>
 
 #include <valhalla/mjolnir/graphtilebuilder.h>


### PR DESCRIPTION
Add missing C++ headers.
Add missing `<sqlite3.h>`
Remove `<spatialite.h>` wherever unused.