### PR TITLE
Predicted speed fix

### DIFF
--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -246,7 +246,7 @@ void GraphTile::Initialize(const GraphId& graphid, char* tile_ptr, const size_t 
   if (header_->predictedspeeds_count() > 0) {
     char* ptr1 = tile_ptr + header_->predictedspeeds_offset();
     char* ptr2 = ptr1 + (header_->directededgecount() * sizeof(int32_t));
-    predictedspeeds_.set_index(reinterpret_cast<uint32_t*>(ptr1));
+    predictedspeeds_.set_offset(reinterpret_cast<uint32_t*>(ptr1));
     predictedspeeds_.set_profiles(reinterpret_cast<int16_t*>(ptr2));
   }
 

--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -245,7 +245,7 @@ void GraphTile::Initialize(const GraphId& graphid, char* tile_ptr, const size_t 
   // Start of predicted speed data.
   if (header_->predictedspeeds_count() > 0) {
     char* ptr1 = tile_ptr + header_->predictedspeeds_offset();
-    char* ptr2 = ptr1 + (header_->directededgecount() * sizeof(int16_t));
+    char* ptr2 = ptr1 + (header_->directededgecount() * sizeof(int32_t));
     predictedspeeds_.set_index(reinterpret_cast<uint32_t*>(ptr1));
     predictedspeeds_.set_profiles(reinterpret_cast<int16_t*>(ptr2));
   }

--- a/test/predictedspeeds.cc
+++ b/test/predictedspeeds.cc
@@ -50,7 +50,7 @@ void try_free_flow_speed(const std::string encoded_str,
                              " but is " + std::to_string(free_flow));
   }
   uint32_t constrained_flow = static_cast<std::uint32_t>(raw[index++] & 0xff);
-  if (constrained_flow != 158) {
+  if (constrained_flow != exp_constrained_flow) {
     throw std::runtime_error("constrained flow speed should be " +
                              std::to_string(exp_constrained_flow) + " but is " +
                              std::to_string(constrained_flow));
@@ -61,6 +61,7 @@ void test_free_flow_speed() {
   try_free_flow_speed("AAie", 8, 158);
 
   // Add additional cases below
+  try_free_flow_speed("AACe", 0, 158);
 }
 
 void test_decoding() {

--- a/test/predictedspeeds.cc
+++ b/test/predictedspeeds.cc
@@ -156,7 +156,7 @@ void test_decoding() {
   // directed edge)
   uint32_t indexes[] = {0};
   PredictedSpeeds pred_speeds;
-  pred_speeds.set_index(indexes);
+  pred_speeds.set_offset(indexes);
   pred_speeds.set_profiles(coefficients);
 
   // Test against 5 minute bucket values
@@ -207,7 +207,7 @@ void test_negative_speeds() {
   // directed edge)
   uint32_t indexes[] = {0};
   PredictedSpeeds pred_speeds;
-  pred_speeds.set_index(indexes);
+  pred_speeds.set_offset(indexes);
   pred_speeds.set_profiles(coefficients);
 
   // Test against 5 minute bucket values

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -437,7 +437,6 @@ public:
     if (de->predicted_speed()) {
       float spd = predictedspeeds_.speed(edgeid.id(), seconds_of_week);
       if (spd > 0.0f && spd < kMaxSpeedKph) {
-        LOG_INFO("Valid speed: " + std::to_string(static_cast<uint32_t>(spd)));
         return static_cast<uint32_t>(spd);
       } else if (spd < 0) {
         LOG_ERROR("Predicted speed = " + std::to_string(spd) +

--- a/valhalla/baldr/predictedspeeds.h
+++ b/valhalla/baldr/predictedspeeds.h
@@ -27,16 +27,16 @@ public:
   /**
    * Constructor.
    */
-  PredictedSpeeds() : index_(nullptr), profiles_(nullptr) {
+  PredictedSpeeds() : offset_(nullptr), profiles_(nullptr) {
   }
 
   /**
-   * Set a pointer to the index data within the GraphTile.
-   * @param  index_ Pointer to the index array in the GraphTile.
+   * Set a pointer to the offset data within the GraphTile.
+   * @param  offset Pointer to the offset array in the GraphTile.
    * @param  profiles Pointer to the profiles array in the GraphTile.
    */
-  void set_index(const uint32_t* index) {
-    index_ = index;
+  void set_offset(const uint32_t* offset) {
+    offset_ = offset;
   }
 
   /**
@@ -55,14 +55,14 @@ public:
   float speed(const uint32_t idx, const uint32_t seconds_of_week) const {
     // Get a pointer to the compressed speed profile for this edge. Assume the edge Id is valid
     // (otherwise an exception would be thrown when getting the directed edge) and the profile
-    // index is valid. If there is no predicted speed profile this method will not be called due
+    // offset is valid. If there is no predicted speed profile this method will not be called due
     // to DirectedEdge::predicted_speed being false.
-    const int16_t* coefficients = profiles_ + (kCoefficientCount * index_[idx]);
+    const int16_t* coefficients = profiles_ + offset_[idx];
 
     // Compute the time bucket
     int bucket = (seconds_of_week / kSpeedBucketSizeSeconds);
 
-    // DTC-III with some speed normalization
+    // DTC-III with speed normalization
     float b = kPiBucketConstant * (bucket + 0.5f);
     float speed = coefficients[0] * k1OverSqrt2;
     for (int k = 1; k < kCoefficientCount; k++) {
@@ -72,7 +72,8 @@ public:
   }
 
 protected:
-  const uint32_t* index_; // Index into the array of compressed speed profiles for each directed edge
+  const uint32_t*
+      offset_; // Offset into the array of compressed speed profiles for each directed edge
   const int16_t* profiles_; // Compressed speed profiles
 };
 

--- a/valhalla/mjolnir/graphtilebuilder.h
+++ b/valhalla/mjolnir/graphtilebuilder.h
@@ -528,8 +528,8 @@ protected:
   // List of turn lanes.
   std::vector<TurnLanes> turnlanes_builder_;
 
-  // Indexes into predicted speed profiles for each directed edge.
-  std::vector<uint32_t> speed_profile_index_builder_;
+  // Offsets into predicted speed profiles for each directed edge.
+  std::vector<uint32_t> speed_profile_offset_builder_;
 
   // Predicted speed profiles. 200 short int for each directed edge which has predicted speed.
   std::vector<int16_t> speed_profile_builder_;


### PR DESCRIPTION
 Fix pointer to the predicted speed coefficients - the indexes/offsets are uint32_t (was using uint16_t size when computing the offset). Propose adding a test once we get Utrecht predicted speed info.

Rename "index" to offset for the predicted speed offsets. 
Added a test to look for negative speed values in the decoding/CT-III algorithm.

 - [x] Add tests
 - [x] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
