### PR TITLE
no need to return tz offset.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
    * UPDATED: Add timezone checks to multimodal routes and isochrones (updates localtime if the path crosses into a timezone different than the start location).
 * **Data Producer Update**
    * UPDATED: Removed boost date time support from transit.  Now using the Howard Hinnant date library.
+* **Bug Fix**
+   * FIXED: We were getting inconsistent results between departing at current date/time vs entering the current date/time.  This issue is due to the fact that the iso_date_time function returns the full iso date_time with the timezone offset (e.g., 2018-09-27T10:23-07:00 vs 2018-09-27T10:23). When we refactored the date_time code to use the new Howard Hinnant date library, we introduced this bug.
 
 ## Release Date: 2018-09-13 Valhalla 2.7.0
 * **Enhancement**

--- a/src/baldr/datetime.cc
+++ b/src/baldr/datetime.cc
@@ -83,10 +83,8 @@ std::string iso_date_time(const date::time_zone* time_zone) {
     return "";
   std::ostringstream iso_date_time;
   const auto date = date::make_zoned(time_zone, std::chrono::system_clock::now());
-  iso_date_time << date::format("%FT%R%z", date);
-  std::string iso_date = iso_date_time.str();
-  iso_date.insert(19, 1, ':');
-  return iso_date;
+  iso_date_time << date::format("%FT%R", date);
+  return iso_date_time.str();
 }
 
 // Get the seconds since epoch time is already adjusted based on TZ


### PR DESCRIPTION
# Issue
Fixes #1550 
We were getting inconsistent results between departing at current date/time vs entering the current date/time.

## Tasklist
 - [x] Review - you must request approval to merge any PR to master
 - [x] Add #fixes with the issue number that this PR addresses
 - [x] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)

New results.  Notice that the results match now.   

Route at current time.  Assume the current time is 2018-09-27T10:31.
0 2018/09/27 17:31:47.642099 GET /route?json={%22costing%22:%22auto%22,%22date_time%22:{%22type%22:0},%22locations%22:[{%22lat%22:%2237.802170%22,%22lon%22:%22-122.40911%22},{%22lat%22:%2237.749036%22,%22lon%22:%22-122.425088%22}]} HTTP/1.1
2018/09/27 17:31:47.642775 [INFO] Got Loki Request 0
2018/09/27 17:31:47.643529 [ANALYTICS] costing_type::auto
2018/09/27 17:31:47.643725 [ANALYTICS] location_distance::6.079715km
2018/09/27 17:31:47.663027 [INFO] Got Thor Request 0
2018/09/27 17:31:47.663236 [ANALYTICS] travel_mode::0
**2018-09-27T10:31**
**start_time 1538069487**
**Day of week = 4**
**Seconds from midnight 37860**
**seconds of the week = 383460**
2018/09/27 17:31:47.744535 [ANALYTICS] admin_state_iso:: CA 
2018/09/27 17:31:47.744557 [ANALYTICS] admin_country_iso:: US 
2018/09/27 17:31:47.744973 [INFO] Got Odin Request 0
2018/09/27 17:31:47.745216 [INFO] trip_path_->node_size()=152
2018/09/27 17:31:47.788120 [INFO] maneuver_count::10
0 2018/09/27 17:31:47.788525 200 5818

Depart at route with a start time equal to the current time above (e.g. 2018-09-27T10:31)
1 2018/09/27 17:32:00.975901 GET /route?json={%22costing%22:%22auto%22,%22date_time%22:{%22type%22:1,%22value%22:%222018-09-27T10:31%22},%22locations%22:[{%22lat%22:%2237.802170%22,%22lon%22:%22-122.40911%22},{%22lat%22:%2237.749036%22,%22lon%22:%22-122.425088%22}]} HTTP/1.1
2018/09/27 17:32:00.976017 [INFO] Got Loki Request 1
2018/09/27 17:32:00.976137 [ANALYTICS] costing_type::auto
2018/09/27 17:32:00.976161 [ANALYTICS] location_distance::6.079715km
2018/09/27 17:32:00.979287 [INFO] Got Thor Request 1
2018/09/27 17:32:00.979369 [ANALYTICS] travel_mode::0
**2018-09-27T10:31**
**start_time 1538069487**
**Day of week = 4**
**Seconds from midnight 37860**
**seconds of the week = 383460**
2018/09/27 17:32:01.033679 [ANALYTICS] admin_state_iso:: CA 
2018/09/27 17:32:01.033700 [ANALYTICS] admin_country_iso:: US 
2018/09/27 17:32:01.034248 [INFO] Got Odin Request 1
2018/09/27 17:32:01.034498 [INFO] trip_path_->node_size()=152
2018/09/27 17:32:01.041134 [INFO] maneuver_count::10
1 2018/09/27 17:32:01.042074 200 5818
