### PR TITLE
Add new costing method: AutoDataFix

### DIFF
--- a/proto/directions_options.proto
+++ b/proto/directions_options.proto
@@ -38,6 +38,7 @@ message DirectionsOptions {
     transit = 8;
     truck = 9;
     motorcycle = 10;
+    auto_data_fix = 11;
   }  
   
   enum DateTimeType {

--- a/src/city_test.cc
+++ b/src/city_test.cc
@@ -222,11 +222,7 @@ int main(int argc, char* argv[]) {
   //  return EXIT_SUCCESS;
 
   CostFactory<DynamicCost> factory;
-  factory.Register("auto", CreateAutoCost);
-  factory.Register("auto_shorter", CreateAutoShorterCost);
-  factory.Register("bus", CreateBusCost);
-  factory.Register("bicycle", CreateBicycleCost);
-  factory.Register("pedestrian", CreatePedestrianCost);
+  factory.RegisterStandardCostingModels();
 
   // Figure out the route type
   std::string routetype = "auto";

--- a/src/loki/worker.cc
+++ b/src/loki/worker.cc
@@ -199,18 +199,8 @@ loki_worker_t::loki_worker_t(const boost::property_tree::ptree& config)
   max_best_paths = config.get<unsigned int>("service_limits.trace.max_best_paths");
   max_best_paths_shape = config.get<size_t>("service_limits.trace.max_best_paths_shape");
 
-  // Register edge/node costing methods
-  // TODO: move this into the loop above
-  factory.Register("auto", sif::CreateAutoCost);
-  factory.Register("auto_shorter", sif::CreateAutoShorterCost);
-  factory.Register("bus", sif::CreateBusCost);
-  factory.Register("bicycle", sif::CreateBicycleCost);
-  factory.Register("hov", sif::CreateHOVCost);
-  factory.Register("motor_scooter", sif::CreateMotorScooterCost);
-  factory.Register("motorcycle", sif::CreateMotorcycleCost);
-  factory.Register("pedestrian", sif::CreatePedestrianCost);
-  factory.Register("truck", sif::CreateTruckCost);
-  factory.Register("transit", sif::CreateTransitCost);
+  // Register standard edge/node costing methods
+  factory.RegisterStandardCostingModels();
 }
 
 void loki_worker_t::cleanup() {

--- a/src/meili/map_matcher_factory.cc
+++ b/src/meili/map_matcher_factory.cc
@@ -32,16 +32,7 @@ MapMatcherFactory::MapMatcherFactory(const boost::property_tree::ptree& root)
                       local_tile_size() / root.get<size_t>("meili.grid.size"),
                       local_tile_size() / root.get<size_t>("meili.grid.size")),
       max_grid_cache_size_(root.get<float>("meili.grid.cache_size")) {
-  cost_factory_.Register("auto", sif::CreateAutoCost);
-  cost_factory_.Register("auto_shorter", sif::CreateAutoShorterCost);
-  cost_factory_.Register("bus", sif::CreateBusCost);
-  cost_factory_.Register("bicycle", sif::CreateBicycleCost);
-  cost_factory_.Register("hov", sif::CreateHOVCost);
-  cost_factory_.Register("motor_scooter", sif::CreateMotorScooterCost);
-  cost_factory_.Register("motorcycle", sif::CreateMotorcycleCost);
-  cost_factory_.Register("pedestrian", sif::CreatePedestrianCost);
-  cost_factory_.Register("truck", sif::CreateTruckCost);
-  cost_factory_.Register("transit", sif::CreateTransitCost);
+  cost_factory_.RegisterStandardCostingModels();
   cost_factory_.Register("multimodal", CreateUniversalCost);
 }
 

--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -120,20 +120,25 @@ public:
    */
   AutoCost(const boost::property_tree::ptree& config);
 
-  virtual ~AutoCost();
+  virtual ~AutoCost() {
+  }
 
   /**
    * Does the costing method allow multiple passes (with relaxed hierarchy
    * limits).
    * @return  Returns true if the costing model allows multiple passes.
    */
-  virtual bool AllowMultiPass() const;
+  virtual bool AllowMultiPass() const {
+    return true;
+  }
 
   /**
    * Get the access mode used by this costing method.
    * @return  Returns access mode.
    */
-  uint32_t access_mode() const;
+  uint32_t access_mode() const {
+    return kAutoAccess;
+  }
 
   /**
    * Checks if access is allowed for the provided directed edge.
@@ -189,7 +194,9 @@ public:
    * @param  node  Pointer to node information.
    * @return  Returns true if access is allowed, false if not.
    */
-  virtual bool Allowed(const baldr::NodeInfo* node) const;
+  virtual bool Allowed(const baldr::NodeInfo* node) const {
+    return (node->access() & kAutoAccess);
+  }
 
   /**
    * Get the cost to traverse the specified directed edge. Cost includes
@@ -234,13 +241,17 @@ public:
    * assume the maximum speed is used to the destination such that the time
    * estimate is less than the least possible time along roads.
    */
-  virtual float AStarCostFactor() const;
+  virtual float AStarCostFactor() const {
+    return speedfactor_[kMaxSpeedKph];
+  }
 
   /**
    * Get the current travel type.
    * @return  Returns the current travel type.
    */
-  virtual uint8_t travel_type() const;
+  virtual uint8_t travel_type() const {
+    return static_cast<uint8_t>(type_);
+  }
 
   /**
    * Returns a function/functor to be used in location searching which will
@@ -383,21 +394,6 @@ AutoCost::AutoCost(const boost::property_tree::ptree& pt)
   }
 }
 
-// Destructor
-AutoCost::~AutoCost() {
-}
-
-// Does the costing method allow multiple passes (with relaxed hierarchy
-// limits).
-bool AutoCost::AllowMultiPass() const {
-  return true;
-}
-
-// Get the access mode used by this costing method.
-uint32_t AutoCost::access_mode() const {
-  return kAutoAccess;
-}
-
 // Check if access is allowed on the specified edge.
 bool AutoCost::Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred,
@@ -474,11 +470,6 @@ bool AutoCost::AllowedReverse(const baldr::DirectedEdge* edge,
     }
   }
   return true;
-}
-
-// Check if access is allowed at the specified node.
-bool AutoCost::Allowed(const baldr::NodeInfo* node) const {
-  return (node->access() & kAutoAccess);
 }
 
 // Get the cost to traverse the edge in seconds
@@ -612,21 +603,6 @@ Cost AutoCost::TransitionCostReverse(const uint32_t idx,
   return {seconds + penalty, seconds};
 }
 
-// Get the cost factor for A* heuristics. This factor is multiplied
-// with the distance to the destination to produce an estimate of the
-// minimum cost to the destination. The A* heuristic must underestimate the
-// cost to the destination. So a time based estimate based on speed should
-// assume the maximum speed is used to the destination such that the time
-// estimate is less than the least possible time along roads.
-float AutoCost::AStarCostFactor() const {
-  return speedfactor_[kMaxSpeedKph];
-}
-
-// Returns the current travel type.
-uint8_t AutoCost::travel_type() const {
-  return static_cast<uint8_t>(type_);
-}
-
 cost_ptr_t CreateAutoCost(const boost::property_tree::ptree& config) {
   return std::make_shared<AutoCost>(config);
 }
@@ -640,11 +616,19 @@ public:
   /**
    * Construct auto costing for shorter (not absolute shortest) path.
    * Pass in configuration using property tree.
-   * @param  config  Property tree with configuration/options.
+   * @param  pt  Property tree with configuration/options.
    */
-  AutoShorterCost(const boost::property_tree::ptree& config);
+  AutoShorterCost(const boost::property_tree::ptree& pt) : AutoCost(pt) {
+    // Create speed cost table that reduces the impact of speed
+    adjspeedfactor_[0] = kSecPerHour; // TODO - what to make speed=0?
+    for (uint32_t s = 1; s <= kMaxSpeedKph; s++) {
+      adjspeedfactor_[s] = (kSecPerHour * 0.001f) / sqrtf(static_cast<float>(s));
+    }
+  }
 
-  virtual ~AutoShorterCost();
+  // virtual destructor
+  virtual ~AutoShorterCost() {
+  }
 
   /**
    * Returns the cost to traverse the edge and an estimate of the actual time
@@ -652,7 +636,11 @@ public:
    * @param  edge     Pointer to a directed edge.
    * @return  Returns the cost to traverse the edge.
    */
-  virtual Cost EdgeCost(const baldr::DirectedEdge* edge) const;
+  virtual Cost EdgeCost(const baldr::DirectedEdge* edge) const {
+    float factor = (edge->use() == Use::kFerry) ? ferry_factor_ : 1.0f;
+    return Cost(edge->length() * adjspeedfactor_[edge->speed()] * factor,
+                edge->length() * speedfactor_[edge->speed()]);
+  }
 
   /**
    * Get the cost factor for A* heuristics. This factor is multiplied
@@ -662,36 +650,13 @@ public:
    * assume the maximum speed is used to the destination such that the time
    * estimate is less than the least possible time along roads.
    */
-  virtual float AStarCostFactor() const;
+  virtual float AStarCostFactor() const {
+    return adjspeedfactor_[kMaxSpeedKph];
+  }
 
 protected:
   float adjspeedfactor_[kMaxSpeedKph + 1];
 };
-
-// Constructor
-AutoShorterCost::AutoShorterCost(const boost::property_tree::ptree& pt) : AutoCost(pt) {
-  // Create speed cost table that reduces the impact of speed
-  adjspeedfactor_[0] = kSecPerHour; // TODO - what to make speed=0?
-  for (uint32_t s = 1; s <= kMaxSpeedKph; s++) {
-    adjspeedfactor_[s] = (kSecPerHour * 0.001f) / sqrtf(static_cast<float>(s));
-  }
-}
-
-// Destructor
-AutoShorterCost::~AutoShorterCost() {
-}
-
-// Returns the cost to traverse the edge and an estimate of the actual time
-// (in seconds) to traverse the edge.
-Cost AutoShorterCost::EdgeCost(const baldr::DirectedEdge* edge) const {
-  float factor = (edge->use() == Use::kFerry) ? ferry_factor_ : 1.0f;
-  return Cost(edge->length() * adjspeedfactor_[edge->speed()] * factor,
-              edge->length() * speedfactor_[edge->speed()]);
-}
-
-float AutoShorterCost::AStarCostFactor() const {
-  return adjspeedfactor_[kMaxSpeedKph];
-}
 
 cost_ptr_t CreateAutoShorterCost(const boost::property_tree::ptree& config) {
   return std::make_shared<AutoShorterCost>(config);
@@ -705,17 +670,23 @@ public:
   /**
    * Construct bus costing.
    * Pass in configuration using property tree.
-   * @param  config  Property tree with configuration/options.
+   * @param  pt  Property tree with configuration/options.
    */
-  BusCost(const boost::property_tree::ptree& config);
+  BusCost(const boost::property_tree::ptree& pt) : AutoCost(pt) {
+    type_ = VehicleType::kBus;
+  }
 
-  virtual ~BusCost();
+  /// virtual destructor
+  virtual ~BusCost() {
+  }
 
   /**
    * Get the access mode used by this costing method.
    * @return  Returns access mode.
    */
-  uint32_t access_mode() const;
+  uint32_t access_mode() const {
+    return kBusAccess;
+  }
 
   /**
    * Checks if access is allowed for the provided directed edge.
@@ -771,7 +742,9 @@ public:
    * @param  node  Pointer to node information.
    * @return  Returns true if access is allowed, false if not.
    */
-  virtual bool Allowed(const baldr::NodeInfo* node) const;
+  virtual bool Allowed(const baldr::NodeInfo* node) const {
+    return (node->access() & kBusAccess);
+  }
 
   /**
    * Returns a function/functor to be used in location searching which will
@@ -802,20 +775,6 @@ public:
     return [](const baldr::NodeInfo* node) { return !(node->access() & kBusAccess); };
   }
 };
-
-// Constructor
-BusCost::BusCost(const boost::property_tree::ptree& pt) : AutoCost(pt) {
-  type_ = VehicleType::kBus;
-}
-
-// Destructor
-BusCost::~BusCost() {
-}
-
-// Get the access mode used by this costing method.
-uint32_t BusCost::access_mode() const {
-  return kBusAccess;
-}
 
 // Check if access is allowed on the specified edge.
 bool BusCost::Allowed(const baldr::DirectedEdge* edge,
@@ -864,8 +823,6 @@ bool BusCost::AllowedReverse(const baldr::DirectedEdge* edge,
                              const baldr::GraphId& opp_edgeid,
                              const uint32_t current_time,
                              const uint32_t tz_index) const {
-  // TODO - obtain and check the access restrictions.
-
   // Check access, U-turn, and simple turn restriction.
   // Allow U-turns at dead-end nodes.
   if (!(opp_edge->forwardaccess() & kBusAccess) ||
@@ -897,11 +854,6 @@ bool BusCost::AllowedReverse(const baldr::DirectedEdge* edge,
   return true;
 }
 
-// Check if access is allowed at the specified node.
-bool BusCost::Allowed(const baldr::NodeInfo* node) const {
-  return (node->access() & kBusAccess);
-}
-
 cost_ptr_t CreateBusCost(const boost::property_tree::ptree& config) {
   return std::make_shared<BusCost>(config);
 }
@@ -915,17 +867,21 @@ public:
   /**
    * Construct hov costing.
    * Pass in configuration using property tree.
-   * @param  config  Property tree with configuration/options.
+   * @param  pt  Property tree with configuration/options.
    */
-  HOVCost(const boost::property_tree::ptree& config);
+  HOVCost(const boost::property_tree::ptree& pt) : AutoCost(pt) {
+  }
 
-  virtual ~HOVCost();
+  virtual ~HOVCost() {
+  }
 
   /**
    * Get the access mode used by this costing method.
    * @return  Returns access mode.
    */
-  uint32_t access_mode() const;
+  uint32_t access_mode() const {
+    return kHOVAccess;
+  }
 
   /**
    * Checks if access is allowed for the provided directed edge.
@@ -980,7 +936,14 @@ public:
    * @param  edge     Pointer to a directed edge.
    * @return  Returns the cost to traverse the edge.
    */
-  virtual Cost EdgeCost(const baldr::DirectedEdge* edge) const;
+  virtual Cost EdgeCost(const baldr::DirectedEdge* edge) const {
+    float factor = (edge->use() == Use::kFerry) ? ferry_factor_ : density_factor_[edge->density()];
+    if ((edge->forwardaccess() & kHOVAccess) && !(edge->forwardaccess() & kAutoAccess)) {
+      factor *= kHOVFactor;
+    }
+    float sec = (edge->length() * speedfactor_[edge->speed()]);
+    return Cost(sec * factor, sec);
+  }
 
   /**
    * Checks if access is allowed for the provided node. Node access can
@@ -988,7 +951,9 @@ public:
    * @param  node  Pointer to node information.
    * @return  Returns true if access is allowed, false if not.
    */
-  virtual bool Allowed(const baldr::NodeInfo* node) const;
+  virtual bool Allowed(const baldr::NodeInfo* node) const {
+    return (node->access() & kHOVAccess);
+  }
 
   /**
    * Returns a function/functor to be used in location searching which will
@@ -1019,19 +984,6 @@ public:
     return [](const baldr::NodeInfo* node) { return !(node->access() & kHOVAccess); };
   }
 };
-
-// Constructor
-HOVCost::HOVCost(const boost::property_tree::ptree& pt) : AutoCost(pt) {
-}
-
-// Destructor
-HOVCost::~HOVCost() {
-}
-
-// Get the access mode used by this costing method.
-uint32_t HOVCost::access_mode() const {
-  return kHOVAccess;
-}
 
 // Check if access is allowed on the specified edge.
 bool HOVCost::Allowed(const baldr::DirectedEdge* edge,
@@ -1114,27 +1066,83 @@ bool HOVCost::AllowedReverse(const baldr::DirectedEdge* edge,
   return true;
 }
 
-// Returns the cost to traverse the edge and an estimate of the actual time
-// (in seconds) to traverse the edge.
-Cost HOVCost::EdgeCost(const baldr::DirectedEdge* edge) const {
-
-  float factor = (edge->use() == Use::kFerry) ? ferry_factor_ : density_factor_[edge->density()];
-
-  if ((edge->forwardaccess() & kHOVAccess) && !(edge->forwardaccess() & kAutoAccess)) {
-    factor *= kHOVFactor;
-  }
-
-  float sec = (edge->length() * speedfactor_[edge->speed()]);
-  return Cost(sec * factor, sec);
-}
-
-// Check if access is allowed at the specified node.
-bool HOVCost::Allowed(const baldr::NodeInfo* node) const {
-  return (node->access() & kHOVAccess);
-}
-
 cost_ptr_t CreateHOVCost(const boost::property_tree::ptree& config) {
   return std::make_shared<HOVCost>(config);
+}
+
+/**
+ * Derived class providing an alternate costing for driving that is ignores
+ * oneways and turn restrictions. This can be useful for map-matching traces
+ * when trying data that may have incorrect restrictions or oneway information.
+ */
+class AutoDataFix : public AutoCost {
+public:
+  /**
+   * Construct auto data fix costing.
+   * Pass in configuration using property tree.
+   * @param  pt  Property tree with configuration/options.
+   */
+  AutoDataFix(const boost::property_tree::ptree& pt) : AutoCost(pt) {
+  }
+
+  virtual ~AutoDataFix() {
+  }
+
+  /**
+   * Checks if access is allowed for the provided directed edge.
+   * This is generally based on mode of travel and the access modes
+   * allowed on the edge. However, it can be extended to exclude access
+   * based on other parameters such as conditional restrictions and
+   * conditional access that can depend on time and travel mode.
+   * @param  edge           Pointer to a directed edge.
+   * @param  pred           Predecessor edge information.
+   * @param  tile           Current tile.
+   * @param  edgeid         GraphId of the directed edge.
+   * @param  current_time   Current time (seconds since epoch). A value of 0
+   *                        indicates the route is not time dependent.
+   * @param  tz_index       timezone index for the node
+   * @return Returns true if access is allowed, false if not.
+   */
+  virtual bool Allowed(const baldr::DirectedEdge* edge,
+                       const EdgeLabel& pred,
+                       const baldr::GraphTile*& tile,
+                       const baldr::GraphId& edgeid,
+                       const uint32_t current_time,
+                       const uint32_t tz_index) const {
+    // Check access and return false (not allowed if no auto access is allowed in either
+    // direction. Also disallow simple U-turns except at dead-end nodes.
+    if (!((edge->forwardaccess() & kAutoAccess) || (edge->reverseaccess() & kAutoAccess)) ||
+        (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
+        edge->surface() == Surface::kImpassable || IsUserAvoidEdge(edgeid) ||
+        (!allow_destination_only_ && !pred.destonly() && edge->destonly())) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Returns a function/functor to be used in location searching which will
+   * exclude and allow ranking results from the search by looking at each
+   * edges attribution and suitability for use as a location by the travel
+   * mode used by the costing method. Function/functor is also used to filter
+   * edges not usable / inaccessible by auto in either direction.
+   */
+  virtual const EdgeFilter GetEdgeFilter() const {
+    // Throw back a lambda that checks the access for this type of costing
+    return [](const baldr::DirectedEdge* edge) {
+      // Do not allow transition edges and edges with no auto access in either direction
+      if (edge->IsTransition() ||
+          !((edge->forwardaccess() & kAutoAccess) || (edge->reverseaccess() & kAutoAccess))) {
+        return 0.0f;
+      } else {
+        return 1.0f;
+      }
+    };
+  }
+};
+
+cost_ptr_t CreateAutoDataFixCost(const boost::property_tree::ptree& config) {
+  return std::make_shared<AutoDataFix>(config);
 }
 
 } // namespace sif

--- a/src/sif/motorscootercost.cc
+++ b/src/sif/motorscootercost.cc
@@ -159,20 +159,26 @@ public:
    */
   MotorScooterCost(const boost::property_tree::ptree& config);
 
-  virtual ~MotorScooterCost();
+  // virtual destructor
+  virtual ~MotorScooterCost() {
+  }
 
   /**
    * Does the costing method allow multiple passes (with relaxed hierarchy
    * limits).
    * @return  Returns true if the costing model allows multiple passes.
    */
-  virtual bool AllowMultiPass() const;
+  virtual bool AllowMultiPass() const {
+    return true;
+  }
 
   /**
    * Get the access mode used by this costing method.
    * @return  Returns access mode.
    */
-  uint32_t access_mode() const;
+  uint32_t access_mode() const {
+    return kMopedAccess;
+  }
 
   /**
    * Checks if access is allowed for the provided directed edge.
@@ -228,7 +234,9 @@ public:
    * @param  node  Pointer to node information.
    * @return  Returns true if access is allowed, false if not.
    */
-  virtual bool Allowed(const baldr::NodeInfo* node) const;
+  virtual bool Allowed(const baldr::NodeInfo* node) const {
+    return (node->access() & kMopedAccess);
+  }
 
   /**
    * Get the cost to traverse the specified directed edge. Cost includes
@@ -273,14 +281,17 @@ public:
    * assume the maximum speed is used to the destination such that the time
    * estimate is less than the least possible time along roads.
    */
-  virtual float AStarCostFactor() const;
+  virtual float AStarCostFactor() const {
+    return speedfactor_[kMaxSpeedKph];
+  }
 
   /**
    * Get the current travel type.
    * @return  Returns the current travel type.
    */
-  virtual uint8_t travel_type() const;
-
+  virtual uint8_t travel_type() const {
+    return static_cast<uint8_t>(VehicleType::kMotorScooter);
+  }
   /**
    * Returns a function/functor to be used in location searching which will
    * exclude and allow ranking results from the search by looking at each
@@ -406,21 +417,6 @@ MotorScooterCost::MotorScooterCost(const boost::property_tree::ptree& pt)
   road_factor_ = (use_primary_ >= 0.5f) ? 1.5f - use_primary_ : 3.0f - use_primary_ * 5.0f;
 }
 
-// Destructor
-MotorScooterCost::~MotorScooterCost() {
-}
-
-// Does the costing method allow multiple passes (with relaxed hierarchy
-// limits).
-bool MotorScooterCost::AllowMultiPass() const {
-  return true;
-}
-
-// Get the access mode for motor scooter
-uint32_t MotorScooterCost::access_mode() const {
-  return kMopedAccess;
-}
-
 // Check if access is allowed on the specified edge.
 bool MotorScooterCost::Allowed(const baldr::DirectedEdge* edge,
                                const EdgeLabel& pred,
@@ -496,11 +492,6 @@ bool MotorScooterCost::AllowedReverse(const baldr::DirectedEdge* edge,
     }
   }
   return opp_edge->surface() <= kMinimumScooterSurface;
-}
-
-// Check if access is allowed at the specified node.
-bool MotorScooterCost::Allowed(const baldr::NodeInfo* node) const {
-  return (node->access() & kMopedAccess);
 }
 
 Cost MotorScooterCost::EdgeCost(const baldr::DirectedEdge* edge) const {
@@ -627,21 +618,6 @@ Cost MotorScooterCost::TransitionCostReverse(const uint32_t idx,
 
   // Return cost (time and penalty)
   return {seconds + penalty, seconds};
-}
-
-// Get the cost factor for A* heuristics. This factor is multiplied
-// with the distance to the destination to produce an estimate of the
-// minimum cost to the destination. The A* heuristic must underestimate the
-// cost to the destination. So a time based estimate based on speed should
-// assume the maximum speed is used to the destination such that the time
-// estimate is less than the least possible time along roads.
-float MotorScooterCost::AStarCostFactor() const {
-  return speedfactor_[kMaxSpeedKph];
-}
-
-// Returns the current travel type.
-uint8_t MotorScooterCost::travel_type() const {
-  return static_cast<uint8_t>(VehicleType::kMotorScooter);
 }
 
 cost_ptr_t CreateMotorScooterCost(const boost::property_tree::ptree& config) {

--- a/src/thor/worker.cc
+++ b/src/thor/worker.cc
@@ -34,10 +34,10 @@ namespace {
 // may want to do this in loki. At this point in thor the costing method
 // has not yet been constructed.
 const std::unordered_map<std::string, float> kMaxDistances = {
-    {"auto_", 43200.0f},      {"auto_shorter", 43200.0f}, {"bicycle", 7200.0f},
-    {"bus", 43200.0f},        {"hov", 43200.0f},          {"motor_scooter", 14400.0f},
-    {"motorcycle", 14400.0f}, {"multimodal", 7200.0f},    {"pedestrian", 7200.0f},
-    {"transit", 14400.0f},    {"truck", 43200.0f},
+    {"auto_", 43200.0f},         {"auto_data_fix", 43200.0f}, {"auto_shorter", 43200.0f},
+    {"bicycle", 7200.0f},        {"bus", 43200.0f},           {"hov", 43200.0f},
+    {"motor_scooter", 14400.0f}, {"motorcycle", 14400.0f},    {"multimodal", 7200.0f},
+    {"pedestrian", 7200.0f},     {"transit", 14400.0f},       {"truck", 43200.0f},
 };
 // a scale factor to apply to the score so that we bias towards closer results more
 constexpr float kDistanceScale = 10.f;
@@ -57,17 +57,8 @@ thor_worker_t::thor_worker_t(const boost::property_tree::ptree& config)
     : mode(valhalla::sif::TravelMode::kPedestrian), matcher_factory(config),
       reader(matcher_factory.graphreader()),
       long_request(config.get<float>("thor.logging.long_request")) {
-  // Register edge/node costing methods
-  factory.Register("auto", sif::CreateAutoCost);
-  factory.Register("auto_shorter", sif::CreateAutoShorterCost);
-  factory.Register("bus", sif::CreateBusCost);
-  factory.Register("bicycle", sif::CreateBicycleCost);
-  factory.Register("hov", sif::CreateHOVCost);
-  factory.Register("motor_scooter", sif::CreateMotorScooterCost);
-  factory.Register("motorcycle", sif::CreateMotorcycleCost);
-  factory.Register("pedestrian", sif::CreatePedestrianCost);
-  factory.Register("transit", sif::CreateTransitCost);
-  factory.Register("truck", sif::CreateTruckCost);
+  // Register standard edge/node costing methods
+  factory.RegisterStandardCostingModels();
 
   for (const auto& item : config.get_child("meili.customizable")) {
     trace_customizable.insert(item.second.get_value<std::string>());

--- a/src/valhalla_path_comparison.cc
+++ b/src/valhalla_path_comparison.cc
@@ -85,15 +85,7 @@ void walk_edges(const std::string& shape,
                 boost::property_tree::ptree& pt) {
   // Register edge/node costing methods
   CostFactory<DynamicCost> factory;
-  factory.Register("auto", CreateAutoCost);
-  factory.Register("auto_shorter", CreateAutoShorterCost);
-  factory.Register("bus", CreateBusCost);
-  factory.Register("bicycle", CreateBicycleCost);
-  factory.Register("hov", CreateHOVCost);
-  factory.Register("motor_scooter", CreateMotorScooterCost);
-  factory.Register("pedestrian", CreatePedestrianCost);
-  factory.Register("transit", CreateTransitCost);
-  factory.Register("truck", CreateTruckCost);
+  factory.RegisterStandardCostingModels();
 
   std::string method_options = "costing_options." + routetype;
   auto costing_options = pt.get_child(method_options, {});
@@ -265,10 +257,7 @@ int main(int argc, char* argv[]) {
 
   // Construct costing
   CostFactory<DynamicCost> factory;
-  factory.Register("auto", CreateAutoCost);
-  factory.Register("bicycle", CreateBicycleCost);
-  factory.Register("pedestrian", CreatePedestrianCost);
-  factory.Register("motor_scooter", CreateMotorScooterCost);
+  factory.RegisterStandardCostingModels();
   std::string method_options = "costing_options." + routetype;
   auto costing_options = json_ptree.get_child(method_options, {});
   cost_ptr_t costing = factory.Create(routetype, costing_options);

--- a/src/valhalla_run_isochrone.cc
+++ b/src/valhalla_run_isochrone.cc
@@ -243,13 +243,7 @@ int main(int argc, char* argv[]) {
 
   // Construct costing
   CostFactory<DynamicCost> factory;
-  factory.Register("auto", CreateAutoCost);
-  factory.Register("auto_shorter", CreateAutoShorterCost);
-  factory.Register("bus", CreateBusCost);
-  factory.Register("bicycle", CreateBicycleCost);
-  factory.Register("pedestrian", CreatePedestrianCost);
-  factory.Register("truck", CreateTruckCost);
-  factory.Register("transit", CreateTransitCost);
+  factory.RegisterStandardCostingModels();
 
   // Figure out the route type
   for (auto& c : routetype) {

--- a/src/valhalla_run_matrix.cc
+++ b/src/valhalla_run_matrix.cc
@@ -212,12 +212,7 @@ int main(int argc, char* argv[]) {
 
   // Construct costing
   CostFactory<DynamicCost> factory;
-  factory.Register("auto", CreateAutoCost);
-  factory.Register("auto_shorter", CreateAutoShorterCost);
-  factory.Register("bus", CreateBusCost);
-  factory.Register("bicycle", CreateBicycleCost);
-  factory.Register("pedestrian", CreatePedestrianCost);
-  factory.Register("transit", CreateTransitCost);
+  factory.RegisterStandardCostingModels();
 
   // Figure out the route type
   for (auto& c : routetype) {

--- a/src/valhalla_run_route.cc
+++ b/src/valhalla_run_route.cc
@@ -591,13 +591,7 @@ int main(int argc, char* argv[]) {
 
   // Construct costing
   CostFactory<DynamicCost> factory;
-  factory.Register("auto", CreateAutoCost);
-  factory.Register("auto_shorter", CreateAutoShorterCost);
-  factory.Register("bus", CreateBusCost);
-  factory.Register("bicycle", CreateBicycleCost);
-  factory.Register("pedestrian", CreatePedestrianCost);
-  factory.Register("truck", CreateTruckCost);
-  factory.Register("transit", CreateTransitCost);
+  factory.RegisterStandardCostingModels();
 
   // Figure out the route type
   for (auto& c : routetype) {

--- a/valhalla/sif/autocost.h
+++ b/valhalla/sif/autocost.h
@@ -23,6 +23,14 @@ cost_ptr_t CreateAutoCost(const boost::property_tree::ptree& config);
 cost_ptr_t CreateAutoShorterCost(const boost::property_tree::ptree& config);
 
 /**
+ * Create an auto costing method for data fixing. This is derived from auto
+ * costing but overrides Allowed rules to allow driving against oneway and
+ * it ignores turn restrictions. his can be useful for map-matching traces
+ * when trying data that may have incorrect restrictions or oneway information.
+ */
+cost_ptr_t CreateAutoDataFixCost(const boost::property_tree::ptree& config);
+
+/**
  * Create a bus cost method. This is derived from auto costing and
  * uses the same rules except for using the bus access flag instead
  * of the auto access flag.

--- a/valhalla/sif/costfactory.h
+++ b/valhalla/sif/costfactory.h
@@ -67,9 +67,25 @@ public:
     config.Accept(writer);
     boost::property_tree::ptree pt;
     std::istringstream is(buffer.GetString());
-    ;
     boost::property_tree::read_json(is, pt);
     return Create(name, pt);
+  }
+
+  /**
+   * Convenience method to register all of the standard costing models.
+   */
+  void RegisterStandardCostingModels() {
+    Register("auto", CreateAutoCost);
+    Register("auto_data_fix", CreateAutoDataFixCost);
+    Register("auto_shorter", CreateAutoShorterCost);
+    Register("bicycle", CreateBicycleCost);
+    Register("bus", CreateBusCost);
+    Register("hov", CreateHOVCost);
+    Register("motor_scooter", CreateMotorScooterCost);
+    Register("motorcycle", CreateMotorScooterCost);
+    Register("pedestrian", CreatePedestrianCost);
+    Register("truck", CreateTruckCost);
+    Register("transit", CreateTransitCost);
   }
 
 private:


### PR DESCRIPTION
This PR adds a new costing methoid, AutoDataFix that can be used for data "fixing" applications that wish to map match GPS traces to roads for the purpose of finding data errors such as invalid oneways and turn restrictions. This costing method ignores oneways and turn restrictions for automobiles (but there must be automobile access in at least one direction of the edge so that walkways and cycleways are not included).

fixes #1273 

Also, this PR adds a convenience method to CostFactory to register all of the standard Valhalla costing models. Applications can call this method to register all of the standard methods - they can then add additional costing models required specifically for the application. It also moves some simple methods in sif to be inline within the class definitions.