### PR TITLE
allow for linear distance cut off when point snapping

### DIFF
--- a/src/midgard/pointll.cc
+++ b/src/midgard/pointll.cc
@@ -125,7 +125,7 @@ float PointLL::Heading(const PointLL& ll2) const {
 // squared to that point and the index of the segment where the closest point
 // lies.
 std::tuple<PointLL, float, int> PointLL::ClosestPoint(
-    const std::vector<PointLL>& pts, size_t begin_index) const {
+    const std::vector<PointLL>& pts, size_t begin_index, float dist_cutoff) const {
   PointLL closest {};
   int closest_segment = -1;
   float mindistsqr = std::numeric_limits<float>::max();
@@ -184,6 +184,11 @@ std::tuple<PointLL, float, int> PointLL::ClosestPoint(
       mindistsqr = sq_distance;
       closest = std::move(point);
     }
+
+    // Check if we should bail early because of looking at too much shape
+    if(dist_cutoff != std::numeric_limits<float>::infinity() &&
+        (dist_cutoff -= u.Distance(v)) < 0)
+      break;
   }
   return std::make_tuple(std::move(closest), sqrt(mindistsqr),
                          closest_segment);

--- a/valhalla/midgard/pointll.h
+++ b/valhalla/midgard/pointll.h
@@ -5,6 +5,7 @@
 #include <valhalla/midgard/constants.h>
 #include <tuple>
 #include <cmath>
+#include <limits>
 
 namespace valhalla {
 namespace midgard {
@@ -119,16 +120,19 @@ class PointLL : public Point2 {
    * Finds the closest point to the supplied polyline as well as the distance
    * to that point and the index of the segment where the closest
    * point lies.
-   * @param  pts  List of points on the polyline.
+   * @param  pts          List of points on the polyline.
    * @param  begin_index  Index where the processing of closest point should start.
    *                      Default value is 0.
+   * @param  dist_cutoff  Minimum linear distance along pts that should be considered
+   *                      before giving up.
    *
    * @return tuple of <Closest point along the polyline,
    *                   Distance in meters of the closest point,
    *                   Index of the segment of the polyline which contains the closest point >
    */
-    std::tuple<PointLL, float, int> ClosestPoint(
-        const std::vector<PointLL>& pts, size_t begin_index = 0) const;
+  std::tuple<PointLL, float, int> ClosestPoint(
+      const std::vector<PointLL>& pts, size_t begin_index = 0,
+      float dist_cutoff = std::numeric_limits<float>::infinity()) const;
 
   /**
    * Calculate the heading from the start index within a polyline of lng,lat


### PR DESCRIPTION
no performance impact when not using distance cut off. about a 10% performance impact when using the cut off but then again if you are using it you probably are trying to avoid looking at the whole of a large set of points.