### PR TITLE
A* dest only fix

### DIFF
--- a/src/sif/motorscootercost.cc
+++ b/src/sif/motorscootercost.cc
@@ -33,7 +33,9 @@ constexpr float kDefaultDestinationOnlyPenalty = 120.0f; // Seconds
 
 constexpr float kDefaultUseHills = 0.5f;   // Factor between 0 and 1
 constexpr float kDefaultUsePrimary = 0.5f; // Factor between 0 and 1
+constexpr uint32_t kMinimumTopSpeed = 20;  // Kilometers per hour
 constexpr uint32_t kDefaultTopSpeed = 45;  // Kilometers per hour
+constexpr uint32_t kMaximumTopSpeed = 120; // Kilometers per hour
 
 constexpr Surface kMinimumScooterSurface = Surface::kDirt;
 
@@ -76,7 +78,8 @@ constexpr ranged_default_t<float> kCountryCrossingPenaltyRange{0, kDefaultCountr
 constexpr ranged_default_t<float> kUseFerryRange{0, kDefaultUseFerry, 1.0f};
 constexpr ranged_default_t<float> kUseHillsRange{0, kDefaultUseHills, 1.0f};
 constexpr ranged_default_t<float> kUsePrimaryRange{0, kDefaultUsePrimary, 1.0f};
-constexpr ranged_default_t<uint32_t> kTopSpeedRange{0, kDefaultTopSpeed, kMaxSpeedKph};
+constexpr ranged_default_t<uint32_t> kTopSpeedRange{kMinimumTopSpeed, kDefaultTopSpeed,
+                                                    kMaximumTopSpeed};
 constexpr ranged_default_t<float> kDestinationOnlyPenaltyRange{0, kDefaultDestinationOnlyPenalty,
                                                                kMaxSeconds};
 

--- a/src/thor/astar.cc
+++ b/src/thor/astar.cc
@@ -16,6 +16,9 @@ namespace thor {
 
 constexpr uint64_t kInitialEdgeLabelCount = 500000;
 
+// Number of iterations to allow with no convergence to the destination
+constexpr uint32_t kMaxIterationsWithoutConvergence = 200000;
+
 // Default constructor
 AStarPathAlgorithm::AStarPathAlgorithm()
     : PathAlgorithm(), mode_(TravelMode::kDrive), travel_type_(0), adjacencylist_(nullptr),
@@ -315,7 +318,7 @@ AStarPathAlgorithm::GetBestPath(odin::Location& origin,
     if (dist2dest < mindist) {
       mindist = dist2dest;
       nc = 0;
-    } else if (nc++ > 50000) {
+    } else if (nc++ > kMaxIterationsWithoutConvergence) {
       if (best_path.first >= 0) {
         return FormPath(best_path.first);
       } else {

--- a/src/thor/timedep_forward.cc
+++ b/src/thor/timedep_forward.cc
@@ -14,6 +14,9 @@ namespace thor {
 
 constexpr uint64_t kInitialEdgeLabelCount = 500000;
 
+// Number of iterations to allow with no convergence to the destination
+constexpr uint32_t kMaxIterationsWithoutConvergence = 200000;
+
 // Default constructor
 TimeDepForward::TimeDepForward() : AStarPathAlgorithm() {
   mode_ = TravelMode::kDrive;
@@ -279,12 +282,14 @@ std::vector<PathInfo> TimeDepForward::GetBestPath(odin::Location& origin,
     }
 
     // Check that distance is converging towards the destination. Return route
-    // failure if no convergence for TODO iterations
+    // failure if no convergence for TODO iterations. NOTE: due to somewhat high
+    // penalty for entering a destination only (private) road this value needs to
+    // be high.
     float dist2dest = pred.distance();
     if (dist2dest < mindist) {
       mindist = dist2dest;
       nc = 0;
-    } else if (nc++ > 50000) {
+    } else if (nc++ > kMaxIterationsWithoutConvergence) {
       if (best_path.first >= 0) {
         return FormPath(best_path.first);
       } else {


### PR DESCRIPTION
This fixes route failures in A* and time dependent forward A* where the destination is on a destination_only edge (private road for instance). The code that provides an early exit when the route is not converging towards the destination required an update (a larger number of increments) due to the somewhat large destination only penalty. This addresses part of #1492  - it fixes failures but does not alleviate performance drop. Note that this fix should not be needed for the time dependent reverse method since if the origin is in a destination only edge it will be leaving, and not entering the edge so no penalty should apply.

In addition, a fix in motorscooter costing was made to set proper limits on top_speed to lie between 20 and 120kph. The prior lower limit of 0 kph didn't make sense!

 - [ ] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update relevant [documentation](docs/README.md)
