### PR TITLE
Remove tile_index_pair and replace with GraphId for transit excludes

### DIFF
--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -253,7 +253,7 @@ void GraphTile::AssociateOneStopIds(const GraphId& graphid) {
   stop_one_stops.reserve(header_->stopcount());
   for (uint32_t i = 0; i < header_->stopcount(); i++) {
     const auto& stop = GetName(transit_stops_[i].one_stop_offset());
-    stop_one_stops[stop] = tile_index_pair(graphid.tileid(), i);
+    stop_one_stops[stop] = { graphid.tileid(), graphid.level(), i };
   }
 
   // Associate route and operator Ids
@@ -263,22 +263,26 @@ void GraphTile::AssociateOneStopIds(const GraphId& graphid) {
     const auto& route_one_stop = GetName(t->one_stop_offset());
     auto stops = route_one_stops.find(route_one_stop);
     if (stops == route_one_stops.end()) {
-      std::list<tile_index_pair> tile_line_ids;
-      tile_line_ids.emplace_back(tile_index_pair(graphid.tileid(), dep.second->lineid()));
+      std::list<GraphId> tile_line_ids;
+      tile_line_ids.emplace_back(graphid.tileid(), graphid.level(),
+          dep.second->lineid());
       route_one_stops[route_one_stop] = tile_line_ids;
     } else {
-      route_one_stops[route_one_stop].emplace_back(tile_index_pair(graphid.tileid(), dep.second->lineid()));
+      route_one_stops[route_one_stop].emplace_back(graphid.tileid(),
+          graphid.level(), dep.second->lineid());
     }
 
     // operators contain all of their route's tile_line pairs.
     const auto& op_one_stop = GetName(t->op_by_onestop_id_offset());
     stops = oper_one_stops.find(op_one_stop);
     if (stops == oper_one_stops.end()) {
-      std::list<tile_index_pair> tile_line_ids;
-      tile_line_ids.emplace_back(tile_index_pair(graphid.tileid(), dep.second->lineid()));
+      std::list<GraphId> tile_line_ids;
+      tile_line_ids.emplace_back(graphid.tileid(), graphid.level(),
+          dep.second->lineid());
       oper_one_stops[op_one_stop] = tile_line_ids;
     } else {
-      oper_one_stops[op_one_stop].emplace_back(tile_index_pair(graphid.tileid(), dep.second->lineid()));
+      oper_one_stops[op_one_stop].emplace_back(graphid.tileid(), graphid.level(),
+          dep.second->lineid());
     }
   }
 }
@@ -757,21 +761,18 @@ std::unordered_map<uint32_t,TransitDeparture*> GraphTile::GetTransitDepartures()
   return deps;
 }
 
-// Get the stop onestops in this tile
-std::unordered_map<std::string, tile_index_pair>
-GraphTile::GetStopOneStops() const {
+// Get the stop onestop Ids in this tile.
+const std::unordered_map<std::string, GraphId>& GraphTile::GetStopOneStops() const {
   return stop_one_stops;
 }
 
-// Get the route onestops in this tile.
-std::unordered_map<std::string, std::list<tile_index_pair>>
-GraphTile::GetRouteOneStops() const {
+// Get the route onestop Ids in this tile.
+const std::unordered_map<std::string, std::list<GraphId>>& GraphTile::GetRouteOneStops() const {
   return route_one_stops;
 }
 
-// Get the operator onestops in this tile.
-std::unordered_map<std::string, std::list<tile_index_pair>>
-GraphTile::GetOperatorOneStops() const {
+// Get the operator onestop Ids in this tile.
+const std::unordered_map<std::string, std::list<GraphId>>& GraphTile::GetOperatorOneStops() const {
   return oper_one_stops;
 }
 

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -30,8 +30,6 @@
 namespace valhalla {
 namespace baldr {
 
-using tile_index_pair = std::pair<uint32_t, uint32_t>;
-
 /**
  * Graph information for a tile within the Tiled Hierarchical Graph.
  */
@@ -309,25 +307,25 @@ class GraphTile {
   std::unordered_map<uint32_t,TransitDeparture*> GetTransitDepartures() const;
 
   /**
-   * Get the stop onestops in this tile
-   * @return  Returns a map of onestops
+   * Get the stop onestop Ids in this tile.
+   * @return  Returns a map of transit stops with onestop Ids as the key and
+   *          a GraphId (transit tile plus the stop Id) as the value.
    */
-  std::unordered_map<std::string, tile_index_pair>
-    GetStopOneStops() const;
+  const std::unordered_map<std::string, GraphId>& GetStopOneStops() const;
 
   /**
-   * Get the route onestops in this tile
-   * @return  Returns a map of onestops
+   * Get the route onestop Ids in this tile.
+   * @return  Returns a map with the route onestop Id as the key and a list
+   *          of GraphIds (transit tile plus route line Id) as the value.
    */
-  std::unordered_map<std::string, std::list<tile_index_pair>>
-    GetRouteOneStops() const;
+  const std::unordered_map<std::string, std::list<GraphId>>& GetRouteOneStops() const;
 
   /**
-   * Get the operator onestops in this tile
-   * @return  Returns a map of onestops
+   * Get the operator onestops in this tile.
+   * @return  Returns a map with onestop Id as the key with a list of GraphIds
+   *          as the value.
    */
-  std::unordered_map<std::string, std::list<tile_index_pair>>
-    GetOperatorOneStops() const;
+  const std::unordered_map<std::string, std::list<GraphId>>& GetOperatorOneStops() const;
 
   /**
    * Get the transit stop given its index
@@ -508,13 +506,13 @@ class GraphTile {
   EdgeElevation* edge_elevation_;
 
   // Map of stop one stops in this tile.
-  std::unordered_map<std::string, tile_index_pair> stop_one_stops;
+  std::unordered_map<std::string, GraphId> stop_one_stops;
 
   // Map of route one stops in this tile.
-  std::unordered_map<std::string, std::list<tile_index_pair>> route_one_stops;
+  std::unordered_map<std::string, std::list<GraphId>> route_one_stops;
 
   // Map of operator one stops in this tile.
-  std::unordered_map<std::string, std::list<tile_index_pair>> oper_one_stops;
+  std::unordered_map<std::string, std::list<GraphId>> oper_one_stops;
 
   /**
    * Set pointers to internal tile data structures.

--- a/valhalla/meili/candidate_search.h
+++ b/valhalla/meili/candidate_search.h
@@ -7,7 +7,6 @@
 #include <algorithm>
 
 #include <boost/property_tree/ptree.hpp>
-#include <boost/iterator/counting_iterator.hpp>
 
 #include <valhalla/midgard/distanceapproximator.h>
 #include <valhalla/midgard/linesegment2.h>


### PR DESCRIPTION
The (now removed) tile_index_pair is basically the tileId (on the transit level) and Id within the tile for a stop or a route/line. Both of these are sequential Ids within the tile so GraphId is the appropriate structure to use for these. This also allows use of the GraphId hash function - removing the need for a special hash method (TileIndexHasher) within transit cost.
Also, the GraphTile methods now return a const address to the internal unordered_map.
Cleaned up some comments. R
Renamed excludes_ to exclude_routes_ to be more explicit.
