### PR TITLE
Add #define HAVE_SPATIALITE to autoconf-generated config.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -118,7 +118,7 @@ AM_COND_IF([DATA_TOOLS], [
     AS_IF([test "x$GEOS_VERSION" = "x"], [AC_MSG_ERROR(['geos' version >= 3.0.0 is required.  Please install geos.])])
 
     # spatialite needed for admin info
-    PKG_CHECK_MODULES([LIBSPATIALITE], [spatialite >= 3.0.0], , AC_MSG_ERROR(['libspatialite-dev' version >= 3.0.0 is required.  Please install libspatialite-dev.]))
+    PKG_CHECK_MODULES([LIBSPATIALITE], [spatialite >= 3.0.0], AC_DEFINE(HAVE_SPATIALITE, [1], [Have Spatialite library]), AC_MSG_ERROR(['libspatialite-dev' version >= 3.0.0 is required.  Please install libspatialite-dev.]))
 
 ])
 

--- a/src/mjolnir/admin.cc
+++ b/src/mjolnir/admin.cc
@@ -4,7 +4,9 @@
 #include <unordered_map>
 #include <boost/filesystem/operations.hpp>
 #include <sqlite3.h>
+#ifdef HAVE_SPATIALITE
 #include <spatialite.h>
+#endif
 
 namespace valhalla {
 namespace mjolnir {
@@ -14,6 +16,7 @@ sqlite3 * GetDBHandle(const std::string& database) {
 
   // Initialize the admin DB (if it exists)
   sqlite3 *db_handle = nullptr;
+#ifdef HAVE_SPATIALITE
   if (!database.empty() && boost::filesystem::exists(database)) {
     spatialite_init(0);
     sqlite3_stmt* stmt = 0;
@@ -42,6 +45,7 @@ sqlite3 * GetDBHandle(const std::string& database) {
       sqlite3_close(db_handle);
     }
   }
+#endif
   return db_handle;
 }
 


### PR DESCRIPTION
Allows to build libvalhalla without Spatialite, if desired.

-----

For majority of valhalla utilities, admin and timezone data is optional and such non-intrusive recognition of `HAVE_SPATIALITE` allows external builders to control Spatialite availability. The Autotools build configuration still checks for Spatialite as required dependency.