### PR TITLE
Graphtile Size Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@ test/sequence
 test/grid
 test/gridded_data
 test/location
+test/access_restrictions
 test/admin
 test/datetime
 test/directededge
@@ -107,6 +108,7 @@ test/double_bucket_queue
 test/edgecollapser
 test/laneconnectivity
 test/graphid
+test/graphtileheader
 test/tilehierarchy
 test/graphtile
 test/nodeinfo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,9 +169,9 @@ endif()
 
 
 ## Tests TODO: move to own namespace
-set(tests aabb2 actor admin attributes_controller datetime directededge
+set(tests aabb2 access_restriction actor admin attributes_controller datetime directededge
   distanceapproximator double_bucket_queue edgecollapser edge_elevation edgestatus ellipse encode
-  enhancedtrippath factory graphid graphreader graphtile gridded_data grid_range_query grid_traversal
+  enhancedtrippath factory graphid graphreader graphtile graphtileheader gridded_data grid_range_query grid_traversal
   json laneconnectivity linesegment2 location logging maneuversbuilder map_matcher_factory
   narrativebuilder narrative_dictionary navigator nodeinfo obb2 optimizer  point2 pointll
   polyline2 queue routing sample sequence serializers sign signs streetname streetnames streetnames_factory

--- a/src/baldr/graphtileheader.cc
+++ b/src/baldr/graphtileheader.cc
@@ -47,17 +47,17 @@ void GraphTileHeader::set_density(const uint32_t density) {
 
 // Set the relative quality of name assignment for this tile.
 void GraphTileHeader::set_name_quality(const uint32_t name_quality) {
-  name_quality_ = name_quality;
+  name_quality_ = (name_quality <= kMaxQualityMeasure) ? name_quality : kMaxQualityMeasure;
 }
 
 // Set the relative quality of speed assignment for this tile.
 void GraphTileHeader::set_speed_quality(const uint32_t speed_quality) {
-  speed_quality_ = speed_quality;
+  speed_quality_ = (speed_quality <= kMaxQualityMeasure) ? speed_quality : kMaxQualityMeasure;
 }
 
 // Set the relative quality of exit signs for this tile.
 void GraphTileHeader::set_exit_quality(const uint32_t exit_quality) {
-  exit_quality_ = exit_quality;
+  exit_quality_ = (exit_quality <= kMaxQualityMeasure) ? exit_quality : kMaxQualityMeasure;
 }
 
 // Sets the number of nodes in this tile.

--- a/test/access_restriction.cc
+++ b/test/access_restriction.cc
@@ -1,0 +1,34 @@
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+#include "baldr/accessrestriction.h"
+
+#include "test.h"
+
+using namespace std;
+using namespace valhalla::baldr;
+
+// Expected size is 16 bytes. We want to alert if somehow any change grows
+// this structure size as that indicates incompatible tiles.
+constexpr size_t kAccessRestrictionExpectedSize = 16;
+
+namespace {
+
+void test_sizeof() {
+  if (sizeof(AccessRestriction) != kAccessRestrictionExpectedSize)
+    throw std::runtime_error("AccessRestriction size should be " +
+                             std::to_string(kAccessRestrictionExpectedSize) + " bytes" + " but is " +
+                             std::to_string(sizeof(AccessRestriction)));
+}
+
+} // namespace
+
+int main() {
+  test::suite suite("access_restriction");
+
+  // Test sizeof the structure
+  suite.test(TEST_CASE(test_sizeof));
+
+  return suite.tear_down();
+}

--- a/test/admin.cc
+++ b/test/admin.cc
@@ -10,7 +10,17 @@
 using namespace std;
 using namespace valhalla::baldr;
 
+// Expected size is 16 bytes. We want to alert if somehow any change grows
+// this structure size as that indicates incompatible tiles.
+constexpr size_t kAdminExpectedSize = 16;
+
 namespace {
+
+void test_sizeof() {
+  if (sizeof(Admin) != kAdminExpectedSize)
+    throw std::runtime_error("Admin size should be " + std::to_string(kAdminExpectedSize) + " bytes" +
+                             " but is " + std::to_string(sizeof(Admin)));
+}
 
 void TestWriteRead() {
   // Make an admin record
@@ -44,7 +54,13 @@ void TestWriteRead() {
 int main() {
   test::suite suite("admin");
 
-  // Write to file and read into EdgeInfo
+  // Test sizeof the structure
+  suite.test(TEST_CASE(test_sizeof));
+
+  // Test structure size
+  suite.test(TEST_CASE(TestWriteRead));
+
+  // Write to file and read into Admin records
   suite.test(TEST_CASE(TestWriteRead));
 
   return suite.tear_down();

--- a/test/graphtileheader.cc
+++ b/test/graphtileheader.cc
@@ -1,0 +1,195 @@
+#include "test.h"
+
+#include "baldr/graphtileheader.h"
+
+using namespace std;
+using namespace valhalla::baldr;
+
+// Expected size is 264 bytes. We want to alert if somehow any change grows
+// this structure size as that indicates incompatible tiles.
+constexpr size_t kGraphTileHeaderExpectedSize = 264;
+
+namespace {
+
+void test_sizeof() {
+  if (sizeof(GraphTileHeader) != kGraphTileHeaderExpectedSize)
+    throw std::runtime_error("GraphTileHeader size should be " +
+                             std::to_string(kGraphTileHeaderExpectedSize) + " bytes" + " but is " +
+                             std::to_string(sizeof(GraphTileHeader)));
+}
+
+void TestWriteRead() {
+  // Test building a directed edge and reading back values
+  GraphTileHeader hdr;
+
+  GraphId tile_id(2555, 2, 0);
+  hdr.set_graphid(tile_id);
+  if (hdr.graphid() != tile_id) {
+    throw runtime_error("Header graphId test failed");
+  }
+  hdr.set_date_created(12345);
+  if (hdr.date_created() != 12345) {
+    throw runtime_error("Header date created test failed");
+  }
+  std::string ver = "v1.5";
+  hdr.set_version(ver);
+  if (hdr.version() != ver) {
+    throw runtime_error("Header version test failed");
+  }
+  hdr.set_dataset_id(5678);
+  if (hdr.dataset_id() != 5678) {
+    throw runtime_error("Header dataset Id test failed");
+  }
+  hdr.set_density(5);
+  if (hdr.density() != 5) {
+    throw runtime_error("Header density test failed");
+  }
+  hdr.set_density(kMaxDensity + 10);
+  if (hdr.density() != kMaxDensity) {
+    throw runtime_error("Header density (bounds check) test failed");
+  }
+  hdr.set_name_quality(5);
+  if (hdr.name_quality() != 5) {
+    throw runtime_error("Header name quality test failed");
+  }
+  hdr.set_name_quality(kMaxQualityMeasure + 10);
+  if (hdr.name_quality() != kMaxQualityMeasure) {
+    throw runtime_error("Header name quality (bounds check) test failed");
+  }
+  hdr.set_speed_quality(5);
+  if (hdr.speed_quality() != 5) {
+    throw runtime_error("Header speed quality test failed");
+  }
+  hdr.set_speed_quality(kMaxQualityMeasure + 10);
+  if (hdr.speed_quality() != kMaxQualityMeasure) {
+    throw runtime_error("Header speed quality (bounds check) test failed");
+  }
+  hdr.set_exit_quality(5);
+  if (hdr.exit_quality() != 5) {
+    throw runtime_error("Header exit quality test failed");
+  }
+  hdr.set_exit_quality(kMaxQualityMeasure + 10);
+  if (hdr.exit_quality() != kMaxQualityMeasure) {
+    throw runtime_error("Header exit quality (bounds check) test failed");
+  }
+  hdr.set_nodecount(55511);
+  if (hdr.nodecount() != 55511) {
+    throw runtime_error("Header node count test failed");
+  }
+  hdr.set_directededgecount(55511);
+  if (hdr.directededgecount() != 55511) {
+    throw runtime_error("Header directed edge count test failed");
+  }
+  hdr.set_signcount(55511);
+  if (hdr.signcount() != 55511) {
+    throw runtime_error("Header sign count test failed");
+  }
+  hdr.set_access_restriction_count(55511);
+  if (hdr.access_restriction_count() != 55511) {
+    throw runtime_error("Header access restriction count test failed");
+  }
+  hdr.set_admincount(55511);
+  if (hdr.admincount() != 55511) {
+    throw runtime_error("Header admin count test failed");
+  }
+  hdr.set_departurecount(555);
+  if (hdr.departurecount() != 555) {
+    throw runtime_error("Header transit departure count test failed");
+  }
+  try {
+    hdr.set_departurecount(kMaxTransitDepartures + 1);
+    throw runtime_error("Header transit departure count bounds check failed");
+  } catch (const std::runtime_error& e) {
+    // Error thrown as it should be
+  }
+  hdr.set_stopcount(555);
+  if (hdr.stopcount() != 555) {
+    throw runtime_error("Header transit stop count test failed");
+  }
+  try {
+    hdr.set_stopcount(kMaxTransitStops + 1);
+    throw runtime_error("Header transit stop count bounds check failed");
+  } catch (const std::runtime_error& e) {
+    // Error thrown as it should be
+  }
+  hdr.set_routecount(555);
+  if (hdr.routecount() != 555) {
+    throw runtime_error("Header transit route count test failed");
+  }
+  try {
+    hdr.set_routecount(kMaxTransitRoutes + 1);
+    throw runtime_error("Header transit route count bounds check failed");
+  } catch (const std::runtime_error& e) {
+    // Error thrown as it should be
+  }
+  hdr.set_schedulecount(555);
+  if (hdr.schedulecount() != 555) {
+    throw runtime_error("Header transit schedule count test failed");
+  }
+  try {
+    hdr.set_schedulecount(kMaxTransitSchedules + 1);
+    throw runtime_error("Header transit schedule count bounds check failed");
+  } catch (const std::runtime_error& e) {
+    // Error thrown as it should be
+  }
+  hdr.set_transfercount(555);
+  if (hdr.transfercount() != 555) {
+    throw runtime_error("Header transit transfer count test failed");
+  }
+  try {
+    hdr.set_transfercount(kMaxTransfers + 1);
+    throw runtime_error("Header transit transfer count bounds check failed");
+  } catch (const std::runtime_error& e) {
+    // Error thrown as it should be
+  }
+  hdr.set_complex_restriction_forward_offset(55511);
+  if (hdr.complex_restriction_forward_offset() != 55511) {
+    throw runtime_error("Header complex restriction forward offset test failed");
+  }
+  hdr.set_complex_restriction_reverse_offset(55511);
+  if (hdr.complex_restriction_reverse_offset() != 55511) {
+    throw runtime_error("Header complex restriction reverse offset test failed");
+  }
+  hdr.set_edgeinfo_offset(55511);
+  if (hdr.edgeinfo_offset() != 55511) {
+    throw runtime_error("Header edgeinfo offset test failed");
+  }
+  hdr.set_textlist_offset(55511);
+  if (hdr.textlist_offset() != 55511) {
+    throw runtime_error("Header textlist offset test failed");
+  }
+
+  // TODO - add tests for edge bin offsets
+  uint32_t offsets[kBinCount];
+  offsets[10] = 66666;
+  hdr.set_edge_bin_offsets(offsets);
+  auto offset = hdr.bin_offset(10);
+  if (offset.second != 66666) {
+    throw runtime_error("Header edge bin offset test failed");
+  }
+
+  // Test for trying to access outside the bin index list
+  try {
+    hdr.bin_offset(kBinCount + 1);
+    throw runtime_error("Header bin index bounds check failed");
+  } catch (const std::runtime_error& e) {
+    // Error thrown as it should be
+  }
+
+  hdr.set_edge_elevation_offset(55511);
+  if (hdr.edge_elevation_offset() != 55511) {
+    throw runtime_error("Header edge elevation offset test failed");
+  }
+}
+} // namespace
+
+int main(void) {
+  test::suite suite("graphtileheader");
+
+  suite.test(TEST_CASE(test_sizeof));
+
+  // Write to file and read into GraphTileHeader
+  suite.test(TEST_CASE(TestWriteRead));
+
+  return suite.tear_down();
+}

--- a/test/sign.cc
+++ b/test/sign.cc
@@ -13,7 +13,17 @@ using namespace std;
 using namespace valhalla::odin;
 using namespace valhalla::baldr;
 
+// Expected size is 8 bytes. We want to alert if somehow any change grows
+// this structure size as that indicates incompatible tiles.
+constexpr size_t kSignExpectedSize = 8;
+
 namespace {
+
+void test_sizeof() {
+  if (sizeof(valhalla::baldr::Sign) != kSignExpectedSize)
+    throw std::runtime_error("Sign size should be " + std::to_string(kSignExpectedSize) + " bytes" +
+                             " but is " + std::to_string(sizeof(valhalla::baldr::Sign)));
+}
 
 void TryCtor(const std::string& text) {
   valhalla::odin::Sign sign(text);
@@ -128,6 +138,9 @@ int main() {
 
   // Constructor
   suite.test(TEST_CASE(TestCtor));
+
+  // Test sizeof the structure
+  suite.test(TEST_CASE(test_sizeof));
 
   // DescendingSortByConsecutiveCount_0_1
   suite.test(TEST_CASE(TestDescendingSortByConsecutiveCount_0_1));

--- a/valhalla/baldr/graphtileheader.h
+++ b/valhalla/baldr/graphtileheader.h
@@ -20,6 +20,9 @@ constexpr size_t kEmptySlots = 13;
 // character array so the GraphTileHeader size remains fixed).
 constexpr size_t kMaxVersionSize = 16;
 
+// Maximum value used for quality metrics
+constexpr uint32_t kMaxQualityMeasure = 15;
+
 // Total number of binned edge bins in the tile
 constexpr size_t kBinsDim = 5;
 constexpr size_t kBinCount = kBinsDim * kBinsDim;


### PR DESCRIPTION
Several data structures within GraphTile do not have tests that ensure the structure size does not change as code changes are made. These are important tests since failures would indicate a "breaking" change to the tile data format. Added tests for GraphTileHeader, Admin, Sign, and AccessRestriction - these are fixed size structures within GraphTiles.