### PR TITLE
Catch invalid filter attributes rather than throwing exception

### DIFF
--- a/src/thor/trace_attributes_action.cc
+++ b/src/thor/trace_attributes_action.cc
@@ -42,12 +42,22 @@ void thor_worker_t::filter_attributes(const valhalla_request_t& request, Attribu
 
   if (filter_action == "include") {
     controller.disable_all();
-    for (const auto& v : rapidjson::get<rapidjson::Value::ConstArray>(request.document, "/filters/attributes"))
-      controller.attributes.at(v.GetString()) = true;
+    for (const auto& v : rapidjson::get<rapidjson::Value::ConstArray>(request.document, "/filters/attributes")) {
+      try {
+        controller.attributes.at(v.GetString()) = true;
+      } catch (...) {
+        LOG_ERROR("Invalid filter attribute " + std::string(v.GetString()));
+      }
+    }
   } else if (filter_action == "exclude") {
     controller.enable_all();
-    for (const auto& v : rapidjson::get<rapidjson::Value::ConstArray>(request.document, "/filters/attributes"))
-      controller.attributes.at(v.GetString()) = false;
+    for (const auto& v : rapidjson::get<rapidjson::Value::ConstArray>(request.document, "/filters/attributes")) {
+      try {
+        controller.attributes.at(v.GetString()) = false;
+      } catch (...) {
+        LOG_ERROR("Invalid filter attribute " + std::string(v.GetString()));
+      }
+    }
   } else {
     controller.enable_all();
   }


### PR DESCRIPTION
Log an error if the include or exclude filter includes an invalid attribute. This allows the request to continue with the valid attributes rather than throwing an exception that doesn't detail the root of the problem.

fixes #1231

example: request below has edge.end_node which is not a valid attribute.

http://localhost:8002/trace_attributes?json={"costing": "auto", "shape_match": "map_snap", "search_radius": 25, "filters": {"action": "include", "attributes": ["shape", "edge.names", "edge.begin_heading", "edge.begin_shape_index", "edge.end_heading", "edge.end_shape_index", "edge.use", "edge.road_class", "edge.way_id", "edge.traversability", "edge.end_node"]}, "shape": [{"lat": 37.81093, "lon": -122.26253}, {"lat": 37.81120, "lon": -122.26431}, {"lat": 37.81144, "lon": -122.26542}]}