### PR TITLE
Fix python bindings on macOS

### DIFF
--- a/src/bindings/python/python.cc
+++ b/src/bindings/python/python.cc
@@ -1,4 +1,5 @@
-// Note: keep include boost/python.hpp first - fixes https://bugs.python.org/issue10910 on FreeBSD/macOS
+// Note: keep include boost/python.hpp first - fixes https://bugs.python.org/issue10910 on
+// FreeBSD/macOS
 #include <boost/python.hpp>
 
 #include <boost/make_shared.hpp>

--- a/src/bindings/python/python.cc
+++ b/src/bindings/python/python.cc
@@ -1,9 +1,11 @@
+// Note: keep include boost/python.hpp first - fixes https://bugs.python.org/issue10910 on FreeBSD/macOS
+#include <boost/python.hpp>
+
 #include <boost/make_shared.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/optional.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
-#include <boost/python.hpp>
 #include <boost/shared_ptr.hpp>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
# Issue

When trying to compile Valhalla with python bindings on macOS, the system-supplied Python libraries and headers (2.7.10 on my system) are detected, but compilation fails with this nasty error:

```
[ 83%] Building CXX object CMakeFiles/python_valhalla.dir/src/bindings/python/python.cc.o
In file included from /Users/danpat/mapbox/valhalla-master/src/bindings/python/python.cc:11:
In file included from /Users/danpat/mapbox/valhalla-master/valhalla/meili/traffic_segment_matcher.h:14:
In file included from /Users/danpat/mapbox/valhalla-master/valhalla/meili/map_matcher.h:12:
In file included from /Users/danpat/mapbox/valhalla-master/valhalla/meili/candidate_search.h:20:
In file included from /Users/danpat/mapbox/valhalla-master/valhalla/sif/dynamiccost.h:5:
In file included from /Users/danpat/mapbox/valhalla-master/valhalla/baldr/datetime.h:9:
In file included from /usr/local/include/boost/date_time/gregorian/gregorian.hpp:34:
In file included from /usr/local/include/boost/date_time/gregorian/parsers.hpp:13:
/usr/local/include/boost/date_time/date_parsing.hpp:50:30: error: too many arguments provided to function-like macro invocation
        std::tolower(inp[i], loc);
                             ^
/usr/include/python2.7/pyport.h:729:9: note: macro 'tolower' defined here
#define tolower(c) towlower(btowc(c))
        ^
In file included from /Users/danpat/mapbox/valhalla-master/src/bindings/python/python.cc:11:
In file included from /Users/danpat/mapbox/valhalla-master/valhalla/meili/traffic_segment_matcher.h:14:
In file included from /Users/danpat/mapbox/valhalla-master/valhalla/meili/map_matcher.h:12:
In file included from /Users/danpat/mapbox/valhalla-master/valhalla/meili/candidate_search.h:20:
In file included from /Users/danpat/mapbox/valhalla-master/valhalla/sif/dynamiccost.h:5:
In file included from /Users/danpat/mapbox/valhalla-master/valhalla/baldr/datetime.h:9:
In file included from /usr/local/include/boost/date_time/gregorian/gregorian.hpp:34:
In file included from /usr/local/include/boost/date_time/gregorian/parsers.hpp:13:
/usr/local/include/boost/date_time/date_parsing.hpp:50:9: error: assigning to 'std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>
      >::value_type' (aka 'char') from incompatible type '<overloaded function type>'
        std::tolower(inp[i], loc);
        ^~~~~~~~~~~~
/usr/include/_ctype.h:292:1: note: candidate function
tolower(int _c)
^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__locale:825:1: note: candidate function
tolower(_CharT __c, const locale& __loc)
^
2 errors generated.
```

It looks like this is a manifestation of https://bugs.python.org/issue10910

> The problem is that pyport tries to replace the ctypes definion of the isascii(ch) and related functions by a replacement that works better with UTF-8 on FreeBSD and OSX. That replacement is incompatible with the localfwd.h header.

`pyport.h` is used by `boost/python.h`.

The fix is to list `boost/python.h` first, so it doesn't clobber `libc++` defined functions from `ctypes`.

## Tasklist

 - [ ] review - you must request approval to merge any PR to master
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Add to release notes in valhalla-docs
 - [ ] update relevant documentation if this is an API impacting change

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
