### PR TITLE
Allow Disabling Edge Candidate Ranking

### DIFF
--- a/proto/directions_options.proto
+++ b/proto/directions_options.proto
@@ -64,4 +64,5 @@ message DirectionsOptions {
   optional DateTimeType date_time_type = 17;        // Are you leaving now or then or arriving then
   optional string date_time = 18;                   // And what day and time
   repeated Location shape = 19;                     // Raw shape for map matching
+  optional double resample_distance = 20;           // Resampling shape at regular intervals
 }

--- a/proto/tripcommon.proto
+++ b/proto/tripcommon.proto
@@ -24,10 +24,10 @@ message Location {
 
   message PathEdge {
     optional uint64 graph_id = 1;
-    optional float dist = 2;
+    optional float percent_along = 2;
     optional LatLng ll = 3;
     optional SideOfStreet side_of_street = 4;
-    optional float score = 5;
+    optional float distance = 5;
     optional int32 minimum_reachability = 6;
     optional bool begin_node = 7;
     optional bool end_node = 8;

--- a/proto/tripcommon.proto
+++ b/proto/tripcommon.proto
@@ -54,12 +54,13 @@ message Location {
   optional uint32 radius = 18 [default = 0];
   optional uint32 accuracy = 19;
   optional double time = 20 [default = -1.0];
+  optional bool rank_candidates = 21 [default = true];
   
   //outputs
-  repeated PathEdge path_edges = 21;
-  repeated PathEdge filtered_edges = 22;
-  optional uint32 original_index = 23;
-  optional LatLng projected_ll = 24;
+  repeated PathEdge path_edges = 22;
+  repeated PathEdge filtered_edges = 23;
+  optional uint32 original_index = 24;
+  optional LatLng projected_ll = 25;
 }
 
 message TransitEgressInfo {

--- a/src/baldr/pathlocation.cc
+++ b/src/baldr/pathlocation.cc
@@ -6,13 +6,13 @@ namespace baldr{
 
   PathLocation::PathEdge::PathEdge(const GraphId& id, const float dist,
     const midgard::PointLL& projected, const float score, const SideOfStreet sos, const unsigned int minimum_reachability):
-    id(id), dist(dist), projected(projected), sos(sos), score(score), minimum_reachability(minimum_reachability) {
+    id(id), percent_along(dist), projected(projected), sos(sos), distance(score), minimum_reachability(minimum_reachability) {
   }
   bool PathLocation::PathEdge::begin_node() const {
-    return dist == 0.f;
+    return percent_along == 0.f;
   }
   bool PathLocation::PathEdge::end_node() const {
-    return dist == 1.f;
+    return percent_along == 1.f;
   }
 
   PathLocation::PathLocation(const Location& location):Location(location) {
@@ -23,8 +23,8 @@ namespace baldr{
     for(const auto& edge : edges) {
       bool found = false;
       for(const auto& other_edge : other.edges) {
-        if(edge.id == other_edge.id && edge.sos == other_edge.sos && midgard::equal<float>(edge.dist, other_edge.dist) &&
-            midgard::similar<float>(edge.score + 1, other_edge.score + 1) && edge.projected.ApproximatelyEqual(other_edge.projected)){
+        if(edge.id == other_edge.id && edge.sos == other_edge.sos && midgard::equal<float>(edge.percent_along, other_edge.percent_along) &&
+            midgard::similar<float>(edge.distance + 1, other_edge.distance + 1) && edge.projected.ApproximatelyEqual(other_edge.projected)){
           found = true;
           break;
         }
@@ -79,9 +79,9 @@ namespace baldr{
     rapidjson::Value e{rapidjson::kObjectType};
 
     e.AddMember("id", edge.id.value, allocator)
-     .AddMember("dist", edge.dist, allocator)
+     .AddMember("dist", edge.percent_along, allocator)
      .AddMember("sos", static_cast<int>(edge.sos), allocator)
-     .AddMember("score", edge.score, allocator)
+     .AddMember("score", edge.distance, allocator)
      .AddMember("minimum_reachability", edge.minimum_reachability, allocator);
 
     // Serialize projected lat,lng as double (otherwise leads to shape

--- a/src/loki/height_action.cc
+++ b/src/loki/height_action.cc
@@ -23,9 +23,6 @@ namespace valhalla {
   namespace loki {
 
     std::vector<PointLL> loki_worker_t::init_height(valhalla_request_t& request) {
-      //get some parameters
-      auto resample_distance = rapidjson::get_optional<double>(request.document, "/resample_distance");
-
       //not enough shape
       if (request.options.shape_size() < 1)
         throw valhalla_exception_t{312};
@@ -36,13 +33,13 @@ namespace valhalla {
 
       //resample the shape
       bool resampled = false;
-      if(resample_distance) {
-        if(*resample_distance < min_resample)
+      if(request.options.has_resample_distance()) {
+        if(request.options.resample_distance() < min_resample)
           throw valhalla_exception_t{313, " " + std::to_string(min_resample) + " meters"};
         if(request.options.shape_size() > 1) {
           //resample the shape but make sure to keep the first and last shapepoint
           auto last = shape.back();
-          shape = midgard::resample_spherical_polyline(shape, *resample_distance);
+          shape = midgard::resample_spherical_polyline(shape, request.options.resample_distance());
           shape.emplace_back(std::move(last));
           //put it back
           request.options.clear_shape();

--- a/src/loki/matrix_action.cc
+++ b/src/loki/matrix_action.cc
@@ -56,12 +56,7 @@ namespace valhalla {
         if (request.options.locations_size() < 2)
           throw valhalla_exception_t{120};
 
-        //create new sources and targets ptree from locations
-        rapidjson::Value sources_child{rapidjson::kArrayType}, targets_child{rapidjson::kArrayType};
-        auto request_locations = rapidjson::get_optional<rapidjson::Value::Array>(request.document, "/locations");
-        auto& allocator = request.document.GetAllocator();
-        request.document.AddMember("targets", rapidjson::Value{request.document["locations"], allocator}, allocator);
-        request.document.AddMember("sources", *request_locations, allocator);
+        //create new sources and targets from locations
         request.options.mutable_targets()->CopyFrom(request.options.locations());
         request.options.mutable_sources()->CopyFrom(request.options.locations());
       }

--- a/src/loki/route_action.cc
+++ b/src/loki/route_action.cc
@@ -53,7 +53,6 @@ namespace valhalla {
       if(costing.back() == '_') costing.pop_back();
       check_locations(request.options.locations_size(), max_locations.find(costing)->second);
       check_distance(reader, request.options.locations(), max_distance.find(costing)->second);
-      auto& allocator = request.document.GetAllocator();
 
       // Validate walking distances (make sure they are in the accepted range)
       if (costing == "multimodal" || costing == "transit") {

--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -662,8 +662,8 @@ struct bin_handler_t {
       //filtered edges so that when finding a route using non filtered edges fails the
       //use of filtered edges are always penalized higher than the non filtered ones
       auto max = std::max_element(correlated.edges.begin(), correlated.edges.end(),
-        [](const PathLocation::PathEdge& a, const PathLocation::PathEdge& b){ return a.score < b.score; });
-      std::for_each(filtered.begin(), filtered.end(), [&max](PathLocation::PathEdge& e){ e.score += (3600.0f + max->score);});
+        [](const PathLocation::PathEdge& a, const PathLocation::PathEdge& b){ return a.distance < b.distance; });
+      std::for_each(filtered.begin(), filtered.end(), [&max](PathLocation::PathEdge& e){ e.distance += (3600.0f + max->distance);});
       correlated.filtered_edges.insert(correlated.filtered_edges.end(), std::make_move_iterator(filtered.begin()),
         std::make_move_iterator(filtered.end()));
 

--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -30,9 +30,6 @@ constexpr float SIDE_OF_STREET_SNAP = 25.f; //this is 5 meters squared, the comp
 constexpr float HEADING_SAMPLE = 30.f;
 //cone width to use for cosine similarity comparisons for favoring heading
 constexpr float DEFAULT_ANGLE_WIDTH = 60.f;
-//a scale factor to apply to the score so that we bias towards closer results more
-constexpr float SCORE_SCALE = 10.f;
-
 
 //TODO: move this to midgard and test the crap out of it
 //we are essentially estimating the angle of the tangent
@@ -306,7 +303,7 @@ struct bin_handler_t {
 
   void correlate_node(const Location& location, const GraphId& found_node, const candidate_t& candidate, PathLocation& correlated, std::vector<PathLocation::PathEdge>& filtered){
     //we need this because we might need to go to different levels
-    auto score = candidate.sq_distance * SCORE_SCALE;
+    auto score = candidate.point.Distance(location.latlng_);
     std::function<void (const GraphId& node_id, bool transition)> crawl;
     crawl = [&](const GraphId& node_id, bool follow_transitions) {
       //now that we have a node we can pass back all the edges leaving and entering it
@@ -361,7 +358,7 @@ struct bin_handler_t {
 
   void correlate_edge(const Location& location, const candidate_t& candidate, PathLocation& correlated, std::vector<PathLocation::PathEdge>& filtered) {
     //now that we have an edge we can pass back all the info about it
-    auto score = candidate.sq_distance * SCORE_SCALE;
+    auto score = candidate.point.Distance(location.latlng_);
     if(candidate.edge != nullptr){
       //we need the ratio in the direction of the edge we are correlated to
       double partial_length = 0;

--- a/src/loki/trace_route_action.cc
+++ b/src/loki/trace_route_action.cc
@@ -138,7 +138,8 @@ namespace valhalla {
 
     void loki_worker_t::trace(valhalla_request_t& request) {
       init_trace(request);
-      std::string costing = request.document["costing"].GetString();
+      auto costing = odin::DirectionsOptions::Costing_Name(request.options.costing());
+      if (costing.back() == '_') costing.pop_back();
       if (costing == "multimodal")
         throw valhalla_exception_t{140, odin::DirectionsOptions::Action_Name(request.options.action())};
     }

--- a/src/meili/map_matcher.cc
+++ b/src/meili/map_matcher.cc
@@ -250,14 +250,14 @@ FindMatchResult(const MapMatcher& mapmatcher,
   // If we get a valid edge and find it in the state that's good
   for(const auto& edge : state.candidate().edges) {
     if (edge.id == edgeid) {
-      return {edge.projected, std::sqrt(edge.score), edgeid, edge.dist, measurement.epoch_time(), stateid};
+      return {edge.projected, std::sqrt(edge.distance), edgeid, edge.percent_along, measurement.epoch_time(), stateid};
     }
   }
 
   // If we failed to get a valid edge or can't find it
   // At least we know which point it matches
   const auto& edge = state.candidate().edges.front();
-  return {edge.projected, std::sqrt(edge.score), edgeid, edge.dist, measurement.epoch_time(), stateid};
+  return {edge.projected, std::sqrt(edge.distance), edgeid, edge.percent_along, measurement.epoch_time(), stateid};
 }
 
 

--- a/src/meili/routing.cc
+++ b/src/meili/routing.cc
@@ -406,11 +406,11 @@ find_shortest_path(baldr::GraphReader& reader,
               // Get cost - use EdgeCost to get time along the edge. Override
               // cost portion to be distance. Heuristic cost from a destination
               // to itself must be 0, so sortcost = cost
-              sif::Cost cost(label.cost().cost + directededge->length() * edge.dist,
-                             label.cost().secs + costing->EdgeCost(directededge).secs * edge.dist);
+              sif::Cost cost(label.cost().cost + directededge->length() * edge.percent_along,
+                             label.cost().secs + costing->EdgeCost(directededge).secs * edge.percent_along);
               // We only add the labels if we are under the limits for distance and for time or time limit is 0
               if (cost.cost < max_dist && (max_time < 0 || cost.secs < max_time)) {
-                labelset->put(dest, edgeid, 0.f, edge.dist, cost, turn_cost,
+                labelset->put(dest, edgeid, 0.f, edge.percent_along, cost, turn_cost,
                               cost.cost, label_idx, directededge, travelmode);
               }
             }
@@ -518,17 +518,17 @@ find_shortest_path(baldr::GraphReader& reader,
           for (const auto other_dest : edge_dests[origin_edge.id]) {
             // All edges of this destination
             for (const auto& other_edge : destinations[other_dest].edges) {
-              if (origin_edge.id == other_edge.id && origin_edge.dist <= other_edge.dist) {
+              if (origin_edge.id == other_edge.id && origin_edge.percent_along <= other_edge.percent_along) {
                 // Get cost - use EdgeCost to get time along the edge. Override
                 // cost portion to be distance. The heuristic cost from a
                 // destination to itself must be 0
-                float f = (other_edge.dist - origin_edge.dist);
+                float f = (other_edge.percent_along - origin_edge.percent_along);
                 sif::Cost cost(label.cost().cost + directededge->length() * f,
                                label.cost().secs + costing->EdgeCost(directededge).secs * f);
                 // We only add the labels if we are under the limits for distance and for time or time limit is 0
                 if (cost.cost < max_dist && (max_time < 0 || cost.secs < max_time)) {
-                  labelset->put(other_dest, origin_edge.id, origin_edge.dist,
-                                other_edge.dist, cost, turn_cost, cost.cost,
+                  labelset->put(other_dest, origin_edge.id, origin_edge.percent_along,
+                                other_edge.percent_along, cost, turn_cost, cost.cost,
                                 label_idx, directededge, travelmode);
                 }
               }
@@ -538,7 +538,7 @@ find_shortest_path(baldr::GraphReader& reader,
           // Get cost - use EdgeCost to get time along the edge. Override
           // cost portion to be distance. The heuristic cost from a
           // destination to itself must be 0
-          float f = (1.0f - origin_edge.dist);
+          float f = (1.0f - origin_edge.percent_along);
           sif::Cost cost(label.cost().cost + directededge->length() * f,
                          label.cost().secs + costing->EdgeCost(directededge).secs * f);
           // We only add the labels if we are under the limits for distance and for time or time limit is 0
@@ -548,7 +548,7 @@ find_shortest_path(baldr::GraphReader& reader,
             if(nodeinfo == nullptr)
               continue;
             float sortcost = cost.cost + heuristic(nodeinfo->latlng());
-            labelset->put(directededge->endnode(), origin_edge.id, origin_edge.dist, 1.f,
+            labelset->put(directededge->endnode(), origin_edge.id, origin_edge.percent_along, 1.f,
                        cost, turn_cost, sortcost, label_idx, directededge, travelmode);
           }
         }

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -595,12 +595,12 @@ void BidirectionalAStar::SetOrigin(GraphReader& graphreader,
     // Get cost and sort cost (based on distance from endnode of this edge
     // to the destination
     nodeinfo = endtile->node(directededge->endnode());
-    Cost cost = costing_->EdgeCost(directededge) * (1.0f - edge.dist());
+    Cost cost = costing_->EdgeCost(directededge) * (1.0f - edge.percent_along());
 
     // We need to penalize this location based on its score (distance in meters from input)
     // We assume the slowest speed you could travel to cover that distance to start/end the route
     // TODO: assumes 1m/s which is a maximum penalty this could vary per costing model
-    cost.cost += edge.score();
+    cost.cost += edge.distance();
     float dist = astarheuristic_forward_.GetDistance(nodeinfo->latlng());
     float sortcost = cost.cost + astarheuristic_forward_.Get(dist);
 
@@ -660,12 +660,12 @@ void BidirectionalAStar::SetDestination(GraphReader& graphreader,
     // directed edge for costing, as this is the forward direction along the
     // destination edge. Note that the end node of the opposing edge is in the
     // same tile as the directed edge.
-    Cost cost = costing_->EdgeCost(directededge) * edge.dist();
+    Cost cost = costing_->EdgeCost(directededge) * edge.percent_along();
 
     // We need to penalize this location based on its score (distance in meters from input)
     // We assume the slowest speed you could travel to cover that distance to start/end the route
     // TODO: assumes 1m/s which is a maximum penalty this could vary per costing model
-    cost.cost += edge.score();
+    cost.cost += edge.distance();
     float dist = astarheuristic_reverse_.GetDistance(tile->node(
                     opp_dir_edge->endnode())->latlng());
     float sortcost = cost.cost + astarheuristic_reverse_.Get(dist);

--- a/src/thor/costmatrix.cc
+++ b/src/thor/costmatrix.cc
@@ -726,13 +726,13 @@ void CostMatrix::SetSources(GraphReader& graphreader,
 
       // Get cost. Get distance along the remainder of this edge.
       Cost edgecost = costing_->EdgeCost(directededge);
-      Cost cost = edgecost * (1.0f - edge.dist());
-      uint32_t d = std::round(directededge->length() * (1.0f - edge.dist()));
+      Cost cost = edgecost * (1.0f - edge.percent_along());
+      uint32_t d = std::round(directededge->length() * (1.0f - edge.percent_along()));
 
       // We need to penalize this location based on its score (distance in meters from input)
       // We assume the slowest speed you could travel to cover that distance to start/end the route
       // TODO: assumes 1m/s which is a maximum penalty this could vary per costing model
-      cost.cost += edge.score();
+      cost.cost += edge.distance();
 
       // Store the edge cost and length in the transition cost (so we can
       // recover the full length and cost for cases where origin and
@@ -805,13 +805,13 @@ void CostMatrix::SetTargets(baldr::GraphReader& graphreader,
       // Use the directed edge for costing, as this is the forward direction
       // along the destination edge.
       Cost edgecost = costing_->EdgeCost(directededge);
-      Cost cost = edgecost * edge.dist();
-      uint32_t d = std::round(directededge->length() * edge.dist());
+      Cost cost = edgecost * edge.percent_along();
+      uint32_t d = std::round(directededge->length() * edge.percent_along());
 
       // We need to penalize this location based on its score (distance in meters from input)
       // We assume the slowest speed you could travel to cover that distance to start/end the route
       // TODO: assumes 1m/s which is a maximum penalty this could vary per costing model
-      cost.cost += edge.score();
+      cost.cost += edge.distance();
 
       // Store the edge cost and length in the transition cost (so we can
       // recover the full length and cost for cases where origin and

--- a/src/thor/isochrone.cc
+++ b/src/thor/isochrone.cc
@@ -945,19 +945,19 @@ void Isochrone::SetOriginLocations(GraphReader& graphreader,
 
       // Get cost
       nodeinfo = endtile->node(directededge->endnode());
-      Cost cost = costing->EdgeCost(directededge) * (1.0f - edge.dist());
+      Cost cost = costing->EdgeCost(directededge) * (1.0f - edge.percent_along());
 
       // We need to penalize this location based on its score (distance in meters from input)
       // We assume the slowest speed you could travel to cover that distance to start/end the route
       // TODO: high edge scores cause issues as there is code to limit cost so
       // that large penalties (e.g., ferries) are excluded.
-      cost.cost += edge.score() * 0.005f;
+      cost.cost += edge.distance() * 0.005f;
 
       // Add EdgeLabel to the adjacency list (but do not set its status).
       // Set the predecessor edge index to invalid to indicate the origin
       // of the path.
       uint32_t idx = edgelabels_.size();
-      uint32_t d = static_cast<uint32_t>(directededge->length() * (1.0f - edge.dist()));
+      uint32_t d = static_cast<uint32_t>(directededge->length() * (1.0f - edge.percent_along()));
       edgestatus_->Set(edgeid, EdgeSet::kTemporary, idx);
       EdgeLabel edge_label(kInvalidLabel, edgeid, directededge, cost,
                            cost.cost, 0.0f, mode_, d);
@@ -1016,19 +1016,19 @@ void Isochrone::SetOriginLocationsMM(GraphReader& graphreader,
 
       // Get cost
       nodeinfo = endtile->node(directededge->endnode());
-      Cost cost = costing->EdgeCost(directededge) * (1.0f - edge.dist());
+      Cost cost = costing->EdgeCost(directededge) * (1.0f - edge.percent_along());
 
       // We need to penalize this location based on its score (distance in meters from input)
       // We assume the slowest speed you could travel to cover that distance to start/end the route
       // TODO: high edge scores cause issues as there is code to limit cost so
       // that large penalties (e.g., ferries) are excluded.
-      cost.cost += edge.score() * 0.005f;
+      cost.cost += edge.distance() * 0.005f;
 
       // Add EdgeLabel to the adjacency list (but do not set its status).
       // Set the predecessor edge index to invalid to indicate the origin
       // of the path.
       uint32_t idx = mmedgelabels_.size();
-      uint32_t d = static_cast<uint32_t>(directededge->length() * (1.0f - edge.dist()));
+      uint32_t d = static_cast<uint32_t>(directededge->length() * (1.0f - edge.percent_along()));
       edgestatus_->Set(edgeid, EdgeSet::kTemporary, idx);
       MMEdgeLabel edge_label(kInvalidLabel, edgeid, directededge, cost,
                              cost.cost, 0.0f, mode_, d, 0, GraphId(), 0, 0, false);
@@ -1092,12 +1092,12 @@ void Isochrone::SetDestinationLocations(GraphReader& graphreader,
       // the end node of the opposing edge is in the same tile as the directed
       // edge.  Use the directed edge for costing, as this is the forward
       // direction along the destination edge.
-      Cost cost = costing->EdgeCost(directededge) * edge.dist();
+      Cost cost = costing->EdgeCost(directededge) * edge.percent_along();
 
       // We need to penalize this location based on its score (distance in meters from input)
       // We assume the slowest speed you could travel to cover that distance to start/end the route
       // TODO: assumes 1m/s which is a maximum penalty this could vary per costing model
-      cost.cost += edge.score();
+      cost.cost += edge.distance();
 
       // Add EdgeLabel to the adjacency list. Set the predecessor edge index
       // to invalid to indicate the origin of the path. Make sure the opposing

--- a/src/thor/optimized_route_action.cc
+++ b/src/thor/optimized_route_action.cc
@@ -54,8 +54,10 @@ namespace valhalla {
     optimal_order = optimizer.Solve(correlated.size(), time_costs);
     //put the optimal order into the locations array
     request.options.mutable_locations()->Clear();
-    for (size_t i = 0; i < optimal_order.size(); i++)
+    for (size_t i = 0; i < optimal_order.size(); i++) {
       request.options.mutable_locations()->Add()->CopyFrom(correlated.Get(optimal_order[i]));
+      request.options.mutable_locations()->rbegin()->set_original_index(optimal_order[i]);
+    }
 
     auto trippaths = path_depart_at(*request.options.mutable_locations(), costing);
 

--- a/src/thor/route_matcher.cc
+++ b/src/thor/route_matcher.cc
@@ -77,7 +77,7 @@ end_node_t GetEndEdges(GraphReader& reader,
       auto* opp_edge = tile->directededge(opp_edge_id);
 
       // Compute partial distance along end edge
-      float dist = opp_edge->length() * edge.dist();
+      float dist = opp_edge->length() * edge.percent_along();
       end_nodes.insert({opp_edge->endnode(), std::make_pair(edge, dist)});
     }
   }
@@ -260,7 +260,7 @@ bool RouteMatcher::FormPath(
     // Initialize indexes and shape
     size_t index = 0;
     float length = 0.0f;
-    float de_remaining_length = de->length() * (1 - edge.dist());
+    float de_remaining_length = de->length() * (1 - edge.percent_along());
     float de_length = length_comparison(de_remaining_length, true);
     EdgeLabel prev_edge_label;
     // Loop over shape to form path from matching edges
@@ -275,7 +275,7 @@ bool RouteMatcher::FormPath(
 
         // Update the elapsed time edge cost at begin edge
         elapsed_time += mode_costing[static_cast<int>(mode)]->EdgeCost(de).secs
-            * (1 - edge.dist());
+            * (1 - edge.percent_along());
 
         // Add begin edge
         path_infos.emplace_back(mode, elapsed_time, graphid, 0);
@@ -318,7 +318,7 @@ bool RouteMatcher::FormPath(
 
           // Update the elapsed time based on edge cost
           elapsed_time += mode_costing[static_cast<int>(mode)]->EdgeCost(end_de).secs *
-                          end_edge.dist();
+                          end_edge.percent_along();
 
           // Add end edge
           path_infos.emplace_back(mode, elapsed_time, end_edge_graphid, 0);
@@ -338,7 +338,7 @@ bool RouteMatcher::FormPath(
       if (end.second.first.graph_id() == edge.graph_id()) {
         // Update the elapsed time based on edge cost
         elapsed_time += mode_costing[static_cast<int>(mode)]->EdgeCost(de).secs *
-                               (end.second.first.dist() - edge.dist());
+                               (end.second.first.percent_along() - edge.percent_along());
 
         // Add end edge
         path_infos.emplace_back(mode, elapsed_time, GraphId(edge.graph_id()), 0);

--- a/src/thor/timedistancematrix.cc
+++ b/src/thor/timedistancematrix.cc
@@ -14,7 +14,7 @@ static bool IsTrivial(const uint64_t& edgeid,
     if (destination_edge.graph_id() == edgeid) {
       for (const auto& origin_edge : origin.path_edges()) {
         if (origin_edge.graph_id() == edgeid &&
-            origin_edge.dist() <= destination_edge.dist()) {
+            origin_edge.percent_along() <= destination_edge.percent_along()) {
           return true;
         }
       }
@@ -450,14 +450,14 @@ void TimeDistanceMatrix::SetOriginOneToMany(GraphReader& graphreader,
 
     // Get cost. Use this as sortcost since A* is not used for time+distance
     // matrix computations. . Get distance along the remainder of this edge.
-    Cost cost = costing_->EdgeCost(directededge) * (1.0f - edge.dist());
+    Cost cost = costing_->EdgeCost(directededge) * (1.0f - edge.percent_along());
     uint32_t d = static_cast<uint32_t>(directededge->length() *
-                             (1.0f - edge.dist()));
+                             (1.0f - edge.percent_along()));
 
     // We need to penalize this location based on its score (distance in meters from input)
     // We assume the slowest speed you could travel to cover that distance to start/end the route
     // TODO: assumes 1m/s which is a maximum penalty this could vary per costing model
-    cost.cost += edge.score();
+    cost.cost += edge.distance();
 
     // Add EdgeLabel to the adjacency list (but do not set its status).
     // Set the predecessor edge index to invalid to indicate the origin
@@ -496,13 +496,13 @@ void TimeDistanceMatrix::SetOriginManyToOne(GraphReader& graphreader,
 
     // Get cost. Use this as sortcost since A* is not used for time
     // distance matrix computations. Get the distance along the edge.
-    Cost cost = costing_->EdgeCost(opp_dir_edge) * edge.dist();
-    uint32_t d = static_cast<uint32_t>(directededge->length() * edge.dist());
+    Cost cost = costing_->EdgeCost(opp_dir_edge) * edge.percent_along();
+    uint32_t d = static_cast<uint32_t>(directededge->length() * edge.percent_along());
 
     // We need to penalize this location based on its score (distance in meters from input)
     // We assume the slowest speed you could travel to cover that distance to start/end the route
     // TODO: assumes 1m/s which is a maximum penalty this could vary per costing model
-    cost.cost += edge.score();
+    cost.cost += edge.distance();
 
     // Add EdgeLabel to the adjacency list (but do not set its status).
     // Set the predecessor edge index to invalid to indicate the origin
@@ -530,7 +530,7 @@ void TimeDistanceMatrix::SetDestinations(GraphReader& graphreader,
     for (const auto& edge : loc.path_edges()) {
       // Keep the id and the partial distance for the
       // remainder of the edge.
-      d.dest_edges[edge.graph_id()] = (1.0f - edge.dist());
+      d.dest_edges[edge.graph_id()] = (1.0f - edge.percent_along());
 
       // Form a threshold cost (the total cost to traverse the edge)
       const GraphTile* tile = graphreader.GetGraphTile(static_cast<GraphId>(edge.graph_id()));
@@ -539,7 +539,7 @@ void TimeDistanceMatrix::SetDestinations(GraphReader& graphreader,
       // We need to penalize this location based on its score (distance in meters from input)
       // We assume the slowest speed you could travel to cover that distance to start/end the route
       // TODO: assumes 1m/s which is a maximum penalty this could vary per costing model
-      c += edge.score();
+      c += edge.distance();
       if (c > d.threshold) {
         d.threshold = c;
       }
@@ -571,7 +571,7 @@ void TimeDistanceMatrix::SetDestinationsManyToOne(GraphReader& graphreader,
 
       // Keep the id and the partial distance for the
       // remainder of the edge.
-      d.dest_edges[opp_edge_id] = edge.dist();
+      d.dest_edges[opp_edge_id] = edge.percent_along();
 
       // Form a threshold cost (the total cost to traverse the edge)
       const GraphTile* tile = graphreader.GetGraphTile(static_cast<GraphId>(edge.graph_id()));
@@ -580,7 +580,7 @@ void TimeDistanceMatrix::SetDestinationsManyToOne(GraphReader& graphreader,
       // We need to penalize this location based on its score (distance in meters from input)
       // We assume the slowest speed you could travel to cover that distance to start/end the route
       // TODO: assumes 1m/s which is a maximum penalty this could vary per costing model
-      c += edge.score();
+      c += edge.distance();
       if (c > d.threshold) {
         d.threshold = c;
       }

--- a/src/thor/trace_route_action.cc
+++ b/src/thor/trace_route_action.cc
@@ -370,7 +370,7 @@ std::vector<std::tuple<float, float, std::vector<thor::MatchResult>, odin::TripP
         auto* pe = origin.mutable_path_edges()->Add();
         pe->CopyFrom(origin.path_edges(0));
         pe->set_graph_id(path_edges.front().edgeid);
-        pe->set_dist(0.f);
+        pe->set_percent_along(0.f);
       }
 
       bool found_destination = false;
@@ -390,7 +390,7 @@ std::vector<std::tuple<float, float, std::vector<thor::MatchResult>, odin::TripP
         auto* pe = destination.mutable_path_edges()->Add();
         pe->CopyFrom(destination.path_edges(0));
         pe->set_graph_id(path_edges.back().edgeid);
-        pe->set_dist(1.f);
+        pe->set_percent_along(1.f);
       }
 
 

--- a/src/thor/trippathbuilder.cc
+++ b/src/thor/trippathbuilder.cc
@@ -564,7 +564,7 @@ TripPath TripPathBuilder::Build(
   PointLL start_vrt;
   for(const auto& e : origin.path_edges()) {
     if (e.graph_id() == path.front().edgeid) {
-      start_pct = e.dist();
+      start_pct = e.percent_along();
       start_sos = e.side_of_street();
       start_vrt = PointLL(e.ll().lng(), e.ll().lat());
       break;
@@ -586,7 +586,7 @@ TripPath TripPathBuilder::Build(
   PointLL end_vrt;
   for(const auto&e : dest.path_edges()) {
     if (e.graph_id() == path.back().edgeid) {
-      end_pct = e.dist();
+      end_pct = e.percent_along();
       end_sos = e.side_of_street();
       end_vrt = PointLL(e.ll().lng(), e.ll().lat());
       break;

--- a/src/thor/worker.cc
+++ b/src/thor/worker.cc
@@ -34,7 +34,7 @@ namespace {
   // Perhaps tie the edge score logic in with the costing type - but
   // may want to do this in loki. At this point in thor the costing method
   // has not yet been constructed.
-  const std::unordered_map<std::string, float> kMaxScores = {
+  const std::unordered_map<std::string, float> kMaxDistances = {
     {"auto_", 43200.0f},
     {"auto_shorter", 43200.0f},
     {"bicycle", 7200.0f},
@@ -47,7 +47,7 @@ namespace {
     {"truck", 43200.0f},
   };
   //a scale factor to apply to the score so that we bias towards closer results more
-  constexpr float kScoreScale = 10.f;
+  constexpr float kDistanceScale = 10.f;
   constexpr double kMilePerMeter = 0.000621371;
 
 }
@@ -249,23 +249,23 @@ namespace valhalla {
             for(auto& candidate : *candidates) {
               //completely disable scores for this location
               if(location.has_rank_candidates() && !location.rank_candidates())
-                candidate.set_score(0);
+                candidate.set_distance(0);
               //scale the score to favor closer results more
               else
-                candidate.set_score(candidate.score() * candidate.score() * kScoreScale);
+                candidate.set_distance(candidate.distance() * candidate.distance() * kDistanceScale);
               //remember the min score
-              if(minScore > candidate.score())
-                minScore = candidate.score();
+              if(minScore > candidate.distance())
+                minScore = candidate.distance();
             }
           }
 
           //subtract off the min score and cap at max so that path algorithm doesnt go too far
-          auto max_score = kMaxScores.find(odin::DirectionsOptions::Costing_Name(request.options.costing()));
+          auto max_score = kMaxDistances.find(odin::DirectionsOptions::Costing_Name(request.options.costing()));
           for(auto* candidates : {location.mutable_path_edges(), location.mutable_filtered_edges()}) {
             for(auto& candidate : *candidates) {
-              candidate.set_score(candidate.score() - minScore);
-              if (candidate.score() > max_score->second)
-                candidate.set_score(max_score->second);
+              candidate.set_distance(candidate.distance() - minScore);
+              if (candidate.distance() > max_score->second)
+                candidate.set_distance(max_score->second);
             }
           }
         }

--- a/src/thor/worker.cc
+++ b/src/thor/worker.cc
@@ -234,7 +234,8 @@ namespace valhalla {
 
     std::string thor_worker_t::parse_costing(const valhalla_request_t& request) {
       // Parse out the type of route - this provides the costing method to use
-      auto costing = rapidjson::get<std::string>(request.document,  "/costing");
+      auto costing = odin::DirectionsOptions::Costing_Name(request.options.costing());
+      if(costing.back() == '_') costing.pop_back();
 
       // Set travel mode and construct costing
       if (costing == "multimodal" || costing == "transit") {

--- a/src/tyr/locate_serializer.cc
+++ b/src/tyr/locate_serializer.cc
@@ -27,8 +27,8 @@ namespace {
               edge.sos == PathLocation::LEFT ? std::string("left") :
                 (edge.sos == PathLocation::RIGHT ? std::string("right") : std::string("neither"))
             },
-            {"percent_along", json::fp_t{edge.dist, 5} },
-            {"score", json::fp_t{edge.score, 1}},
+            {"percent_along", json::fp_t{edge.percent_along, 5} },
+            {"distance", json::fp_t{edge.distance, 1}},
             {"minimum_reachability", static_cast<int64_t>(edge.minimum_reachability)},
             {"edge_id", edge.id.json()},
             {"edge", directed_edge->json()},
@@ -46,7 +46,7 @@ namespace {
                 edge.sos == PathLocation::LEFT ? std::string("left") :
                   (edge.sos == PathLocation::RIGHT ? std::string("right") : std::string("neither"))
               },
-              {"percent_along", json::fp_t{edge.dist, 5} },
+              {"percent_along", json::fp_t{edge.percent_along, 5} },
             })
           );
         }

--- a/src/valhalla_run_route.cc
+++ b/src/valhalla_run_route.cc
@@ -668,11 +668,11 @@ int main(int argc, char *argv[]) {
   for (auto& correlated : path_location) {
     auto minScoreEdge = *std::min_element(correlated.edges.begin(), correlated.edges.end(),
        [](PathLocation::PathEdge i, PathLocation::PathEdge j)->bool {
-         return i.score < j.score;
+         return i.distance < j.distance;
        });
 
     for(auto& e : correlated.edges) {
-      e.score -= minScoreEdge.score;
+      e.distance -= minScoreEdge.distance;
     }
   }
   auto t2 = std::chrono::high_resolution_clock::now();

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -362,6 +362,8 @@ namespace {
           if(accuracy) location->set_accuracy(*accuracy);
           auto time = rapidjson::get_optional<unsigned int>(r_loc, "/time");
           if(time) location->set_time(*time);
+          auto rank_candidates = rapidjson::get_optional<bool>(r_loc, "/rank_candidates");
+          if(rank_candidates) location->set_rank_candidates(*rank_candidates);
         }
         catch (...) { throw valhalla::valhalla_exception_t{location_parse_error_code}; }
       }

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -501,6 +501,11 @@ namespace {
       }
     }
 
+    //get some parameters
+    auto resample_distance = rapidjson::get_optional<double>(doc, "/resample_distance");
+    if(resample_distance)
+      options.set_resample_distance(*resample_distance);
+
     //force these into the output so its obvious what we did to the user
     doc.AddMember({"language", allocator}, {options.language(), allocator}, allocator);
     doc.AddMember({"format", allocator},

--- a/test/astar.cc
+++ b/test/astar.cc
@@ -234,10 +234,10 @@ void assert_is_trivial_path(
 
 void add(GraphId id, float dist, PointLL ll, vo::Location& l) {
   l.mutable_path_edges()->Add()->set_graph_id(id);
-  l.mutable_path_edges()->rbegin()->set_dist(dist);
+  l.mutable_path_edges()->rbegin()->set_percent_along(dist);
   l.mutable_path_edges()->rbegin()->mutable_ll()->set_lng(ll.first);
   l.mutable_path_edges()->rbegin()->mutable_ll()->set_lat(ll.second);
-  l.mutable_path_edges()->rbegin()->set_score(0.0f);
+  l.mutable_path_edges()->rbegin()->set_distance(0.0f);
 }
 
 // test that a path from A to B succeeds, even if the edges from A to C and B

--- a/test/matrix.cc
+++ b/test/matrix.cc
@@ -254,7 +254,7 @@ void test_matrix() {
   loki_worker.matrix (request);
   adjust_scores(request);
 
-  auto request_pt = json_to_pt (rapidjson::to_string(request.document));
+  auto request_pt = json_to_pt (test_request);
 
   GraphReader reader (config.get_child("mjolnir"));
 
@@ -301,7 +301,7 @@ void test_matrix_osrm() {
 
   loki_worker.matrix (request);
   adjust_scores(request);
-  auto request_pt = json_to_pt (rapidjson::to_string(request.document));
+  auto request_pt = json_to_pt (test_request_osrm);
 
   GraphReader reader (config.get_child("mjolnir"));
 

--- a/test/search.cc
+++ b/test/search.cc
@@ -157,10 +157,9 @@ void search(const valhalla::baldr::Location& location, bool expected_node, const
     throw std::runtime_error("Found wrong point");
 
   valhalla::baldr::PathLocation answer(location);
-  DistanceApproximator approx(location.latlng_);
   for(const auto& expected_edge : expected_edges) {
     answer.edges.emplace_back(PathLocation::PathEdge{expected_edge.id, expected_edge.dist,
-      expected_point, approx.DistanceSquared(expected_point) * 10.f, expected_edge.sos});
+      expected_point, expected_point.Distance(location.latlng_), expected_edge.sos});
   }
   //note that this just checks that p has the edges that answer has
   //p can have more edges than answer has and that wont fail this check!

--- a/test/search.cc
+++ b/test/search.cc
@@ -158,7 +158,7 @@ void search(const valhalla::baldr::Location& location, bool expected_node, const
 
   valhalla::baldr::PathLocation answer(location);
   for(const auto& expected_edge : expected_edges) {
-    answer.edges.emplace_back(PathLocation::PathEdge{expected_edge.id, expected_edge.dist,
+    answer.edges.emplace_back(PathLocation::PathEdge{expected_edge.id, expected_edge.percent_along,
       expected_point, expected_point.Distance(location.latlng_), expected_edge.sos});
   }
   //note that this just checks that p has the edges that answer has

--- a/valhalla/baldr/pathlocation.h
+++ b/valhalla/baldr/pathlocation.h
@@ -36,7 +36,7 @@ struct PathLocation : public Location {
     //the directed edge it appears on
     GraphId id;
     //how far along the edge it is (as a percentage  from 0 - 1)
-    float dist;
+    float percent_along;
     //the projected point along the edge where the original location correlates
     midgard::PointLL projected;
     //what side of the edge is it on
@@ -48,7 +48,7 @@ struct PathLocation : public Location {
 
     //a measure of how close the result is to the original input where the
     //lower the score the better the match, maybe there's a better word for this?
-    float score;
+    float distance;
     //minimum number of edges reachable from this edge, this is a lower limit
     //it could be reachable from many many more edges than are reported here
     unsigned int minimum_reachability;
@@ -104,12 +104,12 @@ struct PathLocation : public Location {
     for(const auto& e : pl.edges) {
       auto* edge = path_edges->Add();
       edge->set_graph_id(e.id);
-      edge->set_dist(e.dist);
+      edge->set_percent_along(e.percent_along);
       edge->mutable_ll()->set_lng(e.projected.first);
       edge->mutable_ll()->set_lat(e.projected.second);
       edge->set_side_of_street(e.sos == PathLocation::LEFT ? odin::Location::kLeft :
           (e.sos == PathLocation::RIGHT ? odin::Location::kRight : odin::Location::kNone));
-      edge->set_score(e.score);
+      edge->set_distance(e.distance);
       edge->set_minimum_reachability(e.minimum_reachability);
       for(const auto& n : reader.edgeinfo(e.id).GetNames())
         edge->mutable_names()->Add()->assign(n);
@@ -119,12 +119,12 @@ struct PathLocation : public Location {
     for(const auto& e : pl.edges) {
       auto* edge = filtered_edges->Add();
       edge->set_graph_id(e.id);
-      edge->set_dist(e.dist);
+      edge->set_percent_along(e.percent_along);
       edge->mutable_ll()->set_lng(e.projected.first);
       edge->mutable_ll()->set_lat(e.projected.second);
       edge->set_side_of_street(e.sos == PathLocation::LEFT ? odin::Location::kLeft :
           (e.sos == PathLocation::RIGHT ? odin::Location::kRight : odin::Location::kNone));
-      edge->set_score(e.score);
+      edge->set_distance(e.distance);
       edge->set_minimum_reachability(e.minimum_reachability);
       for(const auto& n : reader.edgeinfo(e.id).GetNames())
         edge->mutable_names()->Add()->assign(n);

--- a/valhalla/meili/emission_cost_model.h
+++ b/valhalla/meili/emission_cost_model.h
@@ -40,7 +40,7 @@ class EmissionCostModel
   { return sq_distance * inv_double_sq_sigma_z_; }
 
   float operator()(const StateId& stateid) const
-  { return CalculateEmissionCost(container_.state(stateid).candidate().edges.front().score); }
+  { return CalculateEmissionCost(container_.state(stateid).candidate().edges.front().distance); }
 
  private:
   baldr::GraphReader& graphreader_;

--- a/valhalla/thor/pathalgorithm.h
+++ b/valhalla/thor/pathalgorithm.h
@@ -98,7 +98,7 @@ class PathAlgorithm {
       if (destination_edge.graph_id() == edgeid) {
         for (const auto& origin_edge : origin.path_edges()) {
           if (origin_edge.graph_id() == edgeid &&
-              origin_edge.dist() <= destination_edge.dist()) {
+              origin_edge.percent_along() <= destination_edge.percent_along()) {
             return true;
           }
         }


### PR DESCRIPTION
Fixes #1160 

If you are only interested in the changes for the edge ranking then this commit is the important one: https://github.com/valhalla/valhalla/commit/43ce1e079d0b62ac9cacdf3d8deab0bd482d8b08

Before:
![before](https://user-images.githubusercontent.com/697548/37779717-70ba5a0e-2dc3-11e8-8eea-3812cb753335.png)

After:
![after](https://user-images.githubusercontent.com/697548/37779725-74d4dd4e-2dc3-11e8-90e9-006e0f7b566a.png)

Do note that the default behavior is still that of the before image. The requester has to choose to disable candidate ranking as described in #1160.

In addition to the above I did two other cleanups. One was that I moved all the logic with respect to hacking the candidate distance metrics to the same file. This will allow us to more easily do the right thing when we get around to working on #1154: https://github.com/valhalla/valhalla/commit/c34b525b510f9d6161d193edd9a5957560bb45a9

I also renamed the fields of the candidate edges so that they reflect what they actually are. Sadly this makes for a big diff: https://github.com/valhalla/valhalla/commit/bdbf9844422dddee990d8f8d1758a8f32ced4934.

There were also some smaller fixes I added in here. I noticed that the original location index was not getting set for optimize so I fixed that and made some other cleanups.