### PR TITLE
Timezone update

### DIFF
--- a/src/baldr/datetime.cc
+++ b/src/baldr/datetime.cc
@@ -432,8 +432,8 @@ uint64_t seconds_since_epoch(const std::string& date_time,
   return 0;
 }
 
-// Get the difference between two timezone using the curent time (seconds from epoch)
-// (taking into account the timezones and dst) and add the difference to the seconds
+// Get the difference between two timezones using the current time (seconds from epoch
+// so that DST can be take into account). Returns the difference in seconds.
 int timezone_diff(const bool is_depart_at,
                   const uint64_t seconds,
                   const boost::local_time::time_zone_ptr& origin_tz,

--- a/src/baldr/datetime.cc
+++ b/src/baldr/datetime.cc
@@ -762,24 +762,6 @@ uint32_t day_of_week_mask(const std::string& date_time) {
   return kDOWNone;
 }
 
-// Get the number of seconds midnight that have elapsed.
-uint32_t seconds_from_midnight(const std::string& date_time) {
-  // date_time is in the format of HH:MM:SS or HH:MM or YYYY-MM-DDTHH:MM
-  // hours can be greater than 24.
-  // please see GTFS spec:
-  // https://developers.google.com/transit/gtfs/reference#stop_times_fields
-
-  boost::posix_time::time_duration td;
-  std::size_t found = date_time.find('T'); // YYYY-MM-DDTHH:MM
-  if (found != std::string::npos) {
-    td = boost::posix_time::duration_from_string(date_time.substr(found + 1));
-  } else {
-    td = boost::posix_time::duration_from_string(date_time);
-  }
-
-  return static_cast<uint32_t>(td.total_seconds());
-}
-
 // add x seconds to a date_time and return a ISO date_time string.
 // date_time is in the format of 20150516 or 2015-05-06T08:00
 std::string get_duration(const std::string& date_time,

--- a/src/baldr/datetime.cc
+++ b/src/baldr/datetime.cc
@@ -432,15 +432,15 @@ uint64_t seconds_since_epoch(const std::string& date_time,
   return 0;
 }
 
-// Get the difference between two timezone using the seconds from epoch
+// Get the difference between two timezone using the curent time (seconds from epoch)
 // (taking into account the timezones and dst) and add the difference to the seconds
-void timezone_diff(const bool is_depart_at,
-                   uint64_t& seconds,
-                   const boost::local_time::time_zone_ptr& origin_tz,
-                   const boost::local_time::time_zone_ptr& dest_tz) {
+int timezone_diff(const bool is_depart_at,
+                  const uint64_t seconds,
+                  const boost::local_time::time_zone_ptr& origin_tz,
+                  const boost::local_time::time_zone_ptr& dest_tz) {
 
-  if ((origin_tz == dest_tz) || (seconds == 0) || (!origin_tz || !dest_tz)) {
-    return;
+  if (!origin_tz || !dest_tz || origin_tz == dest_tz) {
+    return 0;
   }
 
   try {
@@ -516,13 +516,9 @@ void timezone_diff(const bool is_depart_at,
 
     boost::posix_time::time_duration td = origin_pt - dest_pt;
     if (origin_tz->base_utc_offset() < dest_tz->base_utc_offset()) {
-      seconds += abs(td.total_seconds());
+      return abs(td.total_seconds());
     } else {
-      // should never happen
-      if (seconds - abs(td.total_seconds()) < 0) {
-        return;
-      }
-      seconds -= abs(td.total_seconds());
+      return -1 * abs(td.total_seconds());
     }
   } catch (std::exception& e) {}
 }

--- a/src/thor/timedep_forward.cc
+++ b/src/thor/timedep_forward.cc
@@ -73,12 +73,7 @@ void TimeDepForward::ExpandForward(GraphReader& graphreader,
         DateTime::timezone_diff(true, localtime, DateTime::get_tz_db().from_index(origin_tz_index_),
                                 DateTime::get_tz_db().from_index(nodeinfo->timezone()));
     localtime += tz_diff;
-    seconds_of_week += tz_diff;
-    if (seconds_of_week < 0) {
-      seconds_of_week += midgard::kSecondsPerWeek;
-    } else if (seconds_of_week > midgard::kSecondsPerWeek) {
-      seconds_of_week -= midgard::kSecondsPerWeek;
-    }
+    seconds_of_week = DateTime::normalize_seconds_of_week(seconds_of_week + tz_diff);
   }
 
   // Expand from end node.

--- a/src/thor/timedep_forward.cc
+++ b/src/thor/timedep_forward.cc
@@ -52,7 +52,7 @@ void TimeDepForward::ExpandForward(GraphReader& graphreader,
                                    const uint32_t pred_idx,
                                    const bool from_transition,
                                    uint64_t localtime,
-                                   uint32_t seconds_of_week,
+                                   int32_t seconds_of_week,
                                    const odin::Location& destination,
                                    std::pair<int32_t, float>& best_path) {
   // Get the tile and the node info. Skip if tile is null (can happen
@@ -74,6 +74,11 @@ void TimeDepForward::ExpandForward(GraphReader& graphreader,
                                 DateTime::get_tz_db().from_index(nodeinfo->timezone()));
     localtime += tz_diff;
     seconds_of_week += tz_diff;
+    if (seconds_of_week < 0) {
+      seconds_of_week += midgard::kSecondsPerWeek;
+    } else if (seconds_of_week > midgard::kSecondsPerWeek) {
+      seconds_of_week -= midgard::kSecondsPerWeek;
+    }
   }
 
   // Expand from end node.
@@ -301,7 +306,7 @@ std::vector<PathInfo> TimeDepForward::GetBestPath(odin::Location& origin,
 
     // Set local time and seconds of the week.
     uint64_t localtime = start_time + static_cast<uint32_t>(pred.cost().secs);
-    uint32_t seconds_of_week = seconds_of_week_ + static_cast<uint32_t>(pred.cost().secs);
+    int32_t seconds_of_week = seconds_of_week_ + static_cast<uint32_t>(pred.cost().secs);
     if (seconds_of_week > midgard::kSecondsPerWeek) {
       seconds_of_week -= midgard::kSecondsPerWeek;
     }

--- a/src/thor/timedep_forward.cc
+++ b/src/thor/timedep_forward.cc
@@ -68,11 +68,12 @@ void TimeDepForward::ExpandForward(GraphReader& graphreader,
 
   // Adjust for time zone (if different from timezone at the start).
   if (nodeinfo->timezone() != origin_tz_index_) {
-    // TODO - why doesn't this return the seconds difference in timezones?
-    DateTime::timezone_diff(true, localtime, DateTime::get_tz_db().from_index(origin_tz_index_),
-                            DateTime::get_tz_db().from_index(nodeinfo->timezone()));
-
-    // TODO - alter seconds of week based on timezone diff
+    // Get the difference in seconds between the origin tz and current tz
+    int tz_diff =
+        DateTime::timezone_diff(true, localtime, DateTime::get_tz_db().from_index(origin_tz_index_),
+                                DateTime::get_tz_db().from_index(nodeinfo->timezone()));
+    localtime += tz_diff;
+    seconds_of_week += tz_diff;
   }
 
   // Expand from end node.

--- a/src/thor/timedep_reverse.cc
+++ b/src/thor/timedep_reverse.cc
@@ -100,11 +100,12 @@ void TimeDepReverse::ExpandReverse(GraphReader& graphreader,
 
   // Adjust for time zone (if different from timezone at the destination).
   if (nodeinfo->timezone() != dest_tz_index_) {
-    // TODO - why doesn't this return the seconds difference in timezones?
-    DateTime::timezone_diff(false, localtime, DateTime::get_tz_db().from_index(nodeinfo->timezone()),
-                            DateTime::get_tz_db().from_index(dest_tz_index_));
-
-    // TODO - alter seconds of week based on timezone diff
+    // Get the difference in seconds between the destination tz and current tz
+    int tz_diff = DateTime::timezone_diff(false, localtime,
+                                          DateTime::get_tz_db().from_index(nodeinfo->timezone()),
+                                          DateTime::get_tz_db().from_index(dest_tz_index_));
+    localtime += tz_diff;
+    seconds_of_week += tz_diff;
   }
 
   // Expand from end node.

--- a/src/thor/timedep_reverse.cc
+++ b/src/thor/timedep_reverse.cc
@@ -105,12 +105,7 @@ void TimeDepReverse::ExpandReverse(GraphReader& graphreader,
                                           DateTime::get_tz_db().from_index(nodeinfo->timezone()),
                                           DateTime::get_tz_db().from_index(dest_tz_index_));
     localtime += tz_diff;
-    seconds_of_week += tz_diff;
-    if (seconds_of_week < 0) {
-      seconds_of_week += midgard::kSecondsPerWeek;
-    } else if (seconds_of_week > midgard::kSecondsPerWeek) {
-      seconds_of_week -= midgard::kSecondsPerWeek;
-    }
+    seconds_of_week = DateTime::normalize_seconds_of_week(seconds_of_week + tz_diff);
   }
 
   // Expand from end node.
@@ -356,9 +351,7 @@ std::vector<PathInfo> TimeDepReverse::GetBestPath(odin::Location& origin,
     // Set local time and seconds of the week.
     uint32_t secs = static_cast<uint32_t>(pred.cost().secs);
     uint64_t localtime = start_time - secs;
-    int32_t seconds_of_week = (secs < seconds_of_week_)
-                                  ? seconds_of_week_ - secs
-                                  : midgard::kSecondsPerWeek - (secs - seconds_of_week_);
+    int32_t seconds_of_week = DateTime::normalize_seconds_of_week(seconds_of_week_ - secs);
 
     // Get the opposing predecessor directed edge. Need to make sure we get
     // the correct one if a transition occurred

--- a/src/thor/timedep_reverse.cc
+++ b/src/thor/timedep_reverse.cc
@@ -357,8 +357,8 @@ std::vector<PathInfo> TimeDepReverse::GetBestPath(odin::Location& origin,
     uint32_t secs = static_cast<uint32_t>(pred.cost().secs);
     uint64_t localtime = start_time - secs;
     int32_t seconds_of_week = (secs < seconds_of_week_)
-                                   ? seconds_of_week_ - secs
-                                   : midgard::kSecondsPerWeek - (secs - seconds_of_week_);
+                                  ? seconds_of_week_ - secs
+                                  : midgard::kSecondsPerWeek - (secs - seconds_of_week_);
 
     // Get the opposing predecessor directed edge. Need to make sure we get
     // the correct one if a transition occurred

--- a/src/thor/timedep_reverse.cc
+++ b/src/thor/timedep_reverse.cc
@@ -84,7 +84,7 @@ void TimeDepReverse::ExpandReverse(GraphReader& graphreader,
                                    const DirectedEdge* opp_pred_edge,
                                    const bool from_transition,
                                    uint64_t localtime,
-                                   uint32_t seconds_of_week,
+                                   int32_t seconds_of_week,
                                    const odin::Location& destination,
                                    std::pair<int32_t, float>& best_path) {
   // Get the tile and the node info. Skip if tile is null (can happen
@@ -106,6 +106,11 @@ void TimeDepReverse::ExpandReverse(GraphReader& graphreader,
                                           DateTime::get_tz_db().from_index(dest_tz_index_));
     localtime += tz_diff;
     seconds_of_week += tz_diff;
+    if (seconds_of_week < 0) {
+      seconds_of_week += midgard::kSecondsPerWeek;
+    } else if (seconds_of_week > midgard::kSecondsPerWeek) {
+      seconds_of_week -= midgard::kSecondsPerWeek;
+    }
   }
 
   // Expand from end node.
@@ -351,7 +356,7 @@ std::vector<PathInfo> TimeDepReverse::GetBestPath(odin::Location& origin,
     // Set local time and seconds of the week.
     uint32_t secs = static_cast<uint32_t>(pred.cost().secs);
     uint64_t localtime = start_time - secs;
-    uint32_t seconds_of_week = (secs < seconds_of_week_)
+    int32_t seconds_of_week = (secs < seconds_of_week_)
                                    ? seconds_of_week_ - secs
                                    : midgard::kSecondsPerWeek - (secs - seconds_of_week_);
 

--- a/test/datetime.cc
+++ b/test/datetime.cc
@@ -49,8 +49,10 @@ void TryGetDuration(const std::string& date_time,
 }
 
 void TryGetSecondsFromMidnight(const std::string& date_time, uint32_t expected_seconds) {
-  if (DateTime::seconds_from_midnight(date_time) != expected_seconds) {
-    throw std::runtime_error(std::string("Incorrect number of seconds from ") + date_time);
+  auto secs = DateTime::seconds_from_midnight(date_time);
+  if (secs != expected_seconds) {
+    throw std::runtime_error(std::string("Incorrect number of seconds from ") + date_time +
+                             " got: " + std::to_string(secs));
   }
 }
 

--- a/test/datetime.cc
+++ b/test/datetime.cc
@@ -311,7 +311,7 @@ void TryTestTimezoneDiff(const bool is_depart,
 
   std::cout << DateTime::seconds_to_date(dt, tz1) << std::endl;
 
-  DateTime::timezone_diff(is_depart, dt, tz1, tz2);
+  dt += DateTime::timezone_diff(is_depart, dt, tz1, tz2);
   if (DateTime::seconds_to_date(dt, tz1) != expected1)
     throw std::runtime_error("Timezone Diff test #1: " + std::to_string(date_time) +
                              " test failed.  Expected: " + expected1 + " but got " +

--- a/valhalla/baldr/datetime.h
+++ b/valhalla/baldr/datetime.h
@@ -16,6 +16,7 @@
 #include <boost/date_time/local_time/local_time_io.hpp>
 #include <boost/date_time/local_time/tz_database.hpp>
 #include <valhalla/baldr/graphconstants.h>
+#include <valhalla/midgard/constants.h>
 
 namespace valhalla {
 namespace baldr {
@@ -200,14 +201,6 @@ void seconds_to_date(const bool is_depart_at,
 uint32_t day_of_week_mask(const std::string& date_time);
 
 /**
- * Get the number of seconds elapsed from midnight.
- * Hours can be greater than 24.
- * @param   date_time in the format of 01:34:15 or 2015-05-06T08:00
- * @return  Returns the seconds from midnight.
- */
-uint32_t seconds_from_midnight(const std::string& date_time);
-
-/**
  * Add x seconds to a date_time and return a ISO date_time string.
  * @param   date_time   in the format of 01:34:15 or 2015-05-06T08:00
  * @param   seconds     seconds to add to the date.
@@ -324,6 +317,38 @@ static uint32_t day_of_week(const std::string& dt) {
   // Use std::mktime to fill in day of week
   std::mktime(&t);
   return t.tm_wday;
+}
+
+/**
+ * Get the number of seconds elapsed from midnight.
+ * Hours can be greater than 24.
+ * @param   date_time in the format of 01:34:15 or 2015-05-06T08:00
+ * @return  Returns the seconds from midnight.
+ */
+static uint32_t seconds_from_midnight(const std::string& date_time) {
+  // date_time is in the format of HH:MM:SS or HH:MM or YYYY-MM-DDTHH:MM
+  // hours can be greater than 24.
+  // please see GTFS spec:
+  // https://developers.google.com/transit/gtfs/reference#stop_times_fields
+
+  std::string str;
+  std::size_t found = date_time.find('T'); // YYYY-MM-DDTHH:MM
+  if (found != std::string::npos) {
+    str = date_time.substr(found + 1);
+  } else {
+    str = date_time;
+  }
+
+  // Split the string by the delimiter ':'
+  int secs = 0;
+  int multiplier = static_cast<int>(midgard::kSecondsPerHour);
+  std::string item;
+  std::stringstream ss(str);
+  while (std::getline(ss, item, ':')) {
+    secs += std::stoi(item) * multiplier;
+    multiplier = (multiplier == midgard::kSecondsPerHour) ? midgard::kSecondsPerMinute : 1;
+  }
+  return secs;
 }
 
 } // namespace DateTime

--- a/valhalla/baldr/datetime.h
+++ b/valhalla/baldr/datetime.h
@@ -351,6 +351,21 @@ static uint32_t seconds_from_midnight(const std::string& date_time) {
   return secs;
 }
 
+/**
+ * Returns seconds of week within the range [0, kSecondsPerWeek]
+ * @param  secs  Seconds within the week.
+ * @return Returns the seconds within the week within the valid range.
+ */
+static int32_t normalize_seconds_of_week(const int32_t secs) {
+  if (secs < 0) {
+    return secs + midgard::kSecondsPerWeek;
+  } else if (secs > midgard::kSecondsPerWeek) {
+    return secs - midgard::kSecondsPerWeek;
+  } else {
+    return secs;
+  }
+}
+
 } // namespace DateTime
 } // namespace baldr
 } // namespace valhalla

--- a/valhalla/baldr/datetime.h
+++ b/valhalla/baldr/datetime.h
@@ -160,18 +160,18 @@ uint64_t seconds_since_epoch(const std::string& date_time,
                              const boost::local_time::time_zone_ptr& time_zone);
 
 /**
- * Get the difference between two timezone using the seconds from epoch
- * (taking into account the timezones and dst) and add the difference to the seconds
+ * Get the difference between two timezones using the current time (seconds from epoch
+ * so that DST can be take into account).
  * @param   is_depart_at  is this a depart at or arrive by
- * @param   seconds       seconds since epoch for
+ * @param   seconds       seconds since epoch
  * @param   origin_tz     timezone for origin
  * @param   dest_tz       timezone for dest
- *
+ * @return Returns the seconds difference between the 2 timezones.
  */
-void timezone_diff(const bool is_depart_at,
-                   uint64_t& seconds,
-                   const boost::local_time::time_zone_ptr& origin_tz,
-                   const boost::local_time::time_zone_ptr& dest_tz);
+int timezone_diff(const bool is_depart_at,
+                  const uint64_t seconds,
+                  const boost::local_time::time_zone_ptr& origin_tz,
+                  const boost::local_time::time_zone_ptr& dest_tz);
 
 std::string seconds_to_date(const uint64_t seconds, const boost::local_time::time_zone_ptr& tz);
 

--- a/valhalla/midgard/constants.h
+++ b/valhalla/midgard/constants.h
@@ -12,6 +12,8 @@ constexpr float kSecPerMinute = 60.0f;
 constexpr float kMinPerSec = 1.0f / 60.0f;
 constexpr float kSecPerHour = 3600.0f;
 constexpr float kHourPerSec = 1.0f / 3600.0f;
+constexpr uint32_t kSecondsPerMinute = 60;
+constexpr uint32_t kSecondsPerHour = 3600;
 constexpr uint32_t kSecondsPerDay = 86400;
 constexpr uint32_t kSecondsPerWeek = 604800;
 

--- a/valhalla/thor/timedep.h
+++ b/valhalla/thor/timedep.h
@@ -68,7 +68,7 @@ protected:
                      const uint32_t pred_idx,
                      const bool from_transition,
                      uint64_t localtime,
-                     uint32_t seconds_of_week,
+                     int32_t seconds_of_week,
                      const odin::Location& dest,
                      std::pair<int32_t, float>& best_path);
 
@@ -159,7 +159,7 @@ protected:
                      const baldr::DirectedEdge* opp_pred_edge,
                      const bool from_transition,
                      uint64_t localtime,
-                     uint32_t seconds_of_week,
+                     int32_t seconds_of_week,
                      const odin::Location& dest,
                      std::pair<int32_t, float>& best_path);
 


### PR DESCRIPTION
 Update timezone_diff to return seconds difference between timezones. Make localtime a const
and do not update it within the method. Update time dependent path algorithms to update localtime and seconds_of_week based on the timezone difference. Add normalize_seconds_of_week method and use it within time dependent path algorithms to validate that seconds_of_week is within valid range. Update seconds_from_midnight to remove use of Boost. 

fixes #1426 

 - [ ] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
