### PR TITLE
use auto cleanup for actor in node bindings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,7 +239,7 @@ jobs:
       - run:
           command: |
             export PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")
-            export PUBLISH=$([[ "${CIRCLE_TAG:-}" == "v${PACKAGE_JSON_VERSION}" ]] && echo "On" || echo "Off")
+            export PUBLISH=$([[ "${CIRCLE_TAG:-}" == "${PACKAGE_JSON_VERSION}" ]] && echo "On" || echo "Off")
             export COMMIT_MESSAGE=$(git log --oneline --format=%B -n 1 ${CIRCLE_SHA1} | head -n 1)
             export BUILD_TYPE=Debug
             ./scripts/publish.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,7 +207,7 @@ jobs:
       - run:
           command: |
             export PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")
-            export PUBLISH=$([[ "${CIRCLE_TAG:-}" == "v${PACKAGE_JSON_VERSION}" ]] && echo "On" || echo "Off")
+            export PUBLISH=$([[ "${CIRCLE_TAG:-}" == "${PACKAGE_JSON_VERSION}" ]] && echo "On" || echo "Off")
             export COMMIT_MESSAGE=$(git log --oneline --format=%B -n 1 ${CIRCLE_SHA1} | head -n 1)
             export BUILD_TYPE=Release
             ./scripts/publish.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
       - run:
           command: |
             export PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")
-            export PUBLISH=$([[ "${CIRCLE_TAG:-}" == "v${PACKAGE_JSON_VERSION}" ]] && echo "On" || echo "Off")
+            export PUBLISH=$([[ "${CIRCLE_TAG:-}" == "${PACKAGE_JSON_VERSION}" ]] && echo "On" || echo "Off")
             echo circle_tag ${CIRCLE_TAG:-}
             echo package_json_version ${PACKAGE_JSON_VERSION}
             export COMMIT_MESSAGE=$(git log --oneline --format=%B -n 1 ${CIRCLE_SHA1} | head -n 1)
@@ -87,7 +87,7 @@ jobs:
       - run:
           command: |
             export PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")
-            export PUBLISH=$([[ "${CIRCLE_TAG:-}" == "v${PACKAGE_JSON_VERSION}" ]] && echo "On" || echo "Off")
+            export PUBLISH=$([[ "${CIRCLE_TAG:-}" == "${PACKAGE_JSON_VERSION}" ]] && echo "On" || echo "Off")
             export COMMIT_MESSAGE=$(git log --oneline --format=%B -n 1 ${CIRCLE_SHA1} | head -n 1)
             export BUILD_TYPE=Debug
             ./scripts/publish.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Release Date: UNRELEASED Valhalla 3.0
 
+## Release Date: 2018-07-24 Valhalla 3.0.0-rc.2
+* **Node Bindings**
+   * FIXED: turn on the autocleanup functionality for the actor object.
+   [#1439](https://github.com/valhalla/valhalla/pull/1439)
+
 ## Release Date: 2018-07-16 Valhalla 3.0.0-rc.1
 * **Enhancement**
    * ADDED: exposed the rest of the actions to the node bindings and added tests. [#1415](https://github.com/valhalla/valhalla/pull/1415)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "valhalla",
-  "version": "3.0.0-rc.1",
+  "version": "3.0.0-rc.2",
   "main": "lib/index.js",
   "directories": {
     "doc": "docs",

--- a/src/bindings/node/node.cc
+++ b/src/bindings/node/node.cc
@@ -26,7 +26,7 @@ boost::property_tree::ptree make_conf(const char* config) {
   return json_to_pt(config);
 }
 
-// check if napi_status is nap_ok, throw error if not
+// check if napi_status is napi_ok, throw error if not
 void checkNapiStatus(napi_status status, napi_env env, const char* error_message) {
   if (status != napi_ok) {
     napi_throw_error(env, NULL, error_message);

--- a/src/bindings/node/node.cc
+++ b/src/bindings/node/node.cc
@@ -97,7 +97,8 @@ public:
   }
 
 private:
-  explicit Actor(const char* config) : actor(make_conf(config)), env_(nullptr), wrapper_(nullptr) {
+  explicit Actor(const char* config)
+      : actor(make_conf(config), true), env_(nullptr), wrapper_(nullptr) {
   }
   ~Actor() {
     napi_delete_reference(env_, wrapper_);
@@ -178,7 +179,7 @@ private:
     checkNapiStatus(status, env, "Failed to get arg string length");
 
     if (request_str_size > 1024 * 1024) {
-      napi_throw_error(env, NULL, "Too large JSON config");
+      napi_throw_error(env, NULL, "The request exceeds the maximum size");
     }
 
     char request_string[++request_str_size];


### PR DESCRIPTION
The node bindings weren't using the auto-cleanup function for the `actor_t` object. since we are most of the way through the request to pbf refactor this didnt matter too much, but some of the stuff in the refactor isnt all the way done. what this means is that for each request there is some state left around in `thor::worker_t` for example. simultaneously, `actor_t` defaults auto-cleanup to `false`. by setting it to `true` we make sure to clear out this state on every request. this wont be a problem once request state lives in the pbf request object. for now we are in a bit of an in between where some of it is still within the worker classes