### PR TITLE
Set a maximum distance allowed for time dependent routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Release Date: UNRELEASED Valhalla 3.0
 * **Infrastructure**:
-   * 
+   * ADDED: add in time dependent algorithms if the distance between locations is less than 500km.
 * **Data Producer Update**
    * ADDED: is_route_num flag was added to Sign records. Set this to true if the exit sign comes from a route number/ref.
 

--- a/src/thor/route_action.cc
+++ b/src/thor/route_action.cc
@@ -24,7 +24,7 @@ namespace thor {
 // single direction A* there may be performance issues allowing very long
 // routes. Also, for long routes the accuracy of predicted time along the
 // route starts to become suspect (due to user breaks and other factors).
-constexpr float kMaxTimeDependentDistance = 500000.0f;  // 500 km
+constexpr float kMaxTimeDependentDistance = 500000.0f; // 500 km
 
 std::list<valhalla::odin::TripPath> thor_worker_t::route(valhalla_request_t& request) {
   parse_locations(request);

--- a/src/thor/route_action.cc
+++ b/src/thor/route_action.cc
@@ -24,7 +24,7 @@ namespace thor {
 // single direction A* there may be performance issues allowing very long
 // routes. Also, for long routes the accuracy of predicted time along the
 // route starts to become suspect (due to user breaks and other factors).
-constexpr float kMaxTimeDependentDistance = 500.0f;
+constexpr float kMaxTimeDependentDistance = 500000.0f;  // 500 km
 
 std::list<valhalla::odin::TripPath> thor_worker_t::route(valhalla_request_t& request) {
   parse_locations(request);


### PR DESCRIPTION
and enable the time dependent path algorithms if below this distance.

This enables testing of time dependent routes with free flow speed and constrained flow speed (if they are added to the data).

Fixes #1313