### PR TITLE
Fix bus routing

### DIFF
--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -709,7 +709,7 @@ public:
                        const EdgeLabel& pred,
                        const baldr::GraphTile*& tile,
                        const baldr::GraphId& edgeid,
-                       const uint32_t current_time,
+                       const uint64_t current_time,
                        const uint32_t tz_index) const;
 
   /**
@@ -735,7 +735,7 @@ public:
                               const baldr::DirectedEdge* opp_edge,
                               const baldr::GraphTile*& tile,
                               const baldr::GraphId& opp_edgeid,
-                              const uint32_t current_time,
+                              const uint64_t current_time,
                               const uint32_t tz_index) const;
 
   /**
@@ -783,7 +783,7 @@ bool BusCost::Allowed(const baldr::DirectedEdge* edge,
                       const EdgeLabel& pred,
                       const baldr::GraphTile*& tile,
                       const baldr::GraphId& edgeid,
-                      const uint32_t current_time,
+                      const uint64_t current_time,
                       const uint32_t tz_index) const {
   // TODO - obtain and check the access restrictions.
 
@@ -796,6 +796,7 @@ bool BusCost::Allowed(const baldr::DirectedEdge* edge,
       (!allow_destination_only_ && !pred.destonly() && edge->destonly())) {
     return false;
   }
+
   if (edge->access_restriction()) {
     const std::vector<baldr::AccessRestriction>& restrictions =
         tile->GetAccessRestrictions(edgeid.id(), kBusAccess);
@@ -823,7 +824,7 @@ bool BusCost::AllowedReverse(const baldr::DirectedEdge* edge,
                              const baldr::DirectedEdge* opp_edge,
                              const baldr::GraphTile*& tile,
                              const baldr::GraphId& opp_edgeid,
-                             const uint32_t current_time,
+                             const uint64_t current_time,
                              const uint32_t tz_index) const {
   // Check access, U-turn, and simple turn restriction.
   // Allow U-turns at dead-end nodes.
@@ -904,7 +905,7 @@ public:
                        const EdgeLabel& pred,
                        const baldr::GraphTile*& tile,
                        const baldr::GraphId& edgeid,
-                       const uint32_t current_time,
+                       const uint64_t current_time,
                        const uint32_t tz_index) const;
 
   /**
@@ -929,7 +930,7 @@ public:
                               const baldr::DirectedEdge* opp_edge,
                               const baldr::GraphTile*& tile,
                               const baldr::GraphId& opp_edgeid,
-                              const uint32_t current_time,
+                              const uint64_t current_time,
                               const uint32_t tz_index) const;
 
   /**
@@ -993,7 +994,7 @@ bool HOVCost::Allowed(const baldr::DirectedEdge* edge,
                       const EdgeLabel& pred,
                       const baldr::GraphTile*& tile,
                       const baldr::GraphId& edgeid,
-                      const uint32_t current_time,
+                      const uint64_t current_time,
                       const uint32_t tz_index) const {
   // TODO - obtain and check the access restrictions.
 
@@ -1035,7 +1036,7 @@ bool HOVCost::AllowedReverse(const baldr::DirectedEdge* edge,
                              const baldr::DirectedEdge* opp_edge,
                              const baldr::GraphTile*& tile,
                              const baldr::GraphId& opp_edgeid,
-                             const uint32_t current_time,
+                             const uint64_t current_time,
                              const uint32_t tz_index) const {
   // TODO - obtain and check the access restrictions.
 
@@ -1110,7 +1111,7 @@ public:
                        const EdgeLabel& pred,
                        const baldr::GraphTile*& tile,
                        const baldr::GraphId& edgeid,
-                       const uint32_t current_time,
+                       const uint64_t current_time,
                        const uint32_t tz_index) const {
     // Check access and return false (not allowed if no auto access is allowed in either
     // direction. Also disallow simple U-turns except at dead-end nodes.


### PR DESCRIPTION
Bus (and other costing derived from AutoCost) had their Allowed methods using uint32_t current_time while the base AutoCost::Allowed method had uint64_t. This causes the base class method to be called rather than the derived class method.

fixes #1370 

 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
