### PR TITLE
minimal valhalla build for ndk

### DIFF
--- a/src/baldr/tz_alt.cpp
+++ b/src/baldr/tz_alt.cpp
@@ -156,7 +156,7 @@
 #else   // !_WIN32
 #  include <unistd.h>
 #  if !USE_OS_TZDB
-#    include <wordexp.h>
+//#    include <wordexp.h>
 #  endif
 #  include <limits.h>
 #  include <string.h>
@@ -249,12 +249,12 @@ expand_path(std::string path)
 #      if TARGET_OS_IPHONE
     return date::iOSUtils::get_tzdata_path();
 #      else  // !TARGET_OS_IPHONE
-    ::wordexp_t w{};
+/*    ::wordexp_t w{};
     std::unique_ptr<::wordexp_t, void(*)(::wordexp_t*)> hold{&w, ::wordfree};
     ::wordexp(path.c_str(), &w, 0);
     if (w.we_wordc != 1)
         throw std::runtime_error("Cannot expand path: " + path);
-    path = w.we_wordv[0];
+    path = w.we_wordv[0];*/
     return path;
 #      endif  // !TARGET_OS_IPHONE
 }

--- a/valhalla/midgard/sequence.h
+++ b/valhalla/midgard/sequence.h
@@ -47,7 +47,6 @@
 #endif
 
 #ifdef _MSC_VER
-#define NO_ADVISE
 #define WIN32_LEAN_AND_MEAN 1
 #define VC_EXTRALEAN 1
 #define _CRT_SECURE_NO_DEPRECATE 1

--- a/valhalla/midgard/sequence.h
+++ b/valhalla/midgard/sequence.h
@@ -30,7 +30,24 @@
 #endif // _MSC_VER
 #include <fcntl.h>
 
+// if we are on android
+#ifdef __ANDROID__
+// we didnt get a posix alias until 23
+#if __ANDROID_API__ < 23
+#define posix_madvise madvise
+#endif
+// we didnt get these posix aliases until M
+#if __ANDROID_API__ < __ANDROID_API_M__
+#define POSIX_MADV_NORMAL MADV_NORMAL
+#define POSIX_MADV_RANDOM MADV_RANDOM
+#define POSIX_MADV_SEQUENTIAL MADV_SEQUENTIAL
+#define POSIX_MADV_WILLNEED MADV_WILLNEED
+#define POSIX_MADV_DONTNEED MADV_DONTNEED
+#endif
+#endif
+
 #ifdef _MSC_VER
+#define NO_ADVISE
 #define WIN32_LEAN_AND_MEAN 1
 #define VC_EXTRALEAN 1
 #define _CRT_SECURE_NO_DEPRECATE 1


### PR DESCRIPTION
When building with the ndk we ran into two issues:

1. https://android-review.googlesource.com/c/platform/bionic/+/407478/1/libc/include/sys/mman.h
2. https://github.com/HowardHinnant/date/issues/161

The first issue is that the mman header for the ndk only started aliasing the posix defines and functions after certain versions. We simply mimmic this aliasing.

The second issue is that the howard hinnat date library uses wordexp.h to sort some stuff out about expanding `~` in a unix path to the full path for downloading timezone stuff. Since we dont use that, I just commented it out. We can add that to the list of things to PR back to the library with our load tzdb from strings work.

This uses the latest rapidjson as well.