### PR TITLE
Pedestrian Route performance fix (2nd pass)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
    * UPDATED: Refactor to use the pbf options instead of the ptree config [#1428](https://github.com/valhalla/valhalla/pull/1428) This completes [1357](https://github.com/valhalla/valhalla/issues/1357)
    * UPDATED: Removed the boost/date_time dependency from baldr and odin. We added the Howard Hinnant date and time library as a submodule. [#1494](https://github.com/valhalla/valhalla/pull/1494)
    * UPDATED: Fixed 'Drvie' typo [#1505](https://github.com/valhalla/valhalla/pull/1505) This completes [1504](https://github.com/valhalla/valhalla/issues/1504)
+   * UPDATED: Do not run a second pass on long pedestrian routes that include a ferry (but succeed on first pass). This is a performance fix. Long pedestrian routes with A star factor based on ferry speed end up being very inefficient.
 * **Request Parsing**
    * FIXED: Fixed through locations weren't honored [#1449](https://github.com/valhalla/valhalla/pull/1449)
 

--- a/src/thor/route_action.cc
+++ b/src/thor/route_action.cc
@@ -26,6 +26,13 @@ namespace thor {
 // route starts to become suspect (due to user breaks and other factors).
 constexpr float kMaxTimeDependentDistance = 500000.0f; // 500 km
 
+// Threshold for running a second pass pedestrian route with adjusted A*. The first
+// pass for pedestrian routes is run with an aggressive A* threshold based on walking
+// speed. If ferries are included in the path the A* heuristic rules can be violated
+// which can lead to irregular paths. Running a second pass with less aggressive
+// A* can take excessive time for longer paths - so exclude them to protect the service.
+constexpr float kPedestrianMultipassThreshold = 50000.0f; // 50km
+
 std::list<valhalla::odin::TripPath> thor_worker_t::route(valhalla_request_t& request) {
   parse_locations(request);
   auto costing = parse_costing(request);
@@ -92,9 +99,8 @@ std::vector<thor::PathInfo> thor_worker_t::get_path(PathAlgorithm* path_algorith
                                                     odin::Location& origin,
                                                     odin::Location& destination,
                                                     const std::string& costing) {
-  // Find the path. If bidirectional A* disable use of destination only
-  // edges on the first pass. If there is a failure, we allow them on the
-  // second pass.
+  // Find the path. If bidirectional A* disable use of destination only edges on the
+  // first pass. If there is a failure, we allow them on the second pass.
   valhalla::sif::cost_ptr_t cost = mode_costing[static_cast<uint32_t>(mode)];
   if (path_algorithm == &bidir_astar) {
     cost->set_allow_destination_only(false);
@@ -102,24 +108,38 @@ std::vector<thor::PathInfo> thor_worker_t::get_path(PathAlgorithm* path_algorith
   cost->set_pass(0);
   auto path = path_algorithm->GetBestPath(origin, destination, *reader, mode_costing, mode);
 
-  // If path is not found try again with relaxed limits (if allowed)
-  if (path.empty() || (costing == "pedestrian" && path_algorithm->has_ferry())) {
-    if (cost->AllowMultiPass()) {
-      // 2nd pass. Less aggressive hierarchy transitioning, and retry with more candidate
-      // edges(filterd by heading in loki).
+  // Check if we should run a second pass pedestrian route with different A*
+  // (to look for better routes where a ferry is taken)
+  bool ped_second_pass = false;
+  if (!path.empty() && (costing == "pedestrian" && path_algorithm->has_ferry())) {
+    // DO NOT run a second pass on long routes due to performance issues
+    float d = PointLL(origin.ll().lng(), origin.ll().lat())
+                  .Distance(PointLL(destination.ll().lng(), destination.ll().lat()));
+    if (d < kPedestrianMultipassThreshold) {
+      ped_second_pass = true;
+    }
+  }
 
-      // add filtered edges to candidate edges for origin and destination
-      origin.mutable_path_edges()->MergeFrom(origin.filtered_edges());
-      destination.mutable_path_edges()->MergeFrom(destination.filtered_edges());
+  // If path is not found try again with relaxed limits (if allowed). Use less aggressive
+  // hierarchy transition limits, and retry with more candidate edges (add those filtered
+  // by heading on first pass).
+  if ((path.empty() || ped_second_pass) && cost->AllowMultiPass()) {
+    // add filtered edges to candidate edges for origin and destination
+    origin.mutable_path_edges()->MergeFrom(origin.filtered_edges());
+    destination.mutable_path_edges()->MergeFrom(destination.filtered_edges());
 
-      path_algorithm->Clear();
-      cost->set_pass(1);
-      bool using_astar = (path_algorithm == &astar);
-      float relax_factor = using_astar ? 16.0f : 8.0f;
-      float expansion_within_factor = using_astar ? 4.0f : 2.0f;
-      cost->RelaxHierarchyLimits(relax_factor, expansion_within_factor);
-      cost->set_allow_destination_only(true);
-      path = path_algorithm->GetBestPath(origin, destination, *reader, mode_costing, mode);
+    path_algorithm->Clear();
+    cost->set_pass(1);
+    bool using_astar = (path_algorithm == &astar);
+    float relax_factor = using_astar ? 16.0f : 8.0f;
+    float expansion_within_factor = using_astar ? 4.0f : 2.0f;
+    cost->RelaxHierarchyLimits(relax_factor, expansion_within_factor);
+    cost->set_allow_destination_only(true);
+
+    // Get the best path. Return if not empty (else return the original path)
+    auto path2 = path_algorithm->GetBestPath(origin, destination, *reader, mode_costing, mode);
+    if (!path2.empty()) {
+      return path2;
     }
   }
 


### PR DESCRIPTION
Do not run a second pass on long pedestrian routes that include a ferry. The A* factor is ineffective and performance is low.

The following request JSON demonstrates the issue:
{"locations":[{"lat":51.210324789481355,"lon":4.411010742187499},{"lat":51.19999983412068,"lon":6.8060302734375}],"costing":"pedestrian","directions_options":{"language":"en-US"}}

When run locally it takes about 500 ms to generate the initial path (which includes a ferry). It then runs a second pass with less aggressive A* to make sure the initial path is good. This second pass is very slow: 4 seconds.

 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)