### PR TITLE
Add Serialization for OSRM Matching Requests

### DIFF
--- a/src/thor/optimized_route_action.cc
+++ b/src/thor/optimized_route_action.cc
@@ -54,10 +54,8 @@ namespace valhalla {
     optimal_order = optimizer.Solve(correlated.size(), time_costs);
     //put the optimal order into the locations array
     request.options.mutable_locations()->Clear();
-    for (size_t i = 0; i < optimal_order.size(); i++) {
+    for (size_t i = 0; i < optimal_order.size(); i++)
       request.options.mutable_locations()->Add()->CopyFrom(correlated.Get(optimal_order[i]));
-      request.options.mutable_locations()->rbegin()->set_original_index(optimal_order[i]);
-    }
 
     auto trippaths = path_depart_at(*request.options.mutable_locations(), costing);
 

--- a/src/thor/optimized_route_action.cc
+++ b/src/thor/optimized_route_action.cc
@@ -51,15 +51,13 @@ namespace valhalla {
 
     Optimizer optimizer;
     //returns the optimal order of the path_locations
-    optimal_order = optimizer.Solve(correlated.size(), time_costs);
+    auto optimal_order = optimizer.Solve(correlated.size(), time_costs);
     //put the optimal order into the locations array
     request.options.mutable_locations()->Clear();
     for (size_t i = 0; i < optimal_order.size(); i++)
       request.options.mutable_locations()->Add()->CopyFrom(correlated.Get(optimal_order[i]));
 
-    auto trippaths = path_depart_at(*request.options.mutable_locations(), costing);
-
-    return trippaths;
+    return path_depart_at(*request.options.mutable_locations(), costing);
   }
 
   }

--- a/src/thor/trace_route_action.cc
+++ b/src/thor/trace_route_action.cc
@@ -55,9 +55,9 @@ odin::TripPath thor_worker_t::trace_route(valhalla_request_t& request) {
   parse_trace_config(request);
   parse_measurements(request);
 
-  // Initialize the controller with no attribution since this is for a trip path only
+  // Initialize the controller
   odin::TripPath trip_path;
-  AttributesController controller(decltype(AttributesController::kRouteAttributes){});
+  AttributesController controller;
 
   /*
    * A flag indicating whether the input shape is a GPS trace or exact points from a
@@ -199,7 +199,8 @@ std::vector<std::tuple<float, float, std::vector<thor::MatchResult>, odin::TripP
     }
 
     // Associate match points to edges, if enabled
-    if (controller.category_attribute_enabled(kMatchedCategory)) {
+    if (request.options.action() == odin::DirectionsOptions::trace_attributes &&
+        controller.category_attribute_enabled(kMatchedCategory)) {
       // Populate for matched points so we have 1:1 with trace points
       for (const auto& match_result : match_results) {
         // Matched type is set in constructor

--- a/src/tyr/route_serializer.cc
+++ b/src/tyr/route_serializer.cc
@@ -850,7 +850,17 @@ namespace {
       // waypoints (locations).
       std::string status("Ok");
       json->emplace("code", status);
-      json->emplace("waypoints", waypoints(legs));
+      switch(directions_options.action()) {
+        case valhalla::odin::DirectionsOptions::trace_route:
+          json->emplace("tracepoints", osrm::waypoints(directions_options.shape()));
+          break;
+        case valhalla::odin::DirectionsOptions::route:
+          json->emplace("waypoints", osrm::waypoints(directions_options.locations()));
+          break;
+        case valhalla::odin::DirectionsOptions::optimized_route:
+          json->emplace("waypoints", waypoints(legs));
+          break;
+      }
 
       // Add each route
       // TODO - alternate routes (currently Valhalla only has 1 route)
@@ -872,7 +882,10 @@ namespace {
 
         routes->emplace_back(route);
       }
-      json->emplace("routes", routes);
+
+      // Routes are called matchings in osrm
+      json->emplace(directions_options.action() == valhalla::odin::DirectionsOptions::trace_route
+          ? "matchings" : "routes", routes);
 
       std::stringstream ss;
       ss << *json;

--- a/src/tyr/route_serializer.cc
+++ b/src/tyr/route_serializer.cc
@@ -852,7 +852,7 @@ namespace {
       json->emplace("code", status);
       switch(directions_options.action()) {
         case valhalla::odin::DirectionsOptions::trace_route:
-          json->emplace("tracepoints", osrm::waypoints(directions_options.shape()));
+          json->emplace("tracepoints", osrm::waypoints(directions_options.shape(), true));
           break;
         case valhalla::odin::DirectionsOptions::route:
           json->emplace("waypoints", osrm::waypoints(directions_options.locations()));

--- a/src/tyr/serializers.cc
+++ b/src/tyr/serializers.cc
@@ -29,7 +29,7 @@ using namespace std;
 
 namespace osrm {
 
-  valhalla::baldr::json::MapPtr waypoint(const odin::Location& location) {
+  valhalla::baldr::json::MapPtr waypoint(const odin::Location& location, bool tracepoint) {
     // Create a waypoint to add to the array
     auto waypoint = json::map({});
 
@@ -57,7 +57,7 @@ namespace osrm {
     // For now, having multiple path edges is the way to signal to this serializer
     // that the location was used for a match point, so if that is the case
     // trigger the extra serialization for the tracepoint logic
-    if(location.path_edges_size() > 1) {
+    if(tracepoint) {
       waypoint->emplace("alternatives_count", static_cast<uint64_t>(location.path_edges_size() - 1));
       waypoint->emplace("waypoint_index", static_cast<uint64_t>(location.original_index()));
       waypoint->emplace("matchings_index", static_cast<uint64_t>(0)); //we only have one matching for now
@@ -68,10 +68,10 @@ namespace osrm {
 
   // Serialize locations (called waypoints in OSRM). Waypoints are described here:
   //     http://project-osrm.org/docs/v5.5.1/api/#waypoint-object
-  json::ArrayPtr waypoints(const google::protobuf::RepeatedPtrField<odin::Location>& locations){
+  json::ArrayPtr waypoints(const google::protobuf::RepeatedPtrField<odin::Location>& locations, bool tracepoints){
     auto waypoints = json::array({});
     for (const auto& location : locations)
-      waypoints->emplace_back(waypoint(location));
+      waypoints->emplace_back(waypoint(location, tracepoints));
     return waypoints;
   }
 

--- a/src/tyr/serializers.cc
+++ b/src/tyr/serializers.cc
@@ -54,9 +54,7 @@ namespace osrm {
     // Defer this - not currently used in OSRM.
     waypoint->emplace("hint", std::string("TODO"));
 
-    // For now, having multiple path edges is the way to signal to this serializer
-    // that the location was used for a match point, so if that is the case
-    // trigger the extra serialization for the tracepoint logic
+    // If the location was used for a tracepoint we trigger extra serialization
     if(tracepoint) {
       waypoint->emplace("alternatives_count", static_cast<uint64_t>(location.path_edges_size() - 1));
       waypoint->emplace("waypoint_index", static_cast<uint64_t>(location.original_index()));

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -306,11 +306,10 @@ namespace {
 
     auto request_locations = rapidjson::get_optional<rapidjson::Value::ConstArray>(doc, std::string("/" + node).c_str());
     if (request_locations) {
-      int original_index = 0;
       for(const auto& r_loc : *request_locations) {
         try {
           auto* location = locations->Add();
-          location->set_original_index(original_index++);
+          location->set_original_index(locations->size() - 1);
 
           auto lat = rapidjson::get_optional<float>(r_loc, "/lat");
           if (! lat) throw std::runtime_error{"lat is missing"};

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -306,9 +306,12 @@ namespace {
 
     auto request_locations = rapidjson::get_optional<rapidjson::Value::ConstArray>(doc, std::string("/" + node).c_str());
     if (request_locations) {
+      int original_index = 0;
       for(const auto& r_loc : *request_locations) {
         try {
           auto* location = locations->Add();
+          location->set_original_index(original_index++);
+
           auto lat = rapidjson::get_optional<float>(r_loc, "/lat");
           if (! lat) throw std::runtime_error{"lat is missing"};
 

--- a/valhalla/thor/worker.h
+++ b/valhalla/thor/worker.h
@@ -102,9 +102,7 @@ class thor_worker_t : public service_worker_t{
   valhalla::meili::MapMatcherFactory matcher_factory;
   valhalla::baldr::GraphReader& reader;
   std::unordered_set<std::string> trace_customizable;
-  boost::property_tree::ptree trace_config;
-
-  std::vector<uint32_t> optimal_order;
+  boost::property_tree::ptree trace_config;;
 };
 
 }

--- a/valhalla/tyr/serializers.h
+++ b/valhalla/tyr/serializers.h
@@ -110,12 +110,12 @@ namespace osrm {
   /*
    *
    */
-  valhalla::baldr::json::MapPtr waypoint(const valhalla::odin::Location& location);
+  valhalla::baldr::json::MapPtr waypoint(const valhalla::odin::Location& location, bool tracepoint = false);
 
   /*
    *
    */
-  valhalla::baldr::json::ArrayPtr waypoints(const google::protobuf::RepeatedPtrField<valhalla::odin::Location>& locations);
+  valhalla::baldr::json::ArrayPtr waypoints(const google::protobuf::RepeatedPtrField<valhalla::odin::Location>& locations, bool tracepoints = false);
 
 }
 


### PR DESCRIPTION
This the bits for serializing matching requests in osrm format. I havent tested it but wanted to get it up for review. Basical match is the same as route but `routes` are renamed to `matchings` and `waypoints` are renamed to `tracepoints`. There is some extra info in the tracepoints which I've carried along through the shape located in the protobuf object.