### PR TITLE
Default to building in Release mode if CMAKE_BUILD_TYPE not specified.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,27 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 
+# Explicitly set the build type to Release if no other type is specified
+# on the command line.  Without this, cmake defaults to an unoptimized,
+# non-debug build, which almost nobody wants.
+if(NOT CMAKE_BUILD_TYPE)
+  message(STATUS "No build type specified, defaulting to Release")
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
+if(CMAKE_BUILD_TYPE MATCHES Debug)
+  message(STATUS "Configuring in debug mode")
+elseif(CMAKE_BUILD_TYPE MATCHES Release)
+  message(STATUS "Configuring in release mode")
+elseif(CMAKE_BUILD_TYPE MATCHES RelWithDebInfo)
+  message(STATUS "Configuring in release mode with debug flags")
+elseif(CMAKE_BUILD_TYPE MATCHES MinRelSize)
+  message(STATUS "Configuring in release mode with minimized size")
+else()
+  message(STATUS "Unrecognized build type - will use cmake defaults")
+endif()
+
+
 if(ENABLE_CCACHE AND (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU"))
   find_program(CCACHE_FOUND ccache)
   if(CCACHE_FOUND)


### PR DESCRIPTION
# Issue

By default, `cmake` generates no debug or optimization compiler flags.  This is not really all that useful as a build mode - it's neither fast, nor particularly debuggable.

This PR makes our build default to `Release` (`-O3` on most compilers), and prints out a message describing what it did.  If you override with `cmake -DCMAKE_BUILD_TYPE=Debug`, it will print out a message saying that debug mode is selected.  This is helpful when you want to quickly spot which build mode is being used.

## Tasklist

 - [x] review - you must request approval to merge any PR to master
 - [x] Generally use squash merge to rebase and clean comments before merging