### PR TITLE
Move trace_options parsing to map matcher factory

### DIFF
--- a/src/thor/trace_attributes_action.cc
+++ b/src/thor/trace_attributes_action.cc
@@ -74,7 +74,6 @@ std::string thor_worker_t::trace_attributes(valhalla_request_t& request) {
   // Parse request
   parse_locations(request);
   parse_costing(request);
-  parse_trace_config(request);
   parse_measurements(request);
 
   /*

--- a/src/thor/trace_route_action.cc
+++ b/src/thor/trace_route_action.cc
@@ -52,7 +52,6 @@ odin::TripPath thor_worker_t::trace_route(valhalla_request_t& request) {
   // Parse request
   parse_locations(request);
   parse_costing(request);
-  parse_trace_config(request);
   parse_measurements(request);
 
   // Initialize the controller

--- a/test/traffic_matcher.cc
+++ b/test/traffic_matcher.cc
@@ -52,26 +52,26 @@ using sid_t = baldr::GraphId;
 std::vector<std::pair<std::string, ots_matches_t>> test_cases{
     // partial, partial with duplicate point
     std::make_pair(
-        R"({"trace":[{"lon":-76.376045,"lat":40.539207,"time":0},{"lon":-76.357056,"lat":40.541309,"time":99},{"lon":-76.357056,"lat":40.541309,"time":100}],"match_options":{"breakage_distance":10000}})",
+        R"({"trace":[{"lon":-76.376045,"lat":40.539207,"time":0},{"lon":-76.357056,"lat":40.541309,"time":99},{"lon":-76.357056,"lat":40.541309,"time":100}],"trace_options":{"breakage_distance":10000}})",
         ots_matches_t{ots_t{sid_t(0), -1, 0, 50.f, 0, -1}, ots_t{sid_t(0), 50.f, 0, -1, 2, -1}}),
     // partial, partial
     std::make_pair(
-        R"({"trace":[{"lon":-76.376045,"lat":40.539207,"time":0},{"lon":-76.357056,"lat":40.541309,"time":100}],"match_options":{"breakage_distance":10000}})",
+        R"({"trace":[{"lon":-76.376045,"lat":40.539207,"time":0},{"lon":-76.357056,"lat":40.541309,"time":100}],"trace_options":{"breakage_distance":10000}})",
         ots_matches_t{ots_t{sid_t(0), -1, 0, 50.f, 0, -1}, ots_t{sid_t(0), 50.f, 0, -1, 1, -1}}),
     // partial, full, partial
     std::make_pair(
-        R"({"trace":[{"lon":-76.376045,"lat":40.539207,"time":0},{"lon":-76.351089,"lat":40.541504,"time":300}],"match_options":{"breakage_distance":10000}})",
+        R"({"trace":[{"lon":-76.376045,"lat":40.539207,"time":0},{"lon":-76.351089,"lat":40.541504,"time":300}],"trace_options":{"breakage_distance":10000}})",
         ots_matches_t{ots_t{sid_t(0), -1, 0, 110.f, 0, -1}, ots_t{sid_t(0), 110.f, 0, 250.f, 0, 1000},
                       ots_t{sid_t(0), 250.f, 0, -1, 1, -1}}),
     // partial, full, full, full
     std::make_pair(
-        R"({"trace":[{"lon":-76.38126,"lat":40.55602,"time":0},{"lon":-76.35784,"lat":40.56786,"time":600}],"match_options":{"breakage_distance":10000}})",
+        R"({"trace":[{"lon":-76.38126,"lat":40.55602,"time":0},{"lon":-76.35784,"lat":40.56786,"time":600}],"trace_options":{"breakage_distance":10000}})",
         ots_matches_t{ots_t{sid_t(0), -1, 0, 60.f, 0, -1}, ots_t{sid_t(0), 60.f, 0, 110.f, 0, 200},
                       ots_t{sid_t(0), 110.f, 0, 350.f, 0, 1000},
                       ots_t{sid_t(0), 350.f, 0, 600.f, 1, 1000}}),
     // full, full, partial
     std::make_pair(
-        R"({"trace":[{"lon":-76.35784,"lat":40.56786,"time":0},{"lon":-76.38126,"lat":40.55602,"time":600}],"match_options":{"breakage_distance":10000}})",
+        R"({"trace":[{"lon":-76.35784,"lat":40.56786,"time":0},{"lon":-76.38126,"lat":40.55602,"time":600}],"trace_options":{"breakage_distance":10000}})",
         ots_matches_t{ots_t{sid_t(0), 0.f, 0, 250.f, 0, 1000},
                       ots_t{sid_t(0), 250.f, 0, 490.f, 0, 1000},
                       ots_t{sid_t(0), 490.f, 0, -1, 0, -1}}),

--- a/valhalla/meili/map_matcher_factory.h
+++ b/valhalla/meili/map_matcher_factory.h
@@ -6,6 +6,7 @@
 #include <string>
 
 #include <boost/property_tree/ptree.hpp>
+#include <rapidjson/rapidjson.h>
 
 #include <valhalla/baldr/graphreader.h>
 #include <valhalla/sif/costconstants.h>
@@ -38,6 +39,8 @@ public:
   MapMatcher* Create(const std::string& name, const boost::property_tree::ptree& preferences);
 
   MapMatcher* Create(const boost::property_tree::ptree&);
+
+  MapMatcher* Create(const rapidjson::Value&);
 
   boost::property_tree::ptree MergeConfig(const std::string&, const boost::property_tree::ptree&);
 

--- a/valhalla/thor/worker.h
+++ b/valhalla/thor/worker.h
@@ -82,7 +82,6 @@ protected:
 
   void parse_locations(valhalla_request_t& request);
   void parse_measurements(const valhalla_request_t& request);
-  void parse_trace_config(const valhalla_request_t& request);
   std::string parse_costing(const valhalla_request_t& request);
   void filter_attributes(const valhalla_request_t& request, AttributesController& controller);
 
@@ -103,9 +102,6 @@ protected:
   SOURCE_TO_TARGET_ALGORITHM source_to_target_algorithm;
   valhalla::meili::MapMatcherFactory matcher_factory;
   valhalla::baldr::GraphReader& reader;
-  std::unordered_set<std::string> trace_customizable;
-  boost::property_tree::ptree trace_config;
-  ;
 };
 
 } // namespace thor


### PR DESCRIPTION
# Issue

This PR updates map matcher factory to properly apply custom `costing_options` and `trace_options` from the default `trace_route` and `trace_attributes` json payloads. Previously, `trace_*` requests would ignore any `costing_options` passed in. Fixes #1259.

## Tasklist

 - [x] add tests
 - [ ] review - you must request approval to merge any PR to master
 - [x] Add #fixes with the issue number that this PR addresses
 - [x] Generally use squash merge to rebase and clean comments before merging
 - [ ] Add to release notes in valhalla-docs
 - [ ] update relevant documentation if this is an API impacting change