### PR TITLE
Add .gitattributes and update .gitignore with Visual Studio cruft

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.cc text
+*.cpp text
+*.h text
+*.hpp text
+
+# Declare files that will always have LF line endings on checkout.
+*.ac text eol=lf
+*.am text eol=lf
+*.csv text eol=lf
+*.sh text eol=lf
+
+# Declare files that will always have CRLF line endings on checkout.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf

--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,5 @@ coverage/
 .cproject
 .project
 .settings
+/.vs*/
+/*build*/


### PR DESCRIPTION
Preserving LF is especially important for `date_time/zonespec.csv` processed by `xxd` which generates unexpected hex dump from input with CRLF EOLs.

`/.vs*` helps to ignore ignore Visual Studio (Code) generated folders
`/*build*` helps to ignore out-of-source build folders (eg. `build.vs2017x64`, `_build.gcc7`)
