### PR TITLE
handle work pool with node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 * **Request Parsing**
    * FIXED: Fixed through locations weren't honored [#1449](https://github.com/valhalla/valhalla/pull/1449)
 
+## Release Date: 2018-08-02 Valhalla 3.0.0-rc.4
+* **Node Bindings**
+   * UPDATED: add some worker pool handling
+   [#1467](https://github.com/valhalla/valhalla/pull/1467)
+
 ## Release Date: 2018-08-02 Valhalla 3.0.0-rc.3
 * **Node Bindings**
    * UPDATED: replaced N-API with node-addon-api wrapper and made the actor

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,1 +1,98 @@
-module.exports = require('./binding/node_valhalla.node');
+var valhalla = require('./binding/node_valhalla.node');
+const genericPool = require("generic-pool");
+
+module.exports = function(configStr, minWorkers, maxWorkers) {
+    var Valhalla = valhalla(configStr);
+
+    function createWorker() {
+        return new Promise(function(resolve, reject) {
+            var valh;
+            try {
+                valh = new Valhalla(configStr);
+                resolve(valh);
+            } catch (e) {
+                reject(e);
+            }
+        });
+    }
+
+    const actorFactory = {
+        create: createWorker,
+        destroy: function(actor) {
+            return new Promise(function(resolve, reject) {
+                try {
+                    delete actor;
+                    resolve();
+                } catch (e) {
+                    reject(e);
+                }
+            });
+        }
+    };
+
+    const opts = {
+        max: maxWorkers || 1,
+        min: minWorkers || 1
+    };
+    
+    return function Actor(configStr) {
+        try {
+            new Valhalla(configStr);
+        } catch (e) {
+            throw e;
+        }
+
+        const actorPool = genericPool.createPool(actorFactory, opts);
+        function actorMethod(methodName, request, cb) {
+            if (!request || !cb) throw new Error('method must be called with string and callback');
+
+            actorPool.acquire().then(function(actor) {
+                actorPool.on('factoryCreateError', function(err) {
+                    return cb(err);
+                });
+
+                actor[methodName](request, function(err, result) {
+                    actorPool.release(actor);
+                    return cb(err, result);
+                });
+            });
+        }
+
+        this.route = function(request, cb) {
+            return actorMethod('route', request, cb);
+        }
+
+        this.locate = function(request, cb) {
+            return actorMethod('locate', request, cb);
+        }
+
+        this.height = function(request, cb) {
+            return actorMethod('height', request, cb);
+        }
+
+        this.isochrone = function(request, cb) {
+            return actorMethod('isochrone', request, cb);
+        }
+
+        this.matrix = function(request, cb) {
+            return actorMethod('matrix', request, cb);
+        }
+
+        this.optimizedRoute = function(request, cb) {
+            return actorMethod('optimizedRoute', request, cb);
+        }
+
+        this.traceAttributes = function(request, cb) {
+            return actorMethod('traceAttributes', request, cb);
+        }
+
+        this.traceRoute = function(request, cb) {
+            return actorMethod('traceRoute', request, cb);
+        }
+
+        this.transitAvailable = function(request, cb) {
+            return actorMethod('transitAvailable', request, cb);
+        }
+    };
+}
+

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
-var valhalla = require('./binding/node_valhalla.node');
-const genericPool = require("generic-pool");
+const valhalla = require('./binding/node_valhalla.node');
+const genericPool = require('generic-pool');
 
-module.exports = function(configStr, minWorkers, maxWorkers) {
+module.exports = function(configStr, options = {}) {
     var Valhalla = valhalla(configStr);
 
     function createWorker() {
@@ -16,83 +16,67 @@ module.exports = function(configStr, minWorkers, maxWorkers) {
         });
     }
 
+    function deleteWorker(actor) {
+        return new Promise(function(resolve, reject) {
+            try {
+                delete actor;
+                resolve();
+            } catch (e) {
+                reject(e);
+            }
+        });
+    }
+
     const actorFactory = {
         create: createWorker,
-        destroy: function(actor) {
-            return new Promise(function(resolve, reject) {
-                try {
-                    delete actor;
-                    resolve();
-                } catch (e) {
-                    reject(e);
-                }
-            });
-        }
+        destroy: deleteWorker 
     };
 
     const opts = {
-        max: maxWorkers || 1,
-        min: minWorkers || 1
+        max: options.maxWorkers || 1,
+        min: options.minWorkers || 1
     };
     
     return function Actor(configStr) {
-        try {
-            new Valhalla(configStr);
-        } catch (e) {
-            throw e;
-        }
+        // if we can't create a new actor, throw early rather than in the actor pool
+        new Valhalla(configStr);
 
         const actorPool = genericPool.createPool(actorFactory, opts);
-        function actorMethod(methodName, request, cb) {
-            if (!request || !cb) throw new Error('method must be called with string and callback');
 
-            actorPool.acquire().then(function(actor) {
-                actorPool.on('factoryCreateError', function(err) {
-                    return cb(err);
+        function actorMethodFactory(methodName) {
+            return function(request, cb) {
+                if (!request || !cb) throw new Error('method must be called with string and callback');
+
+                actorPool.acquire().then(function(actor) {
+                    actorPool.on('factoryCreateError', function(err) {
+                        return cb(err);
+                    });
+
+                    actor[methodName](request, function(err, result) {
+                        actorPool.release(actor);
+                        return cb(err, result);
+                    });
                 });
-
-                actor[methodName](request, function(err, result) {
-                    actorPool.release(actor);
-                    return cb(err, result);
-                });
-            });
+            }
         }
 
-        this.route = function(request, cb) {
-            return actorMethod('route', request, cb);
-        }
+        this.route = actorMethodFactory('route'); 
 
-        this.locate = function(request, cb) {
-            return actorMethod('locate', request, cb);
-        }
+        this.locate = actorMethodFactory('locate');
 
-        this.height = function(request, cb) {
-            return actorMethod('height', request, cb);
-        }
+        this.height = actorMethodFactory('height');
 
-        this.isochrone = function(request, cb) {
-            return actorMethod('isochrone', request, cb);
-        }
+        this.isochrone = actorMethodFactory('isochrone');
 
-        this.matrix = function(request, cb) {
-            return actorMethod('matrix', request, cb);
-        }
+        this.matrix = actorMethodFactory('matrix');
 
-        this.optimizedRoute = function(request, cb) {
-            return actorMethod('optimizedRoute', request, cb);
-        }
+        this.optimizedRoute = actorMethodFactory('optimizedRoute');
 
-        this.traceAttributes = function(request, cb) {
-            return actorMethod('traceAttributes', request, cb);
-        }
+        this.traceAttributes = actorMethodFactory('traceAttributes');
 
-        this.traceRoute = function(request, cb) {
-            return actorMethod('traceRoute', request, cb);
-        }
+        this.traceRoute = actorMethodFactory('traceRoute');
 
-        this.transitAvailable = function(request, cb) {
-            return actorMethod('transitAvailable', request, cb);
-        }
+        this.transitAvailable = actorMethodFactory('transitAvailable');
     };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "valhalla",
-  "version": "3.0.0-rc.2",
+  "version": "3.0.0-rc.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -287,6 +287,11 @@
         "strip-ansi": "3.0.1",
         "wide-align": "1.1.3"
       }
+    },
+    "generic-pool": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.4.2.tgz",
+      "integrity": "sha512-H7cUpwCQSiJmAHM4c/aFu6fUfrhWXW1ncyh8ftxEPMu6AiYkHw9K8br720TGPZJbk5eOH2bynjZD1yPvdDAmag=="
     },
     "get-caller-file": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/valhalla/valhalla#readme",
   "dependencies": {
+    "generic-pool": "^3.4.2",
     "node-addon-api": "1.4.0",
     "node-pre-gyp": "^0.10.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "valhalla",
-  "version": "3.0.0-rc.3",
+  "version": "3.0.0-rc.4",
   "main": "lib/index.js",
   "directories": {
     "doc": "docs",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/valhalla/valhalla#readme",
   "dependencies": {
-    "generic-pool": "^3.4.2",
+    "generic-pool": "3.4.2",
     "node-addon-api": "1.4.0",
     "node-pre-gyp": "^0.10.0"
   },


### PR DESCRIPTION
# Issue

A single instance of an actor is not threadsafe, and node's async behavior would cause it to send multiple requests to the same actor at the same time, which would result in a segfault. This PR introduces generic-pool into the bindings. The pool creates a certain number of resources to use to fulfill requests, and only allows a resource (actor) to fulfill one request at a time.

## Tasklist

 - [x] Add tests
 - [x] Review - you must request approval to merge any PR to master
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)
 - [x] Update relevant [documentation](docs/README.md)

