### PR TITLE
toward osrm flavoured map matching responses

### DIFF
--- a/src/thor/map_matcher.cc
+++ b/src/thor/map_matcher.cc
@@ -19,8 +19,7 @@ std::vector<PathInfo> MapMatcher::FormPath(
     const std::vector<meili::EdgeSegment>& edge_segments,
     const std::shared_ptr<sif::DynamicCost>* mode_costing,
     const sif::TravelMode mode,
-    std::vector<std::pair<GraphId, GraphId>>& disconnected_edges,
-    bool trace_attributes_action) {
+    std::vector<std::pair<GraphId, GraphId>>& disconnected_edges) {
   // Set the mode and costing
   const auto& costing = mode_costing[static_cast<uint32_t>(mode)];
   // Iterate through the matched path. Form PathInfo - populate elapsed time
@@ -86,10 +85,6 @@ std::vector<PathInfo> MapMatcher::FormPath(
     path.emplace_back(mode, elapsed_time, edge_id, 0);
 
   }
-
-  // Throw exception if not trace attributes action and disconnected path
-  if (!trace_attributes_action && !disconnected_edges.empty())
-      throw valhalla_exception_t{442};
 
   return path;
 }

--- a/src/thor/trace_attributes_action.cc
+++ b/src/thor/trace_attributes_action.cc
@@ -102,7 +102,7 @@ std::string thor_worker_t::trace_attributes(valhalla_request_t& request) {
       case MAP_SNAP:
         try {
           uint32_t best_paths = rapidjson::get<uint32_t>(request.document, "/best_paths", 1);
-          map_match_results = map_match(controller, true, best_paths);
+          map_match_results = map_match(request, controller, best_paths);
         } catch (const std::exception& e) {
           throw valhalla_exception_t{444, shape_match->first + " algorithm failed to snap the shape points to the correct shape."};
         }
@@ -115,7 +115,7 @@ std::string thor_worker_t::trace_attributes(valhalla_request_t& request) {
         if (trip_path.node().size() == 0) {
           LOG_WARN(shape_match->first + " algorithm failed to find exact route match; Falling back to map_match...");
           try {
-            map_match_results = map_match(controller, true);
+            map_match_results = map_match(request, controller);
           } catch (const std::exception& e) {
             throw valhalla_exception_t{444, shape_match->first + " algorithm failed to snap the shape points to the correct shape."};
           }

--- a/src/thor/trace_route_action.cc
+++ b/src/thor/trace_route_action.cc
@@ -55,15 +55,16 @@ odin::TripPath thor_worker_t::trace_route(valhalla_request_t& request) {
   parse_trace_config(request);
   parse_measurements(request);
 
+  // Initialize the controller with no attribution since this is for a trip path only
+  odin::TripPath trip_path;
+  AttributesController controller(decltype(AttributesController::kRouteAttributes){});
+
   /*
    * A flag indicating whether the input shape is a GPS trace or exact points from a
    * prior route run against the Valhalla road network.  Knowing that the input is from
    * Valhalla will allow an efficient “edge-walking” algorithm rather than a more extensive
    * map-matching method. If true, this enforces to only use exact route match algorithm.
    */
-  odin::TripPath trip_path;
-  AttributesController controller;
-
   auto shape_match = STRING_TO_MATCH.find(rapidjson::get<std::string>(request.document, "/shape_match", "walk_or_snap"));
   if (shape_match == STRING_TO_MATCH.cend())
     throw valhalla_exception_t{445};
@@ -170,121 +171,139 @@ std::vector<std::tuple<float, float, std::vector<thor::MatchResult>, odin::TripP
     if (request.options.action() == odin::DirectionsOptions::trace_route && disconnected_edges.size())
         throw valhalla_exception_t{442};
 
-    if (request.options.action() == odin::DirectionsOptions::trace_attributes) {
-      // Associate match points to edges, if enabled
-      if (controller.category_attribute_enabled(kMatchedCategory)) {
-        // Populate for matched points so we have 1:1 with trace points
-        for (const auto& match_result : match_results) {
-          // Matched type is set in constructor
-          enhanced_match_results.emplace_back(match_result);
-        }
+    // OSRM map matching format has both the match points and the route, fill out the match points here
+    // Note that we only support trace_route as OSRM format so best_paths == 1
+    if (request.options.action() == odin::DirectionsOptions::trace_route &&
+        request.options.format() == odin::DirectionsOptions::osrm) {
+      const GraphTile* tile = nullptr;
+      for(int i = 0; i < match_results.size(); ++i) {
+        const auto& match = match_results[i];
+        if(!match.edgeid.Is_Valid())
+          continue;
+        reader.GetGraphTile(match.edgeid, tile);
+        auto* pe = request.options.mutable_shape(i)->mutable_path_edges()->Add();
+        pe->mutable_ll()->set_lat(match.lnglat.lat());
+        pe->mutable_ll()->set_lng(match.lnglat.lng());
+        for(const auto& n : reader.edgeinfo(match.edgeid).GetNames())
+          pe->mutable_names()->Add()->assign(n);
+        //TODO: we should some how signal how many edge candidates there were at this stateid
+      }
+    }
 
-        // Iterate over results to set edge_index, if found
-        int edge_index = 0;
-        int last_matched_edge_index = edge_index;
-        int match_index = 0;
-        auto edge = path_edges.cbegin();
-        auto last_matched_edge = edge;
-        for (auto& enhanced_match_result : enhanced_match_results) {
-          // Reset edge and edge_index to last matched for every matched result
-          edge = last_matched_edge;
-          edge_index = last_matched_edge_index;
+    // Associate match points to edges, if enabled
+    if (controller.category_attribute_enabled(kMatchedCategory)) {
+      // Populate for matched points so we have 1:1 with trace points
+      for (const auto& match_result : match_results) {
+        // Matched type is set in constructor
+        enhanced_match_results.emplace_back(match_result);
+      }
 
-          // Check for result for valid edge id
-          if (enhanced_match_result.edgeid.Is_Valid()) {
-            // Walk edges to find matching id
-            while (edge != path_edges.cend()) {
-              // Find matching edge id in path
-              if (enhanced_match_result.edgeid == edge->edgeid) {
-                // Set match result with matched edge index and break out of the loop
-                enhanced_match_result.edge_index = edge_index;
+      // Iterate over results to set edge_index, if found
+      int edge_index = 0;
+      int last_matched_edge_index = edge_index;
+      int match_index = 0;
+      auto edge = path_edges.cbegin();
+      auto last_matched_edge = edge;
+      for (auto& enhanced_match_result : enhanced_match_results) {
+        // Reset edge and edge_index to last matched for every matched result
+        edge = last_matched_edge;
+        edge_index = last_matched_edge_index;
 
-                // Set the last matched edge and edge_index so we skip matched transition edges
-                last_matched_edge = edge;
-                last_matched_edge_index = edge_index;
-                break;
-              } else {
-                // Increment to next edge and edge_index
-                ++edge;
-                ++edge_index;
-              }
-            }
-          }
-        }
+        // Check for result for valid edge id
+        if (enhanced_match_result.edgeid.Is_Valid()) {
+          // Walk edges to find matching id
+          while (edge != path_edges.cend()) {
+            // Find matching edge id in path
+            if (enhanced_match_result.edgeid == edge->edgeid) {
+              // Set match result with matched edge index and break out of the loop
+              enhanced_match_result.edge_index = edge_index;
 
-        // Mark the disconnected route boundaries
-        auto curr_match_result = enhanced_match_results.begin();
-        auto prev_match_result = curr_match_result;
-        for (auto& disconnected_edge_pair : disconnected_edges) {
-
-          // Find previous(first) edge within the match results
-          while (curr_match_result != enhanced_match_results.end()) {
-            if (curr_match_result->edgeid == disconnected_edge_pair.first.value) {
-              // Found previous edge therefore stop looking
+              // Set the last matched edge and edge_index so we skip matched transition edges
+              last_matched_edge = edge;
+              last_matched_edge_index = edge_index;
               break;
+            } else {
+              // Increment to next edge and edge_index
+              ++edge;
+              ++edge_index;
             }
-            // Increment previous and current match results to continue looking
-            prev_match_result = curr_match_result;
-            ++curr_match_result;
-          }
-
-          // Find the last match result of the previous edge
-          while (curr_match_result != enhanced_match_results.end()) {
-            if (curr_match_result->edgeid != disconnected_edge_pair.first.value) {
-              // Set previous match result as disconnected path and break
-              prev_match_result->begin_route_discontinuity = true;
-
-              // The begin route discontinuity is the edge end info
-              // therefore the second item in the pair
-              if (route_discontinuities.count(prev_match_result->edge_index) > 0) {
-                // Update edge_end_info values
-                auto& edge_end_info = route_discontinuities.at(prev_match_result->edge_index).second;
-                edge_end_info.exists = true;
-                edge_end_info.vertex = prev_match_result->lnglat;
-                edge_end_info.distance_along = prev_match_result->distance_along;
-              } else {
-                // Add new item
-                // Begin distance along defaulted to 0
-                route_discontinuities.insert( {prev_match_result->edge_index,
-                  { {false, {}, 0.f},
-                      {true, prev_match_result->lnglat, prev_match_result->distance_along} }});
-              }
-              break;
-            }
-            // Increment previous and current match results to continue looking
-            prev_match_result = curr_match_result;
-            ++curr_match_result;
-          }
-
-          // Find the current(second) edge within the match results
-          while (curr_match_result != enhanced_match_results.end()) {
-            if (curr_match_result->edgeid == disconnected_edge_pair.second.value) {
-              // Set current match result as disconnected and break
-              curr_match_result->end_route_discontinuity = true;
-
-              // The end route discontinuity is the edge begin info
-              // therefore the first item in the pair
-              if (route_discontinuities.count(curr_match_result->edge_index) > 0) {
-                // Update edge_begin_info values
-                auto& edge_begin_info = route_discontinuities.at(curr_match_result->edge_index).first;
-                edge_begin_info.exists = true;
-                edge_begin_info.vertex = curr_match_result->lnglat;
-                edge_begin_info.distance_along = curr_match_result->distance_along;
-              } else {
-                // Add new item
-                // End distance along defaulted to 1
-                route_discontinuities.insert( {curr_match_result->edge_index,
-                  { {true, curr_match_result->lnglat, curr_match_result->distance_along},
-                      {false, {}, 1.f} }});
-              }
-              break;
-            }
-            // Increment previous and current match results to continue looking
-            prev_match_result = curr_match_result;
-            ++curr_match_result;
           }
         }
       }
+
+      // Mark the disconnected route boundaries
+      auto curr_match_result = enhanced_match_results.begin();
+      auto prev_match_result = curr_match_result;
+      for (auto& disconnected_edge_pair : disconnected_edges) {
+
+        // Find previous(first) edge within the match results
+        while (curr_match_result != enhanced_match_results.end()) {
+          if (curr_match_result->edgeid == disconnected_edge_pair.first.value) {
+            // Found previous edge therefore stop looking
+            break;
+          }
+          // Increment previous and current match results to continue looking
+          prev_match_result = curr_match_result;
+          ++curr_match_result;
+        }
+
+        // Find the last match result of the previous edge
+        while (curr_match_result != enhanced_match_results.end()) {
+          if (curr_match_result->edgeid != disconnected_edge_pair.first.value) {
+            // Set previous match result as disconnected path and break
+            prev_match_result->begin_route_discontinuity = true;
+
+            // The begin route discontinuity is the edge end info
+            // therefore the second item in the pair
+            if (route_discontinuities.count(prev_match_result->edge_index) > 0) {
+              // Update edge_end_info values
+              auto& edge_end_info = route_discontinuities.at(prev_match_result->edge_index).second;
+              edge_end_info.exists = true;
+              edge_end_info.vertex = prev_match_result->lnglat;
+              edge_end_info.distance_along = prev_match_result->distance_along;
+            } else {
+              // Add new item
+              // Begin distance along defaulted to 0
+              route_discontinuities.insert( {prev_match_result->edge_index,
+                { {false, {}, 0.f},
+                    {true, prev_match_result->lnglat, prev_match_result->distance_along} }});
+            }
+            break;
+          }
+          // Increment previous and current match results to continue looking
+          prev_match_result = curr_match_result;
+          ++curr_match_result;
+        }
+
+        // Find the current(second) edge within the match results
+        while (curr_match_result != enhanced_match_results.end()) {
+          if (curr_match_result->edgeid == disconnected_edge_pair.second.value) {
+            // Set current match result as disconnected and break
+            curr_match_result->end_route_discontinuity = true;
+
+            // The end route discontinuity is the edge begin info
+            // therefore the first item in the pair
+            if (route_discontinuities.count(curr_match_result->edge_index) > 0) {
+              // Update edge_begin_info values
+              auto& edge_begin_info = route_discontinuities.at(curr_match_result->edge_index).first;
+              edge_begin_info.exists = true;
+              edge_begin_info.vertex = curr_match_result->lnglat;
+              edge_begin_info.distance_along = curr_match_result->distance_along;
+            } else {
+              // Add new item
+              // End distance along defaulted to 1
+              route_discontinuities.insert( {curr_match_result->edge_index,
+                { {true, curr_match_result->lnglat, curr_match_result->distance_along},
+                    {false, {}, 1.f} }});
+            }
+            break;
+          }
+          // Increment previous and current match results to continue looking
+          prev_match_result = curr_match_result;
+          ++curr_match_result;
+        }
+      }
+
 
 #ifdef LOGGING_LEVEL_TRACE
       ////////////////////////////////////////////////////////////////////////////

--- a/valhalla/thor/map_matcher.h
+++ b/valhalla/thor/map_matcher.h
@@ -29,8 +29,7 @@ class MapMatcher {
       const std::vector<meili::EdgeSegment>& edge_segments,
       const std::shared_ptr<sif::DynamicCost>* mode_costing,
       const sif::TravelMode mode,
-      std::vector<std::pair<baldr::GraphId, baldr::GraphId>>& disconnected_edges,
-      bool trace_attributes_action = false);
+      std::vector<std::pair<baldr::GraphId, baldr::GraphId>>& disconnected_edges);
 
 };
 

--- a/valhalla/thor/match_result.h
+++ b/valhalla/thor/match_result.h
@@ -19,14 +19,7 @@ struct MatchResult : meili::MatchResult {
       kMatched
   };
 
-  MatchResult(meili::MatchResult result) {
-    lnglat = result.lnglat;
-    distance_from = result.distance_from;
-    edgeid = result.edgeid;
-    distance_along = result.distance_along;
-    epoch_time = result.epoch_time;
-    stateid = result.stateid;
-
+  MatchResult(meili::MatchResult result): meili::MatchResult(result) {
     // Set the type based on edge id and state
     if (edgeid.Is_Valid() && HasState())
       type = Type::kMatched;

--- a/valhalla/thor/worker.h
+++ b/valhalla/thor/worker.h
@@ -73,8 +73,7 @@ class thor_worker_t : public service_worker_t{
       const odin::Location& destination);
   odin::TripPath route_match(valhalla_request_t& request, const AttributesController& controller);
   std::vector<std::tuple<float, float, std::vector<thor::MatchResult>, odin::TripPath>> map_match(
-      const AttributesController& controller, bool trace_attributes_action = false,
-      uint32_t best_paths = 1);
+      valhalla_request_t& request, const AttributesController& controller, uint32_t best_paths = 1);
 
   std::list<odin::TripPath> path_arrive_by(
       google::protobuf::RepeatedPtrField<valhalla::odin::Location>& correlated, const std::string &costing);


### PR DESCRIPTION
this is the first step toward osrm map matching responses. the main change here is that we add some information about the map matching results back to the input shape from the request so that later on (when we serialize the route) we can also serialize the match points. specifically the match point and the names of the edges the match point landed on.

note that im not passing back a score for the map match because at present valhalla supports only a single fully connected route for trace_route which is something where osrm style map matching differs.

we could indeed suport, as osrm does, multiple matches for portions of a route with discontinuities in between but that would be some more work which is out of scope for this first pass imho.