### PR TITLE
step name is always present, step ref is always optional

### DIFF
--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -772,7 +772,7 @@ json::ArrayPtr serialize_legs(const std::list<valhalla::odin::TripDirections>& l
 
       bool arrive = (index == leg.maneuver().size() - 1);
       bool depart = (index == 0);
-      // Add street names and refs even if they are empty strings
+      // Add street names and refs. Names get added even if empty
       auto nr = names_and_refs(maneuver, path_leg);
       step->emplace("name", nr.first);
       if (depart) {

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -788,7 +788,7 @@ json::ArrayPtr serialize_legs(const std::list<valhalla::odin::TripDirections>& l
       // if arrive use prev name ref
       if (arrive) {
         step->emplace("name", prev_name);
-        if(!prev_ref.empty())
+        if (!prev_ref.empty())
           step->emplace("ref", prev_ref);
       }
 

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -778,9 +778,11 @@ json::ArrayPtr serialize_legs(const std::list<valhalla::odin::TripDirections>& l
       if (depart) {
         prev_name = nr.first;
       }
-      step->emplace("ref", nr.second);
-      if (depart) {
-        prev_ref = nr.second;
+      if (!nr.second.empty()) {
+        step->emplace("ref", nr.second);
+        if (depart) {
+          prev_ref = nr.second;
+        }
       }
 
       // if arrive use prev name ref

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -772,19 +772,15 @@ json::ArrayPtr serialize_legs(const std::list<valhalla::odin::TripDirections>& l
 
       bool arrive = (index == leg.maneuver().size() - 1);
       bool depart = (index == 0);
-      // Add street names and refs
+      // Add street names and refs even if they are empty strings
       auto nr = names_and_refs(maneuver, path_leg);
-      if (!nr.first.empty()) {
-        step->emplace("name", nr.first);
-        if (depart) {
-          prev_name = nr.first;
-        }
+      step->emplace("name", nr.first);
+      if (depart) {
+        prev_name = nr.first;
       }
-      if (!nr.second.empty()) {
-        step->emplace("ref", nr.second);
-        if (depart) {
-          prev_ref = nr.second;
-        }
+      step->emplace("ref", nr.second);
+      if (depart) {
+        prev_ref = nr.second;
       }
 
       // if arrive use prev name ref

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -788,7 +788,8 @@ json::ArrayPtr serialize_legs(const std::list<valhalla::odin::TripDirections>& l
       // if arrive use prev name ref
       if (arrive) {
         step->emplace("name", prev_name);
-        step->emplace("ref", prev_ref);
+        if(!prev_ref.empty())
+          step->emplace("ref", prev_ref);
       }
 
       // Record street name and distance.. TODO - need to also worry about order

--- a/test/mapmatch.cc
+++ b/test/mapmatch.cc
@@ -117,7 +117,7 @@ std::string json_escape(const std::string& unescaped) {
 int seed = 973;
 int bound = 81;
 std::string make_test_case(PointLL& start, PointLL& end) {
-  static std::default_random_engine generator(seed);
+  static std::minstd_rand0 generator(seed);
   static std::uniform_real_distribution<float> distribution(0, 1);
   float distance = 0;
   do {

--- a/test/mapmatch.cc
+++ b/test/mapmatch.cc
@@ -114,7 +114,7 @@ std::string json_escape(const std::string& unescaped) {
   return escaped;
 }
 
-int seed = 973;
+int seed = 520;
 int bound = 81;
 std::string make_test_case(PointLL& start, PointLL& end) {
   static std::minstd_rand0 generator(seed);


### PR DESCRIPTION
osrm compatibility mode leaves out names and refs that are empty string. this is not the behavior of the software we are emulating. there, a name is present even if its an empty string.