### PR TITLE
Fix missing speed data in tiles

### DIFF
--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -1108,10 +1108,8 @@ void GraphTileBuilder::AddPredictedSpeed(const uint32_t idx, const std::vector<i
 // predicted traffic is written after turn lane data.
 void GraphTileBuilder::UpdatePredictedSpeeds(const std::vector<DirectedEdge>& directededges) {
 
-  // No work to do if not predicted speed were added
-  if (speed_profile_offset_builder_.size() == 0) {
-    return;
-  }
+  // Even if there are no predicted speeds there still may be updated directed edges
+  // with free flow or constrained flow speeds - so don't return if no speed profiles
 
   // Get the name of the file
   boost::filesystem::path filename = tile_dir_ + filesystem::path::preferred_separator +


### PR DESCRIPTION
In UpdatePredictedSpeeds there was a check for presence of predicted speed profiles - if none were present the method returned and no updates to the tile were made. This is incorrect since there may have been free flow or predicted speeds added to the directed edges. Removing the check and adding a comment so we don't try to over optimize this method again.
