### PR TITLE
Add date_time and speed lookup to isochrones.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Release Date: TBD Valhalla 2.7.1
+* **Enhancement**
+   * UPDATED: Added date time support to forward and reverse isochrones. Add speed lookup (predicted speeds and/or free-flow or constrained flow speed) if date_time is present.
+
 ## Release Date: 2018-09-13 Valhalla 2.7.0
 * **Enhancement**
    * UPDATED: Refactor to use the pbf options instead of the ptree config [#1428](https://github.com/valhalla/valhalla/pull/1428) This completes [1357](https://github.com/valhalla/valhalla/issues/1357)

--- a/src/valhalla_run_isochrone.cc
+++ b/src/valhalla_run_isochrone.cc
@@ -81,9 +81,6 @@ int main(int argc, char* argv[]) {
     return EXIT_FAILURE;
   }
 
-  // Isochrone parameters (TODO - later we should test reverse in the interface)
-  bool reverse = false;
-
   // Process json request
   valhalla::valhalla_request_t request;
   request.parse(json, valhalla::odin::DirectionsOptions::isochrone);
@@ -106,6 +103,12 @@ int main(int argc, char* argv[]) {
 
   // Show locations
   bool show_locations = request.options.show_locations();
+
+  // reverse (arrive-by) isochrone - trigger if date time type is arrive by
+  // TODO - is this how we want to expose in the service? only support reverse
+  // for time dependent isochrones? or do we also want a flag to support for
+  // general case with no time?
+  bool reverse = request.options.date_time_type() == valhalla::odin::DirectionsOptions::arrive_by;
 
   // Get Contours
   std::unordered_map<float, std::string> colors{};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,7 +10,7 @@ set(tests aabb2 access_restriction actor admin attributes_controller complexrest
   verbal_text_formatter_us_co verbal_text_formatter_us_tx viterbi_search compression)
 
 if(ENABLE_DATA_TOOLS)
-  list(APPEND tests astar edgeinfobuilder graphbuilder graphparser graphtilebuilder graphreader predictive_traffic
+  list(APPEND tests astar edgeinfobuilder graphbuilder graphparser graphtilebuilder graphreader isochrone predictive_traffic
     idtable matrix names node_search refs search servicedays signinfo timedep_paths timeparsing trivial_paths uniquenames utrecht)
 endif()
 

--- a/test/isochrone.cc
+++ b/test/isochrone.cc
@@ -66,10 +66,10 @@ const auto config = json_to_pt(R"({
 } // namespace
 
 void try_isochrone(GraphReader& reader,
-              loki_worker_t& loki_worker,
-              thor_worker_t& thor_worker,
-              const char* test_request,
-              const std::string& expected) {
+                   loki_worker_t& loki_worker,
+                   thor_worker_t& thor_worker,
+                   const char* test_request,
+                   const std::string& expected) {
   valhalla::valhalla_request_t request;
   request.parse(test_request, valhalla::odin::DirectionsOptions::route);
   loki_worker.isochrones(request);
@@ -91,12 +91,14 @@ void test_isochrones() {
 
   // Test auto isochrone with one contour
   std::string expected1 = "\"type\":\"LineString\"";
-  const auto test_request1 = R"({"locations":[{"lat":52.078937,"lon":5.115321}],"costing":"auto","contours":[{"time":15}],"polygons":false,"denoise":0.2,"generalize":150})";
+  const auto test_request1 =
+      R"({"locations":[{"lat":52.078937,"lon":5.115321}],"costing":"auto","contours":[{"time":15}],"polygons":false,"denoise":0.2,"generalize":150})";
   try_isochrone(reader, loki_worker, thor_worker, test_request1, expected1);
 
   // Try pedestrian isochrone with one contour, polygon=true
   std::string expected2 = "\"type\":\"Polygon\"";
-  const auto test_request2 = R"({"locations":[{"lat":52.078937,"lon":5.115321}],"costing":"bicycle","contours":[{"time":15}],"polygons":true,"denoise":0.2})";
+  const auto test_request2 =
+      R"({"locations":[{"lat":52.078937,"lon":5.115321}],"costing":"bicycle","contours":[{"time":15}],"polygons":true,"denoise":0.2})";
   try_isochrone(reader, loki_worker, thor_worker, test_request2, expected2);
 }
 

--- a/test/isochrone.cc
+++ b/test/isochrone.cc
@@ -1,0 +1,112 @@
+#include "test.h"
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "baldr/rapidjson_utils.h"
+#include "loki/worker.h"
+#include "midgard/logging.h"
+#include "sif/autocost.h"
+#include "sif/bicyclecost.h"
+#include "thor/isochrone.h"
+#include "thor/worker.h"
+#include <boost/property_tree/ptree.hpp>
+
+using namespace valhalla::thor;
+using namespace valhalla::sif;
+using namespace valhalla::loki;
+using namespace valhalla::baldr;
+using namespace valhalla::midgard;
+using namespace valhalla::tyr;
+
+namespace {
+
+boost::property_tree::ptree json_to_pt(const std::string& json) {
+  std::stringstream ss;
+  ss << json;
+  boost::property_tree::ptree pt;
+  rapidjson::read_json(ss, pt);
+  return pt;
+}
+
+const auto config = json_to_pt(R"({
+    "mjolnir":{"tile_dir":"test/data/utrecht_tiles", "concurrency": 1},
+    "loki":{
+      "actions":["sources_to_targets"],
+      "logging":{"long_request": 100},
+      "service_defaults":{"minimum_reachability": 50,"radius": 0}
+    },
+    "thor":{
+      "logging":{"long_request": 100}
+    },
+    "meili":{
+      "grid": {
+        "cache_size": 100240,
+        "size": 500
+      }
+    },
+    "service_limits": {
+      "auto": {"max_distance": 5000000.0, "max_locations": 20,"max_matrix_distance": 400000.0,"max_matrix_locations": 50},
+      "auto_shorter": {"max_distance": 5000000.0,"max_locations": 20,"max_matrix_distance": 400000.0,"max_matrix_locations": 50},
+      "bicycle": {"max_distance": 500000.0,"max_locations": 50,"max_matrix_distance": 200000.0,"max_matrix_locations": 50},
+      "bus": {"max_distance": 5000000.0,"max_locations": 50,"max_matrix_distance": 400000.0,"max_matrix_locations": 50},
+      "hov": {"max_distance": 5000000.0,"max_locations": 20,"max_matrix_distance": 400000.0,"max_matrix_locations": 50},
+      "isochrone": {"max_contours": 4,"max_distance": 25000.0,"max_locations": 1,"max_time": 120},
+      "max_avoid_locations": 50,"max_radius": 200,"max_reachability": 100,
+      "multimodal": {"max_distance": 500000.0,"max_locations": 50,"max_matrix_distance": 0.0,"max_matrix_locations": 0},
+      "pedestrian": {"max_distance": 250000.0,"max_locations": 50,"max_matrix_distance": 200000.0,"max_matrix_locations": 50,"max_transit_walking_distance": 10000,"min_transit_walking_distance": 1},
+      "skadi": {"max_shape": 750000,"min_resample": 10.0},
+      "trace": {"max_distance": 200000.0,"max_gps_accuracy": 100.0,"max_search_radius": 100,"max_shape": 16000,"max_best_paths":4,"max_best_paths_shape":100},
+      "transit": {"max_distance": 500000.0,"max_locations": 50,"max_matrix_distance": 200000.0,"max_matrix_locations": 50},
+      "truck": {"max_distance": 5000000.0,"max_locations": 20,"max_matrix_distance": 400000.0,"max_matrix_locations": 50}
+    }
+  })");
+
+} // namespace
+
+void try_isochrone(GraphReader& reader,
+              loki_worker_t& loki_worker,
+              thor_worker_t& thor_worker,
+              const char* test_request,
+              const std::string& expected) {
+  valhalla::valhalla_request_t request;
+  request.parse(test_request, valhalla::odin::DirectionsOptions::route);
+  loki_worker.isochrones(request);
+
+  // Process isochrone request
+  auto result = thor_worker.isochrones(request);
+
+  // Check if the result contains the expected string
+  if (result.find(expected) == std::string::npos) {
+    throw std::runtime_error("isochrones failed: expected " + expected);
+  }
+}
+
+void test_isochrones() {
+  // Test setup
+  loki_worker_t loki_worker(config);
+  thor_worker_t thor_worker(config);
+  GraphReader reader(config.get_child("mjolnir"));
+
+  // Test auto isochrone with one contour
+  std::string expected1 = "\"type\":\"LineString\"";
+  const auto test_request1 = R"({"locations":[{"lat":52.078937,"lon":5.115321}],"costing":"auto","contours":[{"time":15}],"polygons":false,"denoise":0.2,"generalize":150})";
+  try_isochrone(reader, loki_worker, thor_worker, test_request1, expected1);
+
+  // Try pedestrian isochrone with one contour, polygon=true
+  std::string expected2 = "\"type\":\"Polygon\"";
+  const auto test_request2 = R"({"locations":[{"lat":52.078937,"lon":5.115321}],"costing":"bicycle","contours":[{"time":15}],"polygons":true,"denoise":0.2})";
+  try_isochrone(reader, loki_worker, thor_worker, test_request2, expected2);
+}
+
+int main(int argc, char* argv[]) {
+  test::suite suite("trivial_paths");
+
+  // Silence logs (especially long request logging)
+  logging::Configure({{"type", ""}});
+
+  suite.test(TEST_CASE(test_isochrones));
+
+  return suite.tear_down();
+}

--- a/test/isochrone.cc
+++ b/test/isochrone.cc
@@ -71,7 +71,7 @@ void try_isochrone(GraphReader& reader,
                    const char* test_request,
                    const std::string& expected) {
   valhalla::valhalla_request_t request;
-  request.parse(test_request, valhalla::odin::DirectionsOptions::route);
+  request.parse(test_request, valhalla::odin::DirectionsOptions::isochrone);
   loki_worker.isochrones(request);
 
   // Process isochrone request

--- a/valhalla/thor/isochrone.h
+++ b/valhalla/thor/isochrone.h
@@ -91,9 +91,11 @@ public:
                     const sif::TravelMode mode);
 
 protected:
-  float shape_interval_; // Interval along shape to mark time
-  sif::TravelMode mode_; // Current travel mode
-  uint32_t access_mode_; // Access mode used by the costing method
+  bool has_date_time_;
+  uint32_t seconds_of_week_; // Seconds of week (for isochrones using predicted speeds)
+  float shape_interval_;     // Interval along shape to mark time
+  sif::TravelMode mode_;     // Current travel mode
+  uint32_t access_mode_;     // Access mode used by the costing method
 
   // Current costing mode
   std::shared_ptr<sif::DynamicCost> costing_;
@@ -147,22 +149,36 @@ protected:
 
   /**
    * Expand from the node along the forward search path.
+   * @param graphreader  Graph reader.
+   * @param node Graph Id of the node to expand.
+   * @param pred Edge label of the predecessor edge leading to the node.
+   * @param pred_idx Index in the edge label list of the predecessor edge.
+   * @param from_transition Boolean indicating if this expansion is from a transition edge.
+   * @param seconds_of_week For time dependent isochrones this allows lookup of predicted traffic.
    */
   void ExpandForward(baldr::GraphReader& graphreader,
                      const baldr::GraphId& node,
                      const sif::EdgeLabel& pred,
                      const uint32_t pred_idx,
-                     const bool from_transition);
+                     const bool from_transition,
+                     int32_t seconds_of_week);
 
   /**
    * Expand from the node along the reverse search path.
+   * @param graphreader  Graph reader.
+   * @param node Graph Id of the node to expand.
+   * @param pred Edge label of the predecessor edge leading to the node.
+   * @param pred_idx Index in the edge label list of the predecessor edge.
+   * @param from_transition Boolean indicating if this expansion is from a transition edge.
+   * @param seconds_of_week For time dependent isochrones this allows lookup of predicted traffic.
    */
   void ExpandReverse(baldr::GraphReader& graphreader,
                      const baldr::GraphId& node,
                      const sif::BDEdgeLabel& pred,
                      const uint32_t pred_idx,
                      const baldr::DirectedEdge* opp_pred_edge,
-                     const bool from_transition);
+                     const bool from_transition,
+                     int32_t seconds_of_week);
 
   /**
    * Updates the isotile using the edge information from the predecessor edge

--- a/valhalla/thor/isochrone.h
+++ b/valhalla/thor/isochrone.h
@@ -92,10 +92,10 @@ public:
 
 protected:
   bool has_date_time_;
-  uint32_t seconds_of_week_; // Seconds of week (for isochrones using predicted speeds)
-  float shape_interval_;     // Interval along shape to mark time
-  sif::TravelMode mode_;     // Current travel mode
-  uint32_t access_mode_;     // Access mode used by the costing method
+  int start_tz_index_;   // Timezone at the start of the isochrone
+  float shape_interval_; // Interval along shape to mark time
+  sif::TravelMode mode_; // Current travel mode
+  uint32_t access_mode_; // Access mode used by the costing method
 
   // Current costing mode
   std::shared_ptr<sif::DynamicCost> costing_;
@@ -154,6 +154,7 @@ protected:
    * @param pred Edge label of the predecessor edge leading to the node.
    * @param pred_idx Index in the edge label list of the predecessor edge.
    * @param from_transition Boolean indicating if this expansion is from a transition edge.
+   * @param localtime Current local time.  Seconds since epoch.
    * @param seconds_of_week For time dependent isochrones this allows lookup of predicted traffic.
    */
   void ExpandForward(baldr::GraphReader& graphreader,
@@ -161,6 +162,7 @@ protected:
                      const sif::EdgeLabel& pred,
                      const uint32_t pred_idx,
                      const bool from_transition,
+                     uint64_t localtime,
                      int32_t seconds_of_week);
 
   /**
@@ -170,6 +172,7 @@ protected:
    * @param pred Edge label of the predecessor edge leading to the node.
    * @param pred_idx Index in the edge label list of the predecessor edge.
    * @param from_transition Boolean indicating if this expansion is from a transition edge.
+   * @param localtime Current local time.  Seconds since epoch.
    * @param seconds_of_week For time dependent isochrones this allows lookup of predicted traffic.
    */
   void ExpandReverse(baldr::GraphReader& graphreader,
@@ -178,6 +181,7 @@ protected:
                      const uint32_t pred_idx,
                      const baldr::DirectedEdge* opp_pred_edge,
                      const bool from_transition,
+                     uint64_t localtime,
                      int32_t seconds_of_week);
 
   /**


### PR DESCRIPTION
Support reverse isochrone if date time type is arrive_by (done within valhalla_run_isochrone but not yet within the service).

fixes #1486 

 - [x] Add tests
 - [x] Review - you must request approval to merge any PR to master
 - [x] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)
