### PR TITLE
fix gtfs manoeuver

### DIFF
--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -713,7 +713,9 @@ const TransitDeparture* GraphTile::GetTransitDeparture(const uint32_t lineid,
     mid = (low + high) / 2;
     const auto& dep = departures_[mid];
     // find the first matching lineid in the list
-    if (lineid == dep.lineid()) {
+    if (lineid == dep.lineid() &&
+        ((current_time <= dep.departure_time() && dep.type() == kFixedSchedule) ||
+         (current_time <= dep.end_time() && dep.type() == kFrequencySchedule))) {
       found = mid;
       high = mid - 1;
     } // need a smaller lineid


### PR DESCRIPTION
# Issue

For feeds where the same bus goes several times over the same node/edges in the same GTFS trip, the directions will be invalid (earlier departure time selected). Because 'current_time' wasn't taken into account when looking for the relevant TransitDeparture


Before:

```
 [NARRATIVE] ----------------------------------------------
 [NARRATIVE]    Depart: 8:44 AM from Carrefour.
 [NARRATIVE]    VERBAL_DEPART: Depart at 8:44 AM from Carrefour.
 [NARRATIVE] 2: Take the Basse saison 1 toward Medran. (3 stops) | 2.7 km
 [NARRATIVE]    VERBAL_PRE: Take the Basse saison 1 toward Medran.
 [NARRATIVE]    VERBAL_POST: Travel 3 stops.
 [NARRATIVE]    Arrive: 8:29 AM at Medran.
 [NARRATIVE]    VERBAL_ARRIVE: Arrive at 8:29 AM at Medran.
 [NARRATIVE] ----------------------------------------------
```

After:

```
 [NARRATIVE] ----------------------------------------------
 [NARRATIVE]    Depart: 8:44 AM from Carrefour.
 [NARRATIVE]    VERBAL_DEPART: Depart at 8:44 AM from Carrefour.
 [NARRATIVE] 2: Take the Basse saison 1 toward Medran. (3 stops) | 2.7 km
 [NARRATIVE]    VERBAL_PRE: Take the Basse saison 1 toward Medran.
 [NARRATIVE]    VERBAL_POST: Travel 3 stops.
 [NARRATIVE]    Arrive: 8:57 AM at Medran.
 [NARRATIVE]    VERBAL_ARRIVE: Arrive at 8:57 AM at Medran.
 [NARRATIVE] ----------------------------------------------

```


## Tasklist

 - [ ] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)

## Requirements / Relations

Could ideally be patched in 2.6 branch as well.