### PR TITLE
Increase minimum threshold for completing a driving route.

### DIFF
--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -13,7 +13,7 @@ namespace {
 // the max edge cost in the adjacency set?
 int GetThreshold(const TravelMode mode, const int n) {
   return (mode == TravelMode::kDrive) ?
-      n + std::min(8500, std::max(100, n / 3)) :
+      n + std::min(8500, std::max(200, n / 3)) :
       n + 500;
 }
 


### PR DESCRIPTION
The minimum threshold after which the initial connection is found was too low. Short auto routes that have a lower cost path over a slow road may not be found with such a low threshold.
Fixes #1064 