### PR TITLE
Add OSRM serializer support for optimized route.

### DIFF
--- a/src/tyr/route_serializer.cc
+++ b/src/tyr/route_serializer.cc
@@ -201,25 +201,24 @@ namespace {
     // original location order, and stores an index for the waypoint index in
     // the optimized sequence.
     json::ArrayPtr waypoints(const google::protobuf::RepeatedPtrField<odin::Location>& locs) {
-      // Create a pair with original index and new index.
-      std::vector<std::pair<uint32_t, uint32_t>> locations;
-      int i = 0;
+      // Create a vector of indexes.
+      uint32_t i = 0;
+      std::vector<uint32_t> indexes;
       for (const auto& loc : locs) {
-        locations.push_back(std::make_pair(loc.original_index(), i));
-        i++;
+        indexes.push_back(i++);
       }
 
-      // Sort the locations by original index
-      std::sort(locations.begin(), locations.end(),
-          [](const std::pair<uint32_t, uint32_t>& a,
-             const std::pair<uint32_t, uint32_t>& b) -> bool {
-        return a.first < b.first;
+      // Sort the the vector by the location's original index
+      std::sort(indexes.begin(), indexes.end(),
+          [&locs](const uint32_t a, const uint32_t b) -> bool {
+        return locs.Get(a).original_index() < locs.Get(b).original_index();
       });
 
-      // Output each location (first item in the pair) with its waypoint index (2nd item in the pair).
+      // Output each location in its original index order along with its
+      // waypoint index (which is the index in the optimized order).
       auto waypoints = json::array({});
-      for (const auto& location : locations) {
-        waypoints->emplace_back(osrm::waypoint(locs.Get(location.first), false, true, location.second));
+      for (const auto& index : indexes) {
+        waypoints->emplace_back(osrm::waypoint(locs.Get(index), false, true, index));
       }
       return waypoints;
     }

--- a/src/tyr/route_serializer.cc
+++ b/src/tyr/route_serializer.cc
@@ -201,24 +201,25 @@ namespace {
     // original location order, and stores an index for the waypoint index in
     // the optimized sequence.
     json::ArrayPtr waypoints(const google::protobuf::RepeatedPtrField<odin::Location>& locs) {
-      std::vector<std::pair<valhalla::odin::Location, uint32_t>> locations;
+      // Create a pair with original index and new index.
+      std::vector<std::pair<uint32_t, uint32_t>> locations;
       int i = 0;
       for (const auto& loc : locs) {
-        locations.push_back(std::make_pair(loc, i));
+        locations.push_back(std::make_pair(loc.original_index(), i));
         i++;
       }
 
       // Sort the locations by original index
       std::sort(locations.begin(), locations.end(),
-          [](const std::pair<valhalla::odin::Location, uint32_t>& a,
-              const std::pair<valhalla::odin::Location, uint32_t>& b) -> bool {
-        return a.first.original_index() < b.first.original_index();
+          [](const std::pair<uint32_t, uint32_t>& a,
+             const std::pair<uint32_t, uint32_t>& b) -> bool {
+        return a.first < b.first;
       });
 
       // Output each location (first item in the pair) with its waypoint index (2nd item in the pair).
       auto waypoints = json::array({});
       for (const auto& location : locations) {
-        waypoints->emplace_back(osrm::waypoint(location.first, false, true, location.second));
+        waypoints->emplace_back(osrm::waypoint(locs.Get(location.first), false, true, location.second));
       }
       return waypoints;
     }

--- a/src/tyr/serializers.cc
+++ b/src/tyr/serializers.cc
@@ -29,7 +29,10 @@ using namespace std;
 
 namespace osrm {
 
-  valhalla::baldr::json::MapPtr waypoint(const odin::Location& location, bool tracepoint) {
+  // Serialize a location (waypoint) in OSRM compatible format. Waypoint format is described here:
+  //     http://project-osrm.org/docs/v5.5.1/api/#waypoint-object
+  valhalla::baldr::json::MapPtr waypoint(const odin::Location& location, bool tracepoint,
+        const bool optimized, const uint32_t waypoint_index) {
     // Create a waypoint to add to the array
     auto waypoint = json::map({});
 
@@ -59,6 +62,14 @@ namespace osrm {
       waypoint->emplace("alternatives_count", static_cast<uint64_t>(location.path_edges_size() - 1));
       waypoint->emplace("waypoint_index", static_cast<uint64_t>(location.original_index()));
       waypoint->emplace("matchings_index", static_cast<uint64_t>(0)); //we only have one matching for now
+    }
+
+    // If the location was used for optimized route we add trips_index and waypoint
+    // index (index of the waypoint in the trip)
+    if (optimized) {
+      int trips_index = 0; // TODO
+      waypoint->emplace("trips_index", static_cast<uint64_t>(trips_index));
+      waypoint->emplace("waypoint_index", static_cast<uint64_t>(waypoint_index));
     }
 
     return waypoint;

--- a/valhalla/tyr/serializers.h
+++ b/valhalla/tyr/serializers.h
@@ -110,7 +110,8 @@ namespace osrm {
   /*
    *
    */
-  valhalla::baldr::json::MapPtr waypoint(const valhalla::odin::Location& location, bool tracepoint = false);
+  valhalla::baldr::json::MapPtr waypoint(const valhalla::odin::Location& location, bool tracepoint = false,
+      const bool optimized = false, const uint32_t waypoint_index = 0);
 
   /*
    *


### PR DESCRIPTION
The input locations remain in original order and a waypoint index is added to the output to denote the new index in the optimized order.