### PR TITLE
Lower speeds for parking aisle, fix destination only penalty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
    * 
 * **Data Producer Update**
    * ADDED: is_route_num flag was added to Sign records. Set this to true if the exit sign comes from a route number/ref.
+   * CHANGED: Lower speeds on driveways, drive-thru, and parking aisle. Set destination only flag for drive thru use.
+  **Bug Fix**
+   * CHANGED: Fix destination only penalty for A* and time dependent cases.
 
 ## Release Date: 2018-05-28 Valhalla 2.6.0
 * **Infrastructure**:

--- a/src/mjolnir/directededgebuilder.cc
+++ b/src/mjolnir/directededgebuilder.cc
@@ -42,7 +42,6 @@ DirectedEdgeBuilder::DirectedEdgeBuilder(const OSMWay& way,
     set_use(Use::kRailFerry);
   }
   set_toll(way.toll());
-  set_dest_only(way.destination_only());
 
   if (bike_network) {
     set_bike_network(way.bike_network() | bike_network);
@@ -52,9 +51,8 @@ DirectedEdgeBuilder::DirectedEdgeBuilder(const OSMWay& way,
 
   set_truck_route(way.truck_route());
 
-  if (!way.destination_only()) {
-    set_dest_only(way.no_thru_traffic());
-  }
+  // Set destination only to thru if either destination only or no thru traffic is set
+  set_dest_only(way.destination_only() || way.no_thru_traffic());
 
   set_dismount(way.dismount());
   set_use_sidepath(way.use_sidepath());

--- a/src/mjolnir/directededgebuilder.cc
+++ b/src/mjolnir/directededgebuilder.cc
@@ -51,7 +51,7 @@ DirectedEdgeBuilder::DirectedEdgeBuilder(const OSMWay& way,
 
   set_truck_route(way.truck_route());
 
-  // Set destination only to thru if either destination only or no thru traffic is set
+  // Set destination only to true if either destination only or no thru traffic is set
   set_dest_only(way.destination_only() || way.no_thru_traffic());
 
   set_dismount(way.dismount());

--- a/src/mjolnir/graphenhancer.cc
+++ b/src/mjolnir/graphenhancer.cc
@@ -175,6 +175,16 @@ void UpdateSpeed(DirectedEdge& directededge, const uint32_t density, const uint3
       directededge.set_speed(urban_rc_speed[rc]);
     }
 
+    // Reduce speeds on parking aisles, driveways, and drive-thrus. These uses are
+    // marked as destination only in pbfgraphparser.
+    if (directededge.use() == Use::kParkingAisle) {
+      directededge.set_speed(kParkingAisleSpeed);
+    } else if (directededge.use() == Use::kDriveway) {
+      directededge.set_speed(kDrivewaySpeed);
+    } else if (directededge.use() == Use::kDriveThru) {
+      directededge.set_speed(kDriveThruSpeed);
+    }
+
     // Modify speed based on surface.
     if (directededge.surface() >= Surface::kPavedRough) {
       uint32_t speed = directededge.speed();

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -492,6 +492,7 @@ public:
             w.set_use(Use::kEmergencyAccess);
             break;
           case Use::kDriveThru:
+            w.set_destination_only(true);
             w.set_use(Use::kDriveThru);
             break;
           case Use::kTrack:

--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -761,7 +761,7 @@ Cost BicycleCost::TransitionCost(const baldr::DirectedEdge* edge,
   float seconds = 0.0f;
   float penalty = 0.0f;
 
-  // Special cases with both time and penalty: country crossing,
+  // Special cases with both time and penalty: country crossing, ferry,
   // gate, toll booth
   if (node->type() == NodeType::kBorderControl) {
     seconds += country_crossing_cost_;
@@ -770,23 +770,22 @@ Cost BicycleCost::TransitionCost(const baldr::DirectedEdge* edge,
     seconds += gate_cost_;
     penalty += gate_penalty_;
   }
-
-  // Additional penalties without any time cost
-  uint32_t idx = pred.opp_local_idx();
-  if (pred.use() != Use::kAlley && edge->use() == Use::kAlley) {
-    penalty += alley_penalty_;
-  }
-  if (pred.use() != Use::kDriveway && edge->use() == Use::kDriveway) {
-    penalty += driveway_penalty_;
-  }
-  if ((pred.use() != Use::kFerry && edge->use() == Use::kFerry)) {
+  if (edge->use() == Use::kFerry && pred.use() != Use::kFerry) {
     seconds += ferry_cost_;
     penalty += ferry_penalty_;
   }
 
-  // Ignore name inconsistency when entering a link to avoid double penalizing.
+  // Additional penalties without any time cost
+  uint32_t idx = pred.opp_local_idx();
+  if (edge->use() == Use::kAlley && pred.use() != Use::kAlley) {
+    penalty += alley_penalty_;
+  }
+  if (edge->use() == Use::kDriveway && pred.use() != Use::kDriveway) {
+    penalty += driveway_penalty_;
+  }
+
+  // Maneuver penalty, ignore when entering a link to avoid double penalizing
   if (!edge->link() && !node->name_consistency(idx, edge->localedgeidx())) {
-    // Slight maneuver penalty
     penalty += maneuver_penalty_;
   }
 
@@ -866,7 +865,7 @@ Cost BicycleCost::TransitionCostReverse(const uint32_t idx,
   float seconds = 0.0f;
   float penalty = 0.0f;
 
-  // Special cases with both time and penalty: country crossing,
+  // Special cases with both time and penalty: country crossing, ferry,
   // gate, toll booth
   if (node->type() == NodeType::kBorderControl) {
     seconds += country_crossing_cost_;
@@ -875,22 +874,21 @@ Cost BicycleCost::TransitionCostReverse(const uint32_t idx,
     seconds += gate_cost_;
     penalty += gate_penalty_;
   }
-
-  // Additional penalties without any time cost
-  if (pred->use() != Use::kAlley && edge->use() == Use::kAlley) {
-    penalty += alley_penalty_;
-  }
-  if (pred->use() != Use::kDriveway && edge->use() == Use::kDriveway) {
-    penalty += driveway_penalty_;
-  }
-  if ((pred->use() != Use::kFerry && edge->use() == Use::kFerry)) {
+  if (edge->use() == Use::kFerry && pred->use() != Use::kFerry) {
     seconds += ferry_cost_;
     penalty += ferry_penalty_;
   }
 
-  // Ignore name inconsistency when entering a link to avoid double penalizing.
+  // Additional penalties without any time cost
+  if (edge->use() == Use::kAlley && pred->use() != Use::kAlley) {
+    penalty += alley_penalty_;
+  }
+  if (edge->use() == Use::kDriveway && pred->use() != Use::kDriveway) {
+    penalty += driveway_penalty_;
+  }
+
+  // Maneuver penalty, ignore when entering a link to avoid double penalizing
   if (!edge->link() && !node->name_consistency(idx, edge->localedgeidx())) {
-    // Slight maneuver penalty
     penalty += maneuver_penalty_;
   }
 

--- a/src/sif/motorcyclecost.cc
+++ b/src/sif/motorcyclecost.cc
@@ -22,17 +22,18 @@ namespace sif {
 // Default options/values
 namespace {
 
-constexpr float kDefaultManeuverPenalty = 5.0f;        // Seconds
-constexpr float kDefaultAlleyPenalty = 5.0f;           // Seconds
-constexpr float kDefaultGateCost = 30.0f;              // Seconds
-constexpr float kDefaultGatePenalty = 300.0f;          // Seconds
-constexpr float kDefaultFerryCost = 300.0f;            // Seconds
-constexpr float kDefaultCountryCrossingCost = 600.0f;  // Seconds
-constexpr float kDefaultCountryCrossingPenalty = 0.0f; // Seconds
-constexpr float kDefaultUseFerry = 0.5f;               // Factor between 0 and 1
-constexpr float kDefaultUseHighways = 1.0f;            // Factor between 0 and 1
-constexpr float kDefaultUsePrimary = 0.5f;             // Factor between 0 and 1
-constexpr float kDefaultUseTrails = 0.0f;              // Factor between 0 and 1
+constexpr float kDefaultManeuverPenalty = 5.0f;          // Seconds
+constexpr float kDefaultAlleyPenalty = 5.0f;             // Seconds
+constexpr float kDefaultGateCost = 30.0f;                // Seconds
+constexpr float kDefaultGatePenalty = 300.0f;            // Seconds
+constexpr float kDefaultFerryCost = 300.0f;              // Seconds
+constexpr float kDefaultCountryCrossingCost = 600.0f;    // Seconds
+constexpr float kDefaultCountryCrossingPenalty = 0.0f;   // Seconds
+constexpr float kDefaultUseFerry = 0.5f;                 // Factor between 0 and 1
+constexpr float kDefaultUseHighways = 1.0f;              // Factor between 0 and 1
+constexpr float kDefaultUsePrimary = 0.5f;               // Factor between 0 and 1
+constexpr float kDefaultUseTrails = 0.0f;                // Factor between 0 and 1
+constexpr float kDefaultDestinationOnlyPenalty = 600.0f; // Seconds
 
 constexpr Surface kMinimumMotorcycleSurface = Surface::kDirt;
 
@@ -76,6 +77,8 @@ constexpr ranged_default_t<float> kUseFerryRange{0, kDefaultUseFerry, 1.0f};
 constexpr ranged_default_t<float> kUseHighwaysRange{0, kDefaultUseHighways, 1.0f};
 constexpr ranged_default_t<float> kUsePrimaryRange{0, kDefaultUsePrimary, 1.0f};
 constexpr ranged_default_t<float> kUseTrailsRange{0, kDefaultUseTrails, 1.0f};
+constexpr ranged_default_t<float> kDestinationOnlyPenaltyRange{0, kDefaultDestinationOnlyPenalty,
+                                                               kMaxSeconds};
 
 // Additional penalty to avoid destination only
 constexpr float kDestinationOnlyFactor = 0.2f;
@@ -292,6 +295,7 @@ public:
   float speedfactor_[kMaxSpeedKph + 1];
   float density_factor_[16];       // Density factor
   float maneuver_penalty_;         // Penalty (seconds) when inconsistent names
+  float destination_only_penalty_; // Penalty (seconds) using private road, driveway, or parking aisle
   float gate_cost_;                // Cost (seconds) to go through gate
   float gate_penalty_;             // Penalty (seconds) to go through gate
   float ferry_cost_;               // Cost (seconds) to enter a ferry
@@ -342,6 +346,8 @@ MotorcycleCost::MotorcycleCost(const boost::property_tree::ptree& pt)
 
   maneuver_penalty_ =
       kManeuverPenaltyRange(pt.get<float>("maneuver_penalty", kDefaultManeuverPenalty));
+  destination_only_penalty_ = kDestinationOnlyPenaltyRange(
+      pt.get<float>("destination_only_penalty", kDefaultDestinationOnlyPenalty));
   gate_cost_ = kGateCostRange(pt.get<float>("gate_cost", kDefaultGateCost));
   gate_penalty_ = kGatePenaltyRange(pt.get<float>("gate_penalty", kDefaultGatePenalty));
   alley_penalty_ = kAlleyPenaltyRange(pt.get<float>("alley_penalty", kDefaultAlleyPenalty));
@@ -522,8 +528,7 @@ Cost MotorcycleCost::TransitionCost(const baldr::DirectedEdge* edge,
   float seconds = 0.0f;
   float penalty = 0.0f;
 
-  // Special cases with both time and penalty: country crossing
-  // and gate
+  // Special cases with both time and penalty: country crossing, ferry, and gate
   if (node->type() == NodeType::kBorderControl) {
     seconds += country_crossing_cost_;
     penalty += country_crossing_penalty_;
@@ -531,18 +536,22 @@ Cost MotorcycleCost::TransitionCost(const baldr::DirectedEdge* edge,
     seconds += gate_cost_;
     penalty += gate_penalty_;
   }
-  // Additional penalties without any time cost
-  uint32_t idx = pred.opp_local_idx();
-  if (pred.use() != Use::kAlley && edge->use() == Use::kAlley) {
-    penalty += alley_penalty_;
-  }
-  if (pred.use() != Use::kFerry && edge->use() == Use::kFerry) {
+  if (edge->use() == Use::kFerry && pred.use() != Use::kFerry) {
     seconds += ferry_cost_;
     penalty += ferry_penalty_;
   }
-  // Ignore name inconsistency when entering a link to avoid double penalizing.
+
+  // Additional penalties without any time cost
+  uint32_t idx = pred.opp_local_idx();
+  if (!pred.destonly() && edge->destonly()) {
+    penalty += destination_only_penalty_;
+  }
+  if (pred.use() != Use::kAlley && edge->use() == Use::kAlley) {
+    penalty += alley_penalty_;
+  }
+
+  // Maneuver penalty, ignore when entering a link to avoid double penalizing
   if (!edge->link() && !node->name_consistency(idx, edge->localedgeidx())) {
-    // Slight maneuver penalty
     penalty += maneuver_penalty_;
   }
 
@@ -575,8 +584,7 @@ Cost MotorcycleCost::TransitionCostReverse(const uint32_t idx,
   float seconds = 0.0f;
   float penalty = 0.0f;
 
-  // Special cases with both time and penalty: country crossing
-  // andgate
+  // Special cases with both time and penalty: country crossing, ferry, and gate
   if (node->type() == NodeType::kBorderControl) {
     seconds += country_crossing_cost_;
     penalty += country_crossing_penalty_;
@@ -584,18 +592,22 @@ Cost MotorcycleCost::TransitionCostReverse(const uint32_t idx,
     seconds += gate_cost_;
     penalty += gate_penalty_;
   }
-
-  // Additional penalties without any time cost
-  if (pred->use() != Use::kAlley && edge->use() == Use::kAlley) {
-    penalty += alley_penalty_;
-  }
-  if (pred->use() != Use::kFerry && edge->use() == Use::kFerry) {
+  if (edge->use() == Use::kFerry && pred->use() != Use::kFerry) {
     seconds += ferry_cost_;
     penalty += ferry_penalty_;
   }
-  // Ignore name inconsistency when entering a link to avoid double penalizing.
+
+  // Additional penalties without any time cost
+  if (edge->destonly() && !pred->destonly()) {
+    penalty += destination_only_penalty_;
+  }
+  if (edge->use() == Use::kAlley && pred->use() != Use::kAlley) {
+    penalty += alley_penalty_;
+  }
+
+
+  // Maneuver penalty, ignore when entering a link to avoid double penalizing
   if (!edge->link() && !node->name_consistency(idx, edge->localedgeidx())) {
-    // Slight maneuver penalty
     penalty += maneuver_penalty_;
   }
 

--- a/src/sif/motorcyclecost.cc
+++ b/src/sif/motorcyclecost.cc
@@ -605,7 +605,6 @@ Cost MotorcycleCost::TransitionCostReverse(const uint32_t idx,
     penalty += alley_penalty_;
   }
 
-
   // Maneuver penalty, ignore when entering a link to avoid double penalizing
   if (!edge->link() && !node->name_consistency(idx, edge->localedgeidx())) {
     penalty += maneuver_penalty_;

--- a/src/sif/motorscootercost.cc
+++ b/src/sif/motorscootercost.cc
@@ -22,16 +22,15 @@ namespace sif {
 // Default options/values
 namespace {
 
-constexpr float kDefaultManeuverPenalty = 5.0f;        // Seconds
-constexpr float kDefaultAlleyPenalty = 5.0f;           // Seconds
-constexpr float kDefaultGateCost = 30.0f;              // Seconds
-constexpr float kDefaultGatePenalty = 300.0f;          // Seconds
-constexpr float kDefaultFerryCost = 300.0f;            // Seconds
-constexpr float kDefaultCountryCrossingCost = 600.0f;  // Seconds
-constexpr float kDefaultCountryCrossingPenalty = 0.0f; // Seconds
-constexpr float kDefaultUseFerry = 0.5f;               // Factor between 0 and 1
+constexpr float kDefaultManeuverPenalty = 5.0f;          // Seconds
+constexpr float kDefaultAlleyPenalty = 5.0f;             // Seconds
+constexpr float kDefaultGateCost = 30.0f;                // Seconds
+constexpr float kDefaultGatePenalty = 300.0f;            // Seconds
+constexpr float kDefaultFerryCost = 300.0f;              // Seconds
+constexpr float kDefaultCountryCrossingCost = 600.0f;    // Seconds
+constexpr float kDefaultCountryCrossingPenalty = 0.0f;   // Seconds
+constexpr float kDefaultUseFerry = 0.5f;                 // Factor between 0 and 1
 constexpr float kDefaultDestinationOnlyPenalty = 120.0f; // Seconds
-
 
 constexpr float kDefaultUseHills = 0.5f;   // Factor between 0 and 1
 constexpr float kDefaultUsePrimary = 0.5f; // Factor between 0 and 1
@@ -549,7 +548,7 @@ Cost MotorScooterCost::TransitionCost(const baldr::DirectedEdge* edge,
 
   // Additional penalties without any time cost
   uint32_t idx = pred.opp_local_idx();
-  if ( edge->destonly() && !pred.destonly()) {
+  if (edge->destonly() && !pred.destonly()) {
     penalty += destination_only_penalty_;
   }
   if (edge->use() == Use::kAlley && pred.use() != Use::kAlley) {

--- a/src/sif/pedestriancost.cc
+++ b/src/sif/pedestriancost.cc
@@ -617,7 +617,7 @@ Cost PedestrianCost::TransitionCost(const baldr::DirectedEdge* edge,
     return {step_penalty_, 0.0f};
   }
 
-  // Penalty through gates and border control.
+  // Penalty through gates, ferries, and border control.
   float seconds = 0.0f;
   float penalty = 0.0f;
   if (node->type() == NodeType::kBorderControl) {
@@ -626,17 +626,15 @@ Cost PedestrianCost::TransitionCost(const baldr::DirectedEdge* edge,
   } else if (node->type() == NodeType::kGate) {
     penalty += gate_penalty_;
   }
-
-  if ((pred.use() != Use::kFerry && edge->use() == Use::kFerry)) {
+  if (edge->use() == Use::kFerry && pred.use() != Use::kFerry) {
     seconds += ferry_cost_;
     penalty += ferry_penalty_;
   }
 
+  // Maneuver penalty, ignore when entering a link to avoid double penalizing
   uint32_t idx = pred.opp_local_idx();
-  // Ignore name inconsistency when entering a link to avoid double penalizing.
   if (!edge->link() && edge->use() != Use::kEgressConnection &&
       edge->use() != Use::kPlatformConnection && !node->name_consistency(idx, edge->localedgeidx())) {
-    // Slight maneuver penalty
     penalty += maneuver_penalty_;
   }
 
@@ -660,7 +658,7 @@ Cost PedestrianCost::TransitionCostReverse(const uint32_t idx,
     return {step_penalty_, 0.0f};
   }
 
-  // Penalty through gates and border control.
+  // Penalty through gates, ferries, and border control.
   float seconds = 0.0f;
   float penalty = 0.0f;
   if (node->type() == NodeType::kBorderControl) {
@@ -669,16 +667,14 @@ Cost PedestrianCost::TransitionCostReverse(const uint32_t idx,
   } else if (node->type() == NodeType::kGate) {
     penalty += gate_penalty_;
   }
-
-  if (pred->use() != Use::kFerry && edge->use() == Use::kFerry) {
+  if (edge->use() == Use::kFerry && pred->use() != Use::kFerry) {
     seconds += ferry_cost_;
     penalty += ferry_penalty_;
   }
 
-  // Ignore name inconsistency when entering a link to avoid double penalizing.
+  // Maneuver penalty, ignore when entering a link to avoid double penalizing
   if (!edge->link() && edge->use() != Use::kEgressConnection &&
       edge->use() != Use::kPlatformConnection && !node->name_consistency(idx, edge->localedgeidx())) {
-    // Slight maneuver penalty
     penalty += maneuver_penalty_;
   }
 

--- a/src/sif/truckcost.cc
+++ b/src/sif/truckcost.cc
@@ -273,7 +273,7 @@ public:
   float speedfactor_[kMaxSpeedKph + 1];
   float density_factor_[16];       // Density factor
   float maneuver_penalty_;         // Penalty (seconds) when inconsistent names
-  float destination_only_penalty_; // Penalty (seconds) using a driveway or parking aisle
+  float destination_only_penalty_; // Penalty (seconds) using private road, driveway, or parking aisle
   float gate_cost_;                // Cost (seconds) to go through gate
   float gate_penalty_;             // Penalty (seconds) to go through gate
   float tollbooth_cost_;           // Cost (seconds) to go through toll booth
@@ -513,20 +513,14 @@ bool TruckCost::Allowed(const baldr::NodeInfo* node) const {
 
 // Get the cost to traverse the edge in seconds
 Cost TruckCost::EdgeCost(const DirectedEdge* edge, const uint32_t speed) const {
-
   float factor = density_factor_[edge->density()];
-
   if (edge->truck_route() > 0) {
     factor *= kTruckRouteFactor;
   }
 
-  float sec = 0.0f;
-  if (edge->truck_speed() > 0) {
-    sec = (edge->length() * speedfactor_[edge->truck_speed()]);
-  } else {
-    sec = (edge->length() * speedfactor_[speed]);
-  }
-
+  // Use the lower or truck speed (ir present) and speed
+  uint32_t s = (edge->truck_speed() > 0) ? std::min(edge->truck_speed(), speed) : speed;
+  float sec = edge->length() * speedfactor_[s];
   return {sec * factor, sec};
 }
 
@@ -538,8 +532,7 @@ Cost TruckCost::TransitionCost(const baldr::DirectedEdge* edge,
   float seconds = 0.0f;
   float penalty = 0.0f;
 
-  // Special cases with both time and penalty: country crossing,
-  // gate, toll booth
+  // Special cases with both time and penalty: country crossing, gate, toll booth
   if (node->type() == NodeType::kBorderControl) {
     seconds += country_crossing_cost_;
     penalty += country_crossing_penalty_;
@@ -554,21 +547,20 @@ Cost TruckCost::TransitionCost(const baldr::DirectedEdge* edge,
 
   // Additional penalties without any time cost
   uint32_t idx = pred.opp_local_idx();
-  if (allow_destination_only_ && !pred.destonly() && edge->destonly()) {
+  if (edge->destonly() && !pred.destonly()) {
     penalty += destination_only_penalty_;
   }
-  if (pred.use() != Use::kAlley && edge->use() == Use::kAlley) {
+  if (edge->use() == Use::kAlley && pred.use() != Use::kAlley) {
     penalty += alley_penalty_;
   }
-  // Ignore name inconsistency when entering a link to avoid double penalizing.
-  if (!edge->link() && !node->name_consistency(idx, edge->localedgeidx())) {
-    // Slight maneuver penalty
-    penalty += maneuver_penalty_;
-  }
-
   if (edge->classification() == RoadClass::kResidential ||
       edge->classification() == RoadClass::kServiceOther) {
     penalty += low_class_penalty_;
+  }
+
+  // Maneuver penalty, ignore when entering a link to avoid double penalizing
+  if (!edge->link() && !node->name_consistency(idx, edge->localedgeidx())) {
+    penalty += maneuver_penalty_;
   }
 
   // Transition time = densityfactor * stopimpact * turncost
@@ -600,8 +592,7 @@ Cost TruckCost::TransitionCostReverse(const uint32_t idx,
   float seconds = 0.0f;
   float penalty = 0.0f;
 
-  // Special cases with both time and penalty: country crossing,
-  // gate, toll booth
+  // Special cases with both time and penalty: country crossing, gate, toll booth
   if (node->type() == NodeType::kBorderControl) {
     seconds += country_crossing_cost_;
     penalty += country_crossing_penalty_;
@@ -615,20 +606,20 @@ Cost TruckCost::TransitionCostReverse(const uint32_t idx,
   }
 
   // Additional penalties without any time cost
-  if (allow_destination_only_ && !pred->destonly() && edge->destonly()) {
+  if (edge->destonly() && !pred->destonly()) {
     penalty += destination_only_penalty_;
   }
-  if (pred->use() != Use::kAlley && edge->use() == Use::kAlley) {
+  if (edge->use() == Use::kAlley && pred->use() != Use::kAlley) {
     penalty += alley_penalty_;
   }
-  // Ignore name inconsistency when entering a link to avoid double penalizing.
-  if (!edge->link() && !node->name_consistency(idx, edge->localedgeidx())) {
-    penalty += maneuver_penalty_;
-  }
-
   if (edge->classification() == RoadClass::kResidential ||
       edge->classification() == RoadClass::kServiceOther) {
     penalty += low_class_penalty_;
+  }
+
+  // Maneuver penalty, ignore when entering a link to avoid double penalizing
+  if (!edge->link() && !node->name_consistency(idx, edge->localedgeidx())) {
+    penalty += maneuver_penalty_;
   }
 
   // Transition time = densityfactor * stopimpact * turncost

--- a/test/trivial_paths.cc
+++ b/test/trivial_paths.cc
@@ -166,6 +166,12 @@ void test_trivial_paths() {
   const auto test_request4 = R"({"locations":[{"lat":52.078882,"lon":5.1104848},
                {"lat":52.0785070,"lon":5.110835}],"costing":"auto"})";
   try_path(reader, loki_worker, test_request4, 1);
+  
+  // Test avoidance of parking aisles. Path should avoid the shortcut via a parking aisle.
+  // driveable direction -must not return a single edge
+  const auto test_request5 = R"({"locations":[{"lat":52.072534,"lon":5.125980},
+               {"lat":52.072862,"lon":5.124025}],"costing":"auto"})";
+  try_path(reader, loki_worker, test_request5, 5);
 }
 
 int main(int argc, char* argv[]) {

--- a/valhalla/baldr/graphconstants.h
+++ b/valhalla/baldr/graphconstants.h
@@ -76,6 +76,11 @@ constexpr uint32_t kMaxSpeedKph = 140; // ~85 MPH
 // Maximum ferry speed
 constexpr uint32_t kMaxFerrySpeedKph = 40; // 21 knots
 
+// Special speeds for use with parking aisles, driveways, and drive thrus
+constexpr uint32_t kParkingAisleSpeed = 15; // 15 KPH (10MPH)
+constexpr uint32_t kDriveThruSpeed = 10;    // 10 KPH
+constexpr uint32_t kDrivewaySpeed = 10;     // 10 KPH
+
 // Road class or importance of an edge
 enum class RoadClass : uint8_t {
   kMotorway = 0,


### PR DESCRIPTION
Fixes #1363 

Destination only (private roads) penalty was mistakenly only applied when the allow_destination_only_ flag was set to true. This made it so that A* and time dependent routes did not get destination only penalties applied. Also added the destination only penalty to motorcycle routes and motor scooter routes to help prevent use of private roads.

Also change the order of some costing conditionals so the infrequent condition is checked first.

 - [x] Review - you must request approval to merge any PR to master
 - [x] Add #fixes with the issue number that this PR addresses
 - [x] Update the [changelog](CHANGELOG.md)
