### PR TITLE
Fix isochrone parameter date_time conversion to int, not float

### DIFF
--- a/src/worker.cc
+++ b/src/worker.cc
@@ -468,8 +468,8 @@ namespace {
     parse_locations(doc, options.mutable_avoid_locations(), "avoid_locations", 133, track);
 
     //time type
-    auto date_time_type = rapidjson::get_optional<int>(doc, "/date_time/type");
-    if(date_time_type) {
+    auto date_time_type = rapidjson::get_optional<float>(doc, "/date_time/type");
+    if(date_time_type && valhalla::odin::DirectionsOptions::DateTimeType_IsValid(*date_time_type)
       options.set_date_time_type(static_cast<valhalla::odin::DirectionsOptions::DateTimeType>(*date_time_type));
     }
     else if(options.has_costing() && (options.costing() == valhalla::odin::DirectionsOptions::multimodal ||

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -468,7 +468,7 @@ namespace {
     parse_locations(doc, options.mutable_avoid_locations(), "avoid_locations", 133, track);
 
     //time type
-    auto date_time_type = rapidjson::get_optional<float>(doc, "/date_time/type");
+    auto date_time_type = rapidjson::get_optional<int>(doc, "/date_time/type");
     if(date_time_type) {
       options.set_date_time_type(static_cast<valhalla::odin::DirectionsOptions::DateTimeType>(*date_time_type));
     }

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -469,7 +469,7 @@ namespace {
 
     //time type
     auto date_time_type = rapidjson::get_optional<float>(doc, "/date_time/type");
-    if(date_time_type && valhalla::odin::DirectionsOptions::DateTimeType_IsValid(*date_time_type)
+    if(date_time_type && valhalla::odin::DirectionsOptions::DateTimeType_IsValid(*date_time_type)) {
       options.set_date_time_type(static_cast<valhalla::odin::DirectionsOptions::DateTimeType>(*date_time_type));
     }
     else if(options.has_costing() && (options.costing() == valhalla::odin::DirectionsOptions::multimodal ||


### PR DESCRIPTION
According to the [isochrone API reference](https://github.com/valhalla/valhalla-docs/blob/master/isochrone/api-reference.md#other-request-parameters) value of `date_time::type` can be 0, 1, or 2.