### PR TITLE
Use portable path separator when composing or testing paths

### DIFF
--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -10,6 +10,7 @@
 #include "midgard/sequence.h"
 
 #include "baldr/connectivity_map.h"
+#include "baldr/filesystem_utils.h"
 
 using namespace valhalla::baldr;
 
@@ -191,7 +192,7 @@ bool GraphReader::DoesTileExist(const GraphId& graphid) const {
   //otherwise check memory or disk
   if(cache_->Contains(graphid))
     return true;
-  std::string file_location = tile_dir_ + "/" +
+  std::string file_location = tile_dir_ + filesystem::path_separator +
             GraphTile::FileSuffix(graphid.Tile_Base());
   struct stat buffer;
   return stat(file_location.c_str(), &buffer) == 0 || stat((file_location + ".gz").c_str(), &buffer) == 0;
@@ -206,7 +207,7 @@ bool GraphReader::DoesTileExist(const boost::property_tree::ptree& pt, const Gra
   if(!extract->tiles.empty())
     return extract->tiles.find(graphid) != extract->tiles.cend();
   //otherwise check the disk
-  std::string file_location = pt.get<std::string>("tile_dir") + "/" +
+  std::string file_location = pt.get<std::string>("tile_dir") + filesystem::path_separator +
             GraphTile::FileSuffix(graphid.Tile_Base());
   struct stat buffer;
   return stat(file_location.c_str(), &buffer) == 0 || stat((file_location + ".gz").c_str(), &buffer) == 0;
@@ -479,7 +480,7 @@ std::unordered_set<GraphId> GraphReader::GetTileSet() const {
     //for each level
     for(uint8_t level = 0; level <= TileHierarchy::levels().rbegin()->first + 1; ++level) {
       //crack open this level of tiles directory
-      boost::filesystem::path root_dir(tile_dir_ + '/' + std::to_string(level) + '/');
+      boost::filesystem::path root_dir(tile_dir_ + filesystem::path_separator + std::to_string(level) + filesystem::path_separator);
       if(boost::filesystem::exists(root_dir) && boost::filesystem::is_directory(root_dir)) {
         //iterate over all the files in there
         for (boost::filesystem::recursive_directory_iterator i(root_dir), end; i != end; ++i) {
@@ -508,7 +509,7 @@ std::unordered_set<GraphId> GraphReader::GetTileSet(const uint8_t level) const {
   }//or individually on disk
   else {
     //crack open this level of tiles directory
-    boost::filesystem::path root_dir(tile_dir_ + '/' + std::to_string(level) + '/');
+    boost::filesystem::path root_dir(tile_dir_ + filesystem::path_separator + std::to_string(level) + filesystem::path_separator);
     if (boost::filesystem::exists(root_dir) && boost::filesystem::is_directory(root_dir)) {
       // iterate over all the files in the directory and turn into GraphIds
       for (boost::filesystem::recursive_directory_iterator i(root_dir), end; i != end; ++i) {

--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -1,5 +1,6 @@
 #include "baldr/graphtile.h"
 #include "baldr/datetime.h"
+#include "baldr/filesystem_utils.h"
 #include "baldr/tilehierarchy.h"
 #include "midgard/tiles.h"
 #include "midgard/aabb2.h"
@@ -77,7 +78,7 @@ GraphTile::GraphTile(const std::string& tile_dir, const GraphId& graphid)
     return;
 
   // Open to the end of the file so we can immediately get size;
-  std::string file_location = tile_dir + "/" + FileSuffix(graphid.Tile_Base());
+  std::string file_location = tile_dir + filesystem::path_separator + FileSuffix(graphid.Tile_Base());
   std::ifstream file(file_location, std::ios::in | std::ios::binary | std::ios::ate);
   if (file.is_open()) {
     // Read binary file into memory. TODO - protect against failure to
@@ -128,7 +129,7 @@ GraphTile::GraphTile(const std::string& tile_url, const GraphId& graphid, curler
     return;
 
   // Get the response returned from curl
-  std::string uri = tile_url + "/" + FileSuffix(graphid.Tile_Base());
+  std::string uri = tile_url + filesystem::path_separator + FileSuffix(graphid.Tile_Base());
   long http_code;
   auto tile_data = curler(uri, http_code);
 
@@ -326,9 +327,9 @@ std::string GraphTile::FileSuffix(const GraphId& graphid) {
 
 // Get the tile Id given the full path to the file.
 GraphId GraphTile::GetTileId(const std::string& fname) {
-  const std::unordered_set<std::string::value_type> allowed{ '/', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' };
+  const std::unordered_set<std::string::value_type> allowed{ filesystem::path_separator, '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' };
   //we require slashes
-  auto pos = fname.find_last_of('/');
+  auto pos = fname.find_last_of(filesystem::path_separator);
   if(pos == fname.npos)
     throw std::runtime_error("Invalid tile path: " + fname);
 
@@ -350,7 +351,7 @@ GraphId GraphTile::GetTileId(const std::string& fname) {
     if(allowed.find(c) == allowed.cend())
       throw std::runtime_error("Invalid tile path: " + fname);
     //if its a slash thats another digit
-    if(c == '/') {
+    if(c == filesystem::path_separator) {
       //this is not 3 or 1 digits so its wrong
       auto dist = last - pos;
       if(dist != 4 && dist != 2)

--- a/src/baldr/shared_tiles.cc
+++ b/src/baldr/shared_tiles.cc
@@ -1,5 +1,6 @@
 #include <cstdint>
 #include "baldr/shared_tiles.h"
+#include "baldr/filesystem_utils.h"
 
 #include <string>
 #include <iostream>
@@ -33,7 +34,7 @@ SharedTiles::SharedTiles(const boost::property_tree::ptree& pt) {
 
   // Open to the end of the file so we can immediately get size;
   size_t filesize = 0;
-  std::string file_location = tile_dir + "/" + shared_tile_file;
+  std::string file_location = tile_dir + filesystem::path_separator + shared_tile_file;
   std::ifstream file(file_location, std::ios::in | std::ios::binary | std::ios::ate);
   if (file.is_open()) {
     filesize = file.tellg();

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -3,10 +3,12 @@
 #include "midgard/logging.h"
 #include "baldr/datetime.h"
 #include "baldr/edgeinfo.h"
+#include "baldr/filesystem_utils.h"
 #include "baldr/tilehierarchy.h"
 #include <boost/format.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <stdexcept>
+#include <set>
 #include <list>
 #include <algorithm>
 
@@ -231,8 +233,8 @@ GraphTileBuilder::GraphTileBuilder(const std::string& tile_dir,
 // Output the tile to file. Stores as binary data.
 void GraphTileBuilder::StoreTileData() {
   // Get the name of the file
-  boost::filesystem::path filename = tile_dir_ + '/'
-      + GraphTile::FileSuffix(header_builder_.graphid());
+  boost::filesystem::path filename(tile_dir_ + filesystem::path_separator
+      + GraphTile::FileSuffix(header_builder_.graphid()));
 
   // Make sure the directory exists on the system
   if (!boost::filesystem::exists(filename.parent_path()))
@@ -396,7 +398,7 @@ void GraphTileBuilder::Update(const std::vector<NodeInfo>& nodes,
     const std::vector<DirectedEdge>& directededges) {
 
   // Get the name of the file
-  boost::filesystem::path filename = tile_dir_ + '/' +
+  boost::filesystem::path filename = tile_dir_ + filesystem::path_separator +
         GraphTile::FileSuffix(header_->graphid());
 
   // Make sure the directory exists on the system
@@ -574,7 +576,7 @@ uint32_t GraphTileBuilder::AddEdgeInfo(const uint32_t edgeindex,
       // Verify name is not empty
       if (!(name.empty())) {
         // Add name and add its offset to edge info's list.
-        NameInfo ni({AddName(name)});
+        NameInfo ni{AddName(name)};
         ni.is_ref_= 0;
         if ((types & (1ULL << location)))
           ni.is_ref_= 1; // set the ref bit.
@@ -645,7 +647,7 @@ uint32_t GraphTileBuilder::AddEdgeInfo(const uint32_t edgeindex,
       // Verify name is not empty
       if (!(name.empty())) {
         // Add name and add its offset to edge info's list.
-        NameInfo ni({AddName(name)});
+        NameInfo ni{AddName(name)};
         ni.is_ref_= 0;
         if ((types & (1ULL << location)))
           ni.is_ref_= 1; // set the ref bit.
@@ -890,7 +892,7 @@ void GraphTileBuilder::AddBins(const std::string& tile_dir,
   header.set_edge_elevation_offset(header.edge_elevation_offset() + shift);
   header.set_end_offset(header.end_offset() + shift);
   //rewrite the tile
-  boost::filesystem::path filename = tile_dir + '/' + GraphTile::FileSuffix(header.graphid());
+  boost::filesystem::path filename = tile_dir + filesystem::path_separator + GraphTile::FileSuffix(header.graphid());
   if(!boost::filesystem::exists(filename.parent_path()))
     boost::filesystem::create_directories(filename.parent_path());
   std::ofstream file(filename.c_str(), std::ios::out | std::ios::binary | std::ios::trunc);
@@ -1013,7 +1015,7 @@ void GraphTileBuilder::UpdateTrafficSegments(const bool update_dir_edges) {
   header_builder_.set_end_offset(header_builder_.end_offset() + shift);
 
   // Get the name of the file
-  boost::filesystem::path filename = tile_dir_ + '/'
+  boost::filesystem::path filename = tile_dir_ + filesystem::path_separator
       + GraphTile::FileSuffix(header_builder_.graphid());
 
   // Make sure the directory exists on the system

--- a/src/mjolnir/hierarchybuilder.cc
+++ b/src/mjolnir/hierarchybuilder.cc
@@ -14,6 +14,7 @@
 #include "midgard/logging.h"
 #include "midgard/encoded.h"
 #include "midgard/sequence.h"
+#include "baldr/filesystem_utils.h"
 #include "baldr/tilehierarchy.h"
 #include "baldr/graphid.h"
 #include "baldr/graphconstants.h"
@@ -543,7 +544,7 @@ void RemoveUnusedLocalTiles(const std::string& tile_dir) {
     if (!itr->second ) {
       // Remove the file
       GraphId empty_tile = itr->first;
-      std::string file_location = tile_dir + "/" +
+      std::string file_location = tile_dir + filesystem::path_separator +
           GraphTile::FileSuffix(empty_tile.Tile_Base());
       remove(file_location.c_str());
       LOG_DEBUG("Remove file: " + file_location);

--- a/src/mjolnir/transitbuilder.cc
+++ b/src/mjolnir/transitbuilder.cc
@@ -18,6 +18,7 @@
 #include <boost/foreach.hpp>
 
 #include "baldr/datetime.h"
+#include "baldr/filesystem_utils.h"
 #include "baldr/graphtile.h"
 #include "baldr/graphreader.h"
 #include "baldr/tilehierarchy.h"
@@ -683,11 +684,11 @@ void TransitBuilder::Build(const boost::property_tree::ptree& pt) {
   }
 
   // Get a list of tiles that are on both level 2 (local) and level 3 (transit)
-  transit_dir->push_back('/');
+  transit_dir->push_back(filesystem::path_separator);
   GraphReader reader(hierarchy_properties);
   auto local_level = TileHierarchy::levels().rbegin()->first;
-  if(boost::filesystem::is_directory(*transit_dir + std::to_string(local_level + 1) + "/")) {
-    boost::filesystem::recursive_directory_iterator transit_file_itr(*transit_dir + std::to_string(local_level +1 ) + "/"), end_file_itr;
+  if(boost::filesystem::is_directory(*transit_dir + std::to_string(local_level + 1) + filesystem::path_separator)) {
+    boost::filesystem::recursive_directory_iterator transit_file_itr(*transit_dir + std::to_string(local_level +1 ) + filesystem::path_separator), end_file_itr;
     for(; transit_file_itr != end_file_itr; ++transit_file_itr) {
       if(boost::filesystem::is_regular(transit_file_itr->path()) && transit_file_itr->path().extension() == ".gph") {
         auto graph_id = GraphTile::GetTileId(transit_file_itr->path().string());
@@ -695,7 +696,7 @@ void TransitBuilder::Build(const boost::property_tree::ptree& pt) {
         if(GraphReader::DoesTileExist(hierarchy_properties, local_graph_id)) {
           const GraphTile* tile = reader.GetGraphTile(local_graph_id);
           tiles.emplace(local_graph_id);
-          const std::string destination_path = pt.get<std::string>("mjolnir.tile_dir") + '/' + GraphTile::FileSuffix(graph_id);
+          const std::string destination_path = pt.get<std::string>("mjolnir.tile_dir") + filesystem::path_separator + GraphTile::FileSuffix(graph_id);
           boost::filesystem::path filename = destination_path;
           // Make sure the directory exists on the system and copy to the tile_dir
           if (!boost::filesystem::exists(filename.parent_path()))

--- a/src/mjolnir/util.cc
+++ b/src/mjolnir/util.cc
@@ -13,6 +13,7 @@
 #include "midgard/aabb2.h"
 #include "midgard/polyline2.h"
 #include "midgard/logging.h"
+#include "baldr/filesystem_utils.h"
 #include "baldr/tilehierarchy.h"
 
 #include <boost/filesystem/operations.hpp>
@@ -54,7 +55,7 @@ void build_tile_set(const boost::property_tree::ptree& config, const std::vector
   //set up the directories and purge old tiles
   auto tile_dir = config.get<std::string>("mjolnir.tile_dir");
   for(const auto& level : valhalla::baldr::TileHierarchy::levels()) {
-    auto level_dir = tile_dir + "/" + std::to_string(level.first);
+    auto level_dir = tile_dir + baldr::filesystem::path_separator + std::to_string(level.first);
     if(boost::filesystem::exists(level_dir) && !boost::filesystem::is_empty(level_dir)) {
       LOG_WARN("Non-empty " + level_dir + " will be purged of tiles");
       boost::filesystem::remove_all(level_dir);
@@ -62,7 +63,7 @@ void build_tile_set(const boost::property_tree::ptree& config, const std::vector
   }
 
   //check for transit level.
-  auto level_dir = tile_dir + "/" +
+  auto level_dir = tile_dir + baldr::filesystem::path_separator +
       std::to_string(valhalla::baldr::TileHierarchy::levels().rbegin()->second.level+1);
   if(boost::filesystem::exists(level_dir) && !boost::filesystem::is_empty(level_dir)) {
     LOG_WARN("Non-empty " + level_dir + " will be purged of tiles");

--- a/src/mjolnir/valhalla_build_tiles.cc
+++ b/src/mjolnir/valhalla_build_tiles.cc
@@ -74,7 +74,7 @@ int main(int argc, char** argv) {
     boost::property_tree::read_json(ss, pt);
   }
   else if (vm.count("config") && boost::filesystem::is_regular_file(config_file_path)) {
-    boost::property_tree::read_json(config_file_path.c_str(), pt);
+    boost::property_tree::read_json(config_file_path.string(), pt);
   }
   else {
     std::cerr << "Configuration is required\n\n" << options << "\n\n";

--- a/src/mjolnir/valhalla_build_transit.cc
+++ b/src/mjolnir/valhalla_build_transit.cc
@@ -22,6 +22,7 @@
 #include <google/protobuf/io/coded_stream.h>
 
 #include "midgard/logging.h"
+#include "baldr/filesystem_utils.h"
 #include "baldr/graphconstants.h"
 #include "baldr/graphid.h"
 #include "baldr/tilehierarchy.h"
@@ -720,7 +721,7 @@ void fetch_tiles(const ptree& pt, std::priority_queue<weighted_tile_t>& queue, u
     Transit tile;
     auto file_name = GraphTile::FileSuffix(current);
     file_name = file_name.substr(0, file_name.size() - 3) + "pbf";
-    boost::filesystem::path transit_tile = pt.get<std::string>("mjolnir.transit_dir") + '/' + file_name;
+    boost::filesystem::path transit_tile = pt.get<std::string>("mjolnir.transit_dir") + filesystem::path_separator + file_name;
 
     //tiles are wrote out with .pbf or .pbf.n ext
     uint32_t ext = 0;
@@ -912,7 +913,7 @@ void stitch_tiles(const ptree& pt, const std::unordered_set<GraphId>& all_tiles,
   auto tile_name = [&pt](const GraphId& id){
     auto file_name = GraphTile::FileSuffix(id);
     file_name = file_name.substr(0, file_name.size() - 3) + "pbf";
-    return pt.get<std::string>("mjolnir.transit_dir") + '/' + file_name;
+    return pt.get<std::string>("mjolnir.transit_dir") + filesystem::path_separator + file_name;
   };
 
   //for each tile
@@ -1785,7 +1786,7 @@ void AddToGraph(GraphTileBuilder& tilebuilder_transit,
         std::string file_name = GraphTile::FileSuffix(GraphId(end_platform_graphid.tileid(), end_platform_graphid.level(),0));
         boost::algorithm::trim_if(file_name, boost::is_any_of(".gph"));
         file_name += ".pbf";
-        const std::string file = transit_dir + '/' + file_name;
+        const std::string file = transit_dir + filesystem::path_separator + file_name;
         Transit endtransit = read_pbf(file, lock);
         const Transit_Node& endplatform = endtransit.nodes(end_platform_graphid.id());
         endstopname = endplatform.name();
@@ -1903,7 +1904,7 @@ void build_tiles(const boost::property_tree::ptree& pt, std::mutex& lock,
     std::string file_name = GraphTile::FileSuffix(GraphId(tile_id.tileid(), tile_id.level(),0));
     boost::algorithm::trim_if(file_name, boost::is_any_of(".gph"));
     file_name += ".pbf";
-    const std::string file = transit_dir + '/' + file_name;
+    const std::string file = transit_dir + filesystem::path_separator + file_name;
 
     // Make sure it exists
     if (!boost::filesystem::exists(file)) {
@@ -2216,7 +2217,7 @@ int main(int argc, char** argv) {
   curl_global_cleanup();
 
   //figure out which transit tiles even exist
-  boost::filesystem::recursive_directory_iterator transit_file_itr(pt.get<std::string>("mjolnir.transit_dir") + '/' +
+  boost::filesystem::recursive_directory_iterator transit_file_itr(pt.get<std::string>("mjolnir.transit_dir") + filesystem::path_separator +
                                                                    std::to_string(TileHierarchy::levels().rbegin()->first));
   boost::filesystem::recursive_directory_iterator end_file_itr;
   std::unordered_set<GraphId> all_tiles;

--- a/src/mjolnir/validatetransit.cc
+++ b/src/mjolnir/validatetransit.cc
@@ -14,6 +14,7 @@
 #include "midgard/logging.h"
 #include "midgard/sequence.h"
 #include "baldr/datetime.h"
+#include "baldr/filesystem_utils.h"
 #include "baldr/tilehierarchy.h"
 #include "baldr/graphid.h"
 #include "baldr/graphconstants.h"
@@ -469,11 +470,11 @@ bool ValidateTransit::Validate(const boost::property_tree::ptree& pt,
       return false;
     }
     // Also bail if nothing inside
-    transit_dir->push_back('/');
+    transit_dir->push_back(filesystem::path_separator);
     GraphReader reader(hierarchy_properties);
     auto local_level = TileHierarchy::levels().rbegin()->first;
-    if(boost::filesystem::is_directory(*transit_dir + std::to_string(local_level + 1) + "/")) {
-      boost::filesystem::recursive_directory_iterator transit_file_itr(*transit_dir + std::to_string(local_level +1 ) + "/"), end_file_itr;
+    if(boost::filesystem::is_directory(*transit_dir + std::to_string(local_level + 1) + filesystem::path_separator)) {
+      boost::filesystem::recursive_directory_iterator transit_file_itr(*transit_dir + std::to_string(local_level +1 ) + filesystem::path_separator), end_file_itr;
       for(; transit_file_itr != end_file_itr; ++transit_file_itr) {
         if(boost::filesystem::is_regular(transit_file_itr->path()) && transit_file_itr->path().extension() == ".gph") {
           auto graph_id = GraphTile::GetTileId(transit_file_itr->path().string());

--- a/src/skadi/sample.cc
+++ b/src/skadi/sample.cc
@@ -6,6 +6,7 @@
 #include <limits>
 #include <list>
 #include <fstream>
+#include <string>
 #include <boost/regex.hpp>
 #include <sys/stat.h>
 #include <zlib.h>
@@ -14,6 +15,8 @@
 
 #include <boost/filesystem.hpp>
 #include <boost/optional.hpp>
+
+#include "baldr/filesystem_utils.h"
 
 #include "midgard/logging.h"
 #include "midgard/pointll.h"
@@ -128,7 +131,7 @@ namespace skadi {
   sample::sample(const std::string& data_source):
       mapped_cache(TILE_COUNT), unzipped_cache(-1, std::vector<int16_t>(HGT_PIXELS)), data_source(data_source) {
     //messy but needed
-    while(this->data_source.size() && this->data_source.back() == '/')
+    while(this->data_source.size() && this->data_source.back() == baldr::filesystem::path_separator)
       this->data_source.pop_back();
 
     //check the directory for files that look like what we need

--- a/valhalla/baldr/filesystem_utils.h
+++ b/valhalla/baldr/filesystem_utils.h
@@ -1,0 +1,18 @@
+#ifndef VALHALLA_BALDR_FILESYSTEM_UTILS_H_
+#define VALHALLA_BALDR_FILESYSTEM_UTILS_H_
+
+namespace valhalla {
+namespace baldr {
+namespace filesystem {
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+constexpr char path_separator = L'\\';
+#else
+constexpr char path_separator = L'/';
+#endif
+
+}
+}
+}
+
+#endif /* VALHALLA_BALDR_FILESYSTEM_UTILS_H_ */


### PR DESCRIPTION
Add new `valhalla/baldr/filesystem_utils.h` with separator constant  - resolved at compile-time.
Replace all hardcoded `'/'` with the separator constant.

-----

The `valhalla/baldr/filesystem_utils.h` is located/named after 'rapidjson_utils.h`, as general purpose internal auxiliary header, if you will.