### PR TITLE
Fixed trace_route edge_walk server abort by throwing default exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
    * 
 * **Data Producer Update**
    * ADDED: is_route_num flag was added to Sign records. Set this to true if the exit sign comes from a route number/ref.
+* **Map Matching**
+   * FIXED: Fixed trace_route edge_walk server abort [#1365](https://github.com/valhalla/valhalla/pull/1365)
 
 ## Release Date: 2018-05-28 Valhalla 2.6.0
 * **Infrastructure**:

--- a/src/thor/trace_route_action.cc
+++ b/src/thor/trace_route_action.cc
@@ -76,7 +76,7 @@ odin::TripPath thor_worker_t::trace_route(valhalla_request_t& request) {
         try {
           trip_path = route_match(request, controller);
           if (trip_path.node().size() == 0) {
-            throw;
+            throw std::runtime_error("Invalid " + shape_match->first);
           }
         } catch (...) {
           throw valhalla_exception_t{

--- a/src/thor/trace_route_action.cc
+++ b/src/thor/trace_route_action.cc
@@ -76,7 +76,7 @@ odin::TripPath thor_worker_t::trace_route(valhalla_request_t& request) {
         try {
           trip_path = route_match(request, controller);
           if (trip_path.node().size() == 0) {
-            throw std::runtime_error("Invalid " + shape_match->first);
+            throw std::exception{};
           }
         } catch (...) {
           throw valhalla_exception_t{

--- a/test/mapmatch.cc
+++ b/test/mapmatch.cc
@@ -10,6 +10,7 @@
 #include <boost/property_tree/ptree.hpp>
 
 #include "baldr/json.h"
+#include "exception.h"
 #include "meili/map_matcher.h"
 #include "meili/map_matcher_factory.h"
 #include "midgard/distanceapproximator.h"
@@ -264,6 +265,60 @@ void test32bit() {
   std::string test_case = "{\"costing\":\"auto\",\"locations\":[{\"lat\":52.096672,\"lon\":5."
                           "110825},{\"lat\":52.081371,\"lon\":5.125671}]}";
   actor.route(test_case);
+}
+
+void test_trace_route_edge_walk_expected_error_code() {
+  // tests expected error_code for trace_route edge_walk
+  auto expected_error_code = 443;
+  tyr::actor_t actor(conf, true);
+
+  try {
+    auto response = json_to_pt(actor.trace_route(
+        R"({"costing":"auto","shape_match":"edge_walk","shape":[
+         {"lat":52.088548,"lon":5.15357,"accuracy":30},
+         {"lat":52.088627,"lon":5.153269,"accuracy":30},
+         {"lat":52.08864,"lon":5.15298,"accuracy":30},
+         {"lat":52.08861,"lon":5.15272,"accuracy":30},
+         {"lat":52.08863,"lon":5.15253,"accuracy":30},
+         {"lat":52.08851,"lon":5.15249,"accuracy":30}]})"));
+  } catch (const valhalla_exception_t& e) {
+    if (e.code != expected_error_code) {
+      throw std::logic_error("Expected error code=" + std::to_string(expected_error_code) +
+                             " | found=" + std::to_string(e.code));
+    }
+    // If we get here then all good - return
+    return;
+  }
+
+  // If we get here then throw an exception
+  throw std::logic_error("Expected trace_route edge_walk exception was not found");
+}
+
+void test_trace_attributes_edge_walk_expected_error_code() {
+  // tests expected error_code for trace_attributes edge_walk
+  auto expected_error_code = 443;
+  tyr::actor_t actor(conf, true);
+
+  try {
+    auto response = json_to_pt(actor.trace_attributes(
+        R"({"costing":"auto","shape_match":"edge_walk","shape":[
+         {"lat":52.088548,"lon":5.15357,"accuracy":30},
+         {"lat":52.088627,"lon":5.153269,"accuracy":30},
+         {"lat":52.08864,"lon":5.15298,"accuracy":30},
+         {"lat":52.08861,"lon":5.15272,"accuracy":30},
+         {"lat":52.08863,"lon":5.15253,"accuracy":30},
+         {"lat":52.08851,"lon":5.15249,"accuracy":30}]})"));
+  } catch (const valhalla_exception_t& e) {
+    if (e.code != expected_error_code) {
+      throw std::logic_error("Expected error code=" + std::to_string(expected_error_code) +
+                             " | found=" + std::to_string(e.code));
+    }
+    // If we get here then all good - return
+    return;
+  }
+
+  // If we get here then throw an exception
+  throw std::logic_error("Expected trace_attributes edge_walk exception was not found");
 }
 
 void test_topk_validate() {
@@ -531,6 +586,10 @@ int main(int argc, char* argv[]) {
   suite.test(TEST_CASE(test_distance_only));
 
   suite.test(TEST_CASE(test_time_rejection));
+
+  suite.test(TEST_CASE(test_trace_route_edge_walk_expected_error_code));
+
+  suite.test(TEST_CASE(test_trace_attributes_edge_walk_expected_error_code));
 
   suite.test(TEST_CASE(test_topk_validate));
 


### PR DESCRIPTION
# Issue

The server would abort when a trace_route using `edge_walk` failed. The plain `thow;` in the try block was not caught in the `catch(...)` block.

## Tasklist

 - [x] Throw default exception instead of just plain `throw;`
 - [x] Add tests 
 - [ ] Review - you must request approval to merge any PR to master
 - [x] Update the [changelog](CHANGELOG.md)
