### PR TITLE
Remove #include <spatialite.h> where not used

### DIFF
--- a/src/mjolnir/graphenhancer.cc
+++ b/src/mjolnir/graphenhancer.cc
@@ -18,7 +18,6 @@
 #include <stdexcept>
 
 #include <sqlite3.h>
-#include <spatialite.h>
 #include <boost/filesystem/operations.hpp>
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>


### PR DESCRIPTION
This makes it easier to build Valhalla w/o Spatialite (an optional dependency)