### PR TITLE
Add a has_traffic flag to TransitionCost and TransitionCostReverse. 

### DIFF
--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -214,11 +214,13 @@ public:
    * @param  edge  Directed edge (the to edge)
    * @param  node  Node (intersection) where transition occurs.
    * @param  pred  Predecessor edge information.
+   * @param  has_traffic  Does the transition have traffic information.
    * @return  Returns the cost and time (seconds)
    */
   virtual Cost TransitionCost(const baldr::DirectedEdge* edge,
                               const baldr::NodeInfo* node,
-                              const EdgeLabel& pred) const;
+                              const EdgeLabel& pred,
+                              const bool has_traffic = false) const;
 
   /**
    * Returns the cost to make the transition from the predecessor edge
@@ -227,12 +229,14 @@ public:
    * @param  node  Node (intersection) where transition occurs.
    * @param  pred  the opposing current edge in the reverse tree.
    * @param  edge  the opposing predecessor in the reverse tree
+   * @param  has_traffic  Does the transition have traffic information.
    * @return  Returns the cost and time (seconds)
    */
   virtual Cost TransitionCostReverse(const uint32_t idx,
                                      const baldr::NodeInfo* node,
                                      const baldr::DirectedEdge* pred,
-                                     const baldr::DirectedEdge* edge) const;
+                                     const baldr::DirectedEdge* edge,
+                                     const bool has_traffic = false) const;
 
   /**
    * Get the cost factor for A* heuristics. This factor is multiplied
@@ -490,7 +494,8 @@ Cost AutoCost::EdgeCost(const DirectedEdge* edge, const uint32_t speed) const {
 // Returns the time (in seconds) to make the transition from the predecessor
 Cost AutoCost::TransitionCost(const baldr::DirectedEdge* edge,
                               const baldr::NodeInfo* node,
-                              const EdgeLabel& pred) const {
+                              const EdgeLabel& pred,
+                              const bool has_traffic) const {
   // Accumulate cost and penalty
   float seconds = 0.0f;
   float penalty = 0.0f;
@@ -527,7 +532,8 @@ Cost AutoCost::TransitionCost(const baldr::DirectedEdge* edge,
     penalty += maneuver_penalty_;
   }
 
-  // Transition time = densityfactor * stopimpact * turncost
+  // Intersection transition time = factor * stopimpact * turncost. Factor depends
+  // on density and whether traffic is available
   if (edge->stopimpact(idx) > 0) {
     float turn_cost;
     if (edge->edge_to_right(idx) && edge->edge_to_left(idx)) {
@@ -537,7 +543,17 @@ Cost AutoCost::TransitionCost(const baldr::DirectedEdge* edge,
                       ? kRightSideTurnCosts[static_cast<uint32_t>(edge->turntype(idx))]
                       : kLeftSideTurnCosts[static_cast<uint32_t>(edge->turntype(idx))];
     }
-    seconds += trans_density_factor_[node->density()] * edge->stopimpact(idx) * turn_cost;
+    turn_cost *= edge->stopimpact(idx);
+
+    // Separate time and penalty if using predicted speeds. Even when we reduce time
+    // for a particular turn we still may want to have slight penalties to help avoid
+    // unfavorable turns).
+    if (has_traffic) {
+      seconds += kTrafficTransitionFactor * turn_cost;
+      penalty += (trans_density_factor_[node->density()] - kTrafficTransitionFactor) * turn_cost;
+    } else {
+      seconds += trans_density_factor_[node->density()] * turn_cost;
+    }
   }
 
   // Return cost (time and penalty)
@@ -551,7 +567,8 @@ Cost AutoCost::TransitionCost(const baldr::DirectedEdge* edge,
 Cost AutoCost::TransitionCostReverse(const uint32_t idx,
                                      const baldr::NodeInfo* node,
                                      const baldr::DirectedEdge* pred,
-                                     const baldr::DirectedEdge* edge) const {
+                                     const baldr::DirectedEdge* edge,
+                                     const bool has_traffic) const {
   // Accumulate cost and penalty
   float seconds = 0.0f;
   float penalty = 0.0f;

--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -310,11 +310,13 @@ public:
    * @param  edge  Directed edge (the to edge)
    * @param  node  Node (intersection) where transition occurs.
    * @param  pred  Predecessor edge information.
+   * @param  has_traffic  Does the transition have traffic information.
    * @return  Returns the cost and time (seconds)
    */
   virtual Cost TransitionCost(const baldr::DirectedEdge* edge,
                               const baldr::NodeInfo* node,
-                              const EdgeLabel& pred) const;
+                              const EdgeLabel& pred,
+                              const bool has_traffic = false) const;
 
   /**
    * Returns the cost to make the transition from the predecessor edge
@@ -323,12 +325,14 @@ public:
    * @param  node  Node (intersection) where transition occurs.
    * @param  pred  the opposing current edge in the reverse tree.
    * @param  edge  the opposing predecessor in the reverse tree
+   * @param  has_traffic  Does the transition have traffic information.
    * @return  Returns the cost and time (seconds)
    */
   virtual Cost TransitionCostReverse(const uint32_t idx,
                                      const baldr::NodeInfo* node,
                                      const baldr::DirectedEdge* pred,
-                                     const baldr::DirectedEdge* edge) const;
+                                     const baldr::DirectedEdge* edge,
+                                     const bool has_traffic = false) const;
 
   /**
    * Get the cost factor for A* heuristics. This factor is multiplied
@@ -746,7 +750,8 @@ Cost BicycleCost::EdgeCost(const baldr::DirectedEdge* edge, const uint32_t speed
 // Returns the time (in seconds) to make the transition from the predecessor
 Cost BicycleCost::TransitionCost(const baldr::DirectedEdge* edge,
                                  const baldr::NodeInfo* node,
-                                 const EdgeLabel& pred) const {
+                                 const EdgeLabel& pred,
+                                 const bool has_traffic) const {
   // Accumulate cost and penalty
   float seconds = 0.0f;
   float penalty = 0.0f;
@@ -850,7 +855,8 @@ Cost BicycleCost::TransitionCost(const baldr::DirectedEdge* edge,
 Cost BicycleCost::TransitionCostReverse(const uint32_t idx,
                                         const baldr::NodeInfo* node,
                                         const baldr::DirectedEdge* pred,
-                                        const baldr::DirectedEdge* edge) const {
+                                        const baldr::DirectedEdge* edge,
+                                        const bool has_traffic) const {
   // Accumulate cost and penalty
   float seconds = 0.0f;
   float penalty = 0.0f;

--- a/src/sif/dynamiccost.cc
+++ b/src/sif/dynamiccost.cc
@@ -52,7 +52,8 @@ Cost DynamicCost::EdgeCost(const baldr::DirectedEdge* edge, const uint32_t speed
 // costs (i.e., intersection/turn costs) must override this method.
 Cost DynamicCost::TransitionCost(const DirectedEdge* edge,
                                  const NodeInfo* node,
-                                 const EdgeLabel& pred) const {
+                                 const EdgeLabel& pred,
+                                 const bool has_traffic) const {
   return {0.0f, 0.0f};
 }
 
@@ -63,7 +64,8 @@ Cost DynamicCost::TransitionCost(const DirectedEdge* edge,
 Cost DynamicCost::TransitionCostReverse(const uint32_t idx,
                                         const baldr::NodeInfo* node,
                                         const baldr::DirectedEdge* opp_edge,
-                                        const baldr::DirectedEdge* opp_pred_edge) const {
+                                        const baldr::DirectedEdge* opp_pred_edge,
+                                        const bool has_traffic) const {
   return {0.0f, 0.0f};
 }
 

--- a/src/sif/motorcyclecost.cc
+++ b/src/sif/motorcyclecost.cc
@@ -219,11 +219,13 @@ public:
    * @param  edge  Directed edge (the to edge)
    * @param  node  Node (intersection) where transition occurs.
    * @param  pred  Predecessor edge information.
+   * @param  has_traffic  Does the transition have traffic information.
    * @return  Returns the cost and time (seconds)
    */
   virtual Cost TransitionCost(const baldr::DirectedEdge* edge,
                               const baldr::NodeInfo* node,
-                              const EdgeLabel& pred) const;
+                              const EdgeLabel& pred,
+                              const bool has_traffic = false) const;
 
   /**
    * Returns the cost to make the transition from the predecessor edge
@@ -232,12 +234,14 @@ public:
    * @param  node  Node (intersection) where transition occurs.
    * @param  pred  the opposing current edge in the reverse tree.
    * @param  edge  the opposing predecessor in the reverse tree
+   * @param  has_traffic  Does the transition have traffic information.
    * @return  Returns the cost and time (seconds)
    */
   virtual Cost TransitionCostReverse(const uint32_t idx,
                                      const baldr::NodeInfo* node,
                                      const baldr::DirectedEdge* pred,
-                                     const baldr::DirectedEdge* edge) const;
+                                     const baldr::DirectedEdge* edge,
+                                     const bool has_traffic = false) const;
 
   /**
    * Get the cost factor for A* heuristics. This factor is multiplied
@@ -514,7 +518,8 @@ Cost MotorcycleCost::EdgeCost(const baldr::DirectedEdge* edge, const uint32_t sp
 // Returns the time (in seconds) to make the transition from the predecessor
 Cost MotorcycleCost::TransitionCost(const baldr::DirectedEdge* edge,
                                     const baldr::NodeInfo* node,
-                                    const EdgeLabel& pred) const {
+                                    const EdgeLabel& pred,
+                                    const bool has_traffic) const {
   // Accumulate cost and penalty
   float seconds = 0.0f;
   float penalty = 0.0f;
@@ -575,7 +580,8 @@ Cost MotorcycleCost::TransitionCost(const baldr::DirectedEdge* edge,
 Cost MotorcycleCost::TransitionCostReverse(const uint32_t idx,
                                            const baldr::NodeInfo* node,
                                            const baldr::DirectedEdge* pred,
-                                           const baldr::DirectedEdge* edge) const {
+                                           const baldr::DirectedEdge* edge,
+                                           const bool has_traffic) const {
   // Accumulate cost and penalty
   float seconds = 0.0f;
   float penalty = 0.0f;

--- a/src/sif/motorscootercost.cc
+++ b/src/sif/motorscootercost.cc
@@ -260,11 +260,13 @@ public:
    * @param  edge  Directed edge (the to edge)
    * @param  node  Node (intersection) where transition occurs.
    * @param  pred  Predecessor edge information.
+   * @param  has_traffic  Does the transition have traffic information.
    * @return  Returns the cost and time (seconds)
    */
   virtual Cost TransitionCost(const baldr::DirectedEdge* edge,
                               const baldr::NodeInfo* node,
-                              const EdgeLabel& pred) const;
+                              const EdgeLabel& pred,
+                              const bool has_traffic = false) const;
 
   /**
    * Returns the cost to make the transition from the predecessor edge
@@ -273,12 +275,14 @@ public:
    * @param  node  Node (intersection) where transition occurs.
    * @param  pred  the opposing current edge in the reverse tree.
    * @param  edge  the opposing predecessor in the reverse tree
+   * @param  has_traffic  Does the transition have traffic information.
    * @return  Returns the cost and time (seconds)
    */
   virtual Cost TransitionCostReverse(const uint32_t idx,
                                      const baldr::NodeInfo* node,
                                      const baldr::DirectedEdge* pred,
-                                     const baldr::DirectedEdge* edge) const;
+                                     const baldr::DirectedEdge* edge,
+                                     const bool has_traffic = false) const;
 
   /**
    * Get the cost factor for A* heuristics. This factor is multiplied
@@ -532,7 +536,8 @@ Cost MotorScooterCost::EdgeCost(const baldr::DirectedEdge* edge, const uint32_t 
 // Returns the time (in seconds) to make the transition from the predecessor
 Cost MotorScooterCost::TransitionCost(const baldr::DirectedEdge* edge,
                                       const baldr::NodeInfo* node,
-                                      const EdgeLabel& pred) const {
+                                      const EdgeLabel& pred,
+                                      const bool has_traffic) const {
   // Accumulate cost and penalty
   float seconds = 0.0f;
   float penalty = 0.0f;
@@ -588,7 +593,8 @@ Cost MotorScooterCost::TransitionCost(const baldr::DirectedEdge* edge,
 Cost MotorScooterCost::TransitionCostReverse(const uint32_t idx,
                                              const baldr::NodeInfo* node,
                                              const baldr::DirectedEdge* pred,
-                                             const baldr::DirectedEdge* edge) const {
+                                             const baldr::DirectedEdge* edge,
+                                             const bool has_traffic) const {
   // Accumulate cost and penalty
   float seconds = 0.0f;
   float penalty = 0.0f;

--- a/src/sif/pedestriancost.cc
+++ b/src/sif/pedestriancost.cc
@@ -280,11 +280,13 @@ public:
    * @param  edge  Directed edge (the to edge)
    * @param  node  Node (intersection) where transition occurs.
    * @param  pred  Predecessor edge information.
+   * @param  has_traffic  Does the transition have traffic information.
    * @return  Returns the cost and time (seconds)
    */
   virtual Cost TransitionCost(const baldr::DirectedEdge* edge,
                               const baldr::NodeInfo* node,
-                              const EdgeLabel& pred) const;
+                              const EdgeLabel& pred,
+                              const bool has_traffic = false) const;
 
   /**
    * Returns the cost to make the transition from the predecessor edge
@@ -295,12 +297,14 @@ public:
    * @param  node  Node (intersection) where transition occurs.
    * @param  pred  the opposing current edge in the reverse tree.
    * @param  edge  the opposing predecessor in the reverse tree
+   * @param  has_traffic  Does the transition have traffic information.
    * @return  Returns the cost and time (seconds)
    */
   virtual Cost TransitionCostReverse(const uint32_t idx,
                                      const baldr::NodeInfo* node,
                                      const baldr::DirectedEdge* pred,
-                                     const baldr::DirectedEdge* edge) const;
+                                     const baldr::DirectedEdge* edge,
+                                     const bool has_traffic = false) const;
 
   /**
    * Get the cost factor for A* heuristics. This factor is multiplied
@@ -602,7 +606,8 @@ Cost PedestrianCost::EdgeCost(const baldr::DirectedEdge* edge, const uint32_t sp
 // Returns the time (in seconds) to make the transition from the predecessor
 Cost PedestrianCost::TransitionCost(const baldr::DirectedEdge* edge,
                                     const baldr::NodeInfo* node,
-                                    const EdgeLabel& pred) const {
+                                    const EdgeLabel& pred,
+                                    const bool has_traffic) const {
   // Special cases: fixed penalty for steps/stairs
   if (edge->use() == Use::kSteps) {
     return {step_penalty_, 0.0f};
@@ -643,7 +648,8 @@ Cost PedestrianCost::TransitionCost(const baldr::DirectedEdge* edge,
 Cost PedestrianCost::TransitionCostReverse(const uint32_t idx,
                                            const baldr::NodeInfo* node,
                                            const baldr::DirectedEdge* pred,
-                                           const baldr::DirectedEdge* edge) const {
+                                           const baldr::DirectedEdge* edge,
+                                           const bool has_traffic) const {
   // Special cases: fixed penalty for steps/stairs
   if (edge->use() == Use::kSteps) {
     return {step_penalty_, 0.0f};

--- a/src/sif/transitcost.cc
+++ b/src/sif/transitcost.cc
@@ -176,11 +176,13 @@ public:
    * @param  edge  Directed edge (the to edge)
    * @param  node  Node (intersection) where transition occurs.
    * @param  pred  Predecessor edge information.
+   * @param  has_traffic  Does the transition have traffic information.
    * @return  Returns the cost and time (seconds)
    */
   virtual Cost TransitionCost(const baldr::DirectedEdge* edge,
                               const baldr::NodeInfo* node,
-                              const EdgeLabel& pred) const;
+                              const EdgeLabel& pred,
+                              const bool has_traffic = false) const;
 
   /**
    * Returns the transfer cost between 2 transit stops.
@@ -603,7 +605,8 @@ Cost TransitCost::EdgeCost(const baldr::DirectedEdge* edge,
 // Returns the time (in seconds) to make the transition from the predecessor
 Cost TransitCost::TransitionCost(const baldr::DirectedEdge* edge,
                                  const baldr::NodeInfo* node,
-                                 const EdgeLabel& pred) const {
+                                 const EdgeLabel& pred,
+                                 const bool has_traffic) const {
   if (pred.mode() == TravelMode::kPedestrian) {
     // Apply any mode-based penalties when boarding transit
     // Do we want any time cost to board?

--- a/src/sif/truckcost.cc
+++ b/src/sif/truckcost.cc
@@ -203,11 +203,13 @@ public:
    * @param  edge  Directed edge (the to edge)
    * @param  node  Node (intersection) where transition occurs.
    * @param  pred  Predecessor edge information.
+   * @param  has_traffic  Does the transition have traffic information.
    * @return  Returns the cost and time (seconds)
    */
   virtual Cost TransitionCost(const baldr::DirectedEdge* edge,
                               const baldr::NodeInfo* node,
-                              const EdgeLabel& pred) const;
+                              const EdgeLabel& pred,
+                              const bool has_traffic = false) const;
 
   /**
    * Returns the cost to make the transition from the predecessor edge
@@ -216,12 +218,14 @@ public:
    * @param  node  Node (intersection) where transition occurs.
    * @param  pred  the opposing current edge in the reverse tree.
    * @param  edge  the opposing predecessor in the reverse tree
+   * @param  has_traffic  Does the transition have traffic information.
    * @return  Returns the cost and time (seconds)
    */
   virtual Cost TransitionCostReverse(const uint32_t idx,
                                      const baldr::NodeInfo* node,
                                      const baldr::DirectedEdge* pred,
-                                     const baldr::DirectedEdge* edge) const;
+                                     const baldr::DirectedEdge* edge,
+                                     const bool has_traffic = false) const;
 
   /**
    * Get the cost factor for A* heuristics. This factor is multiplied
@@ -527,7 +531,8 @@ Cost TruckCost::EdgeCost(const DirectedEdge* edge, const uint32_t speed) const {
 // Returns the time (in seconds) to make the transition from the predecessor
 Cost TruckCost::TransitionCost(const baldr::DirectedEdge* edge,
                                const baldr::NodeInfo* node,
-                               const EdgeLabel& pred) const {
+                               const EdgeLabel& pred,
+                               const bool has_traffic) const {
   // Accumulate cost and penalty
   float seconds = 0.0f;
   float penalty = 0.0f;
@@ -587,7 +592,8 @@ Cost TruckCost::TransitionCost(const baldr::DirectedEdge* edge,
 Cost TruckCost::TransitionCostReverse(const uint32_t idx,
                                       const baldr::NodeInfo* node,
                                       const baldr::DirectedEdge* pred,
-                                      const baldr::DirectedEdge* edge) const {
+                                      const baldr::DirectedEdge* edge,
+                                      const bool has_traffic) const {
   // Accumulate cost and penalty
   float seconds = 0.0f;
   float penalty = 0.0f;

--- a/src/thor/timedep_forward.cc
+++ b/src/thor/timedep_forward.cc
@@ -105,11 +105,12 @@ void TimeDepForward::ExpandForward(GraphReader& graphreader,
       continue;
     }
 
-    // Compute the cost to the end of this edge
+    // Compute the cost to the end of this edge. Transition cost will vary based on whether
+    // there is traffic information.
     Cost newcost =
         pred.cost() +
         costing_->EdgeCost(directededge, tile->GetSpeed(directededge, edgeid, seconds_of_week)) +
-        costing_->TransitionCost(directededge, nodeinfo, pred);
+        costing_->TransitionCost(directededge, nodeinfo, pred, directededge->predicted_speed());
 
     // If this edge is a destination, subtract the partial/remainder cost
     // (cost from the dest. location to the end of the edge).

--- a/valhalla/sif/costconstants.h
+++ b/valhalla/sif/costconstants.h
@@ -4,6 +4,12 @@
 namespace valhalla {
 namespace sif {
 
+// Transition factor to use when traffic data is available. This multiplies the
+// turn cost * stop impact (rather than using the density factor). When traffic
+// is available, the edge speeds account for some of the intersection costing
+// due to deceleration and acceleration into and out of an intersection.
+const float kTrafficTransitionFactor = 0.25f;
+
 // Travel modes
 enum class TravelMode : uint8_t {
   kDrive = 0,

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -202,11 +202,13 @@ public:
    * @param   edge  Directed edge (the to edge)
    * @param   node  Node (intersection) where transition occurs.
    * @param   pred  Predecessor edge information.
+   * @param   has_traffic  Does the transition have traffic information.
    * @return  Returns the cost and time (seconds)
    */
   virtual Cost TransitionCost(const baldr::DirectedEdge* edge,
                               const baldr::NodeInfo* node,
-                              const EdgeLabel& pred) const;
+                              const EdgeLabel& pred,
+                              const bool has_traffic = false) const;
 
   /**
    * Returns the cost to make the transition from the predecessor edge
@@ -219,12 +221,14 @@ public:
    *                   "from" or predecessor edge in the transition.
    * @param  opp_pred_edge  Pointer to the opposing directed edge to the
    *                        predecessor. This is the "to" edge.
+   * @param   has_traffic  Does the transition have traffic information.
    * @return  Returns the cost and time (seconds)
    */
   virtual Cost TransitionCostReverse(const uint32_t idx,
                                      const baldr::NodeInfo* node,
                                      const baldr::DirectedEdge* opp_edge,
-                                     const baldr::DirectedEdge* opp_pred_edge) const;
+                                     const baldr::DirectedEdge* opp_pred_edge,
+                                     const bool has_traffic = false) const;
 
   /**
    * Test if an edge should be restricted due to a complex restriction.
@@ -498,6 +502,17 @@ protected:
 
   // User specified edges to avoid
   std::unordered_set<baldr::GraphId> user_avoid_edges_;
+
+  /**
+   * Convenience method to get the transition factor.
+   * @param has_traffic Does the intersection have traffic information? Currently
+   *                    is based on the exiting edge. TODO - determine if we also
+   *                    need this info on the predecessor.
+   * @param density_factor Density factor.
+   */
+  float TransitionFactor(const bool has_traffic, const float density) const {
+    return has_traffic ? kTrafficTransitionFactor : density;
+  }
 };
 
 typedef std::shared_ptr<DynamicCost> cost_ptr_t;


### PR DESCRIPTION
This defaults to false. For time dependent routes where traffic is available at an intersection we want
to lower the influence of transition costs (especially when computing estimated time to traverse the intersection). This change allows future use within all costing models that need to be influenced by traffic, but for now only time dependent, depart-at routes are set to use this flag.

 - [ ] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)