### PR TITLE
Use std::tm and get_time to parse the ISO date time string. 

### DIFF
--- a/src/baldr/datetime.cc
+++ b/src/baldr/datetime.cc
@@ -850,6 +850,7 @@ std::string get_duration(const std::string& date_time,
   return formatted_date_time;
 }
 
+/**
 // checks if string is in the format of %Y-%m-%dT%H:%M
 bool is_iso_local(const std::string& date_time) {
 
@@ -887,6 +888,7 @@ bool is_iso_local(const std::string& date_time) {
   } catch (std::exception& e) { return false; }
   return is_ok;
 }
+**/
 
 // does this date fall in the begin and end date range?
 bool is_restricted(const bool type,

--- a/src/baldr/datetime.cc
+++ b/src/baldr/datetime.cc
@@ -850,46 +850,6 @@ std::string get_duration(const std::string& date_time,
   return formatted_date_time;
 }
 
-/**
-// checks if string is in the format of %Y-%m-%dT%H:%M
-bool is_iso_local(const std::string& date_time) {
-
-  std::stringstream ss("");
-  bool is_ok = true;
-
-  if (date_time.size() != 16) { // YYYY-MM-DDTHH:MM
-    return false;
-  }
-
-  if (date_time.at(4) != '-' || date_time.at(7) != '-' || date_time.at(10) != 'T' ||
-      date_time.at(13) != ':') {
-    return false;
-  }
-
-  try {
-    boost::local_time::local_time_input_facet* input_facet =
-        new boost::local_time::local_time_input_facet();
-    input_facet->format("%Y-%m-%dT%H:%M");
-
-    ss.imbue(std::locale(ss.getloc(), input_facet));
-    boost::posix_time::ptime pt;
-    ss.str(date_time);
-    is_ok = static_cast<bool>(ss >> pt);
-
-    std::size_t found = date_time.find('T'); // YYYY-MM-DDTHH:MM
-    std::string time = date_time.substr(found + 1);
-    uint32_t hour = std::stoi(time.substr(0, 2));
-    uint32_t min = std::stoi(time.substr(3));
-
-    if (hour > 23 || min > 59) {
-      return false;
-    }
-
-  } catch (std::exception& e) { return false; }
-  return is_ok;
-}
-**/
-
 // does this date fall in the begin and end date range?
 bool is_restricted(const bool type,
                    const uint8_t begin_hrs,

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -618,7 +618,7 @@ void from_json(rapidjson::Document& doc, odin::DirectionsOptions& options) {
         if (!date_time_value) {
           throw valhalla_exception_t{160};
         };
-        if (!baldr::DateTime::is_iso_local(*date_time_value)) {
+        if (!baldr::DateTime::is_iso_valid(*date_time_value)) {
           throw valhalla_exception_t{162};
         };
         options.set_date_time(*date_time_value);
@@ -634,7 +634,7 @@ void from_json(rapidjson::Document& doc, odin::DirectionsOptions& options) {
         if (!date_time_value) {
           throw valhalla_exception_t{161};
         };
-        if (!baldr::DateTime::is_iso_local(*date_time_value)) {
+        if (!baldr::DateTime::is_iso_valid(*date_time_value)) {
           throw valhalla_exception_t{162};
         };
         options.set_date_time(*date_time_value);

--- a/test/datetime.cc
+++ b/test/datetime.cc
@@ -22,20 +22,20 @@ std::vector<std::string> GetTagTokens(const std::string& tag_value, char delim) 
   return tokens;
 }
 
-void TryGetDaysFromPivotDate(std::string date_time, uint32_t expected_days) {
+void TryGetDaysFromPivotDate(const std::string& date_time, uint32_t expected_days) {
   if (DateTime::days_from_pivot_date(DateTime::get_formatted_date(date_time)) != expected_days) {
     throw std::runtime_error(std::string("Incorrect number of days from ") + date_time);
   }
 }
 
-void TryGetDOW(std::string date_time, uint32_t expected_dow) {
+void TryGetDOW(const std::string& date_time, uint32_t expected_dow) {
 
   if (DateTime::day_of_week_mask(date_time) != expected_dow) {
     throw std::runtime_error(std::string("Incorrect dow ") + date_time);
   }
 }
 
-void TryGetDuration(std::string date_time, uint32_t seconds, std::string expected_date_time) {
+void TryGetDuration(const std::string& date_time, uint32_t seconds, const std::string& expected_date_time) {
 
   auto tz = DateTime::get_tz_db().from_index(DateTime::get_tz_db().to_index("America/New_York"));
 
@@ -46,7 +46,7 @@ void TryGetDuration(std::string date_time, uint32_t seconds, std::string expecte
   }
 }
 
-void TryGetSecondsFromMidnight(std::string date_time, uint32_t expected_seconds) {
+void TryGetSecondsFromMidnight(const std::string& date_time, uint32_t expected_seconds) {
   if (DateTime::seconds_from_midnight(date_time) != expected_seconds) {
     throw std::runtime_error(std::string("Incorrect number of seconds from ") + date_time);
   }
@@ -90,8 +90,8 @@ void TryIsoDateTime() {
   }
 }
 
-void TryGetServiceDays(std::string begin_date,
-                       std::string end_date,
+void TryGetServiceDays(const std::string& begin_date,
+    const std::string& end_date,
                        uint32_t dow_mask,
                        uint64_t value) {
 
@@ -104,9 +104,9 @@ void TryGetServiceDays(std::string begin_date,
                              " " + std::to_string(days));
 }
 
-void TryGetServiceDays(std::string tile_date,
-                       std::string begin_date,
-                       std::string end_date,
+void TryGetServiceDays(const std::string& tile_date,
+    const std::string& begin_date,
+    const std::string& end_date,
                        uint32_t dow_mask,
                        uint64_t value) {
 
@@ -120,9 +120,9 @@ void TryGetServiceDays(std::string tile_date,
                              " " + std::to_string(days));
 }
 
-void TryIsServiceAvailable(std::string begin_date,
-                           std::string date,
-                           std::string end_date,
+void TryIsServiceAvailable(const std::string& begin_date,
+    const std::string& date,
+    const std::string& end_date,
                            uint64_t days,
                            bool value) {
 
@@ -135,9 +135,9 @@ void TryIsServiceAvailable(std::string begin_date,
                              " " + std::to_string(days));
 }
 
-void TryIsServiceDaysUsingShift(std::string begin_date,
-                                std::string date,
-                                std::string end_date,
+void TryIsServiceDaysUsingShift(const std::string& begin_date,
+    const std::string& date,
+    const std::string& end_date,
                                 uint64_t days,
                                 bool value) {
 
@@ -161,9 +161,9 @@ void TryIsServiceDaysUsingShift(std::string begin_date,
 }
 
 void TryGetServiceDays(bool check_b_date,
-                       std::string begin_date,
-                       std::string date,
-                       std::string end_date,
+    const std::string& begin_date,
+    const std::string& date,
+    const std::string& end_date,
                        uint32_t dow_mask,
                        uint64_t value) {
 
@@ -188,7 +188,7 @@ void TryGetServiceDays(bool check_b_date,
   }
 }
 
-void TryRejectFeed(std::string begin_date, std::string end_date, uint32_t dow_mask, uint64_t value) {
+void TryRejectFeed(const std::string& begin_date, const std::string& end_date, uint32_t dow_mask, uint64_t value) {
 
   auto b = DateTime::get_formatted_date(begin_date);
   auto e = DateTime::get_formatted_date(end_date);
@@ -205,9 +205,9 @@ void TryRejectFeed(std::string begin_date, std::string end_date, uint32_t dow_ma
 }
 
 void TryAddServiceDays(uint64_t days,
-                       std::string begin_date,
-                       std::string end_date,
-                       std::string added_date,
+    const std::string& begin_date,
+    const std::string& end_date,
+    const std::string& added_date,
                        uint64_t value) {
 
   auto b = DateTime::get_formatted_date(begin_date);
@@ -219,9 +219,9 @@ void TryAddServiceDays(uint64_t days,
 }
 
 void TryRemoveServiceDays(uint64_t days,
-                          std::string begin_date,
-                          std::string end_date,
-                          std::string removed_date,
+    const std::string& begin_date,
+    const std::string& end_date,
+    const std::string& removed_date,
                           uint64_t value) {
 
   auto b = DateTime::get_formatted_date(begin_date);
@@ -232,9 +232,9 @@ void TryRemoveServiceDays(uint64_t days,
     throw std::runtime_error("Invalid bits set for added service day. " + removed_date);
 }
 
-void TryTestServiceEndDate(std::string begin_date,
-                           std::string end_date,
-                           std::string new_end_date,
+void TryTestServiceEndDate(const std::string& begin_date,
+    const std::string& end_date,
+    const std::string& new_end_date,
                            uint32_t dow_mask) {
 
   auto b = DateTime::get_formatted_date(begin_date);
@@ -249,18 +249,18 @@ void TryTestServiceEndDate(std::string begin_date,
     throw std::runtime_error("End date not cut off at 60 days.");
 }
 
-void TryTestIsValid(std::string date, bool return_value) {
+void TryTestIsValid(const std::string& date, bool return_value) {
 
-  auto ret = DateTime::is_iso_local(date);
+  auto ret = DateTime::is_iso_valid(date);
   if (ret != return_value)
-    throw std::runtime_error("Test is_iso_local failed: " + date);
+    throw std::runtime_error("Test is_iso_valid failed: " + date);
 }
 
 void TryTestDST(const bool is_depart_at,
                 const uint64_t origin_seconds,
                 const uint64_t dest_seconds,
-                std::string o_value,
-                std::string d_value) {
+                const std::string& o_value,
+                const std::string& d_value) {
 
   auto tz = DateTime::get_tz_db().from_index(DateTime::get_tz_db().to_index("America/New_York"));
 
@@ -276,7 +276,7 @@ void TryTestDST(const bool is_depart_at,
                              iso_dest);
 }
 
-void TryIsRestricted(const TimeDomain td, const std::string date, const bool expected_value) {
+void TryIsRestricted(const TimeDomain td, const std::string& date, const bool expected_value) {
 
   auto tz = DateTime::get_tz_db().from_index(DateTime::get_tz_db().to_index("America/New_York"));
 
@@ -292,10 +292,10 @@ void TryIsRestricted(const TimeDomain td, const std::string date, const bool exp
 
 void TryTestTimezoneDiff(const bool is_depart,
                          const uint64_t date_time,
-                         const std::string expected1,
-                         const std::string expected2,
-                         const std::string time_zone1,
-                         const std::string time_zone2) {
+                         const std::string& expected1,
+                         const std::string& expected2,
+                         const std::string& time_zone1,
+                         const std::string& time_zone2) {
 
   uint64_t dt = date_time;
 
@@ -316,7 +316,7 @@ void TryTestTimezoneDiff(const bool is_depart,
                              DateTime::seconds_to_date(dt, tz2));
 }
 
-void TryConditionalRestrictions(const std::string condition,
+void TryConditionalRestrictions(const std::string& condition,
                                 const std::vector<uint64_t> expected_values) {
 
   std::vector<uint64_t> results = DateTime::get_time_range(condition);
@@ -339,7 +339,7 @@ void TryConditionalRestrictions(const std::string condition,
   }
 }
 
-void TryConditionalRestrictions(const std::string condition,
+void TryConditionalRestrictions(const std::string& condition,
                                 const uint32_t index,
                                 const uint32_t type,
                                 const uint32_t dow,
@@ -567,7 +567,8 @@ void TestIsValid() {
 
   TryTestIsValid("1983-02-30T24:01", false);
   TryTestIsValid("2015-13-06T24:01", false);
-  TryTestIsValid("2015-05-06T24:60", false);
+  TryTestIsValid("2015-05-06T25:59", false);
+  TryTestIsValid("2015-05-06T23:60", false);
   TryTestIsValid("2015-05-06T26:02", false);
   TryTestIsValid("2015-05-06T23:59", true);
   TryTestIsValid("2015-05-06T-3:-9", false);
@@ -576,6 +577,17 @@ void TestIsValid() {
   TryTestIsValid("2015-05-06T01", false);
   TryTestIsValid("01:00", false);
   TryTestIsValid("aefopijafepij", false);
+
+  TryTestIsValid("ABCDEFG", false);
+  TryTestIsValid("2018--26T10:00", false);
+  TryTestIsValid("11800--26T10:00", false);
+  TryTestIsValid("2018-25-26T10:00", false);
+  TryTestIsValid("2018:25:26T10:00", false);
+  TryTestIsValid("2018-1-26M10:00", false);
+  TryTestIsValid("2018-1-26T1000:00", false);
+  TryTestIsValid("2018-1-26T:01:1000", false);
+  TryTestIsValid("2018-1-26T:00", false);
+  TryTestIsValid("2018-07-22T10:89", false);
 }
 
 void TestDST() {
@@ -1128,6 +1140,36 @@ void TestDayOfWeek() {
   }
 }
 
+void TryInvalidISO(const std::string& iso) {
+  std::tm t = DateTime::iso_to_tm(iso);
+  if (t.tm_year != 0) {
+    throw std::runtime_error("DateTime::iso_to_tm did not return an invalid year for improper string: " + iso +
+        " tm values are: " + std::to_string(t.tm_year) + "," + std::to_string(t.tm_mon) + "," + std::to_string(t.tm_mday) +
+        "," + std::to_string(t.tm_hour) + "," + std::to_string(t.tm_min));
+  }
+}
+
+void TestISOToTm() {
+  std::string date = "2018-07-22T10:09";
+  std::tm t = DateTime::iso_to_tm(date);
+  if (t.tm_year != 118) {
+    throw std::runtime_error("DateTime::iso_to_tm year: 118 expected");
+  }
+  // Remember, tm_mon is 0 based
+  if (t.tm_mon != 6) {
+    throw std::runtime_error("DateTime::iso_to_tm month: 6 expected, got: " + std::to_string(t.tm_mon));
+  }
+  if (t.tm_mday != 22) {
+    throw std::runtime_error("DateTime::iso_to_tm month: 22 expected");
+  }
+  if (t.tm_hour != 10) {
+    throw std::runtime_error("DateTime::iso_to_tm hour: 10 expected, got: " + std::to_string(t.tm_hour));
+  }
+  if (t.tm_min != 9) {
+    throw std::runtime_error("DateTime::iso_to_tm min: 9 expected");
+  }
+}
+
 int main(void) {
   test::suite suite("datetime");
 
@@ -1144,6 +1186,8 @@ int main(void) {
   suite.test(TEST_CASE(TestIsRestricted));
   suite.test(TEST_CASE(TestTimezoneDiff));
   suite.test(TEST_CASE(TestDayOfWeek));
+
+  suite.test(TEST_CASE(TestISOToTm));
 
   return suite.tear_down();
 }

--- a/test/datetime.cc
+++ b/test/datetime.cc
@@ -35,7 +35,9 @@ void TryGetDOW(const std::string& date_time, uint32_t expected_dow) {
   }
 }
 
-void TryGetDuration(const std::string& date_time, uint32_t seconds, const std::string& expected_date_time) {
+void TryGetDuration(const std::string& date_time,
+                    uint32_t seconds,
+                    const std::string& expected_date_time) {
 
   auto tz = DateTime::get_tz_db().from_index(DateTime::get_tz_db().to_index("America/New_York"));
 
@@ -91,7 +93,7 @@ void TryIsoDateTime() {
 }
 
 void TryGetServiceDays(const std::string& begin_date,
-    const std::string& end_date,
+                       const std::string& end_date,
                        uint32_t dow_mask,
                        uint64_t value) {
 
@@ -105,8 +107,8 @@ void TryGetServiceDays(const std::string& begin_date,
 }
 
 void TryGetServiceDays(const std::string& tile_date,
-    const std::string& begin_date,
-    const std::string& end_date,
+                       const std::string& begin_date,
+                       const std::string& end_date,
                        uint32_t dow_mask,
                        uint64_t value) {
 
@@ -121,8 +123,8 @@ void TryGetServiceDays(const std::string& tile_date,
 }
 
 void TryIsServiceAvailable(const std::string& begin_date,
-    const std::string& date,
-    const std::string& end_date,
+                           const std::string& date,
+                           const std::string& end_date,
                            uint64_t days,
                            bool value) {
 
@@ -136,8 +138,8 @@ void TryIsServiceAvailable(const std::string& begin_date,
 }
 
 void TryIsServiceDaysUsingShift(const std::string& begin_date,
-    const std::string& date,
-    const std::string& end_date,
+                                const std::string& date,
+                                const std::string& end_date,
                                 uint64_t days,
                                 bool value) {
 
@@ -161,9 +163,9 @@ void TryIsServiceDaysUsingShift(const std::string& begin_date,
 }
 
 void TryGetServiceDays(bool check_b_date,
-    const std::string& begin_date,
-    const std::string& date,
-    const std::string& end_date,
+                       const std::string& begin_date,
+                       const std::string& date,
+                       const std::string& end_date,
                        uint32_t dow_mask,
                        uint64_t value) {
 
@@ -188,7 +190,10 @@ void TryGetServiceDays(bool check_b_date,
   }
 }
 
-void TryRejectFeed(const std::string& begin_date, const std::string& end_date, uint32_t dow_mask, uint64_t value) {
+void TryRejectFeed(const std::string& begin_date,
+                   const std::string& end_date,
+                   uint32_t dow_mask,
+                   uint64_t value) {
 
   auto b = DateTime::get_formatted_date(begin_date);
   auto e = DateTime::get_formatted_date(end_date);
@@ -205,9 +210,9 @@ void TryRejectFeed(const std::string& begin_date, const std::string& end_date, u
 }
 
 void TryAddServiceDays(uint64_t days,
-    const std::string& begin_date,
-    const std::string& end_date,
-    const std::string& added_date,
+                       const std::string& begin_date,
+                       const std::string& end_date,
+                       const std::string& added_date,
                        uint64_t value) {
 
   auto b = DateTime::get_formatted_date(begin_date);
@@ -219,9 +224,9 @@ void TryAddServiceDays(uint64_t days,
 }
 
 void TryRemoveServiceDays(uint64_t days,
-    const std::string& begin_date,
-    const std::string& end_date,
-    const std::string& removed_date,
+                          const std::string& begin_date,
+                          const std::string& end_date,
+                          const std::string& removed_date,
                           uint64_t value) {
 
   auto b = DateTime::get_formatted_date(begin_date);
@@ -233,8 +238,8 @@ void TryRemoveServiceDays(uint64_t days,
 }
 
 void TryTestServiceEndDate(const std::string& begin_date,
-    const std::string& end_date,
-    const std::string& new_end_date,
+                           const std::string& end_date,
+                           const std::string& new_end_date,
                            uint32_t dow_mask) {
 
   auto b = DateTime::get_formatted_date(begin_date);
@@ -1140,15 +1145,6 @@ void TestDayOfWeek() {
   }
 }
 
-void TryInvalidISO(const std::string& iso) {
-  std::tm t = DateTime::iso_to_tm(iso);
-  if (t.tm_year != 0) {
-    throw std::runtime_error("DateTime::iso_to_tm did not return an invalid year for improper string: " + iso +
-        " tm values are: " + std::to_string(t.tm_year) + "," + std::to_string(t.tm_mon) + "," + std::to_string(t.tm_mday) +
-        "," + std::to_string(t.tm_hour) + "," + std::to_string(t.tm_min));
-  }
-}
-
 void TestISOToTm() {
   std::string date = "2018-07-22T10:09";
   std::tm t = DateTime::iso_to_tm(date);
@@ -1157,13 +1153,15 @@ void TestISOToTm() {
   }
   // Remember, tm_mon is 0 based
   if (t.tm_mon != 6) {
-    throw std::runtime_error("DateTime::iso_to_tm month: 6 expected, got: " + std::to_string(t.tm_mon));
+    throw std::runtime_error("DateTime::iso_to_tm month: 6 expected, got: " +
+                             std::to_string(t.tm_mon));
   }
   if (t.tm_mday != 22) {
     throw std::runtime_error("DateTime::iso_to_tm month: 22 expected");
   }
   if (t.tm_hour != 10) {
-    throw std::runtime_error("DateTime::iso_to_tm hour: 10 expected, got: " + std::to_string(t.tm_hour));
+    throw std::runtime_error("DateTime::iso_to_tm hour: 10 expected, got: " +
+                             std::to_string(t.tm_hour));
   }
   if (t.tm_min != 9) {
     throw std::runtime_error("DateTime::iso_to_tm min: 9 expected");

--- a/valhalla/baldr/datetime.h
+++ b/valhalla/baldr/datetime.h
@@ -285,11 +285,11 @@ std::vector<uint64_t> get_time_range(const std::string& condition);
  */
 static std::tm iso_to_tm(const std::string& iso) {
   // Create an invalid tm, then populate it from the ISO string using get_time
-  std::tm t = { 0, -1, -1, -1, -1, 0, 0, 0 };
+  std::tm t = {0, -1, -1, -1, -1, 0, 0, 0};
 
   // Check for invalid string (not the right separators and sizes)
-  if (iso.size() != 16 ||
-      iso.at(4) != '-' || iso.at(7) != '-' || iso.at(10) != 'T' || iso.at(13) != ':') {
+  if (iso.size() != 16 || iso.at(4) != '-' || iso.at(7) != '-' || iso.at(10) != 'T' ||
+      iso.at(13) != ':') {
     return t;
   }
 
@@ -297,11 +297,8 @@ static std::tm iso_to_tm(const std::string& iso) {
   ss >> std::get_time(&t, "%Y-%m-%dT%H:%M");
 
   // Validate fields. Set tm_year to 0 if any of the year,month,day,hour,minute are invalid.
-  if (t.tm_year > 200 ||
-      t.tm_mon < 0 || t.tm_mon > 11 ||
-      t.tm_mday < 0 || t.tm_mday > 31 ||
-      t.tm_hour < 0 || t.tm_hour > 23 ||
-      t.tm_min < 0 || t.tm_min > 59) {
+  if (t.tm_year > 200 || t.tm_mon < 0 || t.tm_mon > 11 || t.tm_mday < 0 || t.tm_mday > 31 ||
+      t.tm_hour < 0 || t.tm_hour > 23 || t.tm_min < 0 || t.tm_min > 59) {
     t.tm_year = 0;
   }
   return t;

--- a/valhalla/baldr/datetime.h
+++ b/valhalla/baldr/datetime.h
@@ -219,13 +219,6 @@ std::string get_duration(const std::string& date_time,
                          const boost::local_time::time_zone_ptr& tz);
 
 /**
- * checks if string is in the format of %Y-%m-%dT%H:%M
- * @param   date_time should be in the format of 2015-05-06T08:00
- * @return true or false
- */
-bool is_iso_local(const std::string& date_time);
-
-/**
  * checks if a date is restricted within a begin and end range.
  * @param   type          type of restriction kYMD or kNthDow
  * @param   begin_hrs     begin hours
@@ -285,17 +278,53 @@ MONTH get_month(const std::string& month);
 std::vector<uint64_t> get_time_range(const std::string& condition);
 
 /**
+ * Convert ISO 8601 time into std::tm.
+ * @param iso  ISO time string (YYYY-mm-ddTmi:sec")
+ * @return Returns std::tm time structure. If the input string is not valid this method
+ *         sets tm_year to 0.
+ */
+static std::tm iso_to_tm(const std::string& iso) {
+  // Create an invalid tm, then populate it from the ISO string using get_time
+  std::tm t = { 0, -1, -1, -1, -1, 0, 0, 0 };
+
+  // Check for invalid string (not the right separators and sizes)
+  if (iso.size() != 16 ||
+      iso.at(4) != '-' || iso.at(7) != '-' || iso.at(10) != 'T' || iso.at(13) != ':') {
+    return t;
+  }
+
+  std::istringstream ss(iso);
+  ss >> std::get_time(&t, "%Y-%m-%dT%H:%M");
+
+  // Validate fields. Set tm_year to 0 if any of the year,month,day,hour,minute are invalid.
+  if (t.tm_year > 200 ||
+      t.tm_mon < 0 || t.tm_mon > 11 ||
+      t.tm_mday < 0 || t.tm_mday > 31 ||
+      t.tm_hour < 0 || t.tm_hour > 23 ||
+      t.tm_min < 0 || t.tm_min > 59) {
+    t.tm_year = 0;
+  }
+  return t;
+}
+
+/**
+ * Checks if string is in the format of %Y-%m-%dT%H:%M
+ * @param   date_time should be in the format of 2015-05-06T08:00
+ * @return true or false
+ */
+static bool is_iso_valid(const std::string& date_time) {
+  return iso_to_tm(date_time).tm_year > 0;
+}
+
+/**
  * Get the day of the week given a time string
  * @param dt Date time string.
  */
 static uint32_t day_of_week(const std::string& dt) {
-  // Split the string at T
-  std::stringstream datestring(dt);
-  std::string d;
-  std::getline(datestring, d, 'T');
-  std::tm t = {};
-  std::istringstream ss(d);
-  ss >> std::get_time(&t, "%Y-%m-%d");
+  // Get the std::tm struct given the ISO string
+  std::tm t = iso_to_tm(dt);
+
+  // Use std::mktime to fill in day of week
   std::mktime(&t);
   return t.tm_wday;
 }


### PR DESCRIPTION
This should allow more use of tm struct values (e.g. day of week, etc.) in a portable way. Rename is_iso_local to is_iso_valid to better reflect its purpose. Also update datetime tests to use const std::string& in method arguments.
 fixes #1422 (which wasn't really an issue - just removing some boost logic here).

 - [ ] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging

