### PR TITLE
Update readme to reflect appropriate steps when building node bindings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - restore_cache:
           keys:
             - ccache
-      - run: npm install
+      - run: npm install --ignore-scripts
       - run: mkdir build
       - run: cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=On
       - run: make -C build -j4
@@ -28,7 +28,7 @@ jobs:
       - restore_cache:
           keys:
             - ccache
-      - run: npm install
+      - run: npm install --ignore-scripts
       - run: mkdir build
       - run: |
           cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=Off -DENABLE_PYTHON_BINDINGS=On \
@@ -56,7 +56,7 @@ jobs:
       - restore_cache:
           keys:
             - ccache
-      - run: npm install
+      - run: npm install --ignore-scripts
       - run: mkdir build
       - run: cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=On -DCPACK_GENERATOR=DEB
       - run: make -C build -j4
@@ -80,7 +80,7 @@ jobs:
       - restore_cache:
           keys:
             - ccache
-      - run: npm install
+      - run: npm install --ignore-scripts
       - run: mkdir build
       - run: |
           cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=On -DENABLE_PYTHON_BINDINGS=On \
@@ -109,7 +109,7 @@ jobs:
       #       - ccache
       - run: wget https://raw.githubusercontent.com/valhalla/homebrew-valhalla/master/Formula/prime_server.rb
       - run: brew install --build-from-source ./prime_server.rb
-      - run: npm install
+      - run: npm install --ignore-scripts
       - run: mkdir -p build
       - run: cd build && cmake .. -DENABLE_PYTHON_BINDINGS=Off
       - run: make -C build -j4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
    * ADDED: Added post process for updating free and constrained speeds in the directed edges.
    * UPDATED: Parse the json request once and store in a protocol buffer to pass along the pipeline. This completed the first portion of [1357](https://github.com/valhalla/valhalla/issues/1357)
    * UPDATED: Changed the shape_match attribute from a string to an enum. Fixes [1376](https://github.com/valhalla/valhalla/issues/1376)
+   * ADDED: Node bindings for route [#1341](https://github.com/valhalla/valhalla/pull/1341)
 
 ## Release Date: 2018-06-28 Valhalla 2.6.2
 * **Data Producer Update**

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ To install on macOS, you need to install its dependencies with [Homebrew](http:/
 
 ```bash
 # install dependencies (czmq is required by prime_server)
-brew install cmake libtool protobuf-c boost-python libspatialite pkg-config sqlite3 lua jq curl wget czmq lz4 npm
+brew install cmake libtool protobuf-c boost-python libspatialite pkg-config sqlite3 lua jq curl wget czmq lz4 node@10 npm
 nvm use 10 # must use node 8.11.1 and up because of N-API
 npm install --ignore-scripts
 ```

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ sudo apt-get install -y libgeos-dev libgeos++-dev liblua5.2-dev libspatialite-de
 if [[ $(grep -cF xenial /etc/lsb-release) > 0 ]]; then sudo apt-get install -y libsqlite3-mod-spatialite; fi
 #if you plan to compile with python bindings, see below for more info
 sudo apt-get install -y python-all-dev
+#if you plan to compile with node bindings, run
+npm install --ignore-scripts
 ```
 
 To install on macOS, you need to install its dependencies with [Homebrew](http://brew.sh):
@@ -105,6 +107,7 @@ To install on macOS, you need to install its dependencies with [Homebrew](http:/
 ```bash
 # install dependencies (czmq is required by prime_server)
 brew install cmake libtool protobuf-c boost-python libspatialite pkg-config sqlite3 lua jq curl wget czmq lz4
+npm install --ignore-scripts
 ```
 
 Then clone and build [`prime_server`](https://github.com/kevinkreiser/prime_server#build-and-install).
@@ -118,8 +121,6 @@ cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release
 make -j$(nproc)
 sudo make install
-// to install with node bindings
-make copy_node_artifacts
 ```
 
 Important build options include:
@@ -189,7 +190,7 @@ Using the Node.js Bindings
 
 The Node.js bindings are still under construction. We are working on building binaries for as many environments as possible, but they may not all be available yet. The first functionality that we are exposing is `route`, but we plan on exposing more functionality over time. Right now, the input and the output are both strings - THAT WILL CHANGE. We plan on ingesting and producing protobufs.
 
-The Node.js bindings provide read-only access to the routing engine. You can install the Node.js bindings via npm install valhalla or from this repository via `$npm install` which will check and use pre-built binaries if they're available for this release and your Node version.
+The Node.js bindings provide read-only access to the routing engine. You can install the Node.js bindings from this repository via `$npm install` which will check and use pre-built binaries if they're available for this release and your Node version. Soon you will be able to run `npm install valhalla` to include the package as a dependency in another project, but we haven't published to the npm org just yet. You can also build bindings from source with the ENABLE_NODE_BINDINGS option.
 
 Example of using in a node project:
 ```js

--- a/README.md
+++ b/README.md
@@ -92,13 +92,14 @@ To install on a Debian or Ubuntu system you need to install its dependencies wit
 ```bash
 sudo add-apt-repository -y ppa:valhalla-core/valhalla
 sudo apt-get update
-sudo apt-get install -y cmake make libtool pkg-config g++ gcc jq lcov protobuf-compiler vim-common libboost-all-dev libboost-all-dev libcurl4-openssl-dev zlib1g-dev liblz4-dev libprime-server0.6.3-dev libprotobuf-dev prime-server0.6.3-bin
+sudo apt-get install -y cmake make libtool pkg-config g++ gcc jq lcov protobuf-compiler vim-common libboost-all-dev libboost-all-dev libcurl4-openssl-dev zlib1g-dev liblz4-dev libprime-server0.6.3-dev libprotobuf-dev prime-server0.6.3-bin nodejs npm
 #if you plan to compile with data building support, see below for more info
 sudo apt-get install -y libgeos-dev libgeos++-dev liblua5.2-dev libspatialite-dev libsqlite3-dev lua5.2 wget
 if [[ $(grep -cF xenial /etc/lsb-release) > 0 ]]; then sudo apt-get install -y libsqlite3-mod-spatialite; fi
 #if you plan to compile with python bindings, see below for more info
 sudo apt-get install -y python-all-dev
 #if you plan to compile with node bindings, run
+nvm use 10 # must use node 8 or 10
 npm install --ignore-scripts
 ```
 
@@ -106,7 +107,7 @@ To install on macOS, you need to install its dependencies with [Homebrew](http:/
 
 ```bash
 # install dependencies (czmq is required by prime_server)
-brew install cmake libtool protobuf-c boost-python libspatialite pkg-config sqlite3 lua jq curl wget czmq lz4
+brew install cmake libtool protobuf-c boost-python libspatialite pkg-config sqlite3 lua jq curl wget czmq lz4 npm
 npm install --ignore-scripts
 ```
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ if [[ $(grep -cF xenial /etc/lsb-release) > 0 ]]; then sudo apt-get install -y l
 #if you plan to compile with python bindings, see below for more info
 sudo apt-get install -y python-all-dev
 #if you plan to compile with node bindings, run
-nvm use 10 # must use node 8 or 10
+nvm use 10 # must use node 8.11.1 and up because of N-API
 npm install --ignore-scripts
 ```
 
@@ -108,6 +108,7 @@ To install on macOS, you need to install its dependencies with [Homebrew](http:/
 ```bash
 # install dependencies (czmq is required by prime_server)
 brew install cmake libtool protobuf-c boost-python libspatialite pkg-config sqlite3 lua jq curl wget czmq lz4 npm
+nvm use 10 # must use node 8.11.1 and up because of N-API
 npm install --ignore-scripts
 ```
 
@@ -192,6 +193,8 @@ Using the Node.js Bindings
 The Node.js bindings are still under construction. We are working on building binaries for as many environments as possible, but they may not all be available yet. The first functionality that we are exposing is `route`, but we plan on exposing more functionality over time. Right now, the input and the output are both strings - THAT WILL CHANGE. We plan on ingesting and producing protobufs.
 
 The Node.js bindings provide read-only access to the routing engine. You can install the Node.js bindings from this repository via `$npm install` which will check and use pre-built binaries if they're available for this release and your Node version. Soon you will be able to run `npm install valhalla` to include the package as a dependency in another project, but we haven't published to the npm org just yet. You can also build bindings from source with the ENABLE_NODE_BINDINGS option.
+
+We are using N-API to create node bindings. N-API aims to provide ABI compatibility guarantees across different Node versions and also across different Node VMs - allowing N-API enabled native modules to just work across different versions and flavors of Node.js without recompilations. N-API is a new feature and was experimental until node 8.11.2, after which is it considered stable. Please make sure you are using node 8.11.2+ if you want to use the node bindings.
 
 Example of using in a node project:
 ```js


### PR DESCRIPTION
# Issue

If you are building the node bindings locally, you should run `npm install --ignore-scripts` because `npm install` will pull down the binary from s3 if it exists.

## Tasklist

 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [x] Update relevant [documentation](docs/README.md)

