### PR TITLE
Allow custom libprime directory

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -83,8 +83,12 @@ find_package(Threads REQUIRED)
 add_library(libprime_server INTERFACE IMPORTED)
 if(ENABLE_SERVICES)
   pkg_check_modules(libprime_server REQUIRED libprime_server>=0.6.3)
+  # workaround for https://gitlab.kitware.com/cmake/cmake/issues/15804
+  find_library(libprime_server_LIBRARY
+    NAME ${libprime_server_LIBRARIES}
+    HINTS ${libprime_server_LIBRARY_DIRS})
   set_target_properties(libprime_server PROPERTIES
-    INTERFACE_LINK_LIBRARIES "${libprime_server_LIBRARIES}"
+    INTERFACE_LINK_LIBRARIES "${libprime_server_LIBRARY}"
     INTERFACE_INCLUDE_DIRECTORIES "${libprime_server_INCLUDE_DIRS}"
     INTERFACE_COMPILE_DEFINITIONS HAVE_HTTP)
 endif()


### PR DESCRIPTION
# Issue

As reported in https://gitlab.kitware.com/cmake/cmake/issues/15804, FindPkgConfig is buggy for custom directories. This PR propose a workaround to this problem.

I didn't open an issue, feel free to ask me to open one if you really want one.

## Tasklist

 - Add tests (irrelevant)
 - [ ] Review - you must request approval to merge any PR to master
 - Add #fixes with the issue number that this PR addresses (irrelevant)
 - [x] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md) Is it needed?
 - Update relevant [documentation](docs/README.md) (irrelevant)

## Requirements / Relations

No requirements
