### PR TITLE
Correctly handle --disable-coverage/--enable-coverage=no

### DIFF
--- a/m4/coverage.m4
+++ b/m4/coverage.m4
@@ -8,7 +8,8 @@ AC_DEFUN([CHECK_COVERAGE],
 AC_ARG_ENABLE([coverage],
   [AS_HELP_STRING([--enable-coverage],
     [enable coverage testing])],
-  [enable_coverage=yes],[enable_coverage=no])
+  [enable_coverage="$enableval"],
+  [enable_coverage=no])
 
 AM_CONDITIONAL(ENABLE_COVERAGE, test "x$enable_coverage" = "xyes")
 


### PR DESCRIPTION
# Issue

This fixes a bug in `m4/coverage.m4` with the `--enable-coverage` flag.

Explanation: `AC_ARG_ENABLE` has the following usage:

```
AC_ARG_ENABLE(option-name, help-string, action-if-present, action-if-not-present)
```

Note that the parameter is called `action-if-present`.  The code was previously written like it was `action-if-true`, which was incorrect.

This PR changes `action-if-present` to take on the actual value assigned.  This makes it work as expected when `--disable-coverage` is passed, as that will set `$enableval` to `no` (see [docs](https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.69/html_node/Package-Options.html)).

This was probably never noticed because the default is `no`, and folks only ever used `--enable-coverage` standalone, which worked as expected.

## Tasklist

 - [x] review - you must request approval to merge any PR to master