### PR TITLE
Initialize ComplexRestriction and check has_dt flag in operator==

### DIFF
--- a/src/mjolnir/complexrestrictionbuilder.cc
+++ b/src/mjolnir/complexrestrictionbuilder.cc
@@ -39,14 +39,20 @@ std::ostream& operator<<(std::ostream& os, const ComplexRestrictionBuilder& crb)
 
 // overloaded == operator - used to ensure no dups in tiles.
 bool ComplexRestrictionBuilder::operator==(const ComplexRestrictionBuilder& other) const {
-  if (from_graphid_ != other.from_graphid_ || has_dt_ != other.has_dt_ ||
-      begin_day_dow_ != other.begin_day_dow_ || begin_month_ != other.begin_month_ ||
-      begin_week_ != other.begin_week_ || begin_hrs_ != other.begin_hrs_ ||
-      to_graphid_ != other.to_graphid_ || dt_type_ != other.dt_type_ ||
-      end_day_dow_ != other.end_day_dow_ || end_month_ != other.end_month_ ||
-      end_week_ != other.end_week_ || end_hrs_ != other.end_hrs_ || via_list_ != other.via_list_ ||
-      type_ != other.type_ || modes_ != other.modes_ || dow_ != other.dow_ ||
-      begin_mins_ != other.begin_mins_ || end_mins_ != other.end_mins_) {
+  if (from_graphid_ != other.from_graphid_ || to_graphid_ != other.to_graphid_ ||
+      type_ != other.type_ || modes_ != other.modes_ || has_dt_ != other.has_dt_) {
+    return false;
+  }
+  if (has_dt_ && (begin_day_dow_ != other.begin_day_dow_ || begin_hrs_ != other.begin_hrs_ ||
+                  begin_mins_ != other.begin_mins_ || begin_month_ != other.begin_month_ ||
+                  begin_week_ != other.begin_week_ || dow_ != other.dow_ ||
+                  dt_type_ != other.dt_type_ || end_day_dow_ != other.end_day_dow_ ||
+                  end_hrs_ != other.end_hrs_ || end_mins_ != other.end_mins_ ||
+                  end_month_ != other.end_month_ || end_week_ != other.end_week_)) {
+    return false;
+  }
+
+  if (via_list_ != other.via_list_) {
     return false;
   }
 

--- a/src/mjolnir/restrictionbuilder.cc
+++ b/src/mjolnir/restrictionbuilder.cc
@@ -395,7 +395,7 @@ void build(const std::string& complex_restriction_file,
                   // determine if we need to add this complex restriction or not.
                   // basically we do not want any dups.
                   bool bfound = false;
-                  auto res = reverse_tmp_cr.equal_range(tmp_ids.at(0));
+                  const auto res = reverse_tmp_cr.equal_range(tmp_ids.at(0));
                   if (res.first != reverse_tmp_cr.end()) {
                     for (auto r = res.first; r != res.second; ++r) {
                       if (complex_restriction == r->second) {
@@ -419,7 +419,7 @@ void build(const std::string& complex_restriction_file,
         if (directededge.end_restriction()) {
 
           // is this edge the end of a restriction?
-          auto to = end_map.equal_range(e_offset.wayid());
+          const auto to = end_map.equal_range(e_offset.wayid());
           if (to.first != end_map.end()) {
             for (auto it = to.first; it != to.second; ++it) {
 
@@ -529,7 +529,7 @@ void build(const std::string& complex_restriction_file,
                       // determine if we need to add this complex restriction or not.
                       // basically we do not want any dups.
                       bool bfound = false;
-                      auto res = forward_tmp_cr.equal_range(tmp_ids.at(0));
+                      const auto res = forward_tmp_cr.equal_range(tmp_ids.at(0));
                       if (res.first != forward_tmp_cr.end()) {
                         for (auto r = res.first; r != res.second; ++r) {
                           if (complex_restriction == r->second) {
@@ -607,9 +607,8 @@ void RestrictionBuilder::Build(const boost::property_tree::ptree& pt,
     LOG_INFO("Adding Restrictions at level " + std::to_string(tile_level.level));
     for (size_t i = 0; i < threads.size(); ++i) {
       threads[i].reset(new std::thread(build, std::cref(complex_restrictions_file),
-                                       std::cref(end_map), std::ref(hierarchy_properties),
-                                       std::ref(tilequeue), std::ref(lock),
-                                       std::ref(std::ref(results[i]))));
+                                       std::cref(end_map), std::cref(hierarchy_properties),
+                                       std::ref(tilequeue), std::ref(lock), std::ref(results[i])));
     }
 
     // Wait for them to finish up their work

--- a/valhalla/baldr/complexrestriction.h
+++ b/valhalla/baldr/complexrestriction.h
@@ -30,6 +30,11 @@ constexpr size_t kMaxViasPerRestriction = 31;
  */
 class ComplexRestriction {
 public:
+  ComplexRestriction()
+      : from_graphid_(kInvalidGraphId), has_dt_(0), to_graphid_(kInvalidGraphId), type_(0), modes_(0),
+        via_count_(0) {
+  }
+
   /**
    * Get the restriction's from graph id
    * @return  Returns the from graph id


### PR DESCRIPTION
# Issue

Added initialization of `ComplexRestriction` bit-fields  and check of `has_dt` in `ComplexRestrictionBuilder::operator==`.

PR fixes undefined behavior in initialization of timed restrictions.

## Tasklist

 - [x] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
