### PR TITLE
Add currenty time to costing Allowed and AllowedReverse

### DIFF
--- a/src/meili/routing.cc
+++ b/src/meili/routing.cc
@@ -150,7 +150,7 @@ inline bool IsEdgeAllowed(const baldr::DirectedEdge* edge,
               const Label& pred_edgelabel,
               const baldr::GraphTile* tile) {
   return !pred_edgelabel.edgeid().Is_Valid() || edgeid == pred_edgelabel.edgeid() ||
-                costing->Allowed(edge, pred_edgelabel, tile, edgeid);
+                costing->Allowed(edge, pred_edgelabel, tile, edgeid, 0);
 }
 
 /**

--- a/src/meili/universal_cost.cc
+++ b/src/meili/universal_cost.cc
@@ -12,13 +12,14 @@ class UniversalCost : public sif::DynamicCost
 {
  public:
   UniversalCost(const boost::property_tree::ptree& pt)
-      : DynamicCost(pt, kUniversalTravelMode) {}
+      : DynamicCost(pt, kUniversalTravelMode) {
+  }
 
   bool Allowed(const baldr::DirectedEdge* edge,
                const sif::EdgeLabel& pred,
                const baldr::GraphTile*& tile,
-               const baldr::GraphId& edgeid) const override
-  {
+               const baldr::GraphId& edgeid,
+               const uint32_t current_time) const override {
     // Disable transit lines
     if (edge->IsTransitLine()) {
       return false;
@@ -34,24 +35,26 @@ class UniversalCost : public sif::DynamicCost
                       const sif::EdgeLabel& pred,
                       const baldr::DirectedEdge* opp_edge,
                       const baldr::GraphTile*& tile,
-                      const baldr::GraphId& edgeid) const override
-  { return true; }
+                      const baldr::GraphId& edgeid,
+                      const uint32_t current_time) const override {
+    return true;
+  }
 
-  bool Allowed(const baldr::NodeInfo* node) const override
-  { return true; }
+  bool Allowed(const baldr::NodeInfo* node) const override {
+    return true;
+  }
 
-  sif::Cost EdgeCost(const baldr::DirectedEdge* edge) const override
-  {
+  sif::Cost EdgeCost(const baldr::DirectedEdge* edge) const override {
     float length = edge->length();
     return { length, length };
   }
 
   // Disable astar
-  float AStarCostFactor() const override
-  { return 0.f; }
+  float AStarCostFactor() const override {
+    return 0.f;
+  }
 
-  virtual const sif::EdgeFilter GetEdgeFilter() const override
-  {
+  virtual const sif::EdgeFilter GetEdgeFilter() const override {
     //throw back a lambda that checks the access for this type of costing
     return [](const baldr::DirectedEdge* edge){
       // Disable transit lines
@@ -62,8 +65,7 @@ class UniversalCost : public sif::DynamicCost
     };
   }
 
-  virtual const sif::NodeFilter GetNodeFilter() const override
-  {
+  virtual const sif::NodeFilter GetNodeFilter() const override {
     //throw back a lambda that checks the access for this type of costing
     return [](const baldr::NodeInfo* node){
       // Do not filter any nodes
@@ -73,8 +75,9 @@ class UniversalCost : public sif::DynamicCost
 };
 
 
-sif::cost_ptr_t CreateUniversalCost(const boost::property_tree::ptree& config)
-{ return std::make_shared<UniversalCost>(config); }
+sif::cost_ptr_t CreateUniversalCost(const boost::property_tree::ptree& config) {
+  return std::make_shared<UniversalCost>(config);
+}
 
 }
 

--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -129,35 +129,45 @@ class AutoCost : public DynamicCost {
    * Checks if access is allowed for the provided directed edge.
    * This is generally based on mode of travel and the access modes
    * allowed on the edge. However, it can be extended to exclude access
-   * based on other parameters.
-   * @param  edge     Pointer to a directed edge.
-   * @param  pred     Predecessor edge information.
-   * @param  tile     current tile
-   * @param  edgeid   edgeid that we care about
-   * @return  Returns true if access is allowed, false if not.
+   * based on other parameters such as conditional restrictions and
+   * conditional access that can depend on time and travel mode.
+   * @param  edge           Pointer to a directed edge.
+   * @param  pred           Predecessor edge information.
+   * @param  tile           Current tile.
+   * @param  edgeid         GraphId of the directed edge.
+   * @param  current_time   Current time (seconds since epoch). A value of 0
+   *                        indicates the route is not time dependent.
+   * @return Returns true if access is allowed, false if not.
    */
   virtual bool Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred,
                        const baldr::GraphTile*& tile,
-                       const baldr::GraphId& edgeid) const;
+                       const baldr::GraphId& edgeid,
+                       const uint32_t current_time) const;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
-   * (from destination towards origin). Both opposing edges are
-   * provided.
+   * (from destination towards origin). Both opposing edges (current and
+   * predecessor) are provided. The access check is generally based on mode
+   * of travel and the access modes allowed on the edge. However, it can be
+   * extended to exclude access based on other parameters such as conditional
+   * restrictions and conditional access that can depend on time and travel
+   * mode.
    * @param  edge           Pointer to a directed edge.
    * @param  pred           Predecessor edge information.
    * @param  opp_edge       Pointer to the opposing directed edge.
-   * @param  tile           Tile for the opposing edge (for looking
-   *                        up restrictions).
-   * @param  opp_edgeid     Opposing edge Id
+   * @param  tile           Current tile.
+   * @param  edgeid         GraphId of the opposing edge.
+   * @param  current_time   Current time (seconds since epoch). A value of 0
+   *                        indicates the route is not time dependent.
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
-                 const EdgeLabel& pred,
-                 const baldr::DirectedEdge* opp_edge,
-                 const baldr::GraphTile*& tile,
-                 const baldr::GraphId& opp_edgeid) const;
+                              const EdgeLabel& pred,
+                              const baldr::DirectedEdge* opp_edge,
+                              const baldr::GraphTile*& tile,
+                              const baldr::GraphId& opp_edgeid,
+                              const uint32_t current_time) const;
 
   /**
    * Checks if access is allowed for the provided node. Node access can
@@ -379,7 +389,8 @@ uint32_t AutoCost::access_mode() const {
 bool AutoCost::Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred,
                        const baldr::GraphTile*& tile,
-                       const baldr::GraphId& edgeid) const {
+                       const baldr::GraphId& edgeid,
+                       const uint32_t current_time) const {
   // TODO - obtain and check the access restrictions.
 
   // Check access, U-turn, and simple turn restriction.
@@ -403,7 +414,8 @@ bool AutoCost::AllowedReverse(const baldr::DirectedEdge* edge,
                const EdgeLabel& pred,
                const baldr::DirectedEdge* opp_edge,
                const baldr::GraphTile*& tile,
-               const baldr::GraphId& opp_edgeid) const {
+               const baldr::GraphId& opp_edgeid,
+               const uint32_t current_time) const {
   // TODO - obtain and check the access restrictions.
 
   // Check access, U-turn, and simple turn restriction.
@@ -665,35 +677,45 @@ class BusCost : public AutoCost {
    * Checks if access is allowed for the provided directed edge.
    * This is generally based on mode of travel and the access modes
    * allowed on the edge. However, it can be extended to exclude access
-   * based on other parameters.
-   * @param  edge     Pointer to a directed edge.
-   * @param  pred     Predecessor edge information.
-   * @param  tile     current tile
-   * @param  edgeid   edgeid that we care about
-   * @return  Returns true if access is allowed, false if not.
+   * based on other parameters such as conditional restrictions and
+   * conditional access that can depend on time and travel mode.
+   * @param  edge           Pointer to a directed edge.
+   * @param  pred           Predecessor edge information.
+   * @param  tile           Current tile.
+   * @param  edgeid         GraphId of the directed edge.
+   * @param  current_time   Current time (seconds since epoch). A value of 0
+   *                        indicates the route is not time dependent.
+   * @return Returns true if access is allowed, false if not.
    */
   virtual bool Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred,
                        const baldr::GraphTile*& tile,
-                       const baldr::GraphId& edgeid) const;
+                       const baldr::GraphId& edgeid,
+                       const uint32_t current_time) const;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
-   * (from destination towards origin). Both opposing edges are
-   * provided.
+   * (from destination towards origin). Both opposing edges (current and
+   * predecessor) are provided. The access check is generally based on mode
+   * of travel and the access modes allowed on the edge. However, it can be
+   * extended to exclude access based on other parameters such as conditional
+   * restrictions and conditional access that can depend on time and travel
+   * mode.
    * @param  edge           Pointer to a directed edge.
    * @param  pred           Predecessor edge information.
    * @param  opp_edge       Pointer to the opposing directed edge.
-   * @param  tile           Tile for the opposing edge (for looking
-   *                        up restrictions).
-   * @param  opp_edgeid     Opposing edge Id
+   * @param  tile           Current tile.
+   * @param  edgeid         GraphId of the opposing edge.
+   * @param  current_time   Current time (seconds since epoch). A value of 0
+   *                        indicates the route is not time dependent.
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
-                 const EdgeLabel& pred,
-                 const baldr::DirectedEdge* opp_edge,
-                 const baldr::GraphTile*& tile,
-                 const baldr::GraphId& opp_edgeid) const;
+                              const EdgeLabel& pred,
+                              const baldr::DirectedEdge* opp_edge,
+                              const baldr::GraphTile*& tile,
+                              const baldr::GraphId& opp_edgeid,
+                              const uint32_t current_time) const;
 
   /**
    * Checks if access is allowed for the provided node. Node access can
@@ -756,7 +778,8 @@ uint32_t BusCost::access_mode() const {
 bool BusCost::Allowed(const baldr::DirectedEdge* edge,
                       const EdgeLabel& pred,
                       const baldr::GraphTile*& tile,
-                      const baldr::GraphId& edgeid) const {
+                      const baldr::GraphId& edgeid,
+                      const uint32_t current_time) const {
   // TODO - obtain and check the access restrictions.
 
   // Check access, U-turn, and simple turn restriction.
@@ -778,7 +801,8 @@ bool BusCost::AllowedReverse(const baldr::DirectedEdge* edge,
                              const EdgeLabel& pred,
                              const baldr::DirectedEdge* opp_edge,
                              const baldr::GraphTile*& tile,
-                             const baldr::GraphId& opp_edgeid) const {
+                             const baldr::GraphId& opp_edgeid,
+                             const uint32_t current_time) const {
   // TODO - obtain and check the access restrictions.
 
   // Check access, U-turn, and simple turn restriction.
@@ -828,35 +852,44 @@ class HOVCost : public AutoCost {
    * Checks if access is allowed for the provided directed edge.
    * This is generally based on mode of travel and the access modes
    * allowed on the edge. However, it can be extended to exclude access
-   * based on other parameters.
-   * @param  edge     Pointer to a directed edge.
-   * @param  pred     Predecessor edge information.
-   * @param  tile     current tile
-   * @param  edgeid   edgeid that we care about
-   * @return  Returns true if access is allowed, false if not.
+   * based on other parameters such as conditional restrictions and
+   * conditional access that can depend on time and travel mode.
+   * @param  edge           Pointer to a directed edge.
+   * @param  pred           Predecessor edge information.
+   * @param  tile           Current tile.
+   * @param  edgeid         GraphId of the directed edge.
+   * @param  current_time   Current time (seconds since epoch). A value of 0
+   *                        indicates the route is not time dependent.
+   * @return Returns true if access is allowed, false if not.
    */
   virtual bool Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred,
                        const baldr::GraphTile*& tile,
-                       const baldr::GraphId& edgeid) const;
+                       const baldr::GraphId& edgeid,
+                       const uint32_t current_time) const;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
-   * (from destination towards origin). Both opposing edges are
-   * provided.
+   * (from destination towards origin). Both opposing edges (current and
+   * predecessor) are provided. The access check is generally based on mode
+   * of travel and the access modes allowed on the edge. However, it can be
+   * extended to exclude access based on other parameters such as conditional
+   * restrictions and conditional access that can depend on time and travel
+   * mode.
    * @param  edge           Pointer to a directed edge.
    * @param  pred           Predecessor edge information.
    * @param  opp_edge       Pointer to the opposing directed edge.
-   * @param  tile           Tile for the opposing edge (for looking
-   *                        up restrictions).
-   * @param  opp_edgeid     Opposing edge Id
-   * @return  Returns true if access is allowed, false if not.
+   * @param  tile           Current tile.
+   * @param  edgeid         GraphId of the opposing edge.
+   * @param  current_time   Current time (seconds since epoch). A value of 0
+   *                        indicates the route is not time dependent.
    */
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
-                 const EdgeLabel& pred,
-                 const baldr::DirectedEdge* opp_edge,
-                 const baldr::GraphTile*& tile,
-                 const baldr::GraphId& opp_edgeid) const;
+                              const EdgeLabel& pred,
+                              const baldr::DirectedEdge* opp_edge,
+                              const baldr::GraphTile*& tile,
+                              const baldr::GraphId& opp_edgeid,
+                              const uint32_t current_time) const;
 
   /**
    * Returns the cost to traverse the edge and an estimate of the actual time
@@ -925,7 +958,8 @@ uint32_t HOVCost::access_mode() const {
 bool HOVCost::Allowed(const baldr::DirectedEdge* edge,
                       const EdgeLabel& pred,
                       const baldr::GraphTile*& tile,
-                      const baldr::GraphId& edgeid) const {
+                      const baldr::GraphId& edgeid,
+                      const uint32_t current_time) const {
   // TODO - obtain and check the access restrictions.
 
   // Check access, U-turn, and simple turn restriction.
@@ -949,7 +983,8 @@ bool HOVCost::AllowedReverse(const baldr::DirectedEdge* edge,
                              const EdgeLabel& pred,
                              const baldr::DirectedEdge* opp_edge,
                              const baldr::GraphTile*& tile,
-                             const baldr::GraphId& opp_edgeid) const {
+                             const baldr::GraphId& opp_edgeid,
+                             const uint32_t current_time) const {
   // TODO - obtain and check the access restrictions.
 
   // Check access, U-turn, and simple turn restriction.

--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -251,35 +251,45 @@ class BicycleCost : public DynamicCost {
    * Checks if access is allowed for the provided directed edge.
    * This is generally based on mode of travel and the access modes
    * allowed on the edge. However, it can be extended to exclude access
-   * based on other parameters.
-   * @param  edge     Pointer to a directed edge.
-   * @param  pred     Predecessor edge information.
-   * @param  tile     current tile
-   * @param  edgeid   edgeid that we care about
-   * @return  Returns true if access is allowed, false if not.
+   * based on other parameters such as conditional restrictions and
+   * conditional access that can depend on time and travel mode.
+   * @param  edge           Pointer to a directed edge.
+   * @param  pred           Predecessor edge information.
+   * @param  tile           Current tile.
+   * @param  edgeid         GraphId of the directed edge.
+   * @param  current_time   Current time (seconds since epoch). A value of 0
+   *                        indicates the route is not time dependent.
+   * @return Returns true if access is allowed, false if not.
    */
   virtual bool Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred,
                        const baldr::GraphTile*& tile,
-                       const baldr::GraphId& edgeid) const;
+                       const baldr::GraphId& edgeid,
+                       const uint32_t current_time) const;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
-   * (from destination towards origin). Both opposing edges are
-   * provided.
+   * (from destination towards origin). Both opposing edges (current and
+   * predecessor) are provided. The access check is generally based on mode
+   * of travel and the access modes allowed on the edge. However, it can be
+   * extended to exclude access based on other parameters such as conditional
+   * restrictions and conditional access that can depend on time and travel
+   * mode.
    * @param  edge           Pointer to a directed edge.
    * @param  pred           Predecessor edge information.
    * @param  opp_edge       Pointer to the opposing directed edge.
-   * @param  tile           Tile for the opposing edge (for looking
-   *                        up restrictions).
-   * @param  opp_edgeid     Opposing edge Id
+   * @param  tile           Current tile.
+   * @param  edgeid         GraphId of the opposing edge.
+   * @param  current_time   Current time (seconds since epoch). A value of 0
+   *                        indicates the route is not time dependent.
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
-                 const EdgeLabel& pred,
-                 const baldr::DirectedEdge* opp_edge,
-                 const baldr::GraphTile*& tile,
-                 const baldr::GraphId& opp_edgeid) const;
+                              const EdgeLabel& pred,
+                              const baldr::DirectedEdge* opp_edge,
+                              const baldr::GraphTile*& tile,
+                              const baldr::GraphId& opp_edgeid,
+                              const uint32_t current_time) const;
 
   /**
    * Checks if access is allowed for the provided node. Node access can
@@ -587,7 +597,8 @@ uint32_t BicycleCost::access_mode() const {
 bool BicycleCost::Allowed(const baldr::DirectedEdge* edge,
                           const EdgeLabel& pred,
                           const baldr::GraphTile*& tile,
-                          const baldr::GraphId& edgeid) const {
+                          const baldr::GraphId& edgeid,
+                          const uint32_t current_time) const {
   // TODO - obtain and check the access restrictions.
 
   // Check bicycle access and turn restrictions. Bicycles should obey
@@ -617,7 +628,8 @@ bool BicycleCost::AllowedReverse(const baldr::DirectedEdge* edge,
                const EdgeLabel& pred,
                const baldr::DirectedEdge* opp_edge,
                const baldr::GraphTile*& tile,
-               const baldr::GraphId& opp_edgeid) const {
+               const baldr::GraphId& opp_edgeid,
+               const uint32_t current_time) const {
   // TODO - obtain and check the access restrictions.
 
   // Check access, U-turn (allow at dead-ends), and simple turn restriction.

--- a/src/sif/motorscootercost.cc
+++ b/src/sif/motorscootercost.cc
@@ -177,35 +177,45 @@ class MotorScooterCost : public DynamicCost {
    * Checks if access is allowed for the provided directed edge.
    * This is generally based on mode of travel and the access modes
    * allowed on the edge. However, it can be extended to exclude access
-   * based on other parameters.
-   * @param  edge     Pointer to a directed edge.
-   * @param  pred     Predecessor edge information.
-   * @param  tile     current tile
-   * @param  edgeid   edgeid that we care about
-   * @return  Returns true if access is allowed, false if not.
+   * based on other parameters such as conditional restrictions and
+   * conditional access that can depend on time and travel mode.
+   * @param  edge           Pointer to a directed edge.
+   * @param  pred           Predecessor edge information.
+   * @param  tile           Current tile.
+   * @param  edgeid         GraphId of the directed edge.
+   * @param  current_time   Current time (seconds since epoch). A value of 0
+   *                        indicates the route is not time dependent.
+   * @return Returns true if access is allowed, false if not.
    */
   virtual bool Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred,
                        const baldr::GraphTile*& tile,
-                       const baldr::GraphId& edgeid) const;
+                       const baldr::GraphId& edgeid,
+                       const uint32_t current_time) const;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
-   * (from destination towards origin). Both opposing edges are
-   * provided.
+   * (from destination towards origin). Both opposing edges (current and
+   * predecessor) are provided. The access check is generally based on mode
+   * of travel and the access modes allowed on the edge. However, it can be
+   * extended to exclude access based on other parameters such as conditional
+   * restrictions and conditional access that can depend on time and travel
+   * mode.
    * @param  edge           Pointer to a directed edge.
    * @param  pred           Predecessor edge information.
    * @param  opp_edge       Pointer to the opposing directed edge.
-   * @param  tile           Tile for the opposing edge (for looking
-   *                        up restrictions).
-   * @param  opp_edgeid     Opposing edge Id
+   * @param  tile           Current tile.
+   * @param  edgeid         GraphId of the opposing edge.
+   * @param  current_time   Current time (seconds since epoch). A value of 0
+   *                        indicates the route is not time dependent.
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
-                 const EdgeLabel& pred,
-                 const baldr::DirectedEdge* opp_edge,
-                 const baldr::GraphTile*& tile,
-                 const baldr::GraphId& opp_edgeid) const;
+                              const EdgeLabel& pred,
+                              const baldr::DirectedEdge* opp_edge,
+                              const baldr::GraphTile*& tile,
+                              const baldr::GraphId& opp_edgeid,
+                              const uint32_t current_time) const;
 
   /**
    * Checks if access is allowed for the provided node. Node access can
@@ -437,7 +447,8 @@ uint32_t MotorScooterCost::access_mode() const {
 bool MotorScooterCost::Allowed(const baldr::DirectedEdge* edge,
                      const EdgeLabel& pred,
                      const baldr::GraphTile*& tile,
-                     const baldr::GraphId& edgeid) const {
+                     const baldr::GraphId& edgeid,
+                     const uint32_t current_time) const {
   // Check access, U-turn, and simple turn restriction.
   // Allow U-turns at dead-end nodes.
   if (!(edge->forwardaccess() & kMopedAccess) ||
@@ -456,7 +467,8 @@ bool MotorScooterCost::AllowedReverse(const baldr::DirectedEdge* edge,
                              const EdgeLabel& pred,
                              const baldr::DirectedEdge* opp_edge,
                              const baldr::GraphTile*& tile,
-                             const baldr::GraphId& opp_edgeid) const {
+                             const baldr::GraphId& opp_edgeid,
+                             const uint32_t current_time) const {
   // Check access, U-turn, and simple turn restriction.
   // Allow U-turns at dead-end nodes.
   if (!(opp_edge->forwardaccess() & kMopedAccess) ||

--- a/src/sif/pedestriancost.cc
+++ b/src/sif/pedestriancost.cc
@@ -187,35 +187,45 @@ class PedestrianCost : public DynamicCost {
    * Checks if access is allowed for the provided directed edge.
    * This is generally based on mode of travel and the access modes
    * allowed on the edge. However, it can be extended to exclude access
-   * based on other parameters.
-   * @param  edge     Pointer to a directed edge.
-   * @param  pred     Predecessor edge information.
-   * @param  tile     current tile
-   * @param  edgeid   edgeid that we care about
-   * @return  Returns true if access is allowed, false if not.
+   * based on other parameters such as conditional restrictions and
+   * conditional access that can depend on time and travel mode.
+   * @param  edge           Pointer to a directed edge.
+   * @param  pred           Predecessor edge information.
+   * @param  tile           Current tile.
+   * @param  edgeid         GraphId of the directed edge.
+   * @param  current_time   Current time (seconds since epoch). A value of 0
+   *                        indicates the route is not time dependent.
+   * @return Returns true if access is allowed, false if not.
    */
   virtual bool Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred,
                        const baldr::GraphTile*& tile,
-                       const baldr::GraphId& edgeid) const;
+                       const baldr::GraphId& edgeid,
+                       const uint32_t current_time) const;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
-   * (from destination towards origin). Both opposing edges are
-   * provided.
+   * (from destination towards origin). Both opposing edges (current and
+   * predecessor) are provided. The access check is generally based on mode
+   * of travel and the access modes allowed on the edge. However, it can be
+   * extended to exclude access based on other parameters such as conditional
+   * restrictions and conditional access that can depend on time and travel
+   * mode.
    * @param  edge           Pointer to a directed edge.
    * @param  pred           Predecessor edge information.
    * @param  opp_edge       Pointer to the opposing directed edge.
-   * @param  tile           Tile for the opposing edge (for looking
-   *                        up restrictions).
-   * @param  opp_edgeid     Opposing edge Id
+   * @param  tile           Current tile.
+   * @param  edgeid         GraphId of the opposing edge.
+   * @param  current_time   Current time (seconds since epoch). A value of 0
+   *                        indicates the route is not time dependent.
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
-                 const EdgeLabel& pred,
-                 const baldr::DirectedEdge* opp_edge,
-                 const baldr::GraphTile*& tile,
-                 const baldr::GraphId& opp_edgeid) const;
+                              const EdgeLabel& pred,
+                              const baldr::DirectedEdge* opp_edge,
+                              const baldr::GraphTile*& tile,
+                              const baldr::GraphId& opp_edgeid,
+                              const uint32_t current_time) const;
 
   /**
    * Checks if access is allowed for the provided node. Node access can
@@ -522,7 +532,8 @@ uint32_t PedestrianCost::access_mode() const {
 bool PedestrianCost::Allowed(const baldr::DirectedEdge* edge,
                              const EdgeLabel& pred,
                              const baldr::GraphTile*& tile,
-                             const baldr::GraphId& edgeid) const {
+                             const baldr::GraphId& edgeid,
+                             const uint32_t current_time) const {
   // TODO - obtain and check the access restrictions.
 
   if (!(edge->forwardaccess() & access_mask_) ||
@@ -549,7 +560,8 @@ bool PedestrianCost::AllowedReverse(const baldr::DirectedEdge* edge,
                const EdgeLabel& pred,
                const baldr::DirectedEdge* opp_edge,
                const baldr::GraphTile*& tile,
-               const baldr::GraphId& opp_edgeid) const {
+               const baldr::GraphId& opp_edgeid,
+               const uint32_t current_time) const {
   // TODO - obtain and check the access restrictions.
 
   // Do not check max walking distance and assume we are not allowing

--- a/src/sif/transitcost.cc
+++ b/src/sif/transitcost.cc
@@ -97,35 +97,43 @@ class TransitCost : public DynamicCost {
    * Checks if access is allowed for the provided directed edge.
    * This is generally based on mode of travel and the access modes
    * allowed on the edge. However, it can be extended to exclude access
-   * based on other parameters.
-   * @param  edge     Pointer to a directed edge.
-   * @param  pred     Predecessor edge information.
-   * @param  tile     current tile
-   * @param  edgeid   edgeid that we care about
-   * @return  Returns true if access is allowed, false if not.
+   * based on other parameters such as conditional restrictions and
+   * conditional access that can depend on time and travel mode.
+   * @param  edge           Pointer to a directed edge.
+   * @param  pred           Predecessor edge information.
+   * @param  tile           Current tile.
+   * @param  edgeid         GraphId of the directed edge.
+   * @param  current_time   Current time (seconds since epoch).
+   * @return Returns true if access is allowed, false if not.
    */
   virtual bool Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred,
                        const baldr::GraphTile*& tile,
-                       const baldr::GraphId& edgeid) const;
+                       const baldr::GraphId& edgeid,
+                       const uint32_t current_time) const;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
-   * (from destination towards origin). Both opposing edges are
-   * provided.
+   * (from destination towards origin). Both opposing edges (current and
+   * predecessor) are provided. The access check is generally based on mode
+   * of travel and the access modes allowed on the edge. However, it can be
+   * extended to exclude access based on other parameters such as conditional
+   * restrictions and conditional access that can depend on time and travel
+   * mode.
    * @param  edge           Pointer to a directed edge.
    * @param  pred           Predecessor edge information.
    * @param  opp_edge       Pointer to the opposing directed edge.
-   * @param  tile           Tile for the opposing edge (for looking
-   *                        up restrictions).
-   * @param  opp_edgeid     Opposing edge Id
+   * @param  tile           Current tile.
+   * @param  edgeid         GraphId of the opposing edge.
+   * @param  current_time   Current time (seconds since epoch).
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
-                 const EdgeLabel& pred,
-                 const baldr::DirectedEdge* opp_edge,
-                 const baldr::GraphTile*& tile,
-                 const baldr::GraphId& opp_edgeid) const;
+                              const EdgeLabel& pred,
+                              const baldr::DirectedEdge* opp_edge,
+                              const baldr::GraphTile*& tile,
+                              const baldr::GraphId& opp_edgeid,
+                              const uint32_t current_time) const;
 
   /**
    * Checks if access is allowed for the provided node. Node access can
@@ -535,7 +543,8 @@ uint32_t TransitCost::access_mode() const {
 bool TransitCost::Allowed(const baldr::DirectedEdge* edge,
                           const EdgeLabel& pred,
                           const baldr::GraphTile*& tile,
-                          const baldr::GraphId& edgeid) const {
+                          const baldr::GraphId& edgeid,
+                          const uint32_t current_time) const {
   // TODO - obtain and check the access restrictions.
 
   if (exclude_stops_.size()) {
@@ -561,7 +570,8 @@ bool TransitCost::AllowedReverse(const baldr::DirectedEdge* edge,
                const EdgeLabel& pred,
                const baldr::DirectedEdge* opp_edge,
                const baldr::GraphTile*& tile,
-               const baldr::GraphId& opp_edgeid) const {
+               const baldr::GraphId& opp_edgeid,
+               const uint32_t current_time) const {
   // TODO - obtain and check the access restrictions.
 
   // This method should not be called since time based routes do not use

--- a/src/sif/truckcost.cc
+++ b/src/sif/truckcost.cc
@@ -132,35 +132,45 @@ class TruckCost : public DynamicCost {
    * Checks if access is allowed for the provided directed edge.
    * This is generally based on mode of travel and the access modes
    * allowed on the edge. However, it can be extended to exclude access
-   * based on other parameters.
-   * @param  edge     Pointer to a directed edge.
-   * @param  pred     Predecessor edge information.
-   * @param  tile     current tile
-   * @param  edgeid   edgeid that we care about
+   * based on other parameters such as conditional restrictions and
+   * conditional access that can depend on time and travel mode.
+   * @param  edge           Pointer to a directed edge.
+   * @param  pred           Predecessor edge information.
+   * @param  tile           Current tile.
+   * @param  edgeid         GraphId of the directed edge.
+   * @param  current_time   Current time (seconds since epoch). A value of 0
+   *                        indicates the route is not time dependent.
    * @return Returns true if access is allowed, false if not.
    */
   virtual bool Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred,
                        const baldr::GraphTile*& tile,
-                       const baldr::GraphId& edgeid) const;
+                       const baldr::GraphId& edgeid,
+                       const uint32_t current_time) const;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
-   * (from destination towards origin). Both opposing edges are
-   * provided.
+   * (from destination towards origin). Both opposing edges (current and
+   * predecessor) are provided. The access check is generally based on mode
+   * of travel and the access modes allowed on the edge. However, it can be
+   * extended to exclude access based on other parameters such as conditional
+   * restrictions and conditional access that can depend on time and travel
+   * mode.
    * @param  edge           Pointer to a directed edge.
    * @param  pred           Predecessor edge information.
    * @param  opp_edge       Pointer to the opposing directed edge.
-   * @param  tile           Tile for the opposing edge (for looking
-   *                        up restrictions).
-   * @param  opp_edgeid     Opposing edge Id
+   * @param  tile           Current tile.
+   * @param  edgeid         GraphId of the opposing edge.
+   * @param  current_time   Current time (seconds since epoch). A value of 0
+   *                        indicates the route is not time dependent.
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
-                 const EdgeLabel& pred,
-                 const baldr::DirectedEdge* opp_edge,
-                 const baldr::GraphTile*& tile,
-                 const baldr::GraphId& opp_edgeid) const;
+                              const EdgeLabel& pred,
+                              const baldr::DirectedEdge* opp_edge,
+                              const baldr::GraphTile*& tile,
+                              const baldr::GraphId& opp_edgeid,
+                              const uint32_t current_time) const;
 
   /**
    * Checks if access is allowed for the provided node. Node access can
@@ -373,7 +383,8 @@ uint32_t TruckCost::access_mode() const {
 bool TruckCost::Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred,
                        const baldr::GraphTile*& tile,
-                       const baldr::GraphId& edgeid) const {
+                       const baldr::GraphId& edgeid,
+                       const uint32_t current_time) const {
   // Check access, U-turn, and simple turn restriction.
   // TODO - perhaps allow U-turns at dead-end nodes?
   if (!(edge->forwardaccess() & kTruckAccess) ||
@@ -390,7 +401,7 @@ bool TruckCost::Allowed(const baldr::DirectedEdge* edge,
         tile->GetAccessRestrictions(edgeid.id(), kTruckAccess);
 
     for (const auto& restriction : restrictions ) {
-      // TODO:  Need to handle restictions that take place only at certain
+      // TODO:  Need to handle restrictions that take place only at certain
       // times.  Currently, we only support kAllDaysOfWeek;
       switch (restriction.type()) {
         case AccessType::kHazmat:
@@ -432,7 +443,8 @@ bool TruckCost::AllowedReverse(const baldr::DirectedEdge* edge,
                const EdgeLabel& pred,
                const baldr::DirectedEdge* opp_edge,
                const baldr::GraphTile*& tile,
-               const baldr::GraphId& opp_edgeid) const {
+               const baldr::GraphId& opp_edgeid,
+               const uint32_t current_time) const {
   // Check access, U-turn, and simple turn restriction.
   // TODO - perhaps allow U-turns at dead-end nodes?
   if (!(opp_edge->forwardaccess() & kTruckAccess) ||

--- a/src/thor/astar.cc
+++ b/src/thor/astar.cc
@@ -156,7 +156,7 @@ void AStarPathAlgorithm::ExpandForward(GraphReader& graphreader,
     // a complex restriction exists.
     if (es->set() == EdgeSet::kPermanent ||
         (shortcuts & directededge->superseded()) ||
-       !costing_->Allowed(directededge, pred, tile, edgeid) ||
+       !costing_->Allowed(directededge, pred, tile, edgeid, 0) ||
         costing_->Restricted(directededge, pred, edgelabels_, tile,
                                      edgeid, true)) {
       continue;

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -148,7 +148,7 @@ void BidirectionalAStar::ExpandForward(GraphReader& graphreader,
     // or if a complex restriction prevents transition onto this edge.
     if (es->set() == EdgeSet::kPermanent ||
         (shortcuts & directededge->superseded()) ||
-        !costing_->Allowed(directededge, pred, tile, edgeid) ||
+        !costing_->Allowed(directededge, pred, tile, edgeid, 0) ||
          costing_->Restricted(directededge, pred, edgelabels_forward_, tile,
                                      edgeid, true)) {
       continue;
@@ -261,7 +261,7 @@ void BidirectionalAStar::ExpandReverse(GraphReader& graphreader,
 
     // Skip this edge if no access is allowed (based on costing method)
     // or if a complex restriction prevents transition onto this edge.
-    if (!costing_->AllowedReverse(directededge, pred, opp_edge, t2, oppedge) ||
+    if (!costing_->AllowedReverse(directededge, pred, opp_edge, t2, oppedge, 0) ||
          costing_->Restricted(directededge, pred, edgelabels_reverse_, tile,
                                      edgeid, false)) {
       continue;

--- a/src/thor/costmatrix.cc
+++ b/src/thor/costmatrix.cc
@@ -327,7 +327,7 @@ void CostMatrix::ForwardSearch(const uint32_t index, const uint32_t n,
 
       // Skip this edge if no access is allowed (based on costing method)
       // or if a complex restriction prevents transition onto this edge.
-      if (!costing_->Allowed(directededge, pred, tile, edgeid) ||
+      if (!costing_->Allowed(directededge, pred, tile, edgeid, 0) ||
            costing_->Restricted(directededge, pred, edgelabels, tile,
                                 edgeid, true)) {
         continue;
@@ -605,7 +605,7 @@ void CostMatrix::BackwardSearch(const uint32_t index,
       // Skip this edge if no access is allowed (based on costing method)
       // or if a complex restriction prevents transition onto this edge.
       const DirectedEdge* opp_edge = t2->directededge(oppedge);
-      if (!costing_->AllowedReverse(directededge, pred, opp_edge, t2, oppedge) ||
+      if (!costing_->AllowedReverse(directededge, pred, opp_edge, t2, oppedge, 0) ||
            costing_->Restricted(directededge, pred, edgelabels, tile,
                                        edgeid, false)) {
         continue;

--- a/src/thor/isochrone.cc
+++ b/src/thor/isochrone.cc
@@ -244,7 +244,7 @@ void Isochrone::ExpandForward(GraphReader& graphreader, const GraphId& node,
     if (directededge->is_shortcut() ||
         es->set() == EdgeSet::kPermanent ||
       !(directededge->forwardaccess() & access_mode_) ||
-      !costing_->Allowed(directededge, pred, tile, edgeid) ||
+      !costing_->Allowed(directededge, pred, tile, edgeid, 0) ||
        costing_->Restricted(directededge, pred, edgelabels_, tile,
                              edgeid, true)) {
       continue;
@@ -385,7 +385,7 @@ void Isochrone::ExpandReverse(GraphReader& graphreader,
 
     // Skip this edge if no access is allowed (based on costing method)
     // or if a complex restriction prevents transition onto this edge.
-    if (!costing_->AllowedReverse(directededge, pred, opp_edge, t2, oppedge) ||
+    if (!costing_->AllowedReverse(directededge, pred, opp_edge, t2, oppedge, 0) ||
          costing_->Restricted(directededge, pred, bdedgelabels_, tile,
                                      edgeid, false)) {
       continue;
@@ -657,7 +657,7 @@ std::shared_ptr<const GriddedData<PointLL> > Isochrone::ComputeMultiModal(
       blockid = 0;
       if (directededge->IsTransitLine()) {
         // Check if transit costing allows this edge
-        if (!tc->Allowed(directededge, pred, tile, edgeid)) {
+        if (!tc->Allowed(directededge, pred, tile, edgeid, 0)) {
           continue;
         }
 
@@ -733,7 +733,7 @@ std::shared_ptr<const GriddedData<PointLL> > Isochrone::ComputeMultiModal(
         // is allowed. If mode is pedestrian this will validate walking
         // distance has not been exceeded.
         if (!mode_costing[static_cast<uint32_t>(mode_)]->Allowed(
-                directededge, pred, tile, edgeid)) {
+                directededge, pred, tile, edgeid, 0)) {
           continue;
         }
 

--- a/src/thor/multimodal.cc
+++ b/src/thor/multimodal.cc
@@ -348,7 +348,7 @@ std::vector<PathInfo> MultiModalPathAlgorithm::GetBestPath(
       blockid = 0;
       if (directededge->IsTransitLine()) {
         // Check if transit costing allows this edge
-        if (!tc->Allowed(directededge, pred, tile, edgeid)) {
+        if (!tc->Allowed(directededge, pred, tile, edgeid, 0)) {
           continue;
         }
         //check if excluded.
@@ -423,7 +423,7 @@ std::vector<PathInfo> MultiModalPathAlgorithm::GetBestPath(
         // is allowed. If mode is pedestrian this will validate walking
         // distance has not been exceeded.
         if (!mode_costing[static_cast<uint32_t>(mode_)]->Allowed(
-                directededge, pred, tile, edgeid)) {
+                directededge, pred, tile, edgeid, 0)) {
           continue;
         }
 
@@ -754,7 +754,7 @@ bool MultiModalPathAlgorithm::CanReachDestination(const odin::Location& destinat
       }
 
       // Skip if access is not allowed for this mode
-      if (!costing->Allowed(directededge, pred, tile, edgeid)) {
+      if (!costing->Allowed(directededge, pred, tile, edgeid, 0)) {
         continue;
       }
 

--- a/src/thor/timedistancematrix.cc
+++ b/src/thor/timedistancematrix.cc
@@ -102,7 +102,7 @@ void TimeDistanceMatrix::ExpandForward(GraphReader& graphreader,
     // directed edge), if no access is allowed to this edge (based on costing
     // method), or if a complex restriction prevents this path.
     if (es->set() == EdgeSet::kPermanent ||
-       !costing_->Allowed(directededge, pred, tile, edgeid) ||
+       !costing_->Allowed(directededge, pred, tile, edgeid, 0) ||
         costing_->Restricted(directededge, pred, edgelabels_, tile,
                                  edgeid, true)) {
       continue;
@@ -266,7 +266,7 @@ void TimeDistanceMatrix::ExpandReverse(GraphReader& graphreader,
     // Get opposing directed edge and check if allowed.
     const DirectedEdge* opp_edge = t2->directededge(oppedge);
     if (opp_edge == nullptr ||
-       !costing_->AllowedReverse(directededge, pred, opp_edge, t2, oppedge)) {
+       !costing_->AllowedReverse(directededge, pred, opp_edge, t2, oppedge, 0)) {
       continue;
     }
 

--- a/src/thor/trafficalgorithm.cc
+++ b/src/thor/trafficalgorithm.cc
@@ -123,7 +123,7 @@ std::vector<PathInfo> TrafficAlgorithm::GetBestPath(odin::Location& origin,
       // this directed edge) or if no access is allowed to this edge (based
       // on costing method)
       if (es->set() == EdgeSet::kPermanent ||
-         !costing_->Allowed(directededge, pred, tile, edgeid)) {
+         !costing_->Allowed(directededge, pred, tile, edgeid, 0)) {
         continue;
       }
 

--- a/src/valhalla_associate_segments.cc
+++ b/src/valhalla_associate_segments.cc
@@ -272,12 +272,14 @@ public:
   bool Allowed(const vb::DirectedEdge* edge,
                const vs::EdgeLabel& pred,
                const vb::GraphTile*& tile,
-               const vb::GraphId& edgeid) const;
+               const vb::GraphId& edgeid,
+               const uint32_t current_time) const;
   bool AllowedReverse(const vb::DirectedEdge* edge,
                       const vs::EdgeLabel& pred,
                       const vb::DirectedEdge* opp_edge,
                       const vb::GraphTile*& tile,
-                      const vb::GraphId& edgeid) const;
+                      const vb::GraphId& edgeid,
+                      const uint32_t current_time) const;
   bool Allowed(const vb::NodeInfo* node) const;
   vs::Cost EdgeCost(const vb::DirectedEdge* edge) const;
   const vs::EdgeFilter GetEdgeFilter() const;
@@ -299,7 +301,8 @@ uint32_t DistanceOnlyCost::access_mode() const {
 bool DistanceOnlyCost::Allowed(const vb::DirectedEdge* edge,
                                const vs::EdgeLabel& pred,
                                const vb::GraphTile*&,
-                               const vb::GraphId&) const {
+                               const vb::GraphId&,
+                               const uint32_t) const {
   // Do not allow U-turns/back-tracking
   return allow_edge_pred(edge) &&
         (pred.opp_local_idx() != edge->localedgeidx());
@@ -309,7 +312,8 @@ bool DistanceOnlyCost::AllowedReverse(const vb::DirectedEdge* edge,
                                       const vs::EdgeLabel& pred,
                                       const vb::DirectedEdge* opp_edge,
                                       const vb::GraphTile*& tile,
-                                      const vb::GraphId& edgeid) const {
+                                      const vb::GraphId& edgeid,
+                                      const uint32_t) const {
   // Do not allow U-turns/back-tracking
   return allow_edge_pred(edge) &&
         (pred.opp_local_idx() != edge->localedgeidx());

--- a/test/matrix.cc
+++ b/test/matrix.cc
@@ -41,7 +41,8 @@ namespace {
     bool Allowed(const DirectedEdge* edge,
           const EdgeLabel& pred,
           const GraphTile*& tile,
-          const GraphId& edgeid) const {
+          const GraphId& edgeid,
+          const uint32_t current_time) const {
       if (!(edge->forwardaccess() & kAutoAccess) ||
           (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
           (pred.restrictions() & (1 << edge->localedgeidx())) ||
@@ -57,7 +58,8 @@ namespace {
           const EdgeLabel& pred,
           const DirectedEdge* opp_edge,
           const GraphTile*& tile,
-          const GraphId& opp_edgeid) const {
+          const GraphId& opp_edgeid,
+          const uint32_t current_time) const {
       if (!(opp_edge->forwardaccess() & kAutoAccess) ||
            (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
            (opp_edge->restrictions() & (1 << pred.opp_local_idx())) ||

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -120,34 +120,45 @@ class DynamicCost {
    * Checks if access is allowed for the provided directed edge.
    * This is generally based on mode of travel and the access modes
    * allowed on the edge. However, it can be extended to exclude access
-   * based on other parameters.
-   * @param  edge     Pointer to a directed edge.
-   * @param  pred     Predecessor edge information.
-   * @param  tile     current tile
-   * @param  edgeid   edgeid that we care about
-   * @return  Returns true if access is allowed, false if not.
+   * based on other parameters such as conditional restrictions and
+   * conditional access that can depend on time and travel mode.
+   * @param  edge           Pointer to a directed edge.
+   * @param  pred           Predecessor edge information.
+   * @param  tile           Current tile.
+   * @param  edgeid         GraphId of the directed edge.
+   * @param  current_time   Current time (seconds since epoch). A value of 0
+   *                        indicates the route is not time dependent.
+   * @return Returns true if access is allowed, false if not.
    */
   virtual bool Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred,
                        const baldr::GraphTile*& tile,
-                       const baldr::GraphId& edgeid) const = 0;
+                       const baldr::GraphId& edgeid,
+                       const uint32_t current_time) const = 0;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
-   * (from destination towards origin). Both opposing edges are
-   * provided.
+   * (from destination towards origin). Both opposing edges (current and
+   * predecessor) are provided. The access check is generally based on mode
+   * of travel and the access modes allowed on the edge. However, it can be
+   * extended to exclude access based on other parameters such as conditional
+   * restrictions and conditional access that can depend on time and travel
+   * mode.
    * @param  edge           Pointer to a directed edge.
    * @param  pred           Predecessor edge information.
    * @param  opp_edge       Pointer to the opposing directed edge.
-   * @param  tile           current tile
-   * @param  edgeid         edgeid that we care about
+   * @param  tile           Current tile.
+   * @param  edgeid         GraphId of the opposing edge.
+   * @param  current_time   Current time (seconds since epoch). A value of 0
+   *                        indicates the route is not time dependent.
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
-                 const EdgeLabel& pred,
-                 const baldr::DirectedEdge* opp_edge,
-                 const baldr::GraphTile*& tile,
-                 const baldr::GraphId& edgeid) const = 0;
+                              const EdgeLabel& pred,
+                              const baldr::DirectedEdge* opp_edge,
+                              const baldr::GraphTile*& tile,
+                              const baldr::GraphId& opp_edgeid,
+                              const uint32_t current_time) const = 0;
 
   /**
    * Checks if access is allowed for the provided node. Node access can


### PR DESCRIPTION
This will allow lookup of time dependent conditions for time dependent routes. The actual lookup is TBD - this takes the first step of adding time to the interface. fixes #1211