### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,6 @@ py-compile
 .libs/
 libvalhalla.la
 date_time_zonespec.csv
-valhalla/valhalla.h
 mason/
 mason_packages/
 

--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,6 @@ valhalla_tyr_worker
 valhalla_associate_segments
 valhalla_fetch_transit
 valhalla_pack_elevation
-valhalla/proto
-src/proto
 genfiles/
 locales/*.UTF-8
 py-compile


### PR DESCRIPTION
Removed valhalla/proto and src/proto from gitignore.
These paths is unused anymore. And it could be difficult to find why valhalla won't build if you have some old headers in those folders.

# Issue

Small code cleanup. I've had files in proto folders and spent 15 minutes to understand why it won't build. With correct gitignore old files will be displayed in `git status` and it's easy to delete them by `git reset --hard`.

## Tasklist

 - [ ] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
