### PR TITLE
add stdexcept to pack elevation

### DIFF
--- a/src/valhalla_pack_elevation.cc
+++ b/src/valhalla_pack_elevation.cc
@@ -6,6 +6,7 @@
 #include <unistd.h>
 #include <cstdint>
 #include <fstream>
+#include <stdexcept>
 
 #include <zlib.h>
 #include <lz4.h>


### PR DESCRIPTION
Missing definition of runtime_error prevented compilation on gcc 4.8. After addition of the corresponding header, all compiled as expected