### PR TITLE
android logging and shared graph reader

### DIFF
--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -39,7 +39,7 @@ struct GraphReader::tile_extract_t : public midgard::tar {
         LOG_WARN("Tile extract could not be loaded");
       } // loaded ok but with possibly bad blocks
       else {
-        LOG_INFO("Tile extract successfully loaded");
+        LOG_INFO("Tile extract successfully loaded with tile count: " + std::to_string(tiles.size()));
         if (corrupt_blocks) {
           LOG_WARN("Tile extract had " + std::to_string(corrupt_blocks) + " corrupt blocks");
         }

--- a/src/loki/isochrone_action.cc
+++ b/src/loki/isochrone_action.cc
@@ -81,10 +81,10 @@ void loki_worker_t::isochrones(valhalla_request_t& request) {
   try {
     // correlate the various locations to the underlying graph
     auto locations = PathLocation::fromPBF(request.options.locations());
-    const auto projections = loki::Search(locations, reader, edge_filter, node_filter);
+    const auto projections = loki::Search(locations, *reader, edge_filter, node_filter);
     for (size_t i = 0; i < locations.size(); ++i) {
       const auto& projection = projections.at(locations[i]);
-      PathLocation::toPBF(projection, request.options.mutable_locations(i), reader);
+      PathLocation::toPBF(projection, request.options.mutable_locations(i), *reader);
     }
   } catch (const std::exception&) { throw valhalla_exception_t{171}; }
 }

--- a/src/loki/locate_action.cc
+++ b/src/loki/locate_action.cc
@@ -25,8 +25,8 @@ std::string loki_worker_t::locate(valhalla_request_t& request) {
   // correlate the various locations to the underlying graph
   init_locate(request);
   auto locations = PathLocation::fromPBF(request.options.locations());
-  auto projections = loki::Search(locations, reader, edge_filter, node_filter);
-  return tyr::serializeLocate(request, locations, projections, reader);
+  auto projections = loki::Search(locations, *reader, edge_filter, node_filter);
+  return tyr::serializeLocate(request, locations, projections, *reader);
 }
 
 } // namespace loki

--- a/src/loki/matrix_action.cc
+++ b/src/loki/matrix_action.cc
@@ -113,7 +113,7 @@ void loki_worker_t::matrix(valhalla_request_t& request) {
   // correlate the various locations to the underlying graph
   std::unordered_map<size_t, size_t> color_counts;
   try {
-    const auto searched = loki::Search(sources_targets, reader, edge_filter, node_filter);
+    const auto searched = loki::Search(sources_targets, *reader, edge_filter, node_filter);
     for (size_t i = 0; i < sources_targets.size(); ++i) {
       const auto& l = sources_targets[i];
       const auto& projection = searched.at(l);
@@ -121,7 +121,7 @@ void loki_worker_t::matrix(valhalla_request_t& request) {
                           i < request.options.sources_size()
                               ? request.options.mutable_sources(i)
                               : request.options.mutable_targets(i - request.options.sources_size()),
-                          reader);
+                          *reader);
       // TODO: get transit level for transit costing
       // TODO: if transit send a non zero radius
       if (!connectivity_map) {

--- a/src/loki/route_action.cc
+++ b/src/loki/route_action.cc
@@ -56,7 +56,7 @@ void loki_worker_t::route(valhalla_request_t& request) {
   init_route(request);
   auto costing = odin::Costing_Name(request.options.costing());
   check_locations(request.options.locations_size(), max_locations.find(costing)->second);
-  check_distance(reader, request.options.locations(), max_distance.find(costing)->second);
+  check_distance(*reader, request.options.locations(), max_distance.find(costing)->second);
 
   // Validate walking distances (make sure they are in the accepted range)
   if (costing == "multimodal" || costing == "transit") {
@@ -85,10 +85,10 @@ void loki_worker_t::route(valhalla_request_t& request) {
   std::unordered_map<size_t, size_t> color_counts;
   try {
     auto locations = PathLocation::fromPBF(request.options.locations());
-    const auto projections = loki::Search(locations, reader, edge_filter, node_filter);
+    const auto projections = loki::Search(locations, *reader, edge_filter, node_filter);
     for (size_t i = 0; i < locations.size(); ++i) {
       const auto& correlated = projections.at(locations[i]);
-      PathLocation::toPBF(correlated, request.options.mutable_locations(i), reader);
+      PathLocation::toPBF(correlated, request.options.mutable_locations(i), *reader);
       // TODO: get transit level for transit costing
       // TODO: if transit send a non zero radius
       if (!connectivity_map) {

--- a/src/loki/trace_route_action.cc
+++ b/src/loki/trace_route_action.cc
@@ -171,12 +171,12 @@ void loki_worker_t::locations_from_shape(valhalla_request_t& request) {
 
   // Add first and last correlated locations to request
   try {
-    auto projections = loki::Search(locations, reader, edge_filter, node_filter);
+    auto projections = loki::Search(locations, *reader, edge_filter, node_filter);
     request.options.clear_locations();
     PathLocation::toPBF(projections.at(locations.front()), request.options.mutable_locations()->Add(),
-                        reader);
+                        *reader);
     PathLocation::toPBF(projections.at(locations.back()), request.options.mutable_locations()->Add(),
-                        reader);
+                        *reader);
   } catch (const std::exception&) { throw valhalla_exception_t{171}; }
 }
 

--- a/src/loki/worker.cc
+++ b/src/loki/worker.cc
@@ -100,13 +100,13 @@ void loki_worker_t::parse_costing(valhalla_request_t& request) {
   if (request.options.avoid_locations_size()) {
     try {
       auto avoid_locations = PathLocation::fromPBF(request.options.avoid_locations());
-      auto results = loki::Search(avoid_locations, reader, edge_filter, node_filter);
+      auto results = loki::Search(avoid_locations, *reader, edge_filter, node_filter);
       std::unordered_set<uint64_t> avoids;
       for (const auto& result : results) {
         for (const auto& edge : result.second.edges) {
           auto inserted = avoids.insert(edge.id);
           GraphId shortcut;
-          if (inserted.second && (shortcut = reader.GetShortcut(edge.id)).Is_Valid()) {
+          if (inserted.second && (shortcut = reader->GetShortcut(edge.id)).Is_Valid()) {
             avoids.insert(shortcut);
           }
         }
@@ -121,8 +121,9 @@ void loki_worker_t::parse_costing(valhalla_request_t& request) {
   }
 }
 
-loki_worker_t::loki_worker_t(const boost::property_tree::ptree& config)
-    : config(config), reader(config.get_child("mjolnir")),
+loki_worker_t::loki_worker_t(const boost::property_tree::ptree& config,
+                             const std::shared_ptr<baldr::GraphReader>& graph_reader)
+    : config(config), reader(graph_reader),
       connectivity_map(config.get<bool>("loki.use_connectivity", true)
                            ? new connectivity_map_t(config.get_child("mjolnir"))
                            : nullptr),
@@ -133,6 +134,9 @@ loki_worker_t::loki_worker_t(const boost::property_tree::ptree& config)
       sample(config.get<std::string>("additional_data.elevation", "test/data/")),
       max_elevation_shape(config.get<size_t>("service_limits.skadi.max_shape")),
       min_resample(config.get<float>("service_limits.skadi.min_resample")) {
+  // If we weren't provided with a graph reader make our own
+  if (!reader)
+    reader.reset(new baldr::GraphReader(config.get_child("mjolnir")));
 
   // Keep a string noting which actions we support, throw if one isnt supported
   odin::DirectionsOptions::Action action;
@@ -206,8 +210,8 @@ loki_worker_t::loki_worker_t(const boost::property_tree::ptree& config)
 }
 
 void loki_worker_t::cleanup() {
-  if (reader.OverCommitted()) {
-    reader.Clear();
+  if (reader->OverCommitted()) {
+    reader->Clear();
   }
 }
 

--- a/src/midgard/logging.cc
+++ b/src/midgard/logging.cc
@@ -62,7 +62,7 @@ const std::unordered_map<valhalla::midgard::logging::LogLevel, std::string, Enum
             {valhalla::midgard::logging::LogLevel::INFO, " \x1b[32;1m[INFO]\x1b[0m "},
             {valhalla::midgard::logging::LogLevel::DEBUG, " \x1b[34;1m[DEBUG]\x1b[0m "},
             {valhalla::midgard::logging::LogLevel::TRACE, " \x1b[37;1m[TRACE]\x1b[0m "}};
-#ifdef ___ANDROID__
+#ifdef __ANDROID__
 const std::unordered_map<valhalla::midgard::logging::LogLevel, android_LogPriority, EnumHasher>
     android_levels{{valhalla::midgard::logging::LogLevel::ERROR, ANDROID_LOG_ERROR},
                    {valhalla::midgard::logging::LogLevel::WARN, ANDROID_LOG_WARN},
@@ -128,14 +128,14 @@ public:
                    : uncolored) {
   }
   virtual void Log(const std::string& message, const LogLevel level) {
-#ifdef ___ANDROID__
+#ifdef __ANDROID__
     __android_log_print(android_levels.find(level)->second, "valhalla", message.cstr());
 #else
     Log(message, levels.find(level)->second);
 #endif
   }
   virtual void Log(const std::string& message, const std::string& custom_directive = " [TRACE] ") {
-#ifdef ___ANDROID__
+#ifdef __ANDROID__
     __android_log_print(ANDROID_LOG_INFO, "valhalla", message.cstr());
 #else
     std::string output;
@@ -164,7 +164,7 @@ bool std_out_logger_registered = RegisterLogger("std_out", [](const LoggingConfi
 class StdErrLogger : public StdOutLogger {
   using StdOutLogger::StdOutLogger;
   virtual void Log(const std::string& message, const std::string& custom_directive = " [TRACE] ") {
-#ifdef ___ANDROID__
+#ifdef __ANDROID__
     __android_log_print(ANDROID_LOG_ERROR, "valhalla", message.cstr());
 #else
     std::string output;

--- a/src/midgard/logging.cc
+++ b/src/midgard/logging.cc
@@ -129,14 +129,14 @@ public:
   }
   virtual void Log(const std::string& message, const LogLevel level) {
 #ifdef __ANDROID__
-    __android_log_print(android_levels.find(level)->second, "valhalla", message.cstr());
+    __android_log_print(android_levels.find(level)->second, "valhalla", message.c_str());
 #else
     Log(message, levels.find(level)->second);
 #endif
   }
   virtual void Log(const std::string& message, const std::string& custom_directive = " [TRACE] ") {
 #ifdef __ANDROID__
-    __android_log_print(ANDROID_LOG_INFO, "valhalla", message.cstr());
+    __android_log_print(ANDROID_LOG_INFO, "valhalla", message.c_str());
 #else
     std::string output;
     output.reserve(message.length() + 64);
@@ -165,7 +165,7 @@ class StdErrLogger : public StdOutLogger {
   using StdOutLogger::StdOutLogger;
   virtual void Log(const std::string& message, const std::string& custom_directive = " [TRACE] ") {
 #ifdef __ANDROID__
-    __android_log_print(ANDROID_LOG_ERROR, "valhalla", message.cstr());
+    __android_log_print(ANDROID_LOG_ERROR, "valhalla", message.c_str());
 #else
     std::string output;
     output.reserve(message.length() + 64);

--- a/src/midgard/logging.cc
+++ b/src/midgard/logging.cc
@@ -129,14 +129,14 @@ public:
   }
   virtual void Log(const std::string& message, const LogLevel level) {
 #ifdef __ANDROID__
-    __android_log_print(android_levels.find(level)->second, "valhalla", message.c_str());
+    __android_log_print(android_levels.find(level)->second, "valhalla", "%s", message.c_str());
 #else
     Log(message, levels.find(level)->second);
 #endif
   }
   virtual void Log(const std::string& message, const std::string& custom_directive = " [TRACE] ") {
 #ifdef __ANDROID__
-    __android_log_print(ANDROID_LOG_INFO, "valhalla", message.c_str());
+    __android_log_print(ANDROID_LOG_INFO, "valhalla", "%s", message.c_str());
 #else
     std::string output;
     output.reserve(message.length() + 64);
@@ -165,7 +165,7 @@ class StdErrLogger : public StdOutLogger {
   using StdOutLogger::StdOutLogger;
   virtual void Log(const std::string& message, const std::string& custom_directive = " [TRACE] ") {
 #ifdef __ANDROID__
-    __android_log_print(ANDROID_LOG_ERROR, "valhalla", message.c_str());
+    __android_log_print(ANDROID_LOG_ERROR, "valhalla", "%s", message.c_str());
 #else
     std::string output;
     output.reserve(message.length() + 64);

--- a/src/midgard/logging.cc
+++ b/src/midgard/logging.cc
@@ -9,6 +9,10 @@
 #include <sstream>
 #include <stdexcept>
 
+#ifdef ___ANDROID__
+#include <android/log.h>
+#endif
+
 namespace {
 
 inline std::tm* get_gmtime(const std::time_t* time, std::tm* tm) {
@@ -39,6 +43,33 @@ std::string TimeStamp() {
           gmt.tm_mday, gmt.tm_hour, gmt.tm_min, fractional_seconds.count());
   return buffer;
 }
+
+// the Log levels we support
+struct EnumHasher {
+  template <typename T> std::size_t operator()(T t) const {
+    return static_cast<std::size_t>(t);
+  }
+};
+const std::unordered_map<valhalla::midgard::logging::LogLevel, std::string, EnumHasher>
+    uncolored{{valhalla::midgard::logging::LogLevel::ERROR, " [ERROR] "},
+              {valhalla::midgard::logging::LogLevel::WARN, " [WARN] "},
+              {valhalla::midgard::logging::LogLevel::INFO, " [INFO] "},
+              {valhalla::midgard::logging::LogLevel::DEBUG, " [DEBUG] "},
+              {valhalla::midgard::logging::LogLevel::TRACE, " [TRACE] "}};
+const std::unordered_map<valhalla::midgard::logging::LogLevel, std::string, EnumHasher>
+    colored{{valhalla::midgard::logging::LogLevel::ERROR, " \x1b[31;1m[ERROR]\x1b[0m "},
+            {valhalla::midgard::logging::LogLevel::WARN, " \x1b[33;1m[WARN]\x1b[0m "},
+            {valhalla::midgard::logging::LogLevel::INFO, " \x1b[32;1m[INFO]\x1b[0m "},
+            {valhalla::midgard::logging::LogLevel::DEBUG, " \x1b[34;1m[DEBUG]\x1b[0m "},
+            {valhalla::midgard::logging::LogLevel::TRACE, " \x1b[37;1m[TRACE]\x1b[0m "}};
+#ifdef ___ANDROID__
+const std::unordered_map<valhalla::midgard::logging::LogLevel, android_LogPriority, EnumHasher>
+    android_levels{{valhalla::midgard::logging::LogLevel::ERROR, ANDROID_LOG_ERROR},
+                   {valhalla::midgard::logging::LogLevel::WARN, ANDROID_LOG_WARN},
+                   {valhalla::midgard::logging::LogLevel::INFO, ANDROID_LOG_INFO},
+                   {valhalla::midgard::logging::LogLevel::DEBUG, ANDROID_LOG_DEBUG},
+                   {valhalla::midgard::logging::LogLevel::TRACE, ANDROID_LOG_VERBOSE}};
+#endif
 
 } // namespace
 
@@ -76,24 +107,6 @@ bool RegisterLogger(const std::string& name, LoggerCreator function_ptr) {
   return success.second;
 }
 
-// the Log levels we support
-struct EnumHasher {
-  template <typename T> std::size_t operator()(T t) const {
-    return static_cast<std::size_t>(t);
-  }
-};
-const std::unordered_map<LogLevel, std::string, EnumHasher> uncolored{{LogLevel::ERROR, " [ERROR] "},
-                                                                      {LogLevel::WARN, " [WARN] "},
-                                                                      {LogLevel::INFO, " [INFO] "},
-                                                                      {LogLevel::DEBUG, " [DEBUG] "},
-                                                                      {LogLevel::TRACE, " [TRACE] "}};
-const std::unordered_map<LogLevel, std::string, EnumHasher>
-    colored{{LogLevel::ERROR, " \x1b[31;1m[ERROR]\x1b[0m "},
-            {LogLevel::WARN, " \x1b[33;1m[WARN]\x1b[0m "},
-            {LogLevel::INFO, " \x1b[32;1m[INFO]\x1b[0m "},
-            {LogLevel::DEBUG, " \x1b[34;1m[DEBUG]\x1b[0m "},
-            {LogLevel::TRACE, " \x1b[37;1m[TRACE]\x1b[0m "}};
-
 // logger base class, not pure virtual so you can use as a null logger if you want
 Logger::Logger(const LoggingConfig& config){};
 Logger::~Logger(){};
@@ -115,9 +128,16 @@ public:
                    : uncolored) {
   }
   virtual void Log(const std::string& message, const LogLevel level) {
+#ifdef ___ANDROID__
+    __android_log_print(android_levels.find(level)->second, "valhalla", message.cstr());
+#else
     Log(message, levels.find(level)->second);
+#endif
   }
   virtual void Log(const std::string& message, const std::string& custom_directive = " [TRACE] ") {
+#ifdef ___ANDROID__
+    __android_log_print(ANDROID_LOG_INFO, "valhalla", message.cstr());
+#else
     std::string output;
     output.reserve(message.length() + 64);
     output.append(TimeStamp());
@@ -130,6 +150,7 @@ public:
     // obviously we dont care if flushes interleave
     std::cout << output;
     std::cout.flush();
+#endif
   }
 
 protected:
@@ -143,6 +164,9 @@ bool std_out_logger_registered = RegisterLogger("std_out", [](const LoggingConfi
 class StdErrLogger : public StdOutLogger {
   using StdOutLogger::StdOutLogger;
   virtual void Log(const std::string& message, const std::string& custom_directive = " [TRACE] ") {
+#ifdef ___ANDROID__
+    __android_log_print(ANDROID_LOG_ERROR, "valhalla", message.cstr());
+#else
     std::string output;
     output.reserve(message.length() + 64);
     output.append(TimeStamp());
@@ -151,6 +175,7 @@ class StdErrLogger : public StdOutLogger {
     output.push_back('\n');
     std::cerr << output;
     std::cerr.flush();
+#endif
   }
 };
 bool std_err_logger_registered = RegisterLogger("std_err", [](const LoggingConfig& config) {

--- a/src/midgard/logging.cc
+++ b/src/midgard/logging.cc
@@ -9,7 +9,7 @@
 #include <sstream>
 #include <stdexcept>
 
-#ifdef ___ANDROID__
+#ifdef __ANDROID__
 #include <android/log.h>
 #endif
 

--- a/src/thor/isochrone_action.cc
+++ b/src/thor/isochrone_action.cc
@@ -32,9 +32,9 @@ std::string thor_worker_t::isochrones(valhalla_request_t& request) {
   // where there has been a higher cost that might still be marked in the isochrone
   auto grid = (costing == "multimodal" || costing == "transit")
                   ? isochrone_gen.ComputeMultiModal(*request.options.mutable_locations(),
-                                                    contours.back() + 10, reader, mode_costing, mode)
+                                                    contours.back() + 10, *reader, mode_costing, mode)
                   : isochrone_gen.Compute(*request.options.mutable_locations(), contours.back() + 10,
-                                          reader, mode_costing, mode);
+                                          *reader, mode_costing, mode);
 
   // turn it into geojson
   auto isolines = grid->GenerateContours(contours, request.options.polygons(),

--- a/src/thor/matrix_action.cc
+++ b/src/thor/matrix_action.cc
@@ -44,12 +44,12 @@ std::string thor_worker_t::matrix(valhalla_request_t& request) {
   std::vector<TimeDistance> time_distances;
   auto costmatrix = [&]() {
     thor::CostMatrix matrix;
-    return matrix.SourceToTarget(request.options.sources(), request.options.targets(), reader,
+    return matrix.SourceToTarget(request.options.sources(), request.options.targets(), *reader,
                                  mode_costing, mode, max_matrix_distance.find(costing)->second);
   };
   auto timedistancematrix = [&]() {
     thor::TimeDistanceMatrix matrix;
-    return matrix.SourceToTarget(request.options.sources(), request.options.targets(), reader,
+    return matrix.SourceToTarget(request.options.sources(), request.options.targets(), *reader,
                                  mode_costing, mode, max_matrix_distance.find(costing)->second);
   };
   switch (source_to_target_algorithm) {

--- a/src/thor/optimized_route_action.cc
+++ b/src/thor/optimized_route_action.cc
@@ -28,7 +28,7 @@ std::list<valhalla::odin::TripPath> thor_worker_t::optimized_route(valhalla_requ
   // Use CostMatrix to find costs from each location to every other location
   CostMatrix costmatrix;
   std::vector<thor::TimeDistance> td =
-      costmatrix.SourceToTarget(request.options.sources(), request.options.targets(), reader,
+      costmatrix.SourceToTarget(request.options.sources(), request.options.targets(), *reader,
                                 mode_costing, mode, max_matrix_distance.find(costing)->second);
 
   // Return an error if any locations are totally unreachable

--- a/src/thor/route_action.cc
+++ b/src/thor/route_action.cc
@@ -100,7 +100,7 @@ std::vector<thor::PathInfo> thor_worker_t::get_path(PathAlgorithm* path_algorith
     cost->set_allow_destination_only(false);
   }
   cost->set_pass(0);
-  auto path = path_algorithm->GetBestPath(origin, destination, reader, mode_costing, mode);
+  auto path = path_algorithm->GetBestPath(origin, destination, *reader, mode_costing, mode);
 
   // If path is not found try again with relaxed limits (if allowed)
   if (path.empty() || (costing == "pedestrian" && path_algorithm->has_ferry())) {
@@ -119,7 +119,7 @@ std::vector<thor::PathInfo> thor_worker_t::get_path(PathAlgorithm* path_algorith
       float expansion_within_factor = using_astar ? 4.0f : 2.0f;
       cost->RelaxHierarchyLimits(relax_factor, expansion_within_factor);
       cost->set_allow_destination_only(true);
-      path = path_algorithm->GetBestPath(origin, destination, reader, mode_costing, mode);
+      path = path_algorithm->GetBestPath(origin, destination, *reader, mode_costing, mode);
     }
   }
 
@@ -184,7 +184,7 @@ std::list<valhalla::odin::TripPath> thor_worker_t::path_arrive_by(
       AttributesController controller;
 
       // Form output information based on path edges
-      auto trip_path = thor::TripPathBuilder::Build(controller, reader, mode_costing, path, *origin,
+      auto trip_path = thor::TripPathBuilder::Build(controller, *reader, mode_costing, path, *origin,
                                                     *destination, throughs, interrupt);
       path.clear();
 
@@ -253,7 +253,7 @@ std::list<valhalla::odin::TripPath> thor_worker_t::path_depart_at(
       AttributesController controller;
 
       // Form output information based on path edges
-      auto trip_path = thor::TripPathBuilder::Build(controller, reader, mode_costing, path, *origin,
+      auto trip_path = thor::TripPathBuilder::Build(controller, *reader, mode_costing, path, *origin,
                                                     *destination, throughs, interrupt);
       path.clear();
 

--- a/src/thor/trace_route_action.cc
+++ b/src/thor/trace_route_action.cc
@@ -120,10 +120,10 @@ odin::TripPath thor_worker_t::route_match(valhalla_request_t& request,
                                           const AttributesController& controller) {
   odin::TripPath trip_path;
   std::vector<PathInfo> path_infos;
-  if (RouteMatcher::FormPath(mode_costing, mode, reader, trace, request.options.locations(),
+  if (RouteMatcher::FormPath(mode_costing, mode, *reader, trace, request.options.locations(),
                              path_infos)) {
     // Form the trip path based on mode costing, origin, destination, and path edges
-    trip_path = thor::TripPathBuilder::Build(controller, reader, mode_costing, path_infos,
+    trip_path = thor::TripPathBuilder::Build(controller, *reader, mode_costing, path_infos,
                                              *request.options.mutable_locations()->begin(),
                                              *request.options.mutable_locations()->rbegin(),
                                              std::list<odin::Location>{}, interrupt);
@@ -185,11 +185,11 @@ thor_worker_t::map_match(valhalla_request_t& request,
         }
 
         // Make one path edge from it
-        reader.GetGraphTile(match.edgeid, tile);
+        reader->GetGraphTile(match.edgeid, tile);
         auto* pe = request.options.mutable_shape(i)->mutable_path_edges()->Add();
         pe->mutable_ll()->set_lat(match.lnglat.lat());
         pe->mutable_ll()->set_lng(match.lnglat.lng());
-        for (const auto& n : reader.edgeinfo(match.edgeid).GetNames()) {
+        for (const auto& n : reader->edgeinfo(match.edgeid).GetNames()) {
           pe->mutable_names()->Add()->assign(n);
         }
 
@@ -395,12 +395,12 @@ thor_worker_t::map_match(valhalla_request_t& request,
       PathLocation::toPBF(matcher->state_container()
                               .state(first_result_with_state->stateid)
                               .candidate(),
-                          &origin, reader);
+                          &origin, *reader);
       odin::Location destination;
       PathLocation::toPBF(matcher->state_container()
                               .state(last_result_with_state->stateid)
                               .candidate(),
-                          &destination, reader);
+                          &destination, *reader);
 
       bool found_origin = false;
       for (const auto& e : origin.path_edges()) {

--- a/src/tyr/actor.cc
+++ b/src/tyr/actor.cc
@@ -15,7 +15,8 @@ namespace tyr {
 
 struct actor_t::pimpl_t {
   pimpl_t(const boost::property_tree::ptree& config)
-      : loki_worker(config), thor_worker(config), odin_worker(config) {
+      : reader(new baldr::GraphReader(config.get_child("mjolnir"))), loki_worker(config, reader),
+        thor_worker(config, reader), odin_worker(config) {
   }
   void set_interrupts(const std::function<void()>& interrupt_function) {
     loki_worker.set_interrupt(interrupt_function);
@@ -27,6 +28,7 @@ struct actor_t::pimpl_t {
     thor_worker.cleanup();
     odin_worker.cleanup();
   }
+  std::shared_ptr<baldr::GraphReader> reader;
   loki::loki_worker_t loki_worker;
   thor::thor_worker_t thor_worker;
   odin::odin_worker_t odin_worker;

--- a/valhalla/loki/worker.h
+++ b/valhalla/loki/worker.h
@@ -27,7 +27,8 @@ void run_service(const boost::property_tree::ptree& config);
 
 class loki_worker_t : public service_worker_t {
 public:
-  loki_worker_t(const boost::property_tree::ptree& config);
+  loki_worker_t(const boost::property_tree::ptree& config,
+                const std::shared_ptr<baldr::GraphReader>& graph_reader = {});
 #ifdef HAVE_HTTP
   virtual worker_t::result_t work(const std::list<zmq::message_t>& job,
                                   void* request_info,
@@ -64,8 +65,8 @@ protected:
   sif::CostFactory<sif::DynamicCost> factory;
   sif::EdgeFilter edge_filter;
   sif::NodeFilter node_filter;
-  valhalla::baldr::GraphReader reader;
-  std::shared_ptr<valhalla::baldr::connectivity_map_t> connectivity_map;
+  std::shared_ptr<baldr::GraphReader> reader;
+  std::shared_ptr<baldr::connectivity_map_t> connectivity_map;
   std::string action_str;
   std::unordered_map<std::string, size_t> max_locations;
   std::unordered_map<std::string, float> max_distance;

--- a/valhalla/meili/map_matcher_factory.h
+++ b/valhalla/meili/map_matcher_factory.h
@@ -20,16 +20,17 @@ namespace meili {
 
 class MapMatcherFactory final {
 public:
-  MapMatcherFactory(const boost::property_tree::ptree& root);
+  MapMatcherFactory(const boost::property_tree::ptree& root,
+                    const std::shared_ptr<baldr::GraphReader>& graph_reader = {});
 
   ~MapMatcherFactory();
 
-  baldr::GraphReader& graphreader() {
+  std::shared_ptr<baldr::GraphReader>& graphreader() {
     return graphreader_;
   }
 
   CandidateQuery& candidatequery() {
-    return candidatequery_;
+    return *candidatequery_;
   }
 
   MapMatcher* Create(const odin::Costing costing, const odin::DirectionsOptions& options);
@@ -53,13 +54,13 @@ private:
 
   boost::property_tree::ptree config_;
 
-  baldr::GraphReader graphreader_;
+  std::shared_ptr<baldr::GraphReader> graphreader_;
 
   valhalla::sif::cost_ptr_t mode_costing_[kModeCostingCount];
 
   sif::CostFactory<sif::DynamicCost> cost_factory_;
 
-  CandidateGridQuery candidatequery_;
+  std::shared_ptr<CandidateGridQuery> candidatequery_;
 
   float max_grid_cache_size_;
 };

--- a/valhalla/thor/worker.h
+++ b/valhalla/thor/worker.h
@@ -38,7 +38,8 @@ void run_service(const boost::property_tree::ptree& config);
 class thor_worker_t : public service_worker_t {
 public:
   enum SOURCE_TO_TARGET_ALGORITHM { SELECT_OPTIMAL = 0, COST_MATRIX = 1, TIME_DISTANCE_MATRIX = 2 };
-  thor_worker_t(const boost::property_tree::ptree& config);
+  thor_worker_t(const boost::property_tree::ptree& config,
+                const std::shared_ptr<baldr::GraphReader>& graph_reader = {});
   virtual ~thor_worker_t();
 #ifdef HAVE_HTTP
   virtual worker_t::result_t work(const std::list<zmq::message_t>& job,
@@ -83,10 +84,10 @@ protected:
   std::string parse_costing(const valhalla_request_t& request);
   void filter_attributes(const valhalla_request_t& request, AttributesController& controller);
 
-  valhalla::sif::TravelMode mode;
+  sif::TravelMode mode;
   std::vector<meili::Measurement> trace;
   sif::CostFactory<sif::DynamicCost> factory;
-  valhalla::sif::cost_ptr_t mode_costing[static_cast<int>(sif::TravelMode::kMaxTravelMode)];
+  sif::cost_ptr_t mode_costing[static_cast<int>(sif::TravelMode::kMaxTravelMode)];
   // Path algorithms (TODO - perhaps use a map?))
   AStarPathAlgorithm astar;
   BidirectionalAStar bidir_astar;
@@ -98,8 +99,8 @@ protected:
   float long_request;
   std::unordered_map<std::string, float> max_matrix_distance;
   SOURCE_TO_TARGET_ALGORITHM source_to_target_algorithm;
-  valhalla::meili::MapMatcherFactory matcher_factory;
-  valhalla::baldr::GraphReader& reader;
+  meili::MapMatcherFactory matcher_factory;
+  std::shared_ptr<baldr::GraphReader> reader;
 };
 
 } // namespace thor


### PR DESCRIPTION
this pr does 4 things:

1. it add logging support for android without special tricks. basically you cant log to stdout and expect the logcat to pick it up, so instead we detect android is there and when it is, we use its logger to log
2. use the same graph reader everywhere if provided. previously when running in single process mode we had a graphreader for every worker object. we have a synchronized tile cache that could have been used to achieve almost the same thing but this adds locking which is slow and isnt needed for single threaded modes. so ive added to the interface the ability to share the same graph reader across all workers (loki, thor (meili)) via shared_ptr. the actor uses this as well.
3. we now log the number of tiles loaded in a tile extract. this is just  useful info :smile: 
4. it allows loading of tars to throw so that we can catch and the log appropriately and not swallow the reason