### PR TITLE
Set has_traffic flag (for transition costs) 

### DIFF
--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -543,16 +543,14 @@ Cost AutoCost::TransitionCost(const baldr::DirectedEdge* edge,
                       ? kRightSideTurnCosts[static_cast<uint32_t>(edge->turntype(idx))]
                       : kLeftSideTurnCosts[static_cast<uint32_t>(edge->turntype(idx))];
     }
-    turn_cost *= edge->stopimpact(idx);
 
-    // Separate time and penalty if using predicted speeds. Even when we reduce time
-    // for a particular turn we still may want to have slight penalties to help avoid
-    // unfavorable turns).
+    // Separate time and penalty when traffic is present. With traffic, edge speeds account for
+    // much of the intersection transition time (TODO - evaluate different elapsed time settings).
+    // Still want to add a penalty so routes avoid high cost intersections.
     if (has_traffic) {
-      seconds += kTrafficTransitionFactor * turn_cost;
-      penalty += (trans_density_factor_[node->density()] - kTrafficTransitionFactor) * turn_cost;
+      penalty += turn_cost * edge->stopimpact(idx);
     } else {
-      seconds += trans_density_factor_[node->density()] * turn_cost;
+      seconds += trans_density_factor_[node->density()] * turn_cost * edge->stopimpact(idx);
     }
   }
 

--- a/src/thor/isochrone.cc
+++ b/src/thor/isochrone.cc
@@ -257,6 +257,7 @@ void Isochrone::ExpandForward(GraphReader& graphreader,
 
     // Check if the edge is allowed or if a restriction occurs. Get the edge speed.
     uint32_t speed;
+    bool has_traffic = directededge->predicted_speed() || directededge->constrained_flow_speed() > 0;
     if (has_date_time_) {
       // With date time we check time dependent restrictions and access as well as get
       // traffic based speed if it exists
@@ -277,7 +278,7 @@ void Isochrone::ExpandForward(GraphReader& graphreader,
     // Compute the cost to the end of this edge
     Cost newcost =
         pred.cost() + costing_->EdgeCost(directededge, speed) +
-        costing_->TransitionCost(directededge, nodeinfo, pred, directededge->predicted_speed());
+        costing_->TransitionCost(directededge, nodeinfo, pred, has_traffic);
 
     // Check if edge is temporarily labeled and this path has less cost. If
     // less cost the predecessor is updated and the sort cost is decremented
@@ -474,8 +475,9 @@ void Isochrone::ExpandReverse(GraphReader& graphreader,
     }
 
     // Compute the cost to the end of this edge with separate transition cost
+    bool has_traffic = opp_pred_edge->predicted_speed() || opp_pred_edge->constrained_flow_speed() > 0;
     Cost tc = costing_->TransitionCostReverse(directededge->localedgeidx(), nodeinfo, opp_edge,
-                                              opp_pred_edge, opp_edge->predicted_speed());
+                                              opp_pred_edge, has_traffic);
     Cost newcost = pred.cost() + costing_->EdgeCost(opp_edge, speed);
     newcost.cost += tc.cost;
 

--- a/src/thor/isochrone.cc
+++ b/src/thor/isochrone.cc
@@ -276,9 +276,8 @@ void Isochrone::ExpandForward(GraphReader& graphreader,
     }
 
     // Compute the cost to the end of this edge
-    Cost newcost =
-        pred.cost() + costing_->EdgeCost(directededge, speed) +
-        costing_->TransitionCost(directededge, nodeinfo, pred, has_traffic);
+    Cost newcost = pred.cost() + costing_->EdgeCost(directededge, speed) +
+                   costing_->TransitionCost(directededge, nodeinfo, pred, has_traffic);
 
     // Check if edge is temporarily labeled and this path has less cost. If
     // less cost the predecessor is updated and the sort cost is decremented
@@ -475,7 +474,8 @@ void Isochrone::ExpandReverse(GraphReader& graphreader,
     }
 
     // Compute the cost to the end of this edge with separate transition cost
-    bool has_traffic = opp_pred_edge->predicted_speed() || opp_pred_edge->constrained_flow_speed() > 0;
+    bool has_traffic =
+        opp_pred_edge->predicted_speed() || opp_pred_edge->constrained_flow_speed() > 0;
     Cost tc = costing_->TransitionCostReverse(directededge->localedgeidx(), nodeinfo, opp_edge,
                                               opp_pred_edge, has_traffic);
     Cost newcost = pred.cost() + costing_->EdgeCost(opp_edge, speed);

--- a/src/thor/timedep_forward.cc
+++ b/src/thor/timedep_forward.cc
@@ -107,10 +107,11 @@ void TimeDepForward::ExpandForward(GraphReader& graphreader,
 
     // Compute the cost to the end of this edge. Transition cost will vary based on whether
     // there is traffic information.
+    bool has_traffic = directededge->predicted_speed() || directededge->constrained_flow_speed() > 0;
     Cost newcost =
         pred.cost() +
         costing_->EdgeCost(directededge, tile->GetSpeed(directededge, edgeid, seconds_of_week)) +
-        costing_->TransitionCost(directededge, nodeinfo, pred, directededge->predicted_speed());
+        costing_->TransitionCost(directededge, nodeinfo, pred, has_traffic);
 
     // If this edge is a destination, subtract the partial/remainder cost
     // (cost from the dest. location to the end of the edge).

--- a/src/thor/timedep_reverse.cc
+++ b/src/thor/timedep_reverse.cc
@@ -148,7 +148,8 @@ void TimeDepReverse::ExpandReverse(GraphReader& graphreader,
       continue;
     }
 
-    bool has_traffic = opp_pred_edge->predicted_speed() || opp_pred_edge->constrained_flow_speed() > 0;
+    bool has_traffic =
+        opp_pred_edge->predicted_speed() || opp_pred_edge->constrained_flow_speed() > 0;
     Cost tc = costing_->TransitionCostReverse(directededge->localedgeidx(), nodeinfo, opp_edge,
                                               opp_pred_edge, has_traffic);
     Cost newcost = pred.cost() +

--- a/src/thor/timedep_reverse.cc
+++ b/src/thor/timedep_reverse.cc
@@ -148,8 +148,9 @@ void TimeDepReverse::ExpandReverse(GraphReader& graphreader,
       continue;
     }
 
+    bool has_traffic = opp_pred_edge->predicted_speed() || opp_pred_edge->constrained_flow_speed() > 0;
     Cost tc = costing_->TransitionCostReverse(directededge->localedgeidx(), nodeinfo, opp_edge,
-                                              opp_pred_edge, opp_pred_edge->predicted_speed());
+                                              opp_pred_edge, has_traffic);
     Cost newcost = pred.cost() +
                    costing_->EdgeCost(opp_edge, t2->GetSpeed(directededge, edgeid, seconds_of_week));
     newcost.cost += tc.cost;


### PR DESCRIPTION
if the edge has either predictive speed or constrained flow speed. Transition costs were too high when edges had free flow or constrained flow speeds.