### PR TITLE
Create npm ignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,10 @@
+*
+!README.md
+!CHANGELOG.md
+!LICENCE.MD
+!package.json
+!package-lock.json
+!docs
+!taginfo.json
+!lib/*.js
+!scripts/node_install.sh


### PR DESCRIPTION
# Issue

We only need to publish a few js files as part of the npm package to the npm registry. This file sets us up to ignore all the unneeded stuff. When someone runs `npm install valhalla`, it gets the package from npm and then node-pre-gyp gets the proper binary from s3.

## Tasklist

 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Generally use squash merge to rebase and clean comments before merging

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
