### PR TITLE
Use CostMatrix for bike and pedestrian 

### DIFF
--- a/src/thor/matrix_action.cc
+++ b/src/thor/matrix_action.cc
@@ -22,6 +22,8 @@ namespace {
 namespace valhalla {
   namespace thor {
 
+    constexpr uint32_t kCostMatrixThreshold = 5;
+
     std::string thor_worker_t::matrix(valhalla_request_t& request) {
       parse_locations(request);
       auto costing = parse_costing(request);
@@ -53,6 +55,15 @@ namespace valhalla {
           switch (mode) {
             case TravelMode::kPedestrian:
             case TravelMode::kBicycle:
+              // Use CostMatrix if number of sources and number of targets
+              // exceeds some threshold
+              if (request.options.sources().size() > kCostMatrixThreshold &&
+                  request.options.targets().size() > kCostMatrixThreshold) {
+                time_distances = costmatrix();
+              } else {
+                time_distances = timedistancematrix();
+              }
+              break;
             case TravelMode::kPublicTransit:
               time_distances = timedistancematrix();
               break;


### PR DESCRIPTION
when number of sources and number of destinations both exceed a threshold (set to 5 for now). Using TimeDistanceMatrix for larger many to many cases can be very slow and this helps alleviate this.

This issue was found during Hacker One trials where a 50x50 pedestrian matrix was found to take approximately 20secs. After this change the request takes ~6-7 secs. Not ideal perhaps but a lot better.