### PR TITLE
Optionally exclude driveways from the Valhalla tile set.

### DIFF
--- a/scripts/valhalla_build_config
+++ b/scripts/valhalla_build_config
@@ -16,6 +16,7 @@ config = {
     'transit_dir': '/data/valhalla/transit',
     'hierarchy': True,
     'shortcuts': True,
+    'include_driveways': True,
     'logging': {
       'type': 'std_out',
       'color': True,

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -55,6 +55,7 @@ struct graph_callback : public OSMPBF::Callback {
       }
     }
 
+    include_driveways_ = pt.get<bool>("include_driveways", true);
   }
 
   static std::string get_lua(const boost::property_tree::ptree& pt) {
@@ -223,6 +224,15 @@ struct graph_callback : public OSMPBF::Callback {
         if (tag.first == "building" || tag.first == "landuse" ||
             tag.first == "leisure"  || tag.first == "natural") {
           //LOG_INFO("Loop wayid " + std::to_string(osmid) + " Discard?");
+          return;
+        }
+      }
+    }
+
+    // Throw away driveways if include_driveways_ is false
+    if (!include_driveways_) {
+      for (const auto& tag : results) {
+        if (tag.first == "use" && (Use)std::stoi(tag.second) == Use::kDriveway) {
           return;
         }
       }
@@ -1342,6 +1352,9 @@ struct graph_callback : public OSMPBF::Callback {
     loops_.clear();
     loops_.shrink_to_fit();
   }
+
+  // Configuration option to include driveways
+  bool include_driveways_;
 
   //Road class assignment needs to be set to the highway cutoff for ferries and auto trains.
   RoadClass highway_cutoff_rc_;


### PR DESCRIPTION
A new config parameter under mjolnir was added: include_driveways. It defaults to true if not present. If false, during OSM way parsing any way that is tagged with Use equal to Driveway is excluded.

Note that during testing on a Maryland OSM data set the size of the Valhalla tile set was reduced by 20% (136MB vs 171MB). The number of OSM ways included was reduced from 419277 to 3263334.

fixes #1138 