### PR TITLE
Midgard test updates

### DIFF
--- a/src/midgard/linesegment2.cc
+++ b/src/midgard/linesegment2.cc
@@ -4,28 +4,6 @@
 namespace valhalla {
 namespace midgard {
 
-// Default constructor.
-template <class coord_t> LineSegment2<coord_t>::LineSegment2() {
-  a_.Set(0.0f, 0.0f);
-  b_.Set(0.0f, 0.0f);
-}
-
-// Constructor given 2 points.
-template <class coord_t> LineSegment2<coord_t>::LineSegment2(const coord_t& p1, const coord_t& p2) {
-  a_ = p1;
-  b_ = p2;
-}
-
-// Get the first point of the segment.
-template <class coord_t> coord_t LineSegment2<coord_t>::a() const {
-  return a_;
-}
-
-// Get the second point of the segment.
-template <class coord_t> coord_t LineSegment2<coord_t>::b() const {
-  return b_;
-}
-
 // Finds the distance squared of a specified point from the line segment
 // and the closest point on the segment to the specified point.
 template <class coord_t>
@@ -53,13 +31,6 @@ float LineSegment2<coord_t>::DistanceSquared(const coord_t& p, coord_t& closest)
     }
   }
   return closest.DistanceSquared(p);
-}
-
-// Finds the distance of a specified point from the line segment
-// and the closest point on the segment to the specified point.
-template <class coord_t>
-float LineSegment2<coord_t>::Distance(const coord_t& p, coord_t& closest) const {
-  return sqrtf(DistanceSquared(p, closest));
 }
 
 // Determines if the current segment intersects the specified segment.
@@ -206,11 +177,6 @@ bool LineSegment2<coord_t>::ClipToPolygon(const std::vector<coord_t>& poly,
   // If candidate interval is not empty then set the clip segment
   clip_segment = {a_ + c * t_in, a_ + c * t_out};
   return true;
-}
-
-// Tests if a point is to left, right, or on the line segment.
-template <class coord_t> float LineSegment2<coord_t>::IsLeft(const coord_t& p) const {
-  return (b_.x() - a_.x()) * (p.y() - a_.y()) - (p.x() - a_.x()) * (b_.y() - a_.y());
 }
 
 // Explicit instantiation

--- a/src/midgard/point2.cc
+++ b/src/midgard/point2.cc
@@ -48,12 +48,11 @@ Vector2 Point2::operator-(const Point2& p) const {
 
 std::tuple<Point2, float, int> Point2::ClosestPoint(const std::vector<Point2>& pts) const {
   Point2 closest;
-  int idx;
   float mindist = std::numeric_limits<float>::max();
 
   // If there are no points we are done
   if (pts.size() == 0) {
-    return std::make_tuple(std::move(closest), std::move(mindist), std::move(idx));
+    return std::make_tuple(std::move(closest), std::move(mindist), 0);
   }
   // If there is one point we are done
   if (pts.size() == 1) {
@@ -62,6 +61,7 @@ std::tuple<Point2, float, int> Point2::ClosestPoint(const std::vector<Point2>& p
 
   // Iterate through the pts
   bool beyond_end = true; // Need to test past the end point?
+  int idx;                // Index of closest segment so far
   Vector2 v1;             // Segment vector (v1)
   Vector2 v2;             // Vector from origin to target (v2)
   Point2 projpt;          // Projected point along v1

--- a/test/distanceapproximator.cc
+++ b/test/distanceapproximator.cc
@@ -45,7 +45,8 @@ void TryDistanceSquared(const PointLL& a, const PointLL& b, const float d2) {
 void TestDistanceSquared() {
   PointLL a(-80.0f, 42.0f);
   PointLL b(-78.0f, 40.0f);
-  TryDistanceSquaredFromTestPt(a, b, a.Distance(b));
+  auto d = a.Distance(b);
+  TryDistanceSquared(a, b, d * d);
 }
 
 } // namespace

--- a/test/linesegment2.cc
+++ b/test/linesegment2.cc
@@ -11,6 +11,14 @@ using namespace valhalla::midgard;
 
 namespace {
 
+void TestDefaultConstructor() {
+  LineSegment2<Point2> l;
+  LineSegment2<Point2> expected(Point2(0.0f, 0.0f), Point2(0.0f, 0.0f));
+  if (!l.ApproximatelyEqual(expected)) {
+    throw runtime_error("LineSegment2 default constructor test failed");
+  }
+}
+
 void TryDistance(const Point2& p, const LineSegment2<Point2>& s, const float res, const Point2& exp) {
   Point2 closest;
   float d = s.Distance(p, closest);
@@ -84,6 +92,10 @@ void TestIntersect() {
   LineSegment2<Point2> s6(Point2(-2.0f, 2.0f), Point2(2.0f, -2.0f));
   TryIntersect(s1, s6, true, Point2(0.0f, 0.0f));
 
+  // Case 4 - parallel line segments should not intersect
+  LineSegment2<Point2> s7(Point2(-3.0f, -2.0f), Point2(3.0f, 4.0f));
+  TryIntersect(s1, s7, false, Point2(0.0f, 0.0f));
+
   // Same cases with PointLL
   // Case 1 - beyond end of s1
   LineSegment2<PointLL> s1ll(PointLL(-2.0f, -2.0f), PointLL(4.0f, 4.0f));
@@ -105,6 +117,10 @@ void TestIntersect() {
   // Case 3 - intersection
   LineSegment2<PointLL> s6ll(PointLL(-2.0f, 2.0f), PointLL(2.0f, -2.0f));
   TryIntersectLL(s1ll, s6ll, true, PointLL(0.0f, 0.0f));
+
+  // Case 4 - parallel line segments should not intersect
+  LineSegment2<PointLL> s7ll(PointLL(-3.0f, -2.0f), PointLL(3.0f, 4.0f));
+  TryIntersectLL(s1ll, s7ll, false, PointLL(0.0f, 0.0f));
 }
 
 void TryPolyIntersect(const LineSegment2<Point2>& s1,
@@ -112,6 +128,23 @@ void TryPolyIntersect(const LineSegment2<Point2>& s1,
                       const bool res) {
   if (s1.Intersect(poly) != res) {
     throw runtime_error("Polygon Intersect test failed");
+  }
+}
+
+void TryPolyClip(const LineSegment2<Point2>& s1,
+                 const std::vector<Point2>& poly,
+                 const bool res,
+                 LineSegment2<Point2>& clip_res) {
+  LineSegment2<Point2> clip_segment;
+  bool intersects = s1.ClipToPolygon(poly, clip_segment);
+  if (intersects != res) {
+    throw runtime_error("LineSegment ClipToPolygon intersection test failed");
+  }
+  if (!clip_res.ApproximatelyEqual(clip_segment)) {
+    throw runtime_error(
+        "LineSegment ClipToPolygon clipped segment mismatch: should be " +
+        std::to_string(clip_segment.a().x()) + "," + std::to_string(clip_segment.a().y()) +
+        " to: " + std::to_string(clip_segment.b().x()) + "," + std::to_string(clip_segment.b().y()));
   }
 }
 
@@ -127,26 +160,38 @@ void TestPolyIntersect() {
   // First point inside
   LineSegment2<Point2> s1(Point2(0.0f, 0.0f), Point2(4.0f, 12.0f));
   TryPolyIntersect(s1, poly, true);
+  LineSegment2<Point2> clip1(Point2(0.0f, 0.0f), Point2(1.0f, 3.0f));
+  TryPolyClip(s1, poly, true, clip1);
 
   // Second point inside
   LineSegment2<Point2> s2(Point2(4.0f, 12.0f), Point2(0.0f, 0.0f));
   TryPolyIntersect(s2, poly, true);
+  LineSegment2<Point2> clip2(Point2(1.0f, 3.0f), Point2(0.0f, 0.0f));
+  TryPolyClip(s2, poly, true, clip2);
 
   // Segment parallel to an edge and outside
   LineSegment2<Point2> s3(Point2(4.0f, -5.0f), Point2(4.0f, 5.0f));
   TryPolyIntersect(s3, poly, false);
+  LineSegment2<Point2> clip3(Point2(0.0f, 0.0f), Point2(0.0f, 0.0f));
+  TryPolyClip(s3, poly, false, clip3);
 
   // Passing through
   LineSegment2<Point2> s4(Point2(-5.0f, -5.0f), Point2(5.0f, 5.0f));
   TryPolyIntersect(s4, poly, true);
+  LineSegment2<Point2> clip4(Point2(-2.857143f, -2.857143f), Point2(2.0f, 2.0f)); // TODO
+  TryPolyClip(s4, poly, true, clip4);
 
   // No intersect with early out
   LineSegment2<Point2> s5(Point2(-10.0f, 5.0f), Point2(2.0f, 5.0f));
   TryPolyIntersect(s5, poly, false);
+  LineSegment2<Point2> clip5(Point2(0.0f, 0.0f), Point2(0.0f, 0.0f));
+  TryPolyClip(s5, poly, false, clip5);
 
   // Segment ends along an edge
   LineSegment2<Point2> s6(Point2(10.0f, 5.0f), Point2(2.0f, 0.0f));
   TryPolyIntersect(s6, poly, true);
+  LineSegment2<Point2> clip6(Point2(2.0f, 0.0f), Point2(2.0f, 0.0f));
+  TryPolyClip(s6, poly, true, clip6);
 }
 
 void TryIsLeft(const Point2& p, const LineSegment2<Point2>& s, const int res) {
@@ -174,6 +219,9 @@ void TestIsLeft() {
 
 int main() {
   test::suite suite("point2");
+
+  // Test the default constructor
+  suite.test(TEST_CASE(TestDefaultConstructor));
 
   // Test distance of a point to a line segment
   suite.test(TEST_CASE(TestDistance));

--- a/test/point2.cc
+++ b/test/point2.cc
@@ -86,7 +86,7 @@ void TryClosestPoint(const std::vector<Point2>& pts,
                      const float res) {
   auto result = p.ClosestPoint(pts);
   if (fabs(std::get<1>(result) - res) > kEpsilon)
-    throw runtime_error("ClosestPoint test failed - distance squared is wrong");
+    throw runtime_error("ClosestPoint test failed - distance is wrong");
   if (idx != std::get<2>(result))
     throw runtime_error("ClosestPoint test failed -index of closest segment is wrong");
   if (fabs(c.x() - std::get<0>(result).x()) > kEpsilon ||
@@ -94,17 +94,27 @@ void TryClosestPoint(const std::vector<Point2>& pts,
     throw runtime_error("ClosestPoint test failed - closest point is wrong");
 }
 void TestClosestPoint() {
-  // Construct a simple polyline
-  std::vector<Point2> pts = {{0.0f, 0.0f}, {2.0f, 2.0f}, {4.0f, 2.0f}, {4.0f, 0.0f}, {12.0f, 0.0f}};
+  // Construct a simple polyline (duplicate a point to make sure it is properly skipped)
+  std::vector<Point2> pts = {{0.0f, 0.0f}, {2.0f, 2.0f}, {4.0f, 2.0f},
+                             {4.0f, 0.0f}, {4.0f, 0.0f}, {12.0f, 0.0f}};
 
   // Closest to the first point
   TryClosestPoint(pts, Point2(-4.0f, 0.0f), Point2(0.0f, 0.0f), 0, 4.0f);
 
   // Closest along the last segment
-  TryClosestPoint(pts, Point2(10.0f, -4.0f), Point2(10.0f, 0.0f), 3, 4.0f);
+  TryClosestPoint(pts, Point2(10.0f, -4.0f), Point2(10.0f, 0.0f), 4, 4.0f);
 
   // Closest to the last point
-  TryClosestPoint(pts, Point2(15.0f, 4.0f), Point2(12.0f, 0.0f), 3, 5.0f);
+  TryClosestPoint(pts, Point2(15.0f, 4.0f), Point2(12.0f, 0.0f), 4, 5.0f);
+
+  // Test ClosestPoint with empty vector
+  std::vector<Point2> empty_pts;
+  TryClosestPoint(empty_pts, Point2(5.0f, 0.0f), Point2(0.0f, 0.0f), 0,
+                  std::numeric_limits<float>::max());
+
+  // Test ClosestPoint with only 1 point in the list
+  std::vector<Point2> pts1 = {{1.0f, 0.0f}};
+  TryClosestPoint(pts1, Point2(5.0f, 0.0f), Point2(1.0f, 0.0f), 0, 4.0f);
 }
 
 void TryWithinConvexPolygon(const std::vector<Point2>& pts, const Point2& p, const bool res) {

--- a/valhalla/midgard/linesegment2.h
+++ b/valhalla/midgard/linesegment2.h
@@ -20,26 +20,34 @@ public:
   /**
    * Default constructor.
    */
-  LineSegment2();
+  LineSegment2() {
+    a_.Set(0.0f, 0.0f);
+    b_.Set(0.0f, 0.0f);
+  }
 
   /**
    * Constructor given 2 points.
    * @param   p1    First point of the segment.
    * @param   p2    Second point of the segment.
    */
-  LineSegment2(const coord_t& p1, const coord_t& p2);
+  LineSegment2(const coord_t& p1, const coord_t& p2) : a_(p1), b_(p2) {
+  }
 
   /**
    * Get the first point of the segment.
    * @return  Returns first point of the segment.
    */
-  coord_t a() const;
+  coord_t a() const {
+    return a_;
+  }
 
   /**
    * Get the second point of the segment.
    * @return  Returns second point of the segment.
    */
-  coord_t b() const;
+  coord_t b() const {
+    return b_;
+  }
 
   /**
    * Finds the distance squared of a specified point from the line segment
@@ -59,7 +67,9 @@ public:
    * @return  Returns the distance from p to the closest point on
    *          the segment.
    */
-  float Distance(const coord_t& p, coord_t& closest) const;
+  float Distance(const coord_t& p, coord_t& closest) const {
+    return sqrtf(DistanceSquared(p, closest));
+  }
 
   /**
    * Determines if the current segment intersects the specified segment.
@@ -96,7 +106,18 @@ public:
    * @return   Returns >0 for point to the left, < 0 for point to the right,
    *           and 0 for a point on the line
    */
-  float IsLeft(const coord_t& p) const;
+  float IsLeft(const coord_t& p) const {
+    return (b_.x() - a_.x()) * (p.y() - a_.y()) - (p.x() - a_.x()) * (b_.y() - a_.y());
+  }
+
+  /**
+   * Equality approximation.
+   * @param   other  Line segment to compare to the current line segment.
+   * @return  Returns true if two line segments are approximately equal, false otherwise.
+   */
+  bool ApproximatelyEqual(const LineSegment2<coord_t>& other) {
+    return a_.ApproximatelyEqual(other.a()) && b_.ApproximatelyEqual(other.b());
+  }
 
 private:
   coord_t a_;

--- a/valhalla/midgard/tiles.h
+++ b/valhalla/midgard/tiles.h
@@ -188,19 +188,6 @@ public:
   coord_t Center(const int32_t tileid) const;
 
   /**
-   * Get the tile Id given a previous tile and a row, column offset.
-   * @param   initial_tile      Id of the tile to offset from.
-   * @param   delta_rows    Number of rows to offset (can be negative).
-   * @param   delta_cols    Number of columns to offset (can be negative).
-   * @return  Tile Id of the new tile.
-   */
-  int32_t GetRelativeTileId(const int32_t initial_tile,
-                            const int32_t delta_rows,
-                            const int32_t delta_cols) const {
-    return initial_tile + (delta_rows * ncolumns_) + delta_cols;
-  }
-
-  /**
    * Get the tile offsets (row,column) between the previous tile Id and
    * a new tileid.  The offsets are returned through arguments (references).
    * Offsets can be positive or negative or 0.


### PR DESCRIPTION
Update some test coverage within midgard: LineSegment2 and Point2 in particular. Move some small methods of LineSegment2 to be inline in the class definition.
Remove untested and unused Tiles::GetRelativeTileId method.