### PR TITLE
Sample.cc now uses reutil namespaces from baldr

### DIFF
--- a/src/skadi/sample.cc
+++ b/src/skadi/sample.cc
@@ -7,7 +7,6 @@
 #include <list>
 #include <fstream>
 #include <string>
-#include <boost/regex.hpp>
 #include <sys/stat.h>
 #include <zlib.h>
 #include <lz4.h>
@@ -16,6 +15,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/optional.hpp>
 
+#include "baldr/reutil.h"
 #include "baldr/filesystem_utils.h"
 
 #include "midgard/logging.h"
@@ -76,9 +76,9 @@ namespace {
 
   template<typename fmt_t>
   uint16_t is_hgt(const std::string& name, fmt_t& fmt) {
-    boost::smatch m;
-    boost::regex e(".*/([NS])([0-9]{2})([WE])([0-9]{3})\\.hgt(\\.gz|\\.lz4)?$");
-    if(boost::regex_search(name, m, e)) {
+    valhalla::baldr::re::smatch m;
+    valhalla::baldr::re::regex e(".*/([NS])([0-9]{2})([WE])([0-9]{3})\\.hgt(\\.gz|\\.lz4)?$");
+    if(valhalla::baldr::re::regex_search(name, m, e)) {
       //enum class format_t{ UNKNOWN = 0, GZIP = 1, LZ4 = 2, RAW = 3 };
       fmt = static_cast<fmt_t>(m[5].length() ? (m[5] == ".lz4" ? 2 : (m[5] == ".gz" ? 1 : 0)) : 3);
       auto lon = std::stoi(m[4]) * (m[3] == "E" ? 1 : -1) + 180;

--- a/valhalla/baldr/reutil.h
+++ b/valhalla/baldr/reutil.h
@@ -10,6 +10,7 @@ using std::regex;
 using std::regex_replace;
 using std::smatch;
 using std::sregex_iterator;
+using std::regex_search;
 namespace regex_constants { using namespace std::regex_constants; }
 }
 }
@@ -23,6 +24,7 @@ using boost::regex;
 using boost::regex_replace;
 using boost::smatch;
 using boost::sregex_iterator;
+using boost::regex_search;
 namespace regex_constants { using namespace boost::regex_constants; }
 }
 }


### PR DESCRIPTION
Hello,

Since there are common namespaces for regexps in `baldr`. They should be used in `sample.cc`. After this change it's possible to switch between `boost::regex` and `std::regex` as designed. 