### PR TITLE
refactor name ref setting stuff again

### DIFF
--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -770,27 +770,31 @@ json::ArrayPtr serialize_legs(const std::list<valhalla::odin::TripDirections>& l
       step->emplace("weight", json::fp_t{duration, 1});
       step->emplace("distance", json::fp_t{distance, 1});
 
-      bool arrive = (index == leg.maneuver().size() - 1);
-      bool depart = (index == 0);
       // Add street names and refs. Names get added even if empty
+      bool depart = (index == 0);
+      bool arrive = (index == leg.maneuver().size() - 1);
       auto nr = names_and_refs(maneuver, path_leg);
-      step->emplace("name", nr.first);
+
+      // We dont have previous stuff yet so we just take what we have now
       if (depart) {
         prev_name = nr.first;
-      }
-      if (!nr.second.empty()) {
-        step->emplace("ref", nr.second);
-        if (depart) {
-          prev_ref = nr.second;
-        }
+        prev_ref = nr.second;
       }
 
-      // if arrive use prev name ref
+      // Arrival step uses previous names
       if (arrive) {
         step->emplace("name", prev_name);
         if (!prev_ref.empty())
           step->emplace("ref", prev_ref);
+      } else {
+        step->emplace("name", nr.first);
+        if (!nr.second.empty())
+          step->emplace("ref", nr.second);
       }
+
+      // Save these for the next round
+      prev_name = nr.first;
+      prev_ref = nr.second;
 
       // Record street name and distance.. TODO - need to also worry about order
       if (maneuver.street_name().size() > 0) {
@@ -802,9 +806,6 @@ json::ArrayPtr serialize_legs(const std::list<valhalla::odin::TripDirections>& l
           man->second += distance;
         }
       }
-
-      prev_name = nr.first;
-      prev_ref = nr.second;
 
       // Add OSRM maneuver
       step->emplace("maneuver", osrm_maneuver(maneuver, path_leg, shape[maneuver.begin_shape_index()],


### PR DESCRIPTION
last pr wasnt quite right. the arrival step didnt always get set. heres the succinct refactor to make this work properly:

```c++
      // Add street names and refs. Names get added even if empty
      bool depart = (index == 0);
      bool arrive = (index == leg.maneuver().size() - 1);
      auto nr = names_and_refs(maneuver, path_leg);

      // We dont have previous stuff yet so we just take what we have now
      if (depart) {
        prev_name = nr.first;
        prev_ref = nr.second;
      }

      // Arrival step uses previous names
      if (arrive) {
        step->emplace("name", prev_name);
        if (!prev_ref.empty())
          step->emplace("ref", prev_ref);
      } else {
        step->emplace("name", nr.first);
        if (!nr.second.empty())
          step->emplace("ref", nr.second);
      }

      // Save these for the next round
      prev_name = nr.first;
      prev_ref = nr.second;
```