### PR TITLE
use specific random generator to avoid cross platform woes

### DIFF
--- a/src/midgard/util.cc
+++ b/src/midgard/util.cc
@@ -300,12 +300,13 @@ std::vector<midgard::PointLL> simulate_gps(const std::vector<gps_segment_t>& seg
                                            std::vector<float>& accuracies,
                                            float smoothing,
                                            float accuracy,
-                                           size_t sample_rate) {
+                                           size_t sample_rate,
+                                           unsigned seed) {
   // resample the coords along a given edge at one second intervals
   auto resampled = resample_at_1hz(segments);
 
   // a way to get noise but only allow for slow change
-  std::default_random_engine generator(0);
+  std::minstd_rand0 generator(seed);
   std::uniform_real_distribution<float> distribution(-1, 1);
   ring_queue_t<std::pair<float, float>> noises(smoothing);
   auto get_noise = [&]() {

--- a/valhalla/midgard/util.h
+++ b/valhalla/midgard/util.h
@@ -506,13 +506,15 @@ struct gps_segment_t {
  * respect to the original point (after resampling, see below)
  * @param sample_rate The final sample rate for the returned points. The determines how much time,
  *                    as a function of the segments speed, passes between individual simulated
+ * @param seed        The seed to use for random number generation
  * points
  */
 std::vector<midgard::PointLL> simulate_gps(const std::vector<gps_segment_t>& segments,
                                            std::vector<float>& accuracies,
                                            float smoothing = 30,
                                            float accuracy = 10.f,
-                                           size_t sample_rate = 1);
+                                           size_t sample_rate = 1,
+                                           unsigned seed = 0);
 
 } // namespace midgard
 } // namespace valhalla


### PR DESCRIPTION
# Issue

Using the `default_random_generator` means that depending on the target platforms implementation you could get a different generator than other target platforms. This causes tests to work differently on different platforms.

## Tasklist

 - [x] add tests
 - [x] review - you must request approval to merge any PR to master
 - [ ] ~Add #fixes with the issue number that this PR addresses~
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] ~Add to release notes in valhalla-docs~
 - [ ] ~update relevant documentation if this is an API impacting change~
