### PR TITLE
Fix configuration of Boost::python by trying different suffixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   lint:
     docker:
-      - image: valhalla/docker:build-2.5.0
+      - image: valhalla/docker:build-2.6.1
     steps:
       - checkout
       - run: apt-get update && apt-get -y install clang-tidy-5.0 clang-5.0 curl git nodejs
@@ -19,7 +19,7 @@ jobs:
 
   build-debug:
     docker:
-      - image: valhalla/docker:build-2.5.0
+      - image: valhalla/docker:build-2.6.1
     steps:
       - checkout
       - run: git submodule sync && git submodule update --init

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,60 +169,11 @@ add_subdirectory(test)
 
 ## Python bindings
 if(ENABLE_PYTHON_BINDINGS)
-  find_package(PythonInterp)
-  find_package(PythonLibs)
+  add_subdirectory(src/bindings/python)
 
-  ## This a workaround for CMake Boost::python configuration
-  if(NOT ${PYTHON_VERSION_MAJOR} EQUAL 3)
-    set(Boost_Python_lib "python")
-    find_package(Boost COMPONENTS python QUIET)
-  endif()
-
-  if(NOT Boost_PYTHON_FOUND)
-    set(Boost_Python_lib "python${PYTHON_VERSION_MAJOR}")
-    set(_Boost_PYTHON${PYTHON_VERSION_MAJOR}_HEADERS "boost/python.hpp")
-    find_package(Boost COMPONENTS python${PYTHON_VERSION_MAJOR} QUIET)
-    if(NOT Boost_PYTHON${PYTHON_VERSION_MAJOR}_FOUND)
-      set(Boost_Python_lib "python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}")
-      set(_Boost_PYTHON${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}_HEADERS "boost/python.hpp")
-      find_package(Boost COMPONENTS python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR} QUIET)
-      if(NOT Boost_PYTHON${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}_FOUND)
-        unset(Boost_Python_lib)
-      endif()
-    endif()
-  endif()
-
-  if(NOT Boost_Python_lib)
-    message(SEND_ERROR "Neither  python, python${PYTHON_VERSION_MAJOR} or "
-      "python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR} Boost library is not found")
-  else()
-    message(STATUS "Found the following Boost libraries:")
-    message(STATUS "  ${Boost_Python_lib}")
-
-    python_add_module(python_valhalla src/bindings/python/python.cc)
-    set_target_properties(python_valhalla PROPERTIES
-      OUTPUT_NAME valhalla
-      LINK_LIBRARIES "${PYTHON_LIBRARIES}"
-      INCLUDE_DIRECTORIES "${PYTHON_INCLUDE_DIRS}")
-    target_link_libraries(python_valhalla valhalla Boost::${Boost_Python_lib})
-    set_target_properties(valhalla PROPERTIES POSITION_INDEPENDENT_CODE ON)
-
-    if (APPLE)
-      set(get_python_lib "sc.get_python_lib(plat_specific=True)")
-    else()
-      set(get_python_lib "sc.get_python_lib(prefix='', plat_specific=True)")
-    endif()
-    execute_process(
-      COMMAND "${PYTHON_EXECUTABLE}" -c "from distutils import sysconfig as sc; print(${get_python_lib})"
-      OUTPUT_VARIABLE PYTHON_SITE_PACKAGES
-      OUTPUT_STRIP_TRAILING_WHITESPACE)
-    install(TARGETS python_valhalla
-      DESTINATION "${PYTHON_SITE_PACKAGES}"
-      COMPONENT python)
-    install(FILES COPYING ChangeLog
-      DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/doc/python-valhalla"
-      COMPONENT python)
-  endif()
+  install(FILES COPYING ChangeLog
+    DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/doc/python-valhalla"
+    COMPONENT python)
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,34 +171,55 @@ add_subdirectory(test)
 if(ENABLE_PYTHON_BINDINGS)
   find_package(PythonInterp)
   find_package(PythonLibs)
-  if(${PYTHON_VERSION_MAJOR} EQUAL 3)
-    set(Boost_Python_lib "Boost::python${PYTHON_VERSION_MAJOR}")
-    set(_Boost_PYTHON${PYTHON_VERSION_MAJOR}_HEADERS "boost/python.hpp")
-    find_package(Boost COMPONENTS python${PYTHON_VERSION_MAJOR})
-  else()
-    set(Boost_Python_lib "Boost::python")
-    find_package(Boost COMPONENTS python)
-  endif()
-  python_add_module(python_valhalla src/bindings/python/python.cc)
-  set_target_properties(python_valhalla PROPERTIES
-    OUTPUT_NAME valhalla
-    LINK_LIBRARIES "${PYTHON_LIBRARIES}"
-    INCLUDE_DIRECTORIES "${PYTHON_INCLUDE_DIRS}")
-  target_link_libraries(python_valhalla valhalla ${Boost_Python_lib})
-  set_target_properties(valhalla PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
-  execute_process(
-    COMMAND "${PYTHON_EXECUTABLE}" -c "
+  ## This a workaround for CMake Boost::python configuration
+  if(NOT ${PYTHON_VERSION_MAJOR} EQUAL 3)
+    set(Boost_Python_lib "python")
+    find_package(Boost COMPONENTS python QUIET)
+  endif()
+
+  if(NOT Boost_PYTHON_FOUND)
+    set(Boost_Python_lib "python${PYTHON_VERSION_MAJOR}")
+    set(_Boost_PYTHON${PYTHON_VERSION_MAJOR}_HEADERS "boost/python.hpp")
+    find_package(Boost COMPONENTS python${PYTHON_VERSION_MAJOR} QUIET)
+    if(NOT Boost_PYTHON${PYTHON_VERSION_MAJOR}_FOUND)
+      set(Boost_Python_lib "python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}")
+      set(_Boost_PYTHON${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}_HEADERS "boost/python.hpp")
+      find_package(Boost COMPONENTS python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR} QUIET)
+      if(NOT Boost_PYTHON${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}_FOUND)
+        unset(Boost_Python_lib)
+      endif()
+    endif()
+  endif()
+
+  if(NOT Boost_Python_lib)
+    message(SEND_ERROR "Neither  python, python${PYTHON_VERSION_MAJOR} or "
+      "python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR} Boost library is not found")
+  else()
+    message(STATUS "Found the following Boost libraries:")
+    message(STATUS "  ${Boost_Python_lib}")
+
+    python_add_module(python_valhalla src/bindings/python/python.cc)
+    set_target_properties(python_valhalla PROPERTIES
+      OUTPUT_NAME valhalla
+      LINK_LIBRARIES "${PYTHON_LIBRARIES}"
+      INCLUDE_DIRECTORIES "${PYTHON_INCLUDE_DIRS}")
+    target_link_libraries(python_valhalla valhalla Boost::${Boost_Python_lib})
+    set_target_properties(valhalla PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+    execute_process(
+      COMMAND "${PYTHON_EXECUTABLE}" -c "
 from distutils import sysconfig as sc
 print(sc.get_python_lib(prefix='', plat_specific=True))"
-    OUTPUT_VARIABLE PYTHON_SITE_PACKAGES
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-  install(TARGETS python_valhalla
-    DESTINATION "${PYTHON_SITE_PACKAGES}"
-    COMPONENT python)
-  install(FILES COPYING ChangeLog
-    DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/doc/python-valhalla"
-    COMPONENT python)
+      OUTPUT_VARIABLE PYTHON_SITE_PACKAGES
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    install(TARGETS python_valhalla
+      DESTINATION "${PYTHON_SITE_PACKAGES}"
+      COMPONENT python)
+    install(FILES COPYING ChangeLog
+      DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/doc/python-valhalla"
+      COMPONENT python)
+  endif()
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,10 +207,13 @@ if(ENABLE_PYTHON_BINDINGS)
     target_link_libraries(python_valhalla valhalla Boost::${Boost_Python_lib})
     set_target_properties(valhalla PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
+    if (APPLE)
+      set(get_python_lib "sc.get_python_lib(plat_specific=True)")
+    else()
+      set(get_python_lib "sc.get_python_lib(prefix='', plat_specific=True)")
+    endif()
     execute_process(
-      COMMAND "${PYTHON_EXECUTABLE}" -c "
-from distutils import sysconfig as sc
-print(sc.get_python_lib(prefix='', plat_specific=True))"
+      COMMAND "${PYTHON_EXECUTABLE}" -c "from distutils import sysconfig as sc; print(${get_python_lib})"
       OUTPUT_VARIABLE PYTHON_SITE_PACKAGES
       OUTPUT_STRIP_TRAILING_WHITESPACE)
     install(TARGETS python_valhalla

--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -1,0 +1,73 @@
+find_package(PythonInterp)
+find_package(PythonLibs)
+
+## This a workaround for CMake Boost::python configuration
+set(Boost_Python_libs
+  python${PYTHON_VERSION_MAJOR}
+  python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}
+  python-py${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
+if(NOT ${PYTHON_VERSION_MAJOR} EQUAL 3)
+  list(INSERT Boost_Python_libs 0 "python")
+endif()
+
+foreach(lib ${Boost_Python_libs})
+  set(Boost_Python_lib "${lib}")
+  string(TOUPPER ${lib} PYTHON_LIB)
+  set(_Boost_${PYTHON_LIB}_HEADERS "boost/python.hpp")
+  find_package(Boost COMPONENTS ${lib} QUIET)
+  if(${Boost_${PYTHON_LIB}_FOUND})
+    message(STATUS "Found the following Boost libraries:")
+    message(STATUS "  ${Boost_Python_lib}")
+    break()
+  endif()
+endforeach()
+
+if(NOT Boost_${PYTHON_LIB}_FOUND)
+  message(SEND_ERROR "Boost::python not found")
+else()
+  python_add_module(python_valhalla python.cc)
+  set_target_properties(python_valhalla PROPERTIES
+    OUTPUT_NAME valhalla
+    LINK_LIBRARIES "${PYTHON_LIBRARIES}"
+    INCLUDE_DIRECTORIES "${PYTHON_INCLUDE_DIRS}")
+  target_link_libraries(python_valhalla valhalla Boost::${Boost_Python_lib})
+  set_target_properties(valhalla PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+  # Part of OpenCVDetectPython.cmake
+  set(_executable ${PYTHON_EXECUTABLE})
+  set(_version_major_minor "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")
+  if(CMAKE_HOST_UNIX)
+    execute_process(COMMAND ${_executable} -c "from distutils.sysconfig import *; print(get_python_lib())"
+      RESULT_VARIABLE _cvpy_process
+      OUTPUT_VARIABLE _std_packages_path
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if("${_std_packages_path}" MATCHES "site-packages")
+      set(_packages_path "python${_version_major_minor}/site-packages")
+    else() #debian based assumed, install to the dist-packages.
+      set(_packages_path "python${_version_major_minor}/dist-packages")
+    endif()
+    if(EXISTS "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/${${packages_path}}")
+      set(_packages_path "lib${LIB_SUFFIX}/${_packages_path}")
+    else()
+      set(_packages_path "lib/${_packages_path}")
+    endif()
+  elseif(CMAKE_HOST_WIN32)
+    get_filename_component(_path "${_executable}" PATH)
+    file(TO_CMAKE_PATH "${_path}" _path)
+    if(NOT EXISTS "${_path}/Lib/site-packages")
+      unset(_path)
+      get_filename_component(_path "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Python\\PythonCore\\${_version_major_minor}\\InstallPath]" ABSOLUTE)
+      if(NOT _path)
+        get_filename_component(_path "[HKEY_CURRENT_USER\\SOFTWARE\\Python\\PythonCore\\${_version_major_minor}\\InstallPath]" ABSOLUTE)
+      endif()
+      file(TO_CMAKE_PATH "${_path}" _path)
+    endif()
+    set(_packages_path "${_path}/Lib/site-packages")
+    unset(_path)
+  endif()
+
+  message(STATUS "Installing python modules to ${CMAKE_INSTALL_PREFIX}/${_packages_path}")
+  install(TARGETS python_valhalla
+    DESTINATION "${_packages_path}"
+    COMPONENT python)
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,8 +47,9 @@ add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/test/data/utrecht_tiles/0/003/196.
 add_custom_target(utrecht_tiles DEPENDS ${CMAKE_BINARY_DIR}/test/data/utrecht_tiles/0/003/196.gph)
 
 add_custom_command(OUTPUT .locales.timestamp
-  COMMAND /bin/bash -c "for loc in $(jq --raw-output \".posix_locale\" *.json); do \
-       localedef --inputfile=$\{loc\%.\*\} --charmap=$\{loc\#\#\*.\} ./$\{loc\} ; \
+  COMMAND /bin/bash -c "for loc in $(jq --raw-output .posix_locale *.json); do \
+       $<$<NOT:$<BOOL:${APPLE}>>:  localedef -i $\{loc\%.\*\} -f $\{loc\#\#\*.\} ./$\{loc\}   ; > \
+       $<$<BOOL:${APPLE}>:         localedef -i /usr/share/locale/$\{loc\} ./$\{loc\} || true ; > \
      done \
      && touch ${CMAKE_CURRENT_BINARY_DIR}/.locales.timestamp"
   WORKING_DIRECTORY ${VALHALLA_SOURCE_DIR}/locales

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -99,7 +99,24 @@ if(ENABLE_SERVICES)
   add_dependencies(run-skadi_service test_directories)
 endif()
 
+if(ENABLE_PYTHON_BINDINGS)
+  find_package(PythonInterp)
+  add_custom_command(OUTPUT python_valhalla.log
+    COMMAND
+      LOCPATH=${VALHALLA_SOURCE_DIR}/locales
+      PYTHONPATH=src/bindings/python
+      /bin/bash -c "${PYTHON_EXECUTABLE} ${VALHALLA_SOURCE_DIR}/test/bindings/python/utrecht-test.py > test/python_valhalla.log"
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    DEPENDS
+      ${VALHALLA_SOURCE_DIR}/test/bindings/python/utrecht-test.py
+      ${VALHALLA_SOURCE_DIR}/test/bindings/python/valhalla.json
+      utrecht_tiles
+      python_valhalla
+    VERBATIM)
+  add_custom_target(run-python_valhalla DEPENDS python_valhalla.log)
+endif()
+
 ## High-level targets
-string(REGEX REPLACE "([^;]+)" "run-\\1" test_targets "${tests};${cost_tests}")
+string(REGEX REPLACE "([^;]+)" "run-\\1" test_targets "${tests};${cost_tests};python_valhalla")
 add_custom_target(check DEPENDS ${test_targets})
 add_custom_target(tests DEPENDS ${tests} ${cost_tests})

--- a/test/bindings/python/utrecht-test.py
+++ b/test/bindings/python/utrecht-test.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+import sys
+import os
+import valhalla
+import json
+
+valhalla.Configure(sys.argv[1] if len(sys.argv) > 1 else os.path.dirname(os.path.abspath(__file__)) + '/valhalla.json')
+actor = valhalla.Actor()
+query = '{"locations":[{"lat":52.08813,"lon":5.03231},{"lat":52.09987,"lon":5.14913}],"costing":"bicycle","directions_options":{"language":"ru-RU"}}'
+route = json.loads(actor.Route(query))
+
+assert('trip' in route)
+assert('units' in route['trip'] and route['trip']['units'] == 'kilometers')
+assert('summary' in route['trip'] and 'length' in route['trip']['summary'] and route['trip']['summary']['length'] > 9.)
+assert('legs' in route['trip'] and len(route['trip']['legs']) > 0)
+assert('maneuvers' in route['trip']['legs'][0] and len(route['trip']['legs'][0]['maneuvers']) > 0)
+assert('instruction' in route['trip']['legs'][0]['maneuvers'][0])
+assert(route['trip']['legs'][0]['maneuvers'][0]['instruction'] == u'Едьте на восток по велосипедная дорожке.')

--- a/test/bindings/python/valhalla.json
+++ b/test/bindings/python/valhalla.json
@@ -1,0 +1,222 @@
+{
+  "additional_data": {
+    "elevation": "/data/valhalla/elevation/"
+  },
+  "httpd": {
+    "service": {
+      "interrupt": "ipc:///tmp/interrupt",
+      "listen": "tcp://*:8002",
+      "loopback": "ipc:///tmp/loopback"
+    }
+  },
+  "loki": {
+    "actions": [
+      "locate",
+      "route",
+      "height",
+      "sources_to_targets",
+      "optimized_route",
+      "isochrone",
+      "trace_route",
+      "trace_attributes",
+      "transit_available"
+    ],
+    "logging": {
+      "color": true,
+      "file_name": "path_to_some_file.log",
+      "long_request": 100.0,
+      "type": "std_out"
+    },
+    "service": {
+      "proxy": "ipc:///tmp/loki"
+    },
+    "service_defaults": {
+      "minimum_reachability": 50,
+      "radius": 0
+    },
+    "use_connectivity": true
+  },
+  "meili": {
+    "auto": {
+      "search_radius": 50,
+      "turn_penalty_factor": 200
+    },
+    "bicycle": {
+      "turn_penalty_factor": 140
+    },
+    "customizable": [
+      "mode",
+      "search_radius",
+      "turn_penalty_factor",
+      "gps_accuracy",
+      "sigma_z",
+      "beta",
+      "max_route_distance_factor",
+      "max_route_time_factor"
+    ],
+    "default": {
+      "beta": 3,
+      "breakage_distance": 2000,
+      "geometry": false,
+      "gps_accuracy": 5.0,
+      "interpolation_distance": 10,
+      "max_route_distance_factor": 5,
+      "max_route_time_factor": 5,
+      "max_search_radius": 100,
+      "route": true,
+      "search_radius": 50,
+      "sigma_z": 4.07,
+      "turn_penalty_factor": 0
+    },
+    "grid": {
+      "cache_size": 100240,
+      "size": 500
+    },
+    "logging": {
+      "color": true,
+      "file_name": "path_to_some_file.log",
+      "type": "std_out"
+    },
+    "mode": "auto",
+    "multimodal": {
+      "turn_penalty_factor": 70
+    },
+    "pedestrian": {
+      "search_radius": 50,
+      "turn_penalty_factor": 100
+    },
+    "service": {
+      "proxy": "ipc:///tmp/meili"
+    },
+    "verbose": false
+  },
+  "mjolnir": {
+    "admin": "/data/valhalla/admin.sqlite",
+    "hierarchy": true,
+    "include_driveways": true,
+    "logging": {
+      "color": true,
+      "file_name": "path_to_some_file.log",
+      "type": "std_out"
+    },
+    "max_cache_size": 1000000000,
+    "shortcuts": true,
+    "tile_dir": "test/data/utrecht_tiles",
+    "tile_extract": "/data/valhalla/tiles.tar",
+    "timezone": "/data/valhalla/tz_world.sqlite",
+    "transit_dir": "/data/valhalla/transit"
+  },
+  "odin": {
+    "logging": {
+      "color": true,
+      "file_name": "path_to_some_file.log",
+      "type": "std_out"
+    },
+    "service": {
+      "proxy": "ipc:///tmp/odin"
+    }
+  },
+  "service_limits": {
+    "auto": {
+      "max_distance": 5000000.0,
+      "max_locations": 20,
+      "max_matrix_distance": 400000.0,
+      "max_matrix_locations": 50
+    },
+    "auto_shorter": {
+      "max_distance": 5000000.0,
+      "max_locations": 20,
+      "max_matrix_distance": 400000.0,
+      "max_matrix_locations": 50
+    },
+    "bicycle": {
+      "max_distance": 500000.0,
+      "max_locations": 50,
+      "max_matrix_distance": 200000.0,
+      "max_matrix_locations": 50
+    },
+    "bus": {
+      "max_distance": 5000000.0,
+      "max_locations": 50,
+      "max_matrix_distance": 400000.0,
+      "max_matrix_locations": 50
+    },
+    "hov": {
+      "max_distance": 5000000.0,
+      "max_locations": 20,
+      "max_matrix_distance": 400000.0,
+      "max_matrix_locations": 50
+    },
+    "isochrone": {
+      "max_contours": 4,
+      "max_distance": 25000.0,
+      "max_locations": 1,
+      "max_time": 120
+    },
+    "max_avoid_locations": 50,
+    "max_radius": 200,
+    "max_reachability": 100,
+    "motor_scooter": {
+      "max_distance": 500000.0,
+      "max_locations": 50,
+      "max_matrix_distance": 200000.0,
+      "max_matrix_locations": 50
+    },
+    "motorcycle": {
+      "max_distance": 500000.0,
+      "max_locations": 50,
+      "max_matrix_distance": 200000.0,
+      "max_matrix_locations": 50
+    },
+    "multimodal": {
+      "max_distance": 500000.0,
+      "max_locations": 50,
+      "max_matrix_distance": 0.0,
+      "max_matrix_locations": 0
+    },
+    "pedestrian": {
+      "max_distance": 250000.0,
+      "max_locations": 50,
+      "max_matrix_distance": 200000.0,
+      "max_matrix_locations": 50,
+      "max_transit_walking_distance": 10000,
+      "min_transit_walking_distance": 1
+    },
+    "skadi": {
+      "max_shape": 750000,
+      "min_resample": 10.0
+    },
+    "trace": {
+      "max_best_paths": 4,
+      "max_best_paths_shape": 100,
+      "max_distance": 200000.0,
+      "max_gps_accuracy": 100.0,
+      "max_search_radius": 100.0,
+      "max_shape": 16000
+    },
+    "transit": {
+      "max_distance": 500000.0,
+      "max_locations": 50,
+      "max_matrix_distance": 200000.0,
+      "max_matrix_locations": 50
+    },
+    "truck": {
+      "max_distance": 5000000.0,
+      "max_locations": 20,
+      "max_matrix_distance": 400000.0,
+      "max_matrix_locations": 50
+    }
+  },
+  "thor": {
+    "logging": {
+      "color": true,
+      "file_name": "path_to_some_file.log",
+      "long_request": 110.0,
+      "type": "std_out"
+    },
+    "service": {
+      "proxy": "ipc:///tmp/thor"
+    },
+    "source_to_target_algorithm": "select_optimal"
+  }
+}

--- a/valhalla/meili/grid_range_query.h
+++ b/valhalla/meili/grid_range_query.h
@@ -2,6 +2,7 @@
 #ifndef MMP_GRID_RANGE_QUERY_H_
 #define MMP_GRID_RANGE_QUERY_H_
 
+#include <string>
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>

--- a/valhalla/midgard/encoded.h
+++ b/valhalla/midgard/encoded.h
@@ -4,6 +4,7 @@
 #include <valhalla/midgard/shape_decoder.h>
 
 #include <cmath>
+#include <string>
 #include <type_traits>
 #include <vector>
 


### PR DESCRIPTION
# Issue

Fixes #1333 with a workaround that tries to find Boost::python, Boost::python2, Boost::python27

/cc @danpat @danpaz @danmactough @chaupow

## Tasklist

 - [x] review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Add to release notes in valhalla-docs
 - [ ] update relevant documentation if this is an API impacting change

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
