### PR TITLE
Return after napi_throw_error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - run: mkdir build
       - run: cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=On
       - run: make -C build -j4
-      - run: run-clang-tidy-5.0.py -p build -header-filter "^$(pwd)/(src|valhalla/(baldr|midgard|sif|odin|thor|skadi|tyr|loki|mjolnir|bindings)/.*" && ./scripts/error_on_dirty.sh
+      - run: ./scripts/tidy.sh && ./scripts/error_on_dirty.sh
 
   build-release-binary-linux:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - run: mkdir build
       - run: cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=On
       - run: make -C build -j4
-      - run: ./scripts/tidy.sh && ./scripts/error_on_dirty.sh
+      - run: cd build && ../scripts/tidy.sh && ../scripts/error_on_dirty.sh
 
   build-release-binary-linux:
     docker:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Release Date: UNRELEASED Valhalla 3.0
 
+## Release Date: 2018-07-24 Valhalla 3.0.0-rc.3
+* **Node Bindings**
+   * FIXED: properly return errors using napi
+   [#1456](https://github.com/valhalla/valhalla/pull/1456)
+
 ## Release Date: 2018-07-24 Valhalla 3.0.0-rc.2
 * **Node Bindings**
    * FIXED: turn on the autocleanup functionality for the actor object.

--- a/src/bindings/node/node.cc
+++ b/src/bindings/node/node.cc
@@ -10,11 +10,11 @@
 #include <sstream>
 #include <string>
 
+#include "src/worker.cc"
+#include "valhalla/exception.h"
 #include "valhalla/tyr/actor.h"
 #include "valhalla/midgard/logging.h"
 #include "valhalla/midgard/util.h"
-#include "valhalla/exception.h"
-#include "src/worker.cc"
 
 boost::property_tree::ptree json_to_pt(const char* json) {
   std::stringstream ss;
@@ -87,8 +87,8 @@ public:
             logging_subtree.get());
         valhalla::midgard::logging::Configure(logging_config);
       }
-    } catch (...) { 
-      napi_throw_error(env, NULL, "Failed to load logging config"); 
+    } catch (...) {
+      napi_throw_error(env, NULL, "Failed to load logging config");
       return NULL;
     }
 
@@ -206,7 +206,8 @@ private:
     }
   }
 
-  static bool ParseRequest(napi_env env, napi_callback_info info, napi_value* jsthis, std::string& req_string) {
+  static bool
+  ParseRequest(napi_env env, napi_callback_info info, napi_value* jsthis, std::string& req_string) {
     napi_status status;
     size_t argc = 1;
     napi_value argv[1];
@@ -274,9 +275,11 @@ private:
     std::string resp_json;
     try {
       resp_json = func(obj->actor, reqString);
-    } catch (const valhalla::valhalla_exception_t& e) { 
+    } catch (const valhalla::valhalla_exception_t& e) {
       auto http_code = ERROR_TO_STATUS.find(e.code)->second;
-      std::string err_message = "{ error_code: " + std::to_string(e.code) + ", http_code: " + std::to_string(http_code) +  ", message: " + e.message + " }";
+      std::string err_message = "{ error_code: " + std::to_string(e.code) +
+                                ", http_code: " + std::to_string(http_code) +
+                                ", message: " + e.message + " }";
       napi_throw_error(env, NULL, err_message.c_str());
       return NULL;
     } catch (const std::exception& e) {

--- a/src/bindings/node/node.cc
+++ b/src/bindings/node/node.cc
@@ -28,13 +28,6 @@ boost::property_tree::ptree make_conf(const char* config) {
   return json_to_pt(config);
 }
 
-// check if napi_status is napi_ok, throw error if not
-void checkNapiStatus(napi_status status, napi_env env, const char* error_message) {
-  if (status != napi_ok) {
-    napi_throw_error(env, NULL, error_message);
-  }
-}
-
 #define DECLARE_NAPI_METHOD(name, func)                                                              \
   { name, 0, func, 0, 0, 0, napi_default, 0 }
 
@@ -57,20 +50,32 @@ public:
     napi_value argv[1];
 
     status = napi_get_cb_info(env, info, &argc, argv, nullptr, nullptr);
-    checkNapiStatus(status, env, "Failed to parse arguments");
+    if (status != napi_ok) {
+      napi_throw_error(env, NULL, "Failed to parse arguments");
+      return NULL;
+    }
 
     // parse config string passed in
     size_t config_string_size;
     status = napi_get_value_string_utf8(env, argv[0], nullptr, 0, &config_string_size);
-    checkNapiStatus(status, env, "Failed to get config string length");
+    if (status != napi_ok) {
+      napi_throw_error(env, NULL, "Failed to get config string length");
+      return NULL;
+    }
+
     if (config_string_size > 1024 * 1024) {
       napi_throw_error(env, NULL, "Too large JSON config");
+      return NULL;
     }
 
     char config_string[++config_string_size];
     status = napi_get_value_string_utf8(env, argv[0], config_string, config_string_size,
                                         &config_string_size);
-    checkNapiStatus(status, env, "Failed to get config string");
+    if (status != napi_ok) {
+      napi_throw_error(env, NULL, "Failed to get config string");
+      return NULL;
+    }
+
     static boost::optional<boost::property_tree::ptree> pt = make_conf(config_string);
     try {
       // configure logging
@@ -82,15 +87,23 @@ public:
             logging_subtree.get());
         valhalla::midgard::logging::Configure(logging_config);
       }
-    } catch (...) { napi_throw_error(env, NULL, "Failed to load logging config"); }
+    } catch (...) { 
+      napi_throw_error(env, NULL, "Failed to load logging config"); 
+      return NULL;
+    }
 
     napi_value actor_constructor;
     status = napi_define_class(env, "Actor", NAPI_AUTO_LENGTH, New, nullptr, 9, properties,
                                &actor_constructor);
-    checkNapiStatus(status, env, "Failed to define class");
-
+    if (status != napi_ok) {
+      napi_throw_error(env, NULL, "Failed to define class");
+      return NULL;
+    }
     status = napi_create_reference(env, actor_constructor, 1, &constructor);
-    checkNapiStatus(status, env, "Failed to create constructor reference");
+    if (status != napi_ok) {
+      napi_throw_error(env, NULL, "Failed to create constructor reference");
+      return NULL;
+    }
 
     return actor_constructor;
   }
@@ -111,7 +124,10 @@ private:
 
     napi_value target;
     status = napi_get_new_target(env, info, &target);
-    checkNapiStatus(status, env, "Failed to get 'new' target");
+    if (status != napi_ok) {
+      napi_throw_error(env, NULL, "Failed to get 'new' target");
+      return NULL;
+    }
     bool is_constructor = target != nullptr;
 
     if (is_constructor) {
@@ -121,21 +137,31 @@ private:
       napi_value argv[1];
 
       status = napi_get_cb_info(env, info, &argc, argv, &jsthis, NULL);
-      checkNapiStatus(status, env, "Failed to parse arguments");
 
+      if (status != napi_ok) {
+        napi_throw_error(env, NULL, "Failed to parse arguments");
+        return NULL;
+      }
       // parse config string passed in
       size_t config_string_size;
       status = napi_get_value_string_utf8(env, argv[0], nullptr, 0, &config_string_size);
-      checkNapiStatus(status, env, "Failed to get config string length");
+      if (status != napi_ok) {
+        napi_throw_error(env, NULL, "Failed to get config string length");
+        return NULL;
+      }
 
       if (config_string_size > 1024 * 1024) {
         napi_throw_error(env, NULL, "Too large JSON config");
+        return NULL;
       }
 
       char config_string[++config_string_size];
       status = napi_get_value_string_utf8(env, argv[0], config_string, config_string_size,
                                           &config_string_size);
-      checkNapiStatus(status, env, "Failed to get config string");
+      if (status != napi_ok) {
+        napi_throw_error(env, NULL, "Failed to get config string");
+        return NULL;
+      }
 
       Actor* obj = new Actor(config_string);
 
@@ -143,7 +169,10 @@ private:
       status = napi_wrap(env, jsthis, reinterpret_cast<void*>(obj), Actor::Destructor,
                          nullptr, // finalize_hint
                          &obj->wrapper_);
-      checkNapiStatus(status, env, "Failed to wrap actor object");
+      if (status != napi_ok) {
+        napi_throw_error(env, NULL, "Failed to wrap actor object");
+        return NULL;
+      }
 
       return jsthis;
     } else {
@@ -151,46 +180,64 @@ private:
       size_t argc_ = 1;
       napi_value args[1];
       status = napi_get_cb_info(env, info, &argc_, args, nullptr, nullptr);
-      checkNapiStatus(status, env, "Failed to parse input args");
+      if (status != napi_ok) {
+        napi_throw_error(env, NULL, "Failed to parse input args");
+        return NULL;
+      }
 
       const size_t argc = 1;
       napi_value argv[argc] = {args[0]};
 
       napi_value actor_constructor;
       status = napi_get_reference_value(env, constructor, &actor_constructor);
-      checkNapiStatus(status, env, "Failed to reference the constructor");
+      if (status != napi_ok) {
+        napi_throw_error(env, NULL, "Failed to reference the constructor");
+        return NULL;
+      }
 
       napi_value instance;
       status = napi_new_instance(env, actor_constructor, 0, NULL, &instance);
-      checkNapiStatus(status, env, "Failed to create new instance");
+      if (status != napi_ok) {
+        napi_throw_error(env, NULL, "Failed to create new instance");
+        return NULL;
+      }
 
       return instance;
     }
   }
 
-  static std::string ParseRequest(napi_env env, napi_callback_info info, napi_value* jsthis) {
+  static bool ParseRequest(napi_env env, napi_callback_info info, napi_value* jsthis, std::string& req_string) {
     napi_status status;
     size_t argc = 1;
     napi_value argv[1];
 
     status = napi_get_cb_info(env, info, &argc, argv, jsthis, nullptr);
-    checkNapiStatus(status, env, "Failed to parse input args");
+    if (status != napi_ok) {
+      napi_throw_error(env, NULL, "Failed to parse argument(s)");
+      return false;
+    }
 
     size_t request_str_size;
     status = napi_get_value_string_utf8(env, argv[0], nullptr, 0, &request_str_size);
-    checkNapiStatus(status, env, "Failed to get arg string length");
-
-    if (request_str_size > 1024 * 1024) {
-      napi_throw_error(env, NULL, "The request exceeds the maximum size");
+    if (status != napi_ok) {
+      napi_throw_error(env, NULL, "Failed to get argument string length");
+      return false;
     }
 
+    if (request_str_size > 1024 * 1024) {
+      status = napi_throw_error(env, NULL, "The request exceeds the maximum size");
+      return false;
+    }
     char request_string[++request_str_size];
     status =
         napi_get_value_string_utf8(env, argv[0], request_string, request_str_size, &request_str_size);
-    checkNapiStatus(status, env, "Unable to parse arg string");
-    std::string reqString(request_string, request_str_size);
+    if (status != napi_ok) {
+      napi_throw_error(env, NULL, "Unable to parse argument string");
+      return false;
+    }
+    req_string = std::string(request_string, request_str_size);
 
-    return reqString;
+    return true;
   }
 
   static napi_value WrapString(napi_env env, std::string cppStr) {
@@ -199,7 +246,10 @@ private:
     const char* outBuff = cppStr.c_str();
     const auto nchars = cppStr.size();
     status = napi_create_string_utf8(env, outBuff, nchars, &napiStr);
-    checkNapiStatus(status, env, "Failed to turn c++ string into napi_value");
+    if (status != napi_ok) {
+      napi_throw_error(env, NULL, "Failed to turn c++ string into napi_value");
+      return NULL;
+    }
     return napiStr;
   }
 
@@ -210,12 +260,16 @@ private:
           func) {
     napi_value jsthis;
     napi_status status;
-
-    std::string reqString = ParseRequest(env, info, &jsthis);
-
+    std::string reqString;
+    if (!ParseRequest(env, info, &jsthis, reqString)) {
+      return NULL;
+    }
     Actor* obj;
     status = napi_unwrap(env, jsthis, reinterpret_cast<void**>(&obj));
-    checkNapiStatus(status, env, "Failed to unwrap js object");
+    if (status != napi_ok) {
+      napi_throw_error(env, NULL, "Failed to unwrap js object");
+      return NULL;
+    }
 
     std::string resp_json;
     try {
@@ -224,8 +278,10 @@ private:
       auto http_code = ERROR_TO_STATUS.find(e.code)->second;
       std::string err_message = "{ error_code: " + std::to_string(e.code) + ", http_code: " + std::to_string(http_code) +  ", message: " + e.message + " }";
       napi_throw_error(env, NULL, err_message.c_str());
+      return NULL;
     } catch (const std::exception& e) {
       napi_throw_error(env, NULL, e.what());
+      return NULL;
     }
 
     auto outStr = WrapString(env, resp_json);
@@ -299,7 +355,10 @@ napi_value Init(napi_env env, napi_value exports) {
   napi_value new_exports;
   napi_status status =
       napi_create_function(env, "", NAPI_AUTO_LENGTH, Actor::Init, nullptr, &new_exports);
-  checkNapiStatus(status, env, "Failed to wrap init function");
+  if (status != napi_ok) {
+    napi_throw_error(env, NULL, "Failed to wrap init function");
+    return NULL;
+  }
   return new_exports;
 }
 

--- a/test/bindings/nodejs/isochrone.test.js
+++ b/test/bindings/nodejs/isochrone.test.js
@@ -16,7 +16,7 @@ test('isochrone: can return info for locations', function(assert) {
 
 test('isochrone: throws error if can\'t match input to map', function(assert) {
   var badRequest = '{"locations":[{"lat":50,"lon":-76.385076}],"costing":"pedestrian","contours":[{"time":15,"color":"ff0000"}]}';
-  assert.throws(() => { valhalla.isochrone(badRequest), /Error: No suitable edges near location/, 'Throws an error when cant match input to map'});
+  assert.throws(() => { valhalla.isochrone(badRequest) }, /error_code: 171, http_code: 400, message: No suitable edges near location/, 'Throws an error when cant match input to map');
   assert.end();
 });
 

--- a/test/bindings/nodejs/matrix.test.js
+++ b/test/bindings/nodejs/matrix.test.js
@@ -17,7 +17,7 @@ test('matrix: can return matrix info info for locations', function(assert) {
 
 test('matrix: returns error if no edges found', function(assert) {
   var hersheyRequest = '{"sources":[{"lat":-40.546115,"lon":-76.385076}],"targets":[{"lat":-40.544232,"lon":-76.385752},{"lat":-40.54424,"lon":-76.38574}],"costing":"pedestrian"}';
-  assert.throws(() => { valhalla.matrix(hersheyRequest)}, /No suitable edges near location/, 'No edges found');
+  assert.throws(() => { valhalla.matrix(hersheyRequest) }, /error_code: 171, http_code: 400, message: No suitable edges near location/, 'Throws an error when cant match input to map');
   assert.end();
 });
 

--- a/test/bindings/nodejs/optimized_route.test.js
+++ b/test/bindings/nodejs/optimized_route.test.js
@@ -16,7 +16,7 @@ test('optimizedRoute: can return info for locations', function(assert) {
 
 test('optimizedRoute: throws error if can\'t match input to map', function(assert) {
   var badRequest = '{"locations":[{"lat":50,"lon":-76.385076}],"costing":"pedestrian","contours":[{"time":15,"color":"ff0000"}]}';
-  assert.throws(() => { valhalla.optimizedRoute(badRequest), /Error: No suitable edges near location/, 'Throws an error when cant match input to map'});
+  assert.throws(() => { valhalla.optimizedRoute(badRequest) }, /error_code: 120, http_code: 400, message: Insufficient number of locations provided/, 'Throws an error when cant match input to map');
   assert.end();
 });
 

--- a/test/bindings/nodejs/route.test.js
+++ b/test/bindings/nodejs/route.test.js
@@ -3,6 +3,13 @@ var config = require('./fixtures/basic_config');
 var Valhalla = require('../../../')(JSON.stringify(config));
 var valhalla = new Valhalla(JSON.stringify(config));
 
+test('route: request sends clear error if called with undefined', function(assert) {
+  assert.throws(() => { valhalla.route() }, /Failed to get argument string length/, 'Throws error when called with no arg');
+  assert.throws(() => { valhalla.route(null) }, /Failed to get argument string length/, 'Throws error when called with null');
+  assert.throws(() => { valhalla.route(undefined) }, /Failed to get argument string length/, 'Throws error when called with undefined');
+  assert.end();
+});
+
 test('route: can get a route in Hershey', function(assert) {
   var hersheyRequest = '{"locations":[{"lat":40.546115,"lon":-76.385076,"type":"break"}, {"lat":40.544232,"lon":-76.385752,"type":"break"}],"costing":"auto"}';
   var route = JSON.parse(valhalla.route(hersheyRequest));

--- a/test/bindings/nodejs/route.test.js
+++ b/test/bindings/nodejs/route.test.js
@@ -15,7 +15,7 @@ test('route: can get a route in Hershey', function(assert) {
 
 test('route: returns an error if no edges found', function(assert) {
   var hersheyRequest = '{"locations":[{"lat":5,"lon":-76.385076,"type":"break"}, {"lat":40.544232,"lon":-76.385752,"type":"break"}],"costing":"auto"}';
-  assert.throws(() => { valhalla.route(hersheyRequest) }, /No suitable edges near location/, 'Throws correct error');
+  assert.throws(() => { valhalla.route(hersheyRequest) }, /{ error_code: 171, http_code: 400, message: No suitable edges near location }/, 'Throws error and has error and http code');
   assert.end();
 });
 

--- a/test/bindings/nodejs/trace_attributes.test.js
+++ b/test/bindings/nodejs/trace_attributes.test.js
@@ -15,7 +15,7 @@ test('traceAttributes: can return info for locations', function(assert) {
 
 test('traceAttributes: throws error if can\'t match input to map', function(assert) {
   var badRequest = '{"shape": [{"lon": 5, "lat": 40.543564},{"lon": 6, "lat": 40.543939},{"lon": 5, "lat": 40.5442815},{"lon": 5, "lat": 40.5447381}],"costing":"auto", "filters":{"attributes":["edge.names","edge.id", "edge.weighted_grade","edge.speed"],"action":"include"}}';
-  assert.throws(() => { valhalla.traceAttributes(badRequest), /Error: No suitable edges near location/, 'Throws an error when cant match input to map'});
+  assert.throws(() => { valhalla.traceAttributes(badRequest) }, /error_code: 171, http_code: 400, message: No suitable edges near location/, 'Throws an error when cant match input to map');
   assert.end();
 });
 

--- a/test/bindings/nodejs/trace_route.test.js
+++ b/test/bindings/nodejs/trace_route.test.js
@@ -16,7 +16,8 @@ test('traceRoute: can return info for locations', function(assert) {
 
 test('traceRoute: throws error if can\'t match input to map', function(assert) {
   var badRequest = '{"shape": [{"lon": 5, "lat": 40.543564},{"lon": 6, "lat": 40.543939},{"lon": 5, "lat": 40.5442815},{"lon": 5, "lat": 40.5447381}],"costing":"auto", "directions_options":{"units":"miles"}}';
-  assert.throws(() => { valhalla.traceRoute(badRequest), /Error: No suitable edges near location/, 'Throws an error when cant match input to map'});
+  assert.throws(() => { valhalla.traceRoute(badRequest) }, /error_code: 171, http_code: 400, message: No suitable edges near location/, 'Throws an error when cant match input to map');
+
   assert.end();
 });
 


### PR DESCRIPTION
# Issue

Per #1444, we were seeing a segfault when the node bindings were called with undefined. That was because the napi_throw_error does not actually throw an exception, but rather tells node to throw an error when the c++ code returns, whenever that might be. That means that the c++ code continued along as if everything was normal, and then potentially hit a segfault. This PR does some refactoring work to make sure we always return NULL after we call napi_throw_error.

closes #1444 

## Tasklist

 - [x] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [x] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
