### PR TITLE
Ferry connections

### DIFF
--- a/src/mjolnir/ferry_connections.cc
+++ b/src/mjolnir/ferry_connections.cc
@@ -3,6 +3,7 @@
 #include <queue>
 #include <unordered_map>
 
+#include "baldr/graphconstants.h"
 #include "midgard/util.h"
 
 namespace valhalla {
@@ -116,8 +117,15 @@ uint32_t ShortestPath(const uint32_t start_node_idx,
         continue;
       }
 
-      // Skip non-driveable edges (based on inbound flag)
+      // Skip destination only and uses other than road / other (service?)
       const OSMWay w = *ways[edge.wayindex_];
+      if (w.destination_only() ||
+          (w.use() != baldr::Use::kOther &&
+           static_cast<int>(w.use()) > static_cast<int>(baldr::Use::kTurnChannel))) {
+        continue;
+      }
+
+      // Skip non-driveable edges (based on inbound flag)
       bool forward = (edge.sourcenode_ == node_index);
       if (forward) {
         if ((inbound && !edge.attributes.driveablereverse) ||

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -34,7 +34,7 @@ namespace {
 // This value controls the initial size of the Id table. If this is exceeded
 // the table will be resized and a warning is generated (indicating we should
 // increase this value).
-constexpr uint64_t kMaxOSMNodeId = 5800000000;
+constexpr uint64_t kMaxOSMNodeId = 6500000000;
 
 // Absurd classification.
 constexpr uint32_t kAbsurdRoadClass = 777777;
@@ -1077,7 +1077,7 @@ public:
     }
 
     // Infer cul-de-sac if a road edge is a loop and is low classification.
-    if (loop_nodes_.size() != nodes.size() && w.use() == Use::kRoad &&
+    if (!w.roundabout() && loop_nodes_.size() != nodes.size() && w.use() == Use::kRoad &&
         w.road_class() > RoadClass::kTertiary) {
       w.set_use(Use::kCuldesac);
     }


### PR DESCRIPTION
Partially fixes #1476 
During data import there is a method that makes sure paths to ferries have at least road classification = 2 so that they do not get filtered out by hierarchy logic. In OSM, many paths to ferries take service roads. In this case of the path to the Dover-Calais ferry there was an issue where destination only edges were upgraded - but these have penalties applied. Also, there was a case where a roundabout edge was identified as a cul-de-sac, which also caused issues. This PR addresses some of these issues, but does not fix the entry to the Eurotunnel on the UK side (which is very complex!).

Also Fixes #1481 (improper identification of cul-de-sacs).