### PR TITLE
Link to an available valhalla icon image (fixes #1451)

### DIFF
--- a/taginfo.json
+++ b/taginfo.json
@@ -7,7 +7,7 @@
       "description": "Open Source Tile-Based Routing Applications and APIs",
       "project_url": "https://github.com/valhalla",
       "doc_url": "",
-      "icon_url": "https://s3.amazonaws.com/assets-staging.mapzen.com/images/mapzen-icon/logo.png",
+      "icon_url": "https://avatars0.githubusercontent.com/u/10232331",
       "contact_name": "Valhalla",
       "contact_email": "valhalla@mapzen.com"
    },


### PR DESCRIPTION
The existing icon location yields an Access Denied. This updates taginfo.json to use the Valhalla avatar logo, which is the *best fit* I could find in a short duration.

# Issue 1451

## Tasklist

 - [ ] Add tests
 - [x] Review - you must request approval to merge any PR to master
 - [x] Add #fixes with the issue number that this PR addresses
 - [x] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)

## Requirements / Relations

No other requirements.
