### PR TITLE
Downgrade classification of any pedestrian uses 

### DIFF
--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -928,7 +928,7 @@ void BuildTileSet(const std::string& ways_file,
           // Downgrade classification of any footways that are not kServiceOther
           if ((directededge.use() == Use::kFootway || directededge.use() == Use::kSteps ||
                directededge.use() == Use::kSidewalk || directededge.use() == Use::kPedestrian) &&
-               directededge.classification() != RoadClass::kServiceOther) {
+              directededge.classification() != RoadClass::kServiceOther) {
             directededge.set_classification(RoadClass::kServiceOther);
           }
 

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -614,10 +614,6 @@ void BuildTileSet(const std::string& ways_file,
             }
           }
 
-          if ((bike_network & kMcn) || (w.bike_network() & kMcn)) {
-            use = Use::kMountainBike;
-          }
-
           // Check for updated ref from relations.
           std::string ref;
           auto iter = osmdata.way_ref.find(w.way_id());
@@ -927,6 +923,13 @@ void BuildTileSet(const std::string& ways_file,
                                             static_cast<uint8_t>(directededge.cyclelane()))) {
               directededge.set_cyclelane(w.cyclelane_left());
             }
+          }
+
+          // Downgrade classification of any footways that are not kServiceOther
+          if ((directededge.use() == Use::kFootway || directededge.use() == Use::kSteps ||
+               directededge.use() == Use::kSidewalk || directededge.use() == Use::kPedestrian) &&
+               directededge.classification() != RoadClass::kServiceOther) {
+            directededge.set_classification(RoadClass::kServiceOther);
           }
 
           // Increment the directed edge index within the tile


### PR DESCRIPTION
to be RoadClass::kServiceOther. We want footways and cycleways to be lowest classification so that shortcuts can be created where higher class roads intersect with them.

Also Remove setting Use::kMountainBike if part of a mountain bike network as this was
changing regular roads to be mountain bike use.

Fixes #1337 