### PR TITLE
Isotile optimization

### DIFF
--- a/src/midgard/util.cc
+++ b/src/midgard/util.cc
@@ -282,16 +282,12 @@ std::vector<PointLL> resample_polyline(const std::vector<PointLL>& polyline, flo
   auto p0 = polyline.cbegin();
   for (auto p1 = std::next(polyline.cbegin()); p1 != polyline.cend(); ++p0, ++p1) {
     // Find distance (meters) between the 2 points of the input polyline.
-    // Use floating point for speed (less worried about precision)
-    float dlon = p1->first - p0->first;
-    float a = p0->second * kRadPerDeg;
-    float c = p1->second * kRadPerDeg;
-    float d =
-        acosf((sinf(a) * sinf(c)) + (cosf(a) * cosf(c) * cosf(dlon * kRadPerDeg))) * kRadEarthMeters;
+    float d = p0->Distance(*p1);
 
     // Interpolate between the prior polyline point if we exceed the resolution
     // (including distance accumulated so far)
     if (d + accumulated_d > resolution) {
+      float dlon = p1->first - p0->first;
       float dlat = p1->second - p0->second;
 
       // Form the first interpolated point

--- a/src/midgard/util.cc
+++ b/src/midgard/util.cc
@@ -267,6 +267,62 @@ resample_spherical_polyline<std::list<PointLL>>(const std::list<PointLL>&, doubl
 template std::list<Point2>
 resample_spherical_polyline<std::list<Point2>>(const std::list<Point2>&, double, bool);
 
+// Resample the polyline to the specified resolution. This is a faster and less precise
+// method than resample_spherical_polyline.
+std::vector<PointLL> resample_polyline(const std::vector<PointLL>& polyline, float resolution) {
+  if (polyline.size() == 0) {
+    return {};
+  }
+
+  // Add the first point
+  std::vector<PointLL> resampled = {polyline.front()};
+
+  // Iterate through line segments of the polyline
+  float accumulated_d = 0.0f;
+  auto p0 = polyline.cbegin();
+  for (auto p1 = std::next(polyline.cbegin()); p1 != polyline.cend(); ++p0, ++p1) {
+    // Find distance (meters) between the 2 points of the input polyline.
+    // Use floating point for speed (less worried about precision)
+    float dlon = p1->first - p0->first;
+    float a = p0->second * kRadPerDeg;
+    float c = p1->second * kRadPerDeg;
+    float d =
+        acosf((sinf(a) * sinf(c)) + (cosf(a) * cosf(c) * cosf(dlon * kRadPerDeg))) * kRadEarthMeters;
+
+    // Interpolate between the prior polyline point if we exceed the resolution
+    // (including distance accumulated so far)
+    if (d + accumulated_d > resolution) {
+      float dlat = p1->second - p0->second;
+
+      // Form the first interpolated point
+      float p = (resolution - accumulated_d) / d;
+      resampled.emplace_back(p0->first + p * dlon, p0->second + p * dlat);
+
+      // Continue to interpolate along the segment while accumulated distance is less than resolution
+      float dp = resolution / d;
+      while (p + dp < 1.0f) {
+        resampled.emplace_back(p0->first + p * dlon, p0->second + p * dlat);
+        p += dp;
+      }
+
+      // Set the accumulated distance to the distance remaining on this segment
+      accumulated_d = d * (1.0f - p);
+
+    } else {
+      // Have not accumulated enough distance. Add d to the accumulated distance
+      accumulated_d += d;
+    }
+  }
+
+  // Replace the last resampled point with the last point in the polyline if distance
+  // remaining is within tolerance (TBD), else add the last polyline point
+  if (resampled.size() > 1 && accumulated_d < (resolution * 0.25f)) {
+    resampled.pop_back();
+  }
+  resampled.push_back(std::move(polyline.back()));
+  return resampled;
+}
+
 // Return the intersection of two infinite lines if any
 template <class coord_t>
 bool intersect(const coord_t& u, const coord_t& v, const coord_t& a, const coord_t& b, coord_t& i) {

--- a/src/thor/isochrone.cc
+++ b/src/thor/isochrone.cc
@@ -861,7 +861,7 @@ void Isochrone::UpdateIsoTile(const EdgeLabel& pred,
   // (just use a bounding box around the segment) so this doesn't miss
   // shape that crosses tile corners
   float minutes = secs0 * kMinPerSec;
-  float delta = ((shape_interval_ * (secs1 - secs0)) / edge->length()) * kMinPerSec;
+  float delta = ((secs1 - secs0) / (resampled.size() - 1)) * kMinPerSec;
   auto itr1 = resampled.begin();
   for (auto itr2 = itr1 + 1; itr2 < resampled.end(); itr1++, itr2++) {
     minutes += delta;

--- a/valhalla/midgard/util.h
+++ b/valhalla/midgard/util.h
@@ -383,6 +383,15 @@ container_t
 resample_spherical_polyline(const container_t& polyline, double resolution, bool preserve = false);
 
 /**
+ * Resample a polyline to the specified resolution. This is less precise than the spherical
+ * resampling.
+ * @param polyline     vector of points in the line
+ * @param resolution   maximum distance (meters) between any two points in the resampled line
+ * @return Returns a vector of resampled points.
+ */
+std::vector<PointLL> resample_polyline(const std::vector<PointLL>& polyline, float resolution);
+
+/**
  * A class to wrap a primitive array in something iterable which is useful for loops mostly
  * Basically if you dont have a vector or list, this makes your array a bit more usable in
  * that it fakes up a container for the purpose of ripping through the array


### PR DESCRIPTION
Generating isotiles can take several seconds for large contours (e.g. a 120 minute auto contour centered on a urban area like Washington, DC). Looking into this, it was noted that there was extraneous code to mark tiles using segments between shape points of an edge. Then there was code to mark the resampled polyline. It was suspected that when the resampling code was added the original marking code was not removed.

Other potential causes of low performance are the large number of trigonometry calls made within the resmaple_spherical_polyline method. A new method, resample_polyline, was added that does linear interpolation of points between the original polyline vertices. This also uses floating point trigonometric methods to improve performance.

Additionally, the IsoTile Intersect method was replaced with simply marking tiles that intersect the bounding box of the segment (rather than those that the segment intersects - using a Bresenham method to identify tiles touched by the line segment). 

These optimizations lead to generation times being cut nearly in half for a 2 hour test case centered in Washington,DC.

 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
