### PR TITLE
Add is_route_num to sign records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Release Date: UNRELEASED Valhalla 3.0
+* **Infrastructure**:
+   * 
+* **Data Producer Update**
+   * ADDED: is_route_num flag was added to Sign records. Set this to true if the exit sign comes from a route number/ref.
 
 ## Release Date: 2018-05-28 Valhalla 2.6.0
 * **Infrastructure**:

--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -560,7 +560,7 @@ std::vector<SignInfo> GraphTile::GetSigns(const uint32_t idx) const {
   // Add signs
   for (; found < count && signs_[found].edgeindex() == idx; ++found) {
     if (signs_[found].text_offset() < textlist_size_) {
-      signs.emplace_back(signs_[found].type(), (textlist_ + signs_[found].text_offset()));
+      signs.emplace_back(signs_[found].type(), signs_[found].is_route_num(), (textlist_ + signs_[found].text_offset()));
     } else {
       throw std::runtime_error("GetSigns: offset exceeds size of text list");
     }

--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -560,7 +560,8 @@ std::vector<SignInfo> GraphTile::GetSigns(const uint32_t idx) const {
   // Add signs
   for (; found < count && signs_[found].edgeindex() == idx; ++found) {
     if (signs_[found].text_offset() < textlist_size_) {
-      signs.emplace_back(signs_[found].type(), signs_[found].is_route_num(), (textlist_ + signs_[found].text_offset()));
+      signs.emplace_back(signs_[found].type(), signs_[found].is_route_num(),
+                         (textlist_ + signs_[found].text_offset()));
     } else {
       throw std::runtime_error("GetSigns: offset exceeds size of text list");
     }

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -1176,12 +1176,12 @@ std::vector<SignInfo> GraphBuilder::CreateExitSignInfoList(const OSMNode& node,
     std::vector<std::string> j_refs =
         GetTagTokens(osmdata.ref_offset_map.name(way.junction_ref_index()));
     for (auto& j_ref : j_refs) {
-      exit_list.emplace_back(Sign::Type::kExitNumber, j_ref);
+      exit_list.emplace_back(Sign::Type::kExitNumber, false, j_ref);
     }
   } else if (node.ref() && !fork) {
     std::vector<std::string> n_refs = GetTagTokens(osmdata.node_ref.find(node.osmid)->second);
     for (auto& n_ref : n_refs) {
-      exit_list.emplace_back(Sign::Type::kExitNumber, n_ref);
+      exit_list.emplace_back(Sign::Type::kExitNumber, false, n_ref);
     }
   }
 
@@ -1196,7 +1196,7 @@ std::vector<SignInfo> GraphBuilder::CreateExitSignInfoList(const OSMNode& node,
     std::vector<std::string> branch_refs =
         GetTagTokens(osmdata.ref_offset_map.name(way.destination_ref_index()));
     for (auto& branch_ref : branch_refs) {
-      exit_list.emplace_back(Sign::Type::kExitBranch, branch_ref);
+      exit_list.emplace_back(Sign::Type::kExitBranch, true, branch_ref);
     }
   }
 
@@ -1206,7 +1206,7 @@ std::vector<SignInfo> GraphBuilder::CreateExitSignInfoList(const OSMNode& node,
     std::vector<std::string> branch_streets =
         GetTagTokens(osmdata.name_offset_map.name(way.destination_street_index()));
     for (auto& branch_street : branch_streets) {
-      exit_list.emplace_back(Sign::Type::kExitBranch, branch_street);
+      exit_list.emplace_back(Sign::Type::kExitBranch, false, branch_street);
     }
   }
 
@@ -1221,7 +1221,7 @@ std::vector<SignInfo> GraphBuilder::CreateExitSignInfoList(const OSMNode& node,
     std::vector<std::string> toward_refs =
         GetTagTokens(osmdata.ref_offset_map.name(way.destination_ref_to_index()));
     for (auto& toward_ref : toward_refs) {
-      exit_list.emplace_back(Sign::Type::kExitToward, toward_ref);
+      exit_list.emplace_back(Sign::Type::kExitToward, true, toward_ref);
     }
   }
 
@@ -1231,7 +1231,7 @@ std::vector<SignInfo> GraphBuilder::CreateExitSignInfoList(const OSMNode& node,
     std::vector<std::string> toward_streets =
         GetTagTokens(osmdata.name_offset_map.name(way.destination_street_to_index()));
     for (auto& toward_street : toward_streets) {
-      exit_list.emplace_back(Sign::Type::kExitToward, toward_street);
+      exit_list.emplace_back(Sign::Type::kExitToward, false, toward_street);
     }
   }
 
@@ -1244,7 +1244,7 @@ std::vector<SignInfo> GraphBuilder::CreateExitSignInfoList(const OSMNode& node,
                                                         : way.destination_backward_index());
     std::vector<std::string> toward_names = GetTagTokens(osmdata.name_offset_map.name(index));
     for (auto& toward_name : toward_names) {
-      exit_list.emplace_back(Sign::Type::kExitToward, toward_name);
+      exit_list.emplace_back(Sign::Type::kExitToward, false, toward_name);
     }
   }
 
@@ -1263,12 +1263,12 @@ std::vector<SignInfo> GraphBuilder::CreateExitSignInfoList(const OSMNode& node,
 
         // remove the "To" For example:  US 11;To I 81;Carlisle;Harrisburg
         if (boost::starts_with(tmp, "to ")) {
-          exit_list.emplace_back(Sign::Type::kExitToward, exit_to.substr(3));
+          exit_list.emplace_back(Sign::Type::kExitToward, false, exit_to.substr(3));
           continue;
         }
         // remove the "Toward" For example:  US 11;Toward I 81;Carlisle;Harrisburg
         if (boost::starts_with(tmp, "toward ")) {
-          exit_list.emplace_back(Sign::Type::kExitToward, exit_to.substr(7));
+          exit_list.emplace_back(Sign::Type::kExitToward, false, exit_to.substr(7));
           continue;
         }
 
@@ -1279,9 +1279,9 @@ std::vector<SignInfo> GraphBuilder::CreateExitSignInfoList(const OSMNode& node,
         if (found != std::string::npos && (tmp.find(" to ", found + 4) == std::string::npos &&
                                            tmp.find(" toward ") == std::string::npos)) {
 
-          exit_list.emplace_back(Sign::Type::kExitBranch, exit_to.substr(0, found));
+          exit_list.emplace_back(Sign::Type::kExitBranch, false, exit_to.substr(0, found));
 
-          exit_list.emplace_back(Sign::Type::kExitToward, exit_to.substr(found + 4));
+          exit_list.emplace_back(Sign::Type::kExitToward, false, exit_to.substr(found + 4));
           continue;
         }
 
@@ -1292,14 +1292,14 @@ std::vector<SignInfo> GraphBuilder::CreateExitSignInfoList(const OSMNode& node,
         if (found != std::string::npos && (tmp.find(" toward ", found + 8) == std::string::npos &&
                                            tmp.find(" to ") == std::string::npos)) {
 
-          exit_list.emplace_back(Sign::Type::kExitBranch, exit_to.substr(0, found));
+          exit_list.emplace_back(Sign::Type::kExitBranch, false, exit_to.substr(0, found));
 
-          exit_list.emplace_back(Sign::Type::kExitToward, exit_to.substr(found + 8));
+          exit_list.emplace_back(Sign::Type::kExitToward, false, exit_to.substr(found + 8));
           continue;
         }
 
         // default to toward.
-        exit_list.emplace_back(Sign::Type::kExitToward, exit_to);
+        exit_list.emplace_back(Sign::Type::kExitToward, false, exit_to);
       }
     }
   }
@@ -1311,7 +1311,7 @@ std::vector<SignInfo> GraphBuilder::CreateExitSignInfoList(const OSMNode& node,
   if (node.name() && !fork) {
     std::vector<std::string> names = GetTagTokens(osmdata.node_name.find(node.osmid)->second);
     for (auto& name : names) {
-      exit_list.emplace_back(Sign::Type::kExitName, name);
+      exit_list.emplace_back(Sign::Type::kExitName, false, name);
     }
   }
 

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -89,7 +89,8 @@ GraphTileBuilder::GraphTileBuilder(const std::string& tile_dir,
   // Create sign builders
   for (uint32_t i = 0; i < header_->signcount(); i++) {
     name_info.insert({signs_[i].text_offset()});
-    signs_builder_.emplace_back(signs_[i].edgeindex(), signs_[i].type(), signs_[i].is_route_num(), signs_[i].text_offset());
+    signs_builder_.emplace_back(signs_[i].edgeindex(), signs_[i].type(), signs_[i].is_route_num(),
+                                signs_[i].text_offset());
   }
 
   // Create admin builders

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -89,7 +89,7 @@ GraphTileBuilder::GraphTileBuilder(const std::string& tile_dir,
   // Create sign builders
   for (uint32_t i = 0; i < header_->signcount(); i++) {
     name_info.insert({signs_[i].text_offset()});
-    signs_builder_.emplace_back(signs_[i].edgeindex(), signs_[i].type(), signs_[i].text_offset());
+    signs_builder_.emplace_back(signs_[i].edgeindex(), signs_[i].type(), signs_[i].is_route_num(), signs_[i].text_offset());
   }
 
   // Create admin builders
@@ -438,7 +438,7 @@ void GraphTileBuilder::AddSigns(const uint32_t idx, const std::vector<SignInfo>&
   for (const auto& sign : signs) {
     if (!(sign.text().empty())) {
       uint32_t offset = AddName(sign.text());
-      signs_builder_.emplace_back(idx, sign.type(), offset);
+      signs_builder_.emplace_back(idx, sign.type(), sign.is_route_num(), offset);
     }
   }
 }

--- a/test/signinfo.cc
+++ b/test/signinfo.cc
@@ -104,6 +104,43 @@ void ExitToTest() {
       throw std::runtime_error("Exitsign text is bad for I 495 Toward I 270 To I 95");
   } else
     throw std::runtime_error("I 495 Toward I 270 To I 95 failed to be parsed.");
+
+  // Add a ref brnahc sign
+  exitsigns.clear();
+  auto index = osmdata.ref_offset_map.index("I 495 N");
+  way.set_destination_ref_index(index);
+  exitsigns = GraphBuilder::CreateExitSignInfoList(node, way, osmdata, fork, forward);
+  if (exitsigns.size() == 1) {
+    if (exitsigns[0].type() != Sign::Type::kExitBranch)
+      throw std::runtime_error("I 495 N should be a branch.");
+
+    if (!exitsigns[0].is_route_num())
+      throw std::runtime_error("I 495 N should be flagged as a route num");
+
+    if (exitsigns[0].text() != "I 495 N")
+      throw std::runtime_error("Exitsign text is bad for I 495 N destination ref");
+  } else {
+    throw std::runtime_error("destination ref I 495 N failed to create exist sign.");
+  }
+
+  // Add a ref toward sign
+  OSMWay way2{};
+  exitsigns.clear();
+  auto index2 = osmdata.ref_offset_map.index("I 695 N");
+  way2.set_destination_ref_to_index(index2);
+  exitsigns = GraphBuilder::CreateExitSignInfoList(node, way2, osmdata, fork, forward);
+  if (exitsigns.size() == 1) {
+    if (exitsigns[0].type() != Sign::Type::kExitToward)
+      throw std::runtime_error("I 695 N should be a toward.");
+
+    if (!exitsigns[0].is_route_num())
+      throw std::runtime_error("I 695 N should be flagged as a route num");
+
+    if (exitsigns[0].text() != "I 695 N")
+      throw std::runtime_error("Exitsign text is bad for I 695 N destination to ref");
+  } else {
+    throw std::runtime_error("destination ref I 695 N failed to create exist sign.");
+  }
 }
 
 } // namespace

--- a/test/signinfo.cc
+++ b/test/signinfo.cc
@@ -105,41 +105,41 @@ void ExitToTest() {
   } else
     throw std::runtime_error("I 495 Toward I 270 To I 95 failed to be parsed.");
 
-  // Add a ref brnahc sign
+  // Add a ref branch sign
   exitsigns.clear();
-  auto index = osmdata.ref_offset_map.index("I 495 N");
+  auto index = osmdata.ref_offset_map.index("I 495 North");
   way.set_destination_ref_index(index);
   exitsigns = GraphBuilder::CreateExitSignInfoList(node, way, osmdata, fork, forward);
   if (exitsigns.size() == 1) {
     if (exitsigns[0].type() != Sign::Type::kExitBranch)
-      throw std::runtime_error("I 495 N should be a branch.");
+      throw std::runtime_error("I 495 North should be a branch.");
 
     if (!exitsigns[0].is_route_num())
-      throw std::runtime_error("I 495 N should be flagged as a route num");
+      throw std::runtime_error("I 495 North should be flagged as a route num");
 
-    if (exitsigns[0].text() != "I 495 N")
-      throw std::runtime_error("Exitsign text is bad for I 495 N destination ref");
+    if (exitsigns[0].text() != "I 495 North")
+      throw std::runtime_error("Exitsign text is bad for I 495 North destination ref");
   } else {
-    throw std::runtime_error("destination ref I 495 N failed to create exist sign.");
+    throw std::runtime_error("destination ref I 495 North failed to create exist sign.");
   }
 
   // Add a ref toward sign
   OSMWay way2{};
   exitsigns.clear();
-  auto index2 = osmdata.ref_offset_map.index("I 695 N");
+  auto index2 = osmdata.ref_offset_map.index("I 695 North");
   way2.set_destination_ref_to_index(index2);
   exitsigns = GraphBuilder::CreateExitSignInfoList(node, way2, osmdata, fork, forward);
   if (exitsigns.size() == 1) {
     if (exitsigns[0].type() != Sign::Type::kExitToward)
-      throw std::runtime_error("I 695 N should be a toward.");
+      throw std::runtime_error("I 695 North should be a toward.");
 
     if (!exitsigns[0].is_route_num())
-      throw std::runtime_error("I 695 N should be flagged as a route num");
+      throw std::runtime_error("I 695 North should be flagged as a route num");
 
-    if (exitsigns[0].text() != "I 695 N")
-      throw std::runtime_error("Exitsign text is bad for I 695 N destination to ref");
+    if (exitsigns[0].text() != "I 695 North")
+      throw std::runtime_error("Exitsign text is bad for I 695 North destination to ref");
   } else {
-    throw std::runtime_error("destination ref I 695 N failed to create exist sign.");
+    throw std::runtime_error("destination ref I 695 North failed to create exist sign.");
   }
 }
 

--- a/valhalla/baldr/sign.h
+++ b/valhalla/baldr/sign.h
@@ -22,10 +22,12 @@ public:
    * Constructor given arguments.
    * @param  idx  Directed edge index to which this sign applies.
    * @param  type Sign type.
+   * @param  rn   Boolean indicating whether this sign indicates a route number.
    * @param  text_offset  Offset to text in the names/text table.
    */
-  Sign(const uint32_t idx, const Sign::Type& type, const uint32_t text_offset)
-      : edgeindex_(idx), type_(static_cast<uint32_t>(type)), spare_(0), text_offset_(text_offset) {
+  Sign(const uint32_t idx, const Sign::Type& type, const bool rn, const uint32_t text_offset)
+      : edgeindex_(idx), type_(static_cast<uint32_t>(type)), is_route_num_(rn), spare_(0),
+        text_offset_(text_offset) {
   }
 
   /**
@@ -54,6 +56,14 @@ public:
   }
 
   /**
+   * Does this sign record indicate a route number.
+   * @return  Returns true if the sign record is a route number.
+   */
+  bool is_route_num() const {
+    return is_route_num_;
+  }
+
+  /**
    * Get the offset into the GraphTile text list for the text associated
    * with the sign.
    * @return  Returns the text offset.
@@ -65,7 +75,8 @@ public:
 protected:
   uint32_t edgeindex_ : 22; // kMaxTileEdgeCount in nodeinfo.h: 22 bits
   uint32_t type_ : 8;
-  uint32_t spare_ : 2;
+  uint32_t is_route_num_ : 1;
+  uint32_t spare_ : 1;
 
   uint32_t text_offset_;
 };

--- a/valhalla/baldr/signinfo.h
+++ b/valhalla/baldr/signinfo.h
@@ -15,9 +15,12 @@ public:
   /**
    * Constructor.
    * @param  type   Sign type.
+   *
+   * @param  rn     Bool indicating if this sign is a route number.
    * @param  text   Text string.
    */
-  SignInfo(const Sign::Type& type, const std::string& text) : type_(type), text_(text) {
+  SignInfo(const Sign::Type& type, const bool rn, const std::string& text)
+      : is_route_num_(rn), type_(type), text_(text) {
   }
 
   /**
@@ -26,6 +29,14 @@ public:
    */
   const Sign::Type& type() const {
     return type_;
+  }
+
+  /**
+   * Does this sign record indicate a route number.
+   * @return  Returns true if the sign record is a route number.
+   */
+  bool is_route_num() const {
+    return is_route_num_;
   }
 
   /**
@@ -38,6 +49,7 @@ public:
 
 protected:
   Sign::Type type_;
+  bool is_route_num_;
   std::string text_;
 };
 


### PR DESCRIPTION
partially fixes #1356

This adds a route_num flag to sign records. Sets this flag in the graph tile builder if the exit sign is derived from a ref. There is still an open question on whether this flag can be inferred in exit_to type records. 
This does NOT change any settings within TripPathBuilder as that depends on updates to the TripPath proto specification. When those changes are made it should be easy to use the is_route_num method on the Sign structure within TripPathBuilder::AddTripEdge.

 - [x] Add tests
 - [x] Review - you must request approval to merge any PR to master
 - [x] Add #fixes with the issue number that this PR addresses
 - [x] Update the [changelog](CHANGELOG.md)
