### PR TITLE
Add curvature measure to directededge

### DIFF
--- a/src/baldr/directededge.cc
+++ b/src/baldr/directededge.cc
@@ -571,7 +571,7 @@ json::MapPtr DirectedEdge::json() const {
     {"geo_attributes", json::map({
       {"length", static_cast<uint64_t>(length_)},
       {"weighted_grade", json::fp_t{static_cast<double>(weighted_grade_ - 6.0) / .6, 2}},
-      //{"curvature", static_cast<uint64_t>(curvature_)},
+      {"curvature", static_cast<uint64_t>(curvature_)},
     })},
     {"access", access_json(forwardaccess_)},
     //{"access", access_json(reverseaccess_)},

--- a/src/midgard/pointll.cc
+++ b/src/midgard/pointll.cc
@@ -101,7 +101,8 @@ float PointLL::Curvature(const PointLL& ll1, const PointLL& ll2) const {
   float c = Distance(ll2);
   float s = (a + b + c) * 0.5f;
   float k = sqrtf(s * (s - a) * (s - b) * (s - c));
-  return ((a * b * c) / (4.0f * k));
+  return (std::isnan(k) || k == 0.0f) ? std::numeric_limits<float>::max() :
+            ((a * b * c) / (4.0f * k));
 }
 
 // Calculates the heading or azimuth from the current lat,lng to the

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -663,8 +663,8 @@ void BuildTileSet(const std::string& ways_file, const std::string& way_nodes_fil
               }
             }
 
-            //TODO: curvature
-            uint32_t curvature = 0;
+            // Compute a curvature metric [0-15]. TODO - use resampled polyline?
+            uint32_t curvature = compute_curvature(shape);
 
             // Add elevation info to the geo attribute cache. TODO - add mean elevation.
             uint32_t forward_grade = static_cast<uint32_t>(std::get<0>(forward_grades)  * .6 + 6.5);

--- a/src/mjolnir/shortcutbuilder.cc
+++ b/src/mjolnir/shortcutbuilder.cc
@@ -23,6 +23,7 @@
 #include "baldr/graphreader.h"
 #include "skadi/sample.h"
 #include "skadi/util.h"
+#include "mjolnir/util.h"
 
 using namespace valhalla::midgard;
 using namespace valhalla::baldr;
@@ -508,7 +509,7 @@ uint32_t AddShortcutEdges(GraphReader& reader, const GraphTile* tile,
         // is added.
         newedge.set_weighted_grade(6);
       }
-      newedge.set_curvature(0); //TODO:
+      newedge.set_curvature(compute_curvature(shape));
       newedge.set_endnode(end_node);
 
       // Sanity check - should never see a shortcut with signs

--- a/src/mjolnir/util.cc
+++ b/src/mjolnir/util.cc
@@ -71,8 +71,6 @@ uint32_t compute_curvature(const std::list<PointLL>& shape) {
       float score = (radius > 1000.0f) ? 0.0f : 1500.0f / radius;
       total_score += (score > 25.0f) ? 25.0f : score;
       n++;
-    } else {
-      printf("nan\n");
     }
   }
   float average_score = (n == 0) ? 0.0f : total_score / n;

--- a/valhalla/midgard/pointll.h
+++ b/valhalla/midgard/pointll.h
@@ -103,7 +103,8 @@ class PointLL : public Point2 {
    * computing the radius of the circle that circumscribes the 3 positions.
    * @param   ll1   Second lng,lat position
    * @param   ll2   Third lng,lat position
-   * @return  Returns the curvature in meters.
+   * @return  Returns the curvature in meters. Returns max float if the points
+   *          are collinear.
    */
   float Curvature(const PointLL& ll1, const PointLL& ll2) const;
 

--- a/valhalla/mjolnir/util.h
+++ b/valhalla/mjolnir/util.h
@@ -2,8 +2,10 @@
 #define VALHALLA_MJOLNIR_UTIL_H_
 
 #include <vector>
+#include <list>
 #include <string>
 #include <boost/property_tree/ptree.hpp>
+#include <valhalla/midgard/pointll.h>
 
 namespace valhalla {
 namespace mjolnir {
@@ -23,6 +25,14 @@ std::vector<std::string> GetTagTokens(const std::string& tag_value,
  * @param  s
  * @return string string with no quotes.
 */std::string remove_double_quotes(const std::string& s);
+
+/**
+ * Compute a curvature metric given an edge shape.
+ * @param  shape  Shape of an edge (list of lat,lon vertices).
+ * @return Returns a curvature measure [0-15] where higher numbers indicate
+ *         more curved and tighter turns.
+ */
+uint32_t compute_curvature(const std::list<midgard::PointLL>& shape);
 
 /**
  * Build an entire valhalla tileset give a config file and some input pbfs


### PR DESCRIPTION
Adds a method to compute curvature based on edge shape. Adds the metric to directededge (in graphbuilder and in shortcutbuilder). I did some quick testing using locate (now returns the curvature value so one can point and click on an edge and read its curvature). May need to adjust the compute_curvature method in the future, but this is centralized within mjolnir util methods.