### PR TITLE
Bicycle updates to improve quality and performance. 

### DIFF
--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -87,8 +87,10 @@ constexpr float kLeftSideTurnPenalties[]  = {
     kTPFavorableSlight
 };
 
+// Additional stress factor for designated truck routes
+const float kTruckStress = 0.5f;
+
 // Cost of traversing an edge with steps. Make this high but not impassible.
-// Equal to about 5 minutes (penalty)
 const float kBicycleStepsFactor = 8.0f;
 
 // Default cycling speed on smooth, flat roads - based on bicycle type (KPH)
@@ -152,9 +154,9 @@ constexpr float kRoadClassFactor[] = {
 // example of speed changes based on "grade", using a base speed of 18 MPH
 // on flat roads
 constexpr float kGradeBasedSpeedFactor[] = {
-  2.5f,      // -10%  - 45
-  2.25f,     // -8%   - 40.5
-  2.0f,      // -6.5% - 36
+  2.2f,      // -10%  - 39.6
+  2.0f,      // -8%   - 36
+  1.9f,      // -6.5% - 34.2
   1.7f,      // -5%   - 30.6
   1.4f,      // -3%   - 25
   1.2f,      // -1.5% - 21.6
@@ -358,9 +360,6 @@ class BicycleCost : public DynamicCost {
   float use_hills_;                      // Preference of using hills between 0 and 1
   float avoid_bad_surfaces_;             // Preference of avoiding bad surfaces for the bike type
 
-  // Density factor used in edge transition costing
-  std::vector<float> trans_density_factor_;
-
   // Average speed (kph) on smooth, flat roads.
   float speed_;
 
@@ -424,15 +423,12 @@ protected:
 };
 
 // Bicycle route costs are distance based with some favor/avoid based on
-// attribution.
+// attribution. Speed is derived based on bicycle type or user input and
+// is modulated based on surface type and grade factors.
 
 // Constructor
 BicycleCost::BicycleCost(const boost::property_tree::ptree& pt)
-    : DynamicCost(pt, TravelMode::kBicycle),
-      trans_density_factor_{ 1.0f,  1.0f, 1.0f,  1.0f,
-                             1.0f,  1.0f, 1.0f,  1.0f,
-                             1.05f, 1.1f, 1.15f, 1.2f,
-                             1.25f, 1.3f, 1.4f,  1.5f } {
+    : DynamicCost(pt, TravelMode::kBicycle) {
   // Set hierarchy to allow unlimited transitions
   for (auto& h : hierarchy_limits_) {
     h.max_up_transitions = kUnlimitedTransitions;
@@ -647,10 +643,10 @@ bool BicycleCost::Allowed(const baldr::NodeInfo* node) const {
 // Returns the cost to traverse the edge and an estimate of the actual time
 // (in seconds) to traverse the edge.
 Cost BicycleCost::EdgeCost(const baldr::DirectedEdge* edge) const {
-  // Stairs/steps - use a high fixed cost so they are generally avoided.
+  // Stairs/steps - high cost (travel speed = 1kph) so they are generally avoided.
   if (edge->use() == Use::kSteps) {
     float sec = (edge->length() * speedfactor_[1]);
-    return {sec * kBicycleStepsFactor, sec };
+    return { sec * kBicycleStepsFactor, sec };
   }
 
   // Ferries are a special case - they use the ferry speed (stored on the edge)
@@ -718,6 +714,11 @@ Cost BicycleCost::EdgeCost(const baldr::DirectedEdge* edge) const {
     // Penalize roads that have more than one lane (in the direction of travel)
     if (edge->lanecount() > 1) {
       roadway_stress += (static_cast<float>(edge->lanecount()) - 1) * 0.05f * road_factor_;
+    }
+
+    // Designated truck routes add to roadway stress
+    if (edge->truck_route()) {
+      roadway_stress += kTruckStress;
     }
 
     // Add in penalization for road classification
@@ -832,9 +833,8 @@ Cost BicycleCost::TransitionCost(const baldr::DirectedEdge* edge,
       turn_cost = kTCCrossing;
     }
 
-    // Transition time = densityfactor * stopimpact * turncost
-    seconds += trans_density_factor_[node->density()] *
-               edge->stopimpact(idx) * turn_cost;
+    // Transition time = stopimpact * turncost
+    seconds += edge->stopimpact(idx) * turn_cost;
   }
 
   // Reduce stress by road class factor the closer use_roads_ is to 0
@@ -936,9 +936,8 @@ Cost BicycleCost::TransitionCostReverse(const uint32_t idx,
       turn_cost = kTCCrossing;
     }
 
-    // Transition time = densityfactor * stopimpact * turncost
-    seconds += trans_density_factor_[node->density()] *
-               edge->stopimpact(idx) * turn_cost;
+    // Transition time = stopimpact * turncost
+    seconds += edge->stopimpact(idx) * turn_cost;
   }
 
   // Reduce stress by road class factor the closer use_roads_ is to 0
@@ -969,8 +968,8 @@ Cost BicycleCost::TransitionCostReverse(const uint32_t idx,
  * estimate is less than the least possible time along roads.
  */
 float BicycleCost::AStarCostFactor() const {
-  // Assume max speed of 80 kph (50 MPH)
-  return speedfactor_[80];
+  // Assume max speed of 2 * the average speed set for costing
+  return speedfactor_[2 * static_cast<uint32_t>(speed_)];
 }
 
 // Returns the current travel type.


### PR DESCRIPTION
1) Set A* factor based on the designated speed (on flats) * 2. This improves performance when using
slower speeds (e.g. mountain bikes). 
2) Reduce speed on steepest downhills.
3) remove density factor from transition costs. Density factors are not as effective at avoiding urban areas for bike routes so they are of questionable use. 
4) Add a stress factor for designated truck routes - cyclists do not want to share the road with tractor trailers!