### PR TITLE
Add #include <winsock2.h> to import Windows equivalent of POSIX function ntohl

### DIFF
--- a/src/mjolnir/osmpbfparser.cc
+++ b/src/mjolnir/osmpbfparser.cc
@@ -28,7 +28,11 @@
 // This is largely based off of: https://github.com/CanalTP/libosmpbfreader
 // there have been some minor changes for our own purposes but its largely the same
 #include <cstdint>
+#ifdef _MSC_VER
+#include <winsock2.h> // ntohl
+#else
 #include <netinet/in.h>
+#endif
 #include <zlib.h>
 #include <vector>
 #include <unordered_map>


### PR DESCRIPTION
This change enables compilation of `src/mjolnir/osmpbfparser.cc` file using Visual C++ on Windows.