### PR TITLE
Fix inconsistency between valhalla_run_route and valhalla_service

### DIFF
--- a/src/valhalla_run_route.cc
+++ b/src/valhalla_run_route.cc
@@ -16,6 +16,7 @@
 #include "baldr/pathlocation.h"
 #include "baldr/tilehierarchy.h"
 #include "loki/search.h"
+#include "loki/worker.h"
 #include "midgard/distanceapproximator.h"
 #include "midgard/encoded.h"
 #include "midgard/logging.h"
@@ -110,12 +111,20 @@ TripPath PathTest(GraphReader& reader,
                   bool multi_run,
                   uint32_t iterations,
                   bool using_astar,
+                  bool using_bd,
                   bool match_test,
                   const std::string& routetype) {
   auto t1 = std::chrono::high_resolution_clock::now();
   std::vector<PathInfo> pathedges;
   pathedges = pathalgorithm->GetBestPath(origin, dest, reader, mode_costing, mode);
   cost_ptr_t cost = mode_costing[static_cast<uint32_t>(mode)];
+
+  // If bidirectional A*, disable use of destination only edges on the first pass.
+  // If there is a failure, we allow them on the second pass.
+  if (using_bd) {
+    cost->set_allow_destination_only(false);
+  }
+
   cost->set_pass(0);
   data.incPasses();
   if (pathedges.size() == 0 || (routetype == "pedestrian" && pathalgorithm->has_ferry())) {
@@ -126,6 +135,7 @@ TripPath PathTest(GraphReader& reader,
       float relax_factor = (using_astar) ? 16.0f : 8.0f;
       float expansion_within_factor = (using_astar) ? 4.0f : 2.0f;
       cost->RelaxHierarchyLimits(using_astar, expansion_within_factor);
+      cost->set_allow_destination_only(true);
       pathedges = pathalgorithm->GetBestPath(origin, dest, reader, mode_costing, mode);
       data.incPasses();
     }
@@ -304,9 +314,13 @@ std::string GetFormattedTime(uint32_t seconds) {
 
 TripDirections DirectionsTest(const DirectionsOptions& directions_options,
                               TripPath& trip_path,
-                              const PathLocation& origin,
-                              const PathLocation& destination,
+                              valhalla::odin::Location& orig,
+                              valhalla::odin::Location& dest,
                               PathStatistics& data) {
+  // TEMPORARY? Change to PathLocation...
+  const PathLocation& origin = PathLocation::fromPBF(orig);
+  const PathLocation& destination = PathLocation::fromPBF(dest);
+
   DirectionsBuilder directions;
   TripDirections trip_directions = directions.Build(directions_options, trip_path);
   std::string units = (directions_options.units() == DirectionsOptions::kilometers ? "km" : "mi");
@@ -414,8 +428,8 @@ int main(int argc, char* argv[]) {
       "\n");
 
   std::string json, config;
-  bool connectivity, multi_run, match_test;
-  connectivity = multi_run = match_test = false;
+  bool multi_run = false;
+  bool match_test = false;
   uint32_t iterations;
 
   options.add_options()("help,h", "Print this help message.")("version,v",
@@ -429,7 +443,6 @@ int main(int argc, char* argv[]) {
       "Headquarters\",\"street\":\"405 East 42nd Street\",\"city\":\"New "
       "York\",\"state\":\"NY\",\"postal_code\":\"10017-3507\",\"country\":\"US\"}],\"costing\":"
       "\"auto\",\"directions_options\":{\"units\":\"miles\"}}'")(
-      "connectivity", "Generate a connectivity map before testing the route.")(
       "match-test", "Test RouteMatcher with resulting shape.")(
       "multi-run", bpo::value<uint32_t>(&iterations),
       "Generate the route N additional times before exiting.")
@@ -462,10 +475,6 @@ int main(int argc, char* argv[]) {
     return EXIT_SUCCESS;
   }
 
-  if (vm.count("connectivity")) {
-    connectivity = true;
-  }
-
   if (vm.count("match-test")) {
     match_test = true;
   }
@@ -489,18 +498,8 @@ int main(int argc, char* argv[]) {
 
   // Locations
   auto locations = valhalla::baldr::PathLocation::fromPBF(directions_options.locations());
-  ;
   if (locations.size() < 2) {
     throw;
-  }
-
-  // Add date time settings to the locations
-  if (directions_options.date_time_type() == DirectionsOptions_DateTimeType_current) {
-    locations.front().date_time_ = "current";
-  } else if (directions_options.date_time_type() == DirectionsOptions_DateTimeType_depart_at) {
-    locations.front().date_time_ = directions_options.date_time();
-  } else if (directions_options.date_time_type() == DirectionsOptions_DateTimeType_arrive_by) {
-    locations.back().date_time_ = directions_options.date_time();
   }
 
   // parse the config
@@ -558,68 +557,18 @@ int main(int argc, char* argv[]) {
     mode_costing[static_cast<uint32_t>(mode)] = cost;
   }
 
-  // Find locations
-  auto t1 = std::chrono::high_resolution_clock::now();
-  std::shared_ptr<DynamicCost> cost = mode_costing[static_cast<uint32_t>(mode)];
-  const auto projections = Search(locations, reader, cost->GetEdgeFilter(), cost->GetNodeFilter());
-  std::vector<PathLocation> path_location;
-  for (const auto& loc : locations) {
-    try {
-      path_location.push_back(projections.at(loc));
-      // TODO: get transit level for transit costing
-      // TODO: if transit send a non zero radius
-    } catch (...) {
-      data.setSuccess("fail_invalid_origin");
-      data.log();
-      return EXIT_FAILURE;
-    }
-  }
-  // If we are testing connectivity
-  if (connectivity) {
-    std::unordered_map<size_t, size_t> color_counts;
-    connectivity_map_t connectivity_map(pt.get_child("mjolnir"));
-    auto colors =
-        connectivity_map.get_colors(TileHierarchy::levels().rbegin()->first, path_location.back(), 0);
-    for (auto color : colors) {
-      auto itr = color_counts.find(color);
-      if (itr == color_counts.cend()) {
-        color_counts[color] = 1;
-      } else {
-        ++itr->second;
-      }
-    }
+  // Find path locations (loki) for sources and targets
+  auto tw0 = std::chrono::high_resolution_clock::now();
+  loki_worker_t lw(pt);
+  auto tw1 = std::chrono::high_resolution_clock::now();
+  auto msw = std::chrono::duration_cast<std::chrono::milliseconds>(tw1 - tw0).count();
+  LOG_INFO("Location Worker construction took " + std::to_string(msw) + " ms");
 
-    // are all the locations in the same color regions
-    bool connected = false;
-    for (const auto& c : color_counts) {
-      if (c.second == locations.size()) {
-        connected = true;
-        break;
-      }
-    }
-    if (!connected) {
-      LOG_INFO("No tile connectivity between locations");
-      data.setSuccess("fail_no_connectivity");
-      data.log();
-      return EXIT_FAILURE;
-    }
-  }
-
-  // Normalize the edge scores
-  for (auto& correlated : path_location) {
-    auto minScoreEdge =
-        *std::min_element(correlated.edges.begin(), correlated.edges.end(),
-                          [](PathLocation::PathEdge i, PathLocation::PathEdge j) -> bool {
-                            return i.distance < j.distance;
-                          });
-
-    for (auto& e : correlated.edges) {
-      e.distance -= minScoreEdge.distance;
-    }
-  }
-  auto t2 = std::chrono::high_resolution_clock::now();
-  uint32_t msecs = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
-  LOG_INFO("Location Processing took " + std::to_string(msecs) + " ms");
+  auto tl0 = std::chrono::high_resolution_clock::now();
+  lw.route(request);
+  auto tl1 = std::chrono::high_resolution_clock::now();
+  auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(tl1 - tl0).count();
+  LOG_INFO("Location Processing took " + std::to_string(ms) + " ms");
 
   // Get the route
   AStarPathAlgorithm astar;
@@ -628,6 +577,10 @@ int main(int argc, char* argv[]) {
   TimeDepForward timedep_forward;
   TimeDepReverse timedep_reverse;
   for (uint32_t i = 0; i < n; i++) {
+    // Set origin and destination for this segment
+    valhalla::odin::Location origin = directions_options.locations(i);
+    valhalla::odin::Location dest = directions_options.locations(i + 1);
+
     // Choose path algorithm
     PathAlgorithm* pathalgorithm;
     if (routetype == "multimodal") {
@@ -643,34 +596,33 @@ int main(int argc, char* argv[]) {
       } else {
         // Use bidirectional except for possible trivial cases
         pathalgorithm = &bd;
-        for (auto& edge1 : path_location[i].edges) {
-          for (auto& edge2 : path_location[i + 1].edges) {
-            if (edge1.id == edge2.id) {
+        for (auto& edge1 : origin.path_edges()) {
+          for (auto& edge2 : dest.path_edges()) {
+            if (edge1.graph_id() == edge2.graph_id()) {
               pathalgorithm = &astar;
             }
           }
         }
       }
     }
-    bool using_astar = (pathalgorithm == &astar);
+    bool using_astar = (pathalgorithm == &astar || pathalgorithm == &timedep_forward ||
+                        pathalgorithm == &timedep_reverse);
+    bool using_bd = pathalgorithm == &bd;
 
     // Get the best path
     try {
-      valhalla::odin::Location src, sync;
-      PathLocation::toPBF(path_location[i], &src, reader);
-      PathLocation::toPBF(path_location[i + 1], &sync, reader);
-      trip_path = PathTest(reader, src, sync, pathalgorithm, mode_costing, mode, data, multi_run,
-                           iterations, using_astar, match_test, routetype);
+      trip_path = PathTest(reader, origin, dest, pathalgorithm, mode_costing, mode, data, multi_run,
+                           iterations, using_astar, using_bd, match_test, routetype);
     } catch (std::runtime_error& rte) { LOG_ERROR("trip_path not found"); }
 
     // If successful get directions
     if (trip_path.node().size() > 0) {
       // Try the the directions
-      t1 = std::chrono::high_resolution_clock::now();
+      auto t1 = std::chrono::high_resolution_clock::now();
       TripDirections trip_directions =
-          DirectionsTest(directions_options, trip_path, path_location[i], path_location[i + 1], data);
-      t2 = std::chrono::high_resolution_clock::now();
-      msecs = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
+          DirectionsTest(directions_options, trip_path, origin, dest, data);
+      auto t2 = std::chrono::high_resolution_clock::now();
+      auto msecs = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
 
       auto trip_time = trip_directions.summary().time();
       auto trip_length = trip_directions.summary().length() * 1609.344f;
@@ -681,9 +633,9 @@ int main(int argc, char* argv[]) {
     } else {
       // Check if origins are unreachable
       bool unreachable_origin = false;
-      for (auto& edge : path_location[i].edges) {
-        const GraphTile* tile = reader.GetGraphTile(edge.id);
-        const DirectedEdge* directededge = tile->directededge(edge.id);
+      for (auto& edge : origin.path_edges()) {
+        const GraphTile* tile = reader.GetGraphTile(GraphId(edge.graph_id()));
+        const DirectedEdge* directededge = tile->directededge(GraphId(edge.graph_id()));
         auto ei = tile->edgeinfo(directededge->edgeinfo_offset());
         if (directededge->unreachable()) {
           LOG_INFO("Origin edge is unconnected: wayid = " + std::to_string(ei.wayid()));
@@ -694,9 +646,9 @@ int main(int argc, char* argv[]) {
 
       // Check if destinations are unreachable
       bool unreachable_dest = false;
-      for (auto& edge : path_location[i + 1].edges) {
-        const GraphTile* tile = reader.GetGraphTile(edge.id);
-        const DirectedEdge* directededge = tile->directededge(edge.id);
+      for (auto& edge : dest.path_edges()) {
+        const GraphTile* tile = reader.GetGraphTile(GraphId(edge.graph_id()));
+        const DirectedEdge* directededge = tile->directededge(GraphId(edge.graph_id()));
         auto ei = tile->edgeinfo(directededge->edgeinfo_offset());
         if (directededge->unreachable()) {
           LOG_INFO("Destination edge is unconnected: wayid = " + std::to_string(ei.wayid()));
@@ -726,8 +678,8 @@ int main(int argc, char* argv[]) {
 
   // Time all stages for the stats file: location processing,
   // path computation, trip path building, and directions
-  t2 = std::chrono::high_resolution_clock::now();
-  msecs = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t0).count();
+  auto t2 = std::chrono::high_resolution_clock::now();
+  auto msecs = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t0).count();
   LOG_INFO("Total time= " + std::to_string(msecs) + " ms");
   data.addRuntime(msecs);
   data.log();


### PR DESCRIPTION
Use loki worker to do edge search. Remove special connectivity map logic (done in loki worker).

Update path algorithm use to be like it is in the service (add set_allow_destination_only
for bidirectional A* to match the service logic). This removes an inconsistency on some routes
when comparing between the 2 (as reported in issue #1476)

Also tested this with date time settings - seems the prior code was adding depart at current improperly (when no date time was set in the request). This fixes that issue.

## Tasklist

 - [ ] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Generally use squash merge to rebase and clean comments before merging