### PR TITLE
Add #define NOGDI for MSVC to avoid WinSock macros clashing with enum/function names

### DIFF
--- a/valhalla/baldr/curler.h
+++ b/valhalla/baldr/curler.h
@@ -1,7 +1,16 @@
 #ifndef VALHALLA_BALDR_CURLER_H_
 #define VALHALLA_BALDR_CURLER_H_
 
+#if defined(_MSC_VER) && !defined(NOGDI)
+#define NOGDI // prevents winsock2.h drag in wingdi.h
+#endif
+
 #include <curl/curl.h>
+
+#if defined(_MSC_VER) && defined(GetNameInfo)
+#undef GetNameInfo // winsock2.h imports #define GetNameInfo which clashes with EdgeInfo::GetNameInfo
+#endif
+
 #include <string>
 #include <vector>
 #include <memory>

--- a/valhalla/midgard/logging.h
+++ b/valhalla/midgard/logging.h
@@ -1,6 +1,10 @@
 #ifndef VALHALLA_MIDGARD_LOGGING_H_
 #define VALHALLA_MIDGARD_LOGGING_H_
 
+#if defined(_MSC_VER) && defined(ERROR)
+#undef ERROR
+#endif
+
 #include <string>
 #include <mutex>
 #include <unordered_map>


### PR DESCRIPTION
This aims to prevent a couple of issues while compiling with Visual C++ on Windows:
  * `winsock2.h` includes `wingdi.h` with `#define ERROR`
    which clash with `midgard::logging::LogLevel:ERROR`
  * `winsock2.h` includes `ws2tcpip.h` with `#define GetNameInfo`
    which clash with `baldr::EdgeInfo::GetNameInfo`