### PR TITLE
make curl optional via -DENABLE_HTTP=ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ list(INSERT CMAKE_MODULE_PATH 0 ${VALHALLA_SOURCE_DIR}/cmake)
 option(ENABLE_TOOLS "Enable Valhalla tools" ON)
 option(ENABLE_DATA_TOOLS "Enable Valhalla data tools" ON)
 option(ENABLE_SERVICES "Enable Valhalla services" ON)
+option(ENABLE_HTTP "Enable the use of CURL" ON)
 option(ENABLE_PYTHON_BINDINGS "Enable Python bindings" ON)
 option(ENABLE_NODE_BINDINGS "Build NodeJs bindings" ON)
 option(ENABLE_CCACHE "Speed up incremental rebuilds via ccache" ON)
@@ -67,7 +68,6 @@ else()
   message(STATUS "Unrecognized build type - will use cmake defaults")
 endif()
 
-
 if(ENABLE_CCACHE AND (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU"))
   find_program(CCACHE_FOUND ccache)
   if(CCACHE_FOUND)
@@ -110,14 +110,18 @@ endif()
 find_package(Threads REQUIRED)
 find_package(ZLIB REQUIRED)
 
-find_package(CURL REQUIRED)
 add_library(CURL::CURL INTERFACE IMPORTED)
-set_target_properties(CURL::CURL PROPERTIES
-  INTERFACE_LINK_LIBRARIES "${CURL_LIBRARIES}"
-  INTERFACE_INCLUDE_DIRECTORIES "${CURL_INCLUDE_DIR}"
-  INTERFACE_COMPILE_DEFINITIONS CURL_STATICLIB)
+if(ENABLE_HTTP OR ENABLE_DATA_TOOLS)
+  if(NOT CURL_FOUND)
+    find_package(CURL REQUIRED)
+  endif()
+  set_target_properties(CURL::CURL PROPERTIES
+    INTERFACE_LINK_LIBRARIES "${CURL_LIBRARIES}"
+    INTERFACE_INCLUDE_DIRECTORIES "${CURL_INCLUDE_DIR}"
+    INTERFACE_COMPILE_DEFINITIONS CURL_STATICLIB)
+endif()
 
-if(NOT PROTOBUF_LIBRARY)
+if(NOT Protobuf_FOUND)
   find_package(Protobuf REQUIRED)
 endif()
 # TODO: remove after switching to CMake >= 3.7
@@ -170,7 +174,7 @@ if(ENABLE_DATA_TOOLS)
 elseif(ENABLE_TOOLS)
   find_package(Boost 1.51 REQUIRED COMPONENTS filesystem system program_options)
 ## Header only boost for the library without mjolnir
-elseif(NOT Boost_INCLUDE_DIRS)
+elseif(NOT Boost_FOUND)
   find_package(Boost 1.51 REQUIRED)
 endif()
 
@@ -189,8 +193,6 @@ endif()
 if (ENABLE_NODE_BINDINGS)
   add_subdirectory(src/bindings/node)
 endif()
-
-
 
 ## Executable targets
 function(get_source_path PATH NAME)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,6 +50,7 @@ function(valhalla_module)
   target_compile_definitions(${library}
     PUBLIC
       RAPIDJSON_HAS_STDSTRING
+      HAS_REMOTE_API=0
     PRIVATE
       $<$<BOOL:${LOGGING_LEVEL}>:LOGGING_LEVEL_${LOGGING_LEVEL}>)
   target_include_directories(${library} ${MODULE_INCLUDE_DIRECTORIES}
@@ -118,6 +119,7 @@ target_compile_definitions(valhalla
     RAPIDJSON_HAS_STDSTRING  # this is a part of the workaround for OBJECT libraries,
                              # because ${libvalhalla_compile_definitions} must be private.
                              # To be removed with ${libvalhalla_compile_definitions} below
+    HAS_REMOTE_API=0
   PRIVATE
     ${libvalhalla_compile_definitions})
 

--- a/src/baldr/CMakeLists.txt
+++ b/src/baldr/CMakeLists.txt
@@ -44,6 +44,7 @@ valhalla_module(NAME baldr
     admin.cc
     compression_utils.cc
     connectivity_map.cc
+    curler.cc
     datetime.cc
     directededge.cc
     edge_elevation.cc

--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -4,7 +4,6 @@
 #include "baldr/tilehierarchy.h"
 #include "filesystem.h"
 #include "midgard/aabb2.h"
-#include "midgard/logging.h"
 #include "midgard/pointll.h"
 #include "midgard/tiles.h"
 

--- a/valhalla/baldr/curler.h
+++ b/valhalla/baldr/curler.h
@@ -1,113 +1,34 @@
-#ifndef VALHALLA_BALDR_CURLER_H_
-#define VALHALLA_BALDR_CURLER_H_
+#pragma once
 
-#if defined(_MSC_VER) && !defined(NOGDI)
-#define NOGDI // prevents winsock2.h drag in wingdi.h
-#endif
-
-#include <curl/curl.h>
-
-#if defined(_MSC_VER) && defined(GetNameInfo)
-#undef GetNameInfo // winsock2.h imports #define GetNameInfo which clashes with
-                   // EdgeInfo::GetNameInfo
-#endif
-
-#include <functional>
+#include <array>
 #include <memory>
-#include <stdexcept>
 #include <string>
-#include <valhalla/midgard/logging.h>
 #include <vector>
-
-namespace {
-
-struct curl_singleton_t {
-  curl_singleton_t() {
-    curl_global_init(CURL_GLOBAL_DEFAULT);
-  }
-  ~curl_singleton_t() {
-    curl_global_cleanup();
-  }
-};
-
-static std::shared_ptr<CURL> init_curl() {
-  static curl_singleton_t s;
-  return std::shared_ptr<CURL>(curl_easy_init(), [](CURL* c) { curl_easy_cleanup(c); });
-}
-
-char ALL_ENCODINGS[] = "";
-
-} // namespace
 
 namespace valhalla {
 namespace baldr {
 
 struct curler_t {
-  struct logged_error_t : public std::runtime_error {
-    logged_error_t(const std::string& msg) : std::runtime_error(msg) {
-      LOG_ERROR(msg);
-    }
-  };
+  /**
+   * Constructor
+   */
+  curler_t();
 
-  curler_t() : connection(init_curl()) {
-    if (connection.get() == nullptr) {
-      throw logged_error_t("Failed to created CURL connection");
-    }
-    assert_curl(curl_easy_setopt(connection.get(), CURLOPT_ERRORBUFFER, error),
-                "Failed to set error buffer");
-    assert_curl(curl_easy_setopt(connection.get(), CURLOPT_FOLLOWLOCATION, 1L),
-                "Failed to set redirect option ");
-    assert_curl(curl_easy_setopt(connection.get(), CURLOPT_WRITEFUNCTION, write_callback),
-                "Failed to set writer ");
-    // this is less secure but we'll worry about that later
-    assert_curl(curl_easy_setopt(connection.get(), CURLOPT_SSL_VERIFYPEER, 0L),
-                "Failed to disable peer verification ");
-    assert_curl(curl_easy_setopt(connection.get(), CURLOPT_SSL_VERIFYHOST, 0L),
-                "Failed to disable host verification ");
-  }
-
-  // TODO: retries?
+  /**
+   * Fetch a url and return the bytes that we got
+   *
+   * @param  url                the url to fetch
+   * @param  http_code          the code we got back when fetching
+   * @param  allow_compression  whether to allow and automatically handle compressed content types
+   * @return the bytes we fetched
+   */
   std::vector<char>
-  operator()(const std::string& url, long& http_code, bool allow_compression = true) {
-    // sending content encoding as "" makes curl automatically handle identity, gzip or deflate
-    // sending nullptr tells curl to only accept identity (no decoding needed)
-    assert_curl(curl_easy_setopt(connection.get(), CURLOPT_ACCEPT_ENCODING,
-                                 allow_compression ? ALL_ENCODINGS : nullptr),
-                "Failed to set content encoding header ");
-    // set the url
-    assert_curl(curl_easy_setopt(connection.get(), CURLOPT_URL, url.c_str()), "Failed to set URL ");
-    // set the location of the result
-    std::vector<char> result;
-    assert_curl(curl_easy_setopt(connection.get(), CURLOPT_WRITEDATA, &result),
-                "Failed to set write data ");
-    // get the url
-    assert_curl(curl_easy_perform(connection.get()), "Failed to get URL ");
-    // grab the return code
-    curl_easy_getinfo(connection.get(), CURLINFO_RESPONSE_CODE, &http_code);
-    // hand over the results
-    return result;
-  }
+  operator()(const std::string& url, long& http_code, bool allow_compression = true);
 
 protected:
-  void assert_curl(CURLcode code, const std::string& msg) {
-    if (code != CURLE_OK) {
-      throw logged_error_t(msg + error);
-    }
-  };
-
-  static size_t write_callback(char* in, size_t block_size, size_t blocks, std::vector<char>* out) {
-    if (!out) {
-      return static_cast<size_t>(0);
-    }
-    out->insert(out->end(), in, in + (block_size * blocks));
-    return block_size * blocks;
-  }
-
-  std::shared_ptr<CURL> connection;
-  char error[CURL_ERROR_SIZE];
+  struct pimpl_t;
+  std::shared_ptr<pimpl_t> pimpl;
 };
 
 } // namespace baldr
 } // namespace valhalla
-
-#endif // VALHALLA_BALDR_CURLER_H_

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -25,6 +25,7 @@
 #include <valhalla/baldr/turnlanes.h>
 
 #include <valhalla/midgard/aabb2.h>
+#include <valhalla/midgard/logging.h>
 #include <valhalla/midgard/util.h>
 
 #include <memory>

--- a/valhalla/valhalla.h.in
+++ b/valhalla/valhalla.h.in
@@ -1,11 +1,5 @@
-#ifndef __VALHALLA_VERSION_H__
-#define __VALHALLA_VERSION_H__
+#pragma once
 
 #define VALHALLA_VERSION_MAJOR 2
 #define VALHALLA_VERSION_MINOR 6
 #define VALHALLA_VERSION_PATCH 1
-
-//whether the API was configured with http service support or not
-@HAVE_HTTP_DEFINE@
-
-#endif


### PR DESCRIPTION
You can now disable the curl dependency if you `cmake  -DENABLE_HTTP=OFF -DENABLE_DATA_TOOLS=OFF`

This was a bit of a trick to get working. There are 3 places where curl is in our code base:

1. fetching graph tiles on the fly
2. fetching transit data
3. fetching timezone database

I was mostly focused on `1`, `2` i left un touched and `3` i disabled via a flag. I'll comment the PR for more detail.