### PR TITLE
remove threadsafe ptree json_parser

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
             echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
             echo 'nvm install v8.11.2' >> $BASH_ENV
             echo 'nvm alias default v8.11.2' >> $BASH_ENV
+      - run: ./scripts/format.sh && ./scripts/error_on_dirty.sh
       - run: git submodule sync && git submodule update --init
       - restore_cache:
           keys:
@@ -72,6 +73,7 @@ jobs:
             echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
             echo 'nvm install v8.11.2' >> $BASH_ENV
             echo 'nvm alias default v8.11.2' >> $BASH_ENV
+      - run: ./scripts/format.sh && ./scripts/error_on_dirty.sh
       - run: git submodule sync && git submodule update --init
       - restore_cache:
           keys:
@@ -101,6 +103,7 @@ jobs:
       - image: valhalla/docker:build-2.6.1
     steps:
       - checkout
+      - run: ./scripts/format.sh && ./scripts/error_on_dirty.sh
       - run: git submodule sync && git submodule update --init
       - restore_cache:
           keys:
@@ -125,6 +128,7 @@ jobs:
       - image: valhalla/docker:build-2.6.1
     steps:
       - checkout
+      - run: ./scripts/format.sh && ./scripts/error_on_dirty.sh
       - run: git submodule sync && git submodule update --init
       - restore_cache:
           keys:
@@ -163,6 +167,7 @@ jobs:
             echo 'nvm install v8.11.2' >> $BASH_ENV
             echo 'nvm alias default v8.11.2' >> $BASH_ENV
       - checkout
+      - run: ./scripts/format.sh && ./scripts/error_on_dirty.sh
       - run: git submodule sync && git submodule update --init
       # - restore_cache:
       #     keys:
@@ -199,6 +204,7 @@ jobs:
             echo 'nvm install v8.11.2' >> $BASH_ENV
             echo 'nvm alias default v8.11.2' >> $BASH_ENV
       - checkout
+      - run: ./scripts/format.sh && ./scripts/error_on_dirty.sh
       - run: git submodule sync && git submodule update --init
       - run: npm install --ignore-scripts
       - run: mkdir -p build
@@ -231,6 +237,7 @@ jobs:
             echo 'nvm install v8.11.2' >> $BASH_ENV
             echo 'nvm alias default v8.11.2' >> $BASH_ENV
       - checkout
+      - run: ./scripts/format.sh && ./scripts/error_on_dirty.sh
       - run: git submodule sync && git submodule update --init
       - run: npm install --ignore-scripts
       - run: mkdir -p build

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,10 +37,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   list(APPEND boost_components zlib)
 endif()
 find_package(Boost 1.51 REQUIRED COMPONENTS ${boost_components})
-if(${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION} VERSION_LESS 1.59)
-  set(REQUIRES_SPIRIT_THREADSAFE 1)
-  find_package(Boost 1.51 REQUIRED COMPONENTS thread)
-endif()
 
 find_package(CURL REQUIRED)
 add_library(CURL::CURL INTERFACE IMPORTED)
@@ -116,7 +112,6 @@ function(valhalla_module)
   target_compile_definitions(${library}
     PUBLIC
       RAPIDJSON_HAS_STDSTRING
-      $<$<BOOL:${REQUIRES_SPIRIT_THREADSAFE}>:BOOST_SPIRIT_THREADSAFE>
     PRIVATE
       $<$<BOOL:${LOGGING_LEVEL}>:LOGGING_LEVEL_${LOGGING_LEVEL}>)
   target_include_directories(${library} ${MODULE_INCLUDE_DIRECTORIES}
@@ -192,7 +187,6 @@ add_library(valhalla worker.cc ${CMAKE_CURRENT_BINARY_DIR}/valhalla/config.h ${v
 target_compile_definitions(valhalla
   PUBLIC
     $<$<BOOL:${MSVC}>:"VC_EXTRALEAN;WIN32_LEAN_AND_MEAN;NOMINMAX;NOGDI">
-    $<$<BOOL:${REQUIRES_SPIRIT_THREADSAFE}>:BOOST_SPIRIT_THREADSAFE>
     RAPIDJSON_HAS_STDSTRING  # this is a part of the workaround for OBJECT libraries,
                              # because ${libvalhalla_compile_definitions} must be private.
                              # To be removed with ${libvalhalla_compile_definitions} below
@@ -217,7 +211,6 @@ target_include_directories(valhalla
 target_link_libraries(valhalla
   PUBLIC
     ${libvalhalla_link_libraries}
-    $<$<BOOL:${REQUIRES_SPIRIT_THREADSAFE}>:Boost::thread>
   PRIVATE
     $<$<BOOL:${ENABLE_COVERAGE}>:gcov>
     Threads::Threads)

--- a/src/bindings/node/node.cc
+++ b/src/bindings/node/node.cc
@@ -1,7 +1,7 @@
+#include "baldr/rapidjson_utils.h"
 #include <boost/make_shared.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/optional.hpp>
-#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <boost/shared_ptr.hpp>
 #include <functional>

--- a/src/bindings/node/node.cc
+++ b/src/bindings/node/node.cc
@@ -1,7 +1,7 @@
 #include <boost/make_shared.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/optional.hpp>
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <boost/shared_ptr.hpp>
 #include <functional>
@@ -22,7 +22,7 @@ boost::property_tree::ptree json_to_pt(const char* json) {
   std::stringstream ss;
   ss << json;
   boost::property_tree::ptree pt;
-  boost::property_tree::read_json(ss, pt);
+  rapidjson::read_json(ss, pt);
   return pt;
 }
 

--- a/src/bindings/python/python.cc
+++ b/src/bindings/python/python.cc
@@ -5,7 +5,7 @@
 #include <boost/make_shared.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/optional.hpp>
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <boost/shared_ptr.hpp>
 #include <sstream>
@@ -28,7 +28,7 @@ configure(const boost::optional<std::string>& config = boost::none) {
     try {
       // parse the config
       boost::property_tree::ptree temp_pt;
-      boost::property_tree::read_json(config.get(), temp_pt);
+      rapidjson::read_json(config.get(), temp_pt);
       pt = temp_pt;
 
       // configure logging

--- a/src/bindings/python/python.cc
+++ b/src/bindings/python/python.cc
@@ -2,10 +2,10 @@
 // FreeBSD/macOS
 #include <boost/python.hpp>
 
+#include "baldr/rapidjson_utils.h"
 #include <boost/make_shared.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/optional.hpp>
-#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <boost/shared_ptr.hpp>
 #include <sstream>

--- a/src/city_test.cc
+++ b/src/city_test.cc
@@ -1,7 +1,7 @@
 #include <boost/format.hpp>
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <boost/tokenizer.hpp>
 #include <cstdint>
@@ -174,7 +174,7 @@ int main(int argc, char* argv[]) {
 
   // Parse the config
   boost::property_tree::ptree pt;
-  boost::property_tree::read_json(config.c_str(), pt);
+  rapidjson::read_json(config.c_str(), pt);
 
   // Configure logging
   boost::optional<boost::property_tree::ptree&> logging_subtree =

--- a/src/city_test.cc
+++ b/src/city_test.cc
@@ -1,7 +1,7 @@
+#include "baldr/rapidjson_utils.h"
 #include <boost/format.hpp>
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
-#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <boost/tokenizer.hpp>
 #include <cstdint>

--- a/src/loki/isochrone_action.cc
+++ b/src/loki/isochrone_action.cc
@@ -3,7 +3,6 @@
 #include "loki/search.h"
 #include "loki/worker.h"
 #include "midgard/logging.h"
-#include <boost/property_tree/json_parser.hpp>
 
 using namespace valhalla;
 using namespace valhalla::baldr;

--- a/src/loki/worker.cc
+++ b/src/loki/worker.cc
@@ -1,4 +1,3 @@
-#include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <cstdint>
 #include <functional>

--- a/src/meili/traffic_segment_matcher.cc
+++ b/src/meili/traffic_segment_matcher.cc
@@ -6,7 +6,6 @@
 #include "midgard/pointll.h"
 #include "midgard/util.h"
 #include "worker.h"
-#include <boost/property_tree/json_parser.hpp>
 
 namespace {
 

--- a/src/meili/valhalla_run_map_match.cc
+++ b/src/meili/valhalla_run_map_match.cc
@@ -1,4 +1,4 @@
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 
 #include "meili/map_matcher_factory.h"
@@ -41,7 +41,7 @@ int main(int argc, char* argv[]) {
   }
 
   boost::property_tree::ptree config;
-  boost::property_tree::read_json(argv[1], config);
+  rapidjson::read_json(argv[1], config);
   const std::string modename = config.get<std::string>("meili.mode");
   valhalla::odin::Costing costing;
   if (!valhalla::odin::Costing_Parse(modename, &costing)) {

--- a/src/mjolnir/valhalla_add_predicted_traffic.cc
+++ b/src/mjolnir/valhalla_add_predicted_traffic.cc
@@ -11,7 +11,7 @@
 #include <boost/archive/iterators/transform_width.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <boost/tokenizer.hpp>
 
@@ -362,9 +362,9 @@ int main(int argc, char** argv) {
   if (vm.count("inline-config")) {
     std::stringstream ss;
     ss << inline_config;
-    boost::property_tree::read_json(ss, pt);
+    rapidjson::read_json(ss, pt);
   } else if (vm.count("config") && boost::filesystem::is_regular_file(config_file_path)) {
-    boost::property_tree::read_json(config_file_path.string(), pt);
+    rapidjson::read_json(config_file_path.string(), pt);
   } else {
     std::cerr << "Configuration is required\n\n" << options << "\n\n";
     return EXIT_FAILURE;

--- a/src/mjolnir/valhalla_add_predicted_traffic.cc
+++ b/src/mjolnir/valhalla_add_predicted_traffic.cc
@@ -6,12 +6,12 @@
 #include <cmath>
 #include <cstdint>
 
+#include "baldr/rapidjson_utils.h"
 #include <boost/archive/iterators/base64_from_binary.hpp>
 #include <boost/archive/iterators/binary_from_base64.hpp>
 #include <boost/archive/iterators/transform_width.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
-#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <boost/tokenizer.hpp>
 

--- a/src/mjolnir/valhalla_benchmark_admins.cc
+++ b/src/mjolnir/valhalla_benchmark_admins.cc
@@ -21,7 +21,7 @@
 #include <boost/geometry/multi/geometries/multi_polygon.hpp>
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 
 // sqlite must be included before spatialite
@@ -276,7 +276,7 @@ int main(int argc, char** argv) {
 
   // Ccheck what type of input we are getting
   boost::property_tree::ptree pt;
-  boost::property_tree::read_json(config_file_path.c_str(), pt);
+  rapidjson::read_json(config_file_path.c_str(), pt);
 
   // Configure logging
   boost::optional<boost::property_tree::ptree&> logging_subtree =

--- a/src/mjolnir/valhalla_benchmark_admins.cc
+++ b/src/mjolnir/valhalla_benchmark_admins.cc
@@ -13,6 +13,7 @@
 
 #include "config.h"
 
+#include "baldr/rapidjson_utils.h"
 #include <boost/filesystem/operations.hpp>
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
@@ -21,7 +22,6 @@
 #include <boost/geometry/multi/geometries/multi_polygon.hpp>
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
-#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 
 // sqlite must be included before spatialite

--- a/src/mjolnir/valhalla_build_admins.cc
+++ b/src/mjolnir/valhalla_build_admins.cc
@@ -42,10 +42,10 @@ using namespace geos::operation::linemerge;
 using namespace valhalla::mjolnir;
 using namespace valhalla::baldr;
 
+#include "baldr/rapidjson_utils.h"
 #include <boost/filesystem/operations.hpp>
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
-#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <ostream>
 

--- a/src/mjolnir/valhalla_build_admins.cc
+++ b/src/mjolnir/valhalla_build_admins.cc
@@ -45,7 +45,7 @@ using namespace valhalla::baldr;
 #include <boost/filesystem/operations.hpp>
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <ostream>
 
@@ -659,7 +659,7 @@ int main(int argc, char** argv) {
 
   // check what type of input we are getting
   boost::property_tree::ptree pt;
-  boost::property_tree::read_json(config_file_path.c_str(), pt);
+  rapidjson::read_json(config_file_path.c_str(), pt);
 
   // configure logging
   boost::optional<boost::property_tree::ptree&> logging_subtree =

--- a/src/mjolnir/valhalla_build_connectivity.cc
+++ b/src/mjolnir/valhalla_build_connectivity.cc
@@ -11,10 +11,10 @@
 
 using namespace valhalla::baldr;
 
+#include "baldr/rapidjson_utils.h"
 #include <boost/filesystem/operations.hpp>
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
-#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <ostream>
 

--- a/src/mjolnir/valhalla_build_connectivity.cc
+++ b/src/mjolnir/valhalla_build_connectivity.cc
@@ -14,7 +14,7 @@ using namespace valhalla::baldr;
 #include <boost/filesystem/operations.hpp>
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <ostream>
 
@@ -112,7 +112,7 @@ int main(int argc, char** argv) {
 
   // Get the config to see which coverage we are using
   boost::property_tree::ptree pt;
-  boost::property_tree::read_json(config_file_path.c_str(), pt);
+  rapidjson::read_json(config_file_path.c_str(), pt);
 
   // Get something we can use to fetch tiles
   valhalla::baldr::connectivity_map_t connectivity_map(pt.get_child("mjolnir"));

--- a/src/mjolnir/valhalla_build_speeds.cc
+++ b/src/mjolnir/valhalla_build_speeds.cc
@@ -9,10 +9,10 @@
 
 #include "config.h"
 
+#include "baldr/rapidjson_utils.h"
 #include <boost/filesystem/operations.hpp>
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
-#include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <ostream>
 
@@ -201,7 +201,7 @@ int main(int argc, char** argv) {
 
   // Get the config to see which coverage we are using
   boost::property_tree::ptree pt;
-  boost::property_tree::read_json(config_file_path.c_str(), pt);
+  rapidjson::read_json(config_file_path.string(), pt);
 
   // Get the tile directory from the config
   std::string tile_dir = pt.get<std::string>("mjolnir.tile_dir");

--- a/src/mjolnir/valhalla_build_statistics.cc
+++ b/src/mjolnir/valhalla_build_statistics.cc
@@ -5,7 +5,7 @@
 #include <boost/filesystem/operations.hpp>
 #include <boost/format.hpp>
 #include <boost/program_options.hpp>
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <future>
 #include <iostream>
@@ -612,7 +612,7 @@ int main(int argc, char** argv) {
 
   // check the type of input
   boost::property_tree::ptree pt;
-  boost::property_tree::read_json(config_file_path.c_str(), pt);
+  rapidjson::read_json(config_file_path.c_str(), pt);
 
   // configure logging
   boost::optional<boost::property_tree::ptree&> logging_subtree =

--- a/src/mjolnir/valhalla_build_statistics.cc
+++ b/src/mjolnir/valhalla_build_statistics.cc
@@ -2,10 +2,10 @@
 
 #include "statistics.h"
 
+#include "baldr/rapidjson_utils.h"
 #include <boost/filesystem/operations.hpp>
 #include <boost/format.hpp>
 #include <boost/program_options.hpp>
-#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <future>
 #include <iostream>

--- a/src/mjolnir/valhalla_build_tiles.cc
+++ b/src/mjolnir/valhalla_build_tiles.cc
@@ -9,7 +9,7 @@ using namespace valhalla::mjolnir;
 #include <boost/filesystem/operations.hpp>
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <iostream>
 
@@ -72,9 +72,9 @@ int main(int argc, char** argv) {
   if (vm.count("inline-config")) {
     std::stringstream ss;
     ss << inline_config;
-    boost::property_tree::read_json(ss, pt);
+    rapidjson::read_json(ss, pt);
   } else if (vm.count("config") && boost::filesystem::is_regular_file(config_file_path)) {
-    boost::property_tree::read_json(config_file_path.string(), pt);
+    rapidjson::read_json(config_file_path.string(), pt);
   } else {
     std::cerr << "Configuration is required\n\n" << options << "\n\n";
     return EXIT_FAILURE;

--- a/src/mjolnir/valhalla_build_tiles.cc
+++ b/src/mjolnir/valhalla_build_tiles.cc
@@ -6,10 +6,10 @@
 
 using namespace valhalla::mjolnir;
 
+#include "baldr/rapidjson_utils.h"
 #include <boost/filesystem/operations.hpp>
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
-#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <iostream>
 

--- a/src/mjolnir/valhalla_build_transit.cc
+++ b/src/mjolnir/valhalla_build_transit.cc
@@ -11,10 +11,10 @@
 #include <thread>
 #include <unordered_set>
 
+#include "baldr/rapidjson_utils.h"
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/format.hpp>
-#include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/tokenizer.hpp>
 #include <curl/curl.h>
@@ -157,7 +157,7 @@ struct pt_curler_t {
         if (http_code == 200) {
           bool threw = false;
           try {
-            read_json(result, pt);
+            rapidjson::read_json(result, pt);
           } catch (...) { threw = true; }
           // has to parse and have required info
           if (!threw && (retry_if_no.empty() || pt.get_child_optional(retry_if_no))) {
@@ -2387,7 +2387,7 @@ int main(int argc, char** argv) {
 
   // args and config file loading
   ptree pt;
-  boost::property_tree::read_json(std::string(argv[1]), pt);
+  rapidjson::read_json(std::string(argv[1]), pt);
   pt.erase("base_url");
   pt.add("base_url", std::string(argv[2]));
   pt.erase("per_page");

--- a/src/mjolnir/valhalla_fetch_transit.cc
+++ b/src/mjolnir/valhalla_fetch_transit.cc
@@ -11,10 +11,10 @@
 #include <thread>
 #include <unordered_set>
 
+#include "baldr/rapidjson_utils.h"
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/format.hpp>
-#include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/tokenizer.hpp>
 #include <curl/curl.h>
@@ -25,6 +25,7 @@
 #include "baldr/graphconstants.h"
 #include "baldr/graphid.h"
 #include "baldr/graphtile.h"
+#include "baldr/rapidjson_utils.h"
 #include "baldr/tilehierarchy.h"
 #include "midgard/encoded.h"
 #include "midgard/logging.h"
@@ -96,7 +97,7 @@ struct pt_curler_t {
         if (http_code == 200) {
           bool threw = false;
           try {
-            read_json(result, pt);
+            rapidjson::read_json(result, pt);
           } catch (...) { threw = true; }
           // has to parse and have required info
           if (!threw && (retry_if_no.empty() || pt.get_child_optional(retry_if_no))) {
@@ -1042,7 +1043,7 @@ int main(int argc, char** argv) {
 
   // args and config file loading
   ptree pt;
-  boost::property_tree::read_json(std::string(argv[1]), pt);
+  rapidjson::read_json(std::string(argv[1]), pt);
   pt.erase("base_url");
   pt.add("base_url", std::string(argv[2]));
   pt.erase("per_page");

--- a/src/mjolnir/valhalla_query_transit.cc
+++ b/src/mjolnir/valhalla_query_transit.cc
@@ -3,13 +3,13 @@
 //#include "mjolnir/graphtilebuilder.h"
 #include <valhalla/proto/transit.pb.h>
 
+#include "baldr/rapidjson_utils.h"
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/foreach.hpp>
 #include <boost/format.hpp>
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
-#include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <fstream>
 #include <iostream>
@@ -418,7 +418,7 @@ int main(int argc, char* argv[]) {
 
   // Read config
   boost::property_tree::ptree pt;
-  boost::property_tree::read_json(config.c_str(), pt);
+  rapidjson::read_json(config, pt);
 
   LOG_INFO("Read config");
 

--- a/src/mjolnir/valhalla_validate_transit.cc
+++ b/src/mjolnir/valhalla_validate_transit.cc
@@ -11,7 +11,7 @@ using namespace valhalla::mjolnir;
 #include <boost/filesystem/operations.hpp>
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <ostream>
 
@@ -91,7 +91,7 @@ int main(int argc, char** argv) {
 
   // check what type of input we are getting
   boost::property_tree::ptree pt;
-  boost::property_tree::read_json(config_file_path.c_str(), pt);
+  rapidjson::read_json(config_file_path.c_str(), pt);
 
   // configure logging
   boost::optional<boost::property_tree::ptree&> logging_subtree =

--- a/src/mjolnir/valhalla_validate_transit.cc
+++ b/src/mjolnir/valhalla_validate_transit.cc
@@ -8,10 +8,10 @@
 
 using namespace valhalla::mjolnir;
 
+#include "baldr/rapidjson_utils.h"
 #include <boost/filesystem/operations.hpp>
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
-#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <ostream>
 

--- a/src/mjolnir/valhalla_ways_to_edges.cc
+++ b/src/mjolnir/valhalla_ways_to_edges.cc
@@ -10,7 +10,7 @@
 #include <boost/filesystem/operations.hpp>
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <ostream>
 
@@ -104,7 +104,7 @@ int main(int argc, char** argv) {
 
   // Get the config to see which coverage we are using
   boost::property_tree::ptree pt;
-  boost::property_tree::read_json(config_file_path.c_str(), pt);
+  rapidjson::read_json(config_file_path.c_str(), pt);
 
   // Get something we can use to fetch tiles
   auto tile_properties = pt.get_child("mjolnir");

--- a/src/mjolnir/valhalla_ways_to_edges.cc
+++ b/src/mjolnir/valhalla_ways_to_edges.cc
@@ -7,10 +7,10 @@
 
 #include "config.h"
 
+#include "baldr/rapidjson_utils.h"
 #include <boost/filesystem/operations.hpp>
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
-#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <ostream>
 

--- a/src/odin/util.cc
+++ b/src/odin/util.cc
@@ -1,9 +1,9 @@
+#include "baldr/rapidjson_utils.h"
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/date_time/local_time/local_time.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include "baldr/rapidjson_utils.h"
 
 #include "locales.h"
 #include "midgard/logging.h"

--- a/src/odin/util.cc
+++ b/src/odin/util.cc
@@ -3,7 +3,7 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/date_time/local_time/local_time.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 
 #include "locales.h"
 #include "midgard/logging.h"
@@ -22,7 +22,7 @@ valhalla::odin::locales_singleton_t load_narrative_locals() {
     boost::property_tree::ptree narrative_pt;
     std::stringstream ss;
     ss << json.second;
-    boost::property_tree::read_json(ss, narrative_pt);
+    rapidjson::read_json(ss, narrative_pt);
     LOG_TRACE("JSON read");
     // parse it into an object and add it to the map
     auto narrative_dictionary =

--- a/src/odin/worker.cc
+++ b/src/odin/worker.cc
@@ -6,7 +6,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 
 #include "baldr/json.h"

--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -12,7 +12,6 @@
 
 #ifdef INLINE_TEST
 #include "test/test.h"
-#include <boost/property_tree/json_parser.hpp>
 #include <random>
 #endif
 

--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -10,7 +10,6 @@
 
 #ifdef INLINE_TEST
 #include "test/test.h"
-#include <boost/property_tree/json_parser.hpp>
 #include <random>
 #endif
 

--- a/src/sif/motorcyclecost.cc
+++ b/src/sif/motorcyclecost.cc
@@ -9,8 +9,8 @@
 #include <iostream>
 
 #ifdef INLINE_TEST
-#include "test/test.h"
 #include "baldr/rapidjson_utils.h"
+#include "test/test.h"
 #include <random>
 #endif
 

--- a/src/sif/motorcyclecost.cc
+++ b/src/sif/motorcyclecost.cc
@@ -10,7 +10,7 @@
 
 #ifdef INLINE_TEST
 #include "test/test.h"
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <random>
 #endif
 
@@ -746,7 +746,7 @@ MotorcycleCost* make_motorcyclecost_from_json(const std::string& property, float
   std::stringstream ss;
   ss << R"({")" << property << R"(":)" << testVal << "}";
   boost::property_tree::ptree costing_ptree;
-  boost::property_tree::read_json(ss, costing_ptree);
+  rapidjson::read_json(ss, costing_ptree);
   return new MotorcycleCost(costing_ptree);
 }
 

--- a/src/sif/motorscootercost.cc
+++ b/src/sif/motorscootercost.cc
@@ -11,7 +11,6 @@
 
 #ifdef INLINE_TEST
 #include "test/test.h"
-#include <boost/property_tree/json_parser.hpp>
 #include <random>
 #endif
 

--- a/src/sif/pedestriancost.cc
+++ b/src/sif/pedestriancost.cc
@@ -8,7 +8,6 @@
 
 #ifdef INLINE_TEST
 #include "test/test.h"
-#include <boost/property_tree/json_parser.hpp>
 #include <random>
 #endif
 

--- a/src/sif/transitcost.cc
+++ b/src/sif/transitcost.cc
@@ -7,7 +7,6 @@
 
 #ifdef INLINE_TEST
 #include "test/test.h"
-#include <boost/property_tree/json_parser.hpp>
 #include <random>
 #endif
 

--- a/src/sif/truckcost.cc
+++ b/src/sif/truckcost.cc
@@ -10,7 +10,6 @@
 
 #ifdef INLINE_TEST
 #include "test/test.h"
-#include <boost/property_tree/json_parser.hpp>
 #include <random>
 #endif
 

--- a/src/thor/worker.cc
+++ b/src/thor/worker.cc
@@ -10,7 +10,6 @@
 #include "exception.h"
 #include "midgard/constants.h"
 #include "midgard/logging.h"
-#include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 
 #include "thor/isochrone.h"

--- a/src/tyr/actor.cc
+++ b/src/tyr/actor.cc
@@ -6,7 +6,6 @@
 #include "thor/worker.h"
 #include "tyr/serializers.h"
 
-#include <boost/property_tree/json_parser.hpp>
 
 using namespace valhalla;
 using namespace valhalla::loki;

--- a/src/tyr/actor.cc
+++ b/src/tyr/actor.cc
@@ -6,7 +6,6 @@
 #include "thor/worker.h"
 #include "tyr/serializers.h"
 
-
 using namespace valhalla;
 using namespace valhalla::loki;
 using namespace valhalla::thor;

--- a/src/tyr/serializers.cc
+++ b/src/tyr/serializers.cc
@@ -1,4 +1,3 @@
-#include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <cstdint>
 #include <functional>

--- a/src/unconnected_ways.cc
+++ b/src/unconnected_ways.cc
@@ -1,7 +1,7 @@
+#include "baldr/rapidjson_utils.h"
 #include <boost/format.hpp>
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
-#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <cmath>
 #include <cstdint>

--- a/src/unconnected_ways.cc
+++ b/src/unconnected_ways.cc
@@ -1,7 +1,7 @@
 #include <boost/format.hpp>
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <cmath>
 #include <cstdint>
@@ -84,7 +84,7 @@ int main(int argc, char* argv[]) {
 
   // Parse the config
   boost::property_tree::ptree pt;
-  boost::property_tree::read_json(config.c_str(), pt);
+  rapidjson::read_json(config.c_str(), pt);
 
   // configure logging
   boost::optional<boost::property_tree::ptree&> logging_subtree =

--- a/src/valhalla_associate_segments.cc
+++ b/src/valhalla_associate_segments.cc
@@ -9,12 +9,12 @@
 #include <cmath>
 #include <cstdint>
 
+#include "baldr/rapidjson_utils.h"
 #include <boost/algorithm/cxx11/all_of.hpp>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/iterator/reverse_iterator.hpp>
 #include <boost/program_options.hpp>
-#include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 
 #include <algorithm>
@@ -1020,7 +1020,7 @@ int main(int argc, char** argv) {
 
   // parse the config
   bpt::ptree pt;
-  bpt::read_json(config.c_str(), pt);
+  rapidjson::read_json(config, pt);
 
   // fire off some threads to do the work
   LOG_INFO("Associating local traffic segments with " + std::to_string(num_threads) + " threads");

--- a/src/valhalla_benchmark_loki.cc
+++ b/src/valhalla_benchmark_loki.cc
@@ -9,7 +9,7 @@
 #include <boost/filesystem/operations.hpp>
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <fstream>
 #include <future>
@@ -193,7 +193,7 @@ int main(int argc, char** argv) {
 
   // check what type of input we are getting
   boost::property_tree::ptree pt;
-  boost::property_tree::read_json(config_file_path.c_str(), pt);
+  rapidjson::read_json(config_file_path.c_str(), pt);
 
   // configure logging
   boost::optional<boost::property_tree::ptree&> logging_subtree =

--- a/src/valhalla_benchmark_loki.cc
+++ b/src/valhalla_benchmark_loki.cc
@@ -4,12 +4,12 @@
 #include "midgard/logging.h"
 #include "midgard/pointll.h"
 
+#include "baldr/rapidjson_utils.h"
 #include <algorithm>
 #include <atomic>
 #include <boost/filesystem/operations.hpp>
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
-#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <fstream>
 #include <future>

--- a/src/valhalla_export_edges.cc
+++ b/src/valhalla_export_edges.cc
@@ -1,5 +1,5 @@
-#include <boost/program_options.hpp>
 #include "baldr/rapidjson_utils.h"
+#include <boost/program_options.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <cstdint>
 

--- a/src/valhalla_export_edges.cc
+++ b/src/valhalla_export_edges.cc
@@ -1,5 +1,5 @@
 #include <boost/program_options.hpp>
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <cstdint>
 
@@ -203,7 +203,7 @@ int main(int argc, char* argv[]) {
 
   // parse the config
   boost::property_tree::ptree pt;
-  boost::property_tree::read_json(config.c_str(), pt);
+  rapidjson::read_json(config.c_str(), pt);
 
   // configure logging
   valhalla::midgard::logging::Configure({{"type", "std_err"}, {"color", "true"}});

--- a/src/valhalla_loki_worker.cc
+++ b/src/valhalla_loki_worker.cc
@@ -1,6 +1,6 @@
 #include <iostream>
 
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 
 #include "loki/worker.h"
@@ -15,7 +15,7 @@ int main(int argc, char** argv) {
   // config file
   std::string config_file(argv[1]);
   boost::property_tree::ptree config;
-  boost::property_tree::read_json(config_file, config);
+  rapidjson::read_json(config_file, config);
 
   // run the service worker
   valhalla::loki::run_service(config);

--- a/src/valhalla_odin_worker.cc
+++ b/src/valhalla_odin_worker.cc
@@ -1,6 +1,6 @@
 #include <iostream>
 
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 
 #include "odin/worker.h"
@@ -15,7 +15,7 @@ int main(int argc, char** argv) {
   // config file
   std::string config_file(argv[1]);
   boost::property_tree::ptree config;
-  boost::property_tree::read_json(config_file, config);
+  rapidjson::read_json(config_file, config);
 
   // run the service worker
   valhalla::odin::run_service(config);

--- a/src/valhalla_path_comparison.cc
+++ b/src/valhalla_path_comparison.cc
@@ -1,6 +1,6 @@
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <cstdint>
 #include <iostream>
@@ -214,7 +214,7 @@ int main(int argc, char* argv[]) {
   if (vm.count("json")) {
     request.parse(json, valhalla::odin::DirectionsOptions::trace_route);
     std::stringstream stream(json);
-    boost::property_tree::read_json(stream, json_ptree);
+    rapidjson::read_json(stream, json_ptree);
     try {
       for (const auto& path : json_ptree.get_child("paths")) {
         paths.push_back({});
@@ -266,7 +266,7 @@ int main(int argc, char* argv[]) {
 
   // parse the config
   boost::property_tree::ptree pt;
-  boost::property_tree::read_json(config.c_str(), pt);
+  rapidjson::read_json(config.c_str(), pt);
 
   // Get something we can use to fetch tiles
   valhalla::baldr::GraphReader reader(pt.get_child("mjolnir"));

--- a/src/valhalla_path_comparison.cc
+++ b/src/valhalla_path_comparison.cc
@@ -1,6 +1,6 @@
+#include "baldr/rapidjson_utils.h"
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
-#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <cstdint>
 #include <iostream>

--- a/src/valhalla_run_isochrone.cc
+++ b/src/valhalla_run_isochrone.cc
@@ -1,7 +1,7 @@
+#include "baldr/rapidjson_utils.h"
 #include <boost/format.hpp>
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
-#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <cmath>
 #include <cstdint>

--- a/src/valhalla_run_isochrone.cc
+++ b/src/valhalla_run_isochrone.cc
@@ -1,7 +1,7 @@
 #include <boost/format.hpp>
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <cmath>
 #include <cstdint>
@@ -113,7 +113,7 @@ int main(int argc, char* argv[]) {
 
   std::stringstream stream;
   stream << json;
-  boost::property_tree::read_json(stream, json_ptree);
+  rapidjson::read_json(stream, json_ptree);
 
   if (vm.count("minutes")) {
     LOG_WARN("minutes parameter is being overwritten by JSON contours");
@@ -157,7 +157,7 @@ int main(int argc, char* argv[]) {
 
   // parse the config
   boost::property_tree::ptree pt;
-  boost::property_tree::read_json(config.c_str(), pt);
+  rapidjson::read_json(config.c_str(), pt);
 
   // configure logging
   boost::optional<boost::property_tree::ptree&> logging_subtree =

--- a/src/valhalla_run_matrix.cc
+++ b/src/valhalla_run_matrix.cc
@@ -1,7 +1,7 @@
 #include <boost/format.hpp>
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <cmath>
 #include <cstdint>
@@ -141,7 +141,7 @@ int main(int argc, char* argv[]) {
 
   // parse the config
   boost::property_tree::ptree pt;
-  boost::property_tree::read_json(config.c_str(), pt);
+  rapidjson::read_json(config.c_str(), pt);
 
   // configure logging
   boost::optional<boost::property_tree::ptree&> logging_subtree =

--- a/src/valhalla_run_matrix.cc
+++ b/src/valhalla_run_matrix.cc
@@ -1,7 +1,7 @@
+#include "baldr/rapidjson_utils.h"
 #include <boost/format.hpp>
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
-#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <cmath>
 #include <cstdint>

--- a/src/valhalla_run_route.cc
+++ b/src/valhalla_run_route.cc
@@ -504,7 +504,7 @@ int main(int argc, char* argv[]) {
 
   // parse the config
   boost::property_tree::ptree pt;
-  boost::property_tree::read_json(config.c_str(), pt);
+  rapidjson::read_json(config.c_str(), pt);
 
   // configure logging
   boost::optional<boost::property_tree::ptree&> logging_subtree =

--- a/src/valhalla_service.cc
+++ b/src/valhalla_service.cc
@@ -9,7 +9,7 @@
 #include <thread>
 #include <unordered_set>
 
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 
 #include <prime_server/http_protocol.hpp>
@@ -33,7 +33,7 @@ int main(int argc, char** argv) {
   // TODO: validate the config
   std::string config_file(argv[1]);
   boost::property_tree::ptree config;
-  boost::property_tree::read_json(config_file, config);
+  rapidjson::read_json(config_file, config);
 
   // grab the endpoints
   std::string listen = config.get<std::string>("httpd.service.listen");

--- a/src/valhalla_thor_worker.cc
+++ b/src/valhalla_thor_worker.cc
@@ -1,6 +1,6 @@
 #include <iostream>
 
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 
 #include "thor/worker.h"
@@ -15,7 +15,7 @@ int main(int argc, char** argv) {
   // config file
   std::string config_file(argv[1]);
   boost::property_tree::ptree config;
-  boost::property_tree::read_json(config_file, config);
+  rapidjson::read_json(config_file, config);
 
   // run the service worker
   valhalla::thor::run_service(config);

--- a/test/actor.cc
+++ b/test/actor.cc
@@ -2,7 +2,7 @@
 
 #include <stdexcept>
 
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 
 #include "tyr/actor.h"
@@ -19,7 +19,7 @@ boost::property_tree::ptree json_to_pt(const std::string& json) {
   std::stringstream ss;
   ss << json;
   boost::property_tree::ptree pt;
-  boost::property_tree::read_json(ss, pt);
+  rapidjson::read_json(ss, pt);
   return pt;
 }
 

--- a/test/astar.cc
+++ b/test/astar.cc
@@ -27,9 +27,9 @@
 #include <valhalla/proto/tripdirections.pb.h>
 #include <valhalla/proto/trippath.pb.h>
 
+#include "baldr/rapidjson_utils.h"
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
-#include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <fstream>
 
@@ -218,7 +218,7 @@ void assert_is_trivial_path(vo::Location& origin, vo::Location& dest, uint32_t e
   std::stringstream json;
   json << "{ \"tile_dir\": \"" VALHALLA_SOURCE_DIR "test/fake_tiles_astar\" }";
   bpt::ptree conf;
-  bpt::json_parser::read_json(json, conf);
+  rapidjson::read_json(json, conf);
 
   vb::GraphReader reader(conf);
   auto* tile = reader.GetGraphTile(tile_id);
@@ -315,7 +315,7 @@ void TestTrivialPathTriangle() {
 
 void trivial_path_no_uturns(const std::string& config_file) {
   boost::property_tree::ptree conf;
-  boost::property_tree::json_parser::read_json(config_file, conf);
+  rapidjson::read_json(config_file, conf);
 
   // setup and purge
   vb::GraphReader graph_reader(conf.get_child("mjolnir"));

--- a/test/countryaccess.cc
+++ b/test/countryaccess.cc
@@ -7,8 +7,8 @@
 #include "test.h"
 #include <cstdint>
 
-#include <boost/filesystem.hpp>
 #include "baldr/rapidjson_utils.h"
+#include <boost/filesystem.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <fstream>
 

--- a/test/countryaccess.cc
+++ b/test/countryaccess.cc
@@ -8,7 +8,7 @@
 #include <cstdint>
 
 #include <boost/filesystem.hpp>
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <fstream>
 
@@ -68,7 +68,7 @@ OSMWay GetWay(uint64_t way_id, sequence<OSMWay>& ways) {
 
 void CountryAccess(const std::string& config_file) {
   boost::property_tree::ptree conf;
-  boost::property_tree::json_parser::read_json(config_file, conf);
+  rapidjson::read_json(config_file, conf);
 
   // setup and purge
   GraphReader graph_reader(conf.get_child("mjolnir"));

--- a/test/edgecollapser.cc
+++ b/test/edgecollapser.cc
@@ -5,7 +5,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 
 #include "baldr/directededge.h"
@@ -69,7 +69,7 @@ struct graph_tile_builder {
 boost::property_tree::ptree read_json(const std::string& json) {
   boost::property_tree::ptree p;
   std::istringstream istr(json);
-  boost::property_tree::json_parser::read_json(istr, p);
+  rapidjson::read_json(istr, p);
   return p;
 }
 

--- a/test/graphbuilder.cc
+++ b/test/graphbuilder.cc
@@ -4,7 +4,6 @@
 
 #include <algorithm>
 #include <boost/optional.hpp>
-#include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <memory>
 #include <sstream>

--- a/test/graphparser.cc
+++ b/test/graphparser.cc
@@ -5,7 +5,7 @@
 #include <cstdint>
 
 #include <boost/filesystem.hpp>
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <fstream>
 
@@ -46,7 +46,7 @@ OSMWay GetWay(uint64_t way_id, sequence<OSMWay>& ways) {
 
 void BollardsGatesAndAccess(const std::string& config_file) {
   boost::property_tree::ptree conf;
-  boost::property_tree::json_parser::read_json(config_file, conf);
+  rapidjson::read_json(config_file, conf);
 
   std::string ways_file = "test_ways.bin";
   std::string way_nodes_file = "test_way_nodes.bin";
@@ -182,7 +182,7 @@ void BollardsGatesAndAccess(const std::string& config_file) {
 
 void RemovableBollards(const std::string& config_file) {
   boost::property_tree::ptree conf;
-  boost::property_tree::json_parser::read_json(config_file, conf);
+  rapidjson::read_json(config_file, conf);
 
   std::string ways_file = "test_ways.bin";
   std::string way_nodes_file = "test_way_nodes.bin";
@@ -210,7 +210,7 @@ void RemovableBollards(const std::string& config_file) {
 
 void Exits(const std::string& config_file) {
   boost::property_tree::ptree conf;
-  boost::property_tree::json_parser::read_json(config_file, conf);
+  rapidjson::read_json(config_file, conf);
 
   std::string ways_file = "test_ways.bin";
   std::string way_nodes_file = "test_way_nodes.bin";
@@ -245,7 +245,7 @@ void Exits(const std::string& config_file) {
 
 void Baltimore(const std::string& config_file) {
   boost::property_tree::ptree conf;
-  boost::property_tree::json_parser::read_json(config_file, conf);
+  rapidjson::read_json(config_file, conf);
 
   std::string ways_file = "test_ways.bin";
   std::string way_nodes_file = "test_way_nodes.bin";
@@ -328,7 +328,7 @@ void Baltimore(const std::string& config_file) {
 
 void Bike(const std::string& config_file) {
   boost::property_tree::ptree conf;
-  boost::property_tree::json_parser::read_json(config_file, conf);
+  rapidjson::read_json(config_file, conf);
 
   std::string ways_file = "test_ways.bin";
   std::string way_nodes_file = "test_way_nodes.bin";
@@ -385,7 +385,7 @@ void Bike(const std::string& config_file) {
 
 void Bus(const std::string& config_file) {
   boost::property_tree::ptree conf;
-  boost::property_tree::json_parser::read_json(config_file, conf);
+  rapidjson::read_json(config_file, conf);
 
   std::string ways_file = "test_ways.bin";
   std::string way_nodes_file = "test_way_nodes.bin";
@@ -433,7 +433,7 @@ void Bus(const std::string& config_file) {
 
 void BicycleTrafficSignals(const std::string& config_file) {
   boost::property_tree::ptree conf;
-  boost::property_tree::json_parser::read_json(config_file, conf);
+  rapidjson::read_json(config_file, conf);
 
   std::string ways_file = "test_ways.bin";
   std::string way_nodes_file = "test_way_nodes.bin";

--- a/test/graphparser.cc
+++ b/test/graphparser.cc
@@ -4,8 +4,8 @@
 #include "test.h"
 #include <cstdint>
 
-#include <boost/filesystem.hpp>
 #include "baldr/rapidjson_utils.h"
+#include <boost/filesystem.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <fstream>
 

--- a/test/json.cc
+++ b/test/json.cc
@@ -1,7 +1,7 @@
 #include "baldr/json.h"
+#include "baldr/rapidjson_utils.h"
 #include "test.h"
-#include <boost/property_tree/json_parser.hpp>
-#include <boost/property_tree/ptree.hpp>
+
 #include <cstdint>
 #include <set>
 
@@ -64,28 +64,9 @@ void TestJsonSerialize() {
             "geometry\":\"ozyulA~p_clCfc@ywApTar@li@ybBqe@c[ue@e[ue@i[ci@dcB}^rkA\",\"status_"
             "message\":\"Found route between points\",\"via_indices\":[0,9],\"status\":0}";
 
-  boost::property_tree::ptree res, ans;
-  boost::property_tree::read_json(result, res);
-  boost::property_tree::read_json(answer, ans);
-  res.sort();
-  ans.sort();
-
-  stringstream res_formatted, ans_formatted;
-  boost::property_tree::write_json(res_formatted, res);
-  boost::property_tree::write_json(ans_formatted, ans);
-
-  multiset<string> res_set, ans_set;
-  for (string line; getline(res_formatted, line);)
-    res_set.insert(line);
-  for (string line; getline(ans_formatted, line);)
-    ans_set.insert(line);
-  if (res_set.size() != ans_set.size())
-    throw std::logic_error("Wrong json!");
-
-  auto res_itr = res_set.cbegin(), ans_itr = ans_set.cbegin();
-  for (; res_itr != res_set.cend() && ans_itr != ans_set.cend(); ++res_itr, ++ans_itr)
-    if (*res_itr != *ans_itr)
-      throw std::runtime_error("Wrong json!");
+  rapidjson::Document res, ans;
+  if (res != ans)
+    throw std::logic_error("Wrong json");
 }
 
 } // namespace

--- a/test/loki_service.cc
+++ b/test/loki_service.cc
@@ -1,8 +1,8 @@
 #include "test.h"
 #include <cstdint>
 
+#include "baldr/rapidjson_utils.h"
 #include "midgard/logging.h"
-#include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <prime_server/http_protocol.hpp>
 #include <prime_server/prime_server.hpp>
@@ -368,7 +368,7 @@ void start_service() {
       },
       "costing_options": { "auto": {}, "pedestrian": {} }
     })";
-  boost::property_tree::json_parser::read_json(json, config);
+  rapidjson::read_json(json, config);
 
   // service worker
   std::thread worker(valhalla::loki::run_service, config);

--- a/test/map_matcher_factory.cc
+++ b/test/map_matcher_factory.cc
@@ -1,7 +1,7 @@
 // -*- mode: c++ -*-
 #include <string>
 
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 
 #include "sif/costconstants.h"
@@ -51,7 +51,7 @@ void create_costing_options(valhalla::odin::DirectionsOptions& directions_option
 
 void TestMapMatcherFactory() {
   ptree root;
-  boost::property_tree::read_json(VALHALLA_SOURCE_DIR "test/valhalla.json", root);
+  rapidjson::read_json(VALHALLA_SOURCE_DIR "test/valhalla.json", root);
 
   // Do it thousand times to check memory leak
   for (size_t i = 0; i < 3000; i++) {
@@ -177,7 +177,7 @@ void TestMapMatcherFactory() {
 
 void TestMapMatcher() {
   ptree root;
-  boost::property_tree::read_json(VALHALLA_SOURCE_DIR "test/valhalla.json", root);
+  rapidjson::read_json(VALHALLA_SOURCE_DIR "test/valhalla.json", root);
 
   // Nothing special to test for the moment
 

--- a/test/mapmatch.cc
+++ b/test/mapmatch.cc
@@ -5,8 +5,8 @@
 #include <utility>
 #include <vector>
 
+#include "baldr/rapidjson_utils.h"
 #include <boost/optional/optional.hpp>
-#include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 
 #include "baldr/json.h"
@@ -69,7 +69,7 @@ boost::property_tree::ptree json_to_pt(const std::string& json) {
   std::stringstream ss;
   ss << json;
   boost::property_tree::ptree pt;
-  boost::property_tree::read_json(ss, pt);
+  rapidjson::read_json(ss, pt);
   return pt;
 }
 

--- a/test/matrix.cc
+++ b/test/matrix.cc
@@ -4,7 +4,7 @@
 #include <string>
 #include <vector>
 
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 
 #include "loki/worker.h"
@@ -123,7 +123,7 @@ boost::property_tree::ptree json_to_pt(const std::string& json) {
   std::stringstream ss;
   ss << json;
   boost::property_tree::ptree pt;
-  boost::property_tree::read_json(ss, pt);
+  rapidjson::read_json(ss, pt);
   return pt;
 }
 

--- a/test/node_search.cc
+++ b/test/node_search.cc
@@ -2,7 +2,7 @@
 #include "test.h"
 #include <cstdint>
 
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 #include <unordered_set>
 
@@ -314,7 +314,7 @@ void make_tile() {
   json << ", \"concurrency\": 1";
   json << " }";
   boost::property_tree::ptree conf;
-  boost::property_tree::json_parser::read_json(json, conf);
+  rapidjson::read_json(json, conf);
 
   vj::GraphValidator::Validate(conf);
 }
@@ -324,7 +324,7 @@ void test_single_node() {
   std::stringstream json;
   json << "{ \"tile_dir\": \"" << test_tile_dir << "\" }";
   boost::property_tree::ptree conf;
-  boost::property_tree::json_parser::read_json(json, conf);
+  rapidjson::read_json(json, conf);
 
   vb::GraphReader reader(conf);
   // this should only find the node a 0,0
@@ -342,7 +342,7 @@ void test_small_node_block() {
   std::stringstream json;
   json << "{ \"tile_dir\": \"" << test_tile_dir << "\" }";
   boost::property_tree::ptree conf;
-  boost::property_tree::json_parser::read_json(json, conf);
+  rapidjson::read_json(json, conf);
 
   vb::GraphReader reader(conf);
   // this should find the four nodes which form a square at the lower left of
@@ -362,7 +362,7 @@ void test_node_at_tile_boundary() {
   std::stringstream json;
   json << "{ \"tile_dir\": \"" << test_tile_dir << "\" }";
   boost::property_tree::ptree conf;
-  boost::property_tree::json_parser::read_json(json, conf);
+  rapidjson::read_json(json, conf);
 
   vb::GraphReader reader(conf);
   // this should find node which is at the tile boundary
@@ -402,7 +402,7 @@ void test_opposite_in_another_tile() {
   std::stringstream json;
   json << "{ \"tile_dir\": \"" << test_tile_dir << "\" }";
   boost::property_tree::ptree conf;
-  boost::property_tree::json_parser::read_json(json, conf);
+  rapidjson::read_json(json, conf);
 
   vb::GraphReader reader(conf);
   // this should find the four nodes which form a square at the lower left of

--- a/test/predictive_traffic.cc
+++ b/test/predictive_traffic.cc
@@ -9,7 +9,7 @@
 #include "baldr/nodeinfo.h"
 #include "mjolnir/graphtilebuilder.h"
 
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 
 using namespace valhalla::baldr;
@@ -21,7 +21,7 @@ boost::property_tree::ptree json_to_pt(const std::string& json) {
   std::stringstream ss;
   ss << json;
   boost::property_tree::ptree pt;
-  boost::property_tree::read_json(ss, pt);
+  rapidjson::read_json(ss, pt);
   return pt;
 }
 

--- a/test/search.cc
+++ b/test/search.cc
@@ -3,7 +3,6 @@
 #include <cstdint>
 
 #include <boost/filesystem.hpp>
-#include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <unordered_set>
 

--- a/test/skadi_service.cc
+++ b/test/skadi_service.cc
@@ -217,7 +217,7 @@ void start_service(zmq::context_t& context) {
       },
       "costing_options": { "auto": {}, "pedestrian": {} }
     })";
-  boost::property_tree::json_parser::read_json(json, config);
+  rapidjson::read_json(json, config);
 
   std::thread worker(valhalla::loki::run_service, config);
   worker.detach();

--- a/test/thor_service.cc
+++ b/test/thor_service.cc
@@ -6,7 +6,6 @@
 
 #include <thread>
 
-#include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <prime_server/http_protocol.hpp>
 #include <prime_server/prime_server.hpp>

--- a/test/tilehierarchy.cc
+++ b/test/tilehierarchy.cc
@@ -4,7 +4,6 @@
 
 #include "test.h"
 
-#include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 
 using namespace std;

--- a/test/timedep_paths.cc
+++ b/test/timedep_paths.cc
@@ -4,13 +4,13 @@
 #include <string>
 #include <vector>
 
+#include "baldr/rapidjson_utils.h"
 #include "loki/worker.h"
 #include "midgard/logging.h"
 #include "sif/autocost.h"
 #include "thor/timedep.h"
 #include "thor/worker.h"
 #include "worker.h"
-#include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 
 using namespace valhalla::thor;
@@ -26,7 +26,7 @@ boost::property_tree::ptree json_to_pt(const std::string& json) {
   std::stringstream ss;
   ss << json;
   boost::property_tree::ptree pt;
-  boost::property_tree::read_json(ss, pt);
+  rapidjson::read_json(ss, pt);
   return pt;
 }
 

--- a/test/traffic_matcher.cc
+++ b/test/traffic_matcher.cc
@@ -2,7 +2,7 @@
 
 #include <stdexcept>
 
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 
 #include "baldr/graphid.h"
@@ -115,7 +115,7 @@ void test_matcher() {
                "search_radius":50,"sigma_z":4.07,"turn_penalty_factor":200}}
     })";
   boost::property_tree::ptree conf;
-  boost::property_tree::read_json(conf_json, conf);
+  rapidjson::read_json(conf_json, conf);
   conf.get_child("mjolnir").put("tile_dir", VALHALLA_SOURCE_DIR "test/traffic_matcher_tiles");
 
   // find me a find, catch me a catch
@@ -127,7 +127,7 @@ void test_matcher() {
     std::stringstream json_ss;
     json_ss << json;
     boost::property_tree::ptree answer;
-    boost::property_tree::read_json(json_ss, answer);
+    rapidjson::read_json(json_ss, answer);
 
     const auto& a_segs = test_case.second;
     auto& b_segs = matcher.segments;

--- a/test/trivial_paths.cc
+++ b/test/trivial_paths.cc
@@ -9,7 +9,7 @@
 #include "sif/autocost.h"
 #include "thor/astar.h"
 #include "thor/worker.h"
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 
 using namespace valhalla::thor;
@@ -25,7 +25,7 @@ boost::property_tree::ptree json_to_pt(const std::string& json) {
   std::stringstream ss;
   ss << json;
   boost::property_tree::ptree pt;
-  boost::property_tree::read_json(ss, pt);
+  rapidjson::read_json(ss, pt);
   return pt;
 }
 

--- a/test/trivial_paths.cc
+++ b/test/trivial_paths.cc
@@ -4,12 +4,12 @@
 #include <string>
 #include <vector>
 
+#include "baldr/rapidjson_utils.h"
 #include "loki/worker.h"
 #include "midgard/logging.h"
 #include "sif/autocost.h"
 #include "thor/astar.h"
 #include "thor/worker.h"
-#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 
 using namespace valhalla::thor;

--- a/test/util_odin.cc
+++ b/test/util_odin.cc
@@ -1,7 +1,7 @@
+#include "baldr/rapidjson_utils.h"
 #include "midgard/logging.h"
 #include "odin/util.h"
 #include "test.h"
-#include "baldr/rapidjson_utils.h"
 #include <boost/regex.hpp>
 #include <locale>
 #include <set>

--- a/test/util_odin.cc
+++ b/test/util_odin.cc
@@ -1,7 +1,7 @@
 #include "midgard/logging.h"
 #include "odin/util.h"
 #include "test.h"
-#include <boost/property_tree/json_parser.hpp>
+#include "baldr/rapidjson_utils.h"
 #include <boost/regex.hpp>
 #include <locale>
 #include <set>
@@ -136,7 +136,7 @@ void test_supported_locales() {
   boost::property_tree::ptree en_us;
   std::stringstream ss;
   ss << en_us_json->second;
-  boost::property_tree::read_json(ss, en_us);
+  rapidjson::read_json(ss, en_us);
 
   // look at each one
   for (const auto& locale : jsons) {
@@ -145,7 +145,7 @@ void test_supported_locales() {
     boost::property_tree::ptree other;
     std::stringstream other_ss;
     other_ss << locale.second;
-    boost::property_tree::read_json(other_ss, other);
+    rapidjson::read_json(other_ss, other);
 
     // check the locale is supported
     std::string posix_locale = other.get<std::string>("posix_locale");

--- a/test/utrecht.cc
+++ b/test/utrecht.cc
@@ -5,7 +5,6 @@
 #include <cstdint>
 
 #include <boost/filesystem.hpp>
-#include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <fstream>
 

--- a/valhalla/sif/costfactory.h
+++ b/valhalla/sif/costfactory.h
@@ -14,9 +14,6 @@
 #include <valhalla/sif/transitcost.h>
 #include <valhalla/sif/truckcost.h>
 
-#include <boost/property_tree/json_parser.hpp>
-#include <boost/property_tree/ptree.hpp>
-
 namespace valhalla {
 namespace sif {
 


### PR DESCRIPTION
fixes #1474 

this is the first step in no longer using ptree for json. currently we have a bunch of different ways we interact with json. we use rapidjson for request parsing (where we used to use ptree) and we use ptree for configs and for loading language files and we use another thing for serializing json (also a dumb idea in hindsight). 

because our systems can be multithreaded we needed to make use of threadsafe mode for ptree. under the hood this requires boost::spirit and boost::thread. other than that ptree is a header-only library. we would like to use it in this way for the time being just because there so much code to change to switch to rapidjson.

so to make our build have less dependencies ive removed the property_tree::json_parser and replaced it with a method that uses rapidjson to do the parsing of the json and converts the rapidjson object into a ptree. eventually we want to go to full on rapidjson but it will take time and lots of code changes.