### PR TITLE
Fixes the ramp turn modifiers for osrm compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Release Date: TBD
+* **Bug Fix**
+   * FIXED: Fixed the ramp turn modifiers for osrm compat [#1569](https://github.com/valhalla/valhalla/pull/1569)
+
 ## Release Date: 2018-10-02 Valhalla 2.7.1
 * **Enhancement**
    * UPDATED: Added date time support to forward and reverse isochrones. Add speed lookup (predicted speeds and/or free-flow or constrained flow speed) if date_time is present.

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -423,7 +423,6 @@ std::string destinations(const valhalla::odin::TripDirections::Maneuver& maneuve
 
 // Get the turn modifier based on incoming edge bearing and outgoing edge
 // bearing.
-// TODO - resolve differences between OSRM turn modifiers and Valhalla turn degrees.
 std::string turn_modifier(const uint32_t in_brg, const uint32_t out_brg) {
   auto turn_degree = GetTurnDegree(in_brg, out_brg);
   auto turn_type = Turn::GetType(turn_degree);
@@ -444,6 +443,59 @@ std::string turn_modifier(const uint32_t in_brg, const uint32_t out_brg) {
       return "left";
     case baldr::Turn::Type::kSlightLeft:
       return "slight left";
+  }
+}
+
+// Get the turn modifier based on the maneuver type
+// or if needed, the incoming edge bearing and outgoing edge bearing.
+std::string turn_modifier(const valhalla::odin::TripDirections::Maneuver& maneuver,
+                          const uint32_t in_brg,
+                          const uint32_t out_brg) {
+  switch (maneuver.type()) {
+    case valhalla::odin::TripDirections_Maneuver_Type_kStart:
+    case valhalla::odin::TripDirections_Maneuver_Type_kDestination:
+      return "";
+    case valhalla::odin::TripDirections_Maneuver_Type_kSlightRight:
+    case valhalla::odin::TripDirections_Maneuver_Type_kStayRight:
+    case valhalla::odin::TripDirections_Maneuver_Type_kExitRight:
+      return "slight right";
+    case valhalla::odin::TripDirections_Maneuver_Type_kRight:
+    case valhalla::odin::TripDirections_Maneuver_Type_kStartRight:
+    case valhalla::odin::TripDirections_Maneuver_Type_kDestinationRight:
+      return "right";
+    case valhalla::odin::TripDirections_Maneuver_Type_kSharpRight:
+      return "sharp right";
+    case valhalla::odin::TripDirections_Maneuver_Type_kUturnRight:
+    case valhalla::odin::TripDirections_Maneuver_Type_kUturnLeft:
+      return "uturn";
+    case valhalla::odin::TripDirections_Maneuver_Type_kSharpLeft:
+      return "sharp left";
+    case valhalla::odin::TripDirections_Maneuver_Type_kLeft:
+    case valhalla::odin::TripDirections_Maneuver_Type_kStartLeft:
+    case valhalla::odin::TripDirections_Maneuver_Type_kDestinationLeft:
+      return "left";
+    case valhalla::odin::TripDirections_Maneuver_Type_kSlightLeft:
+    case valhalla::odin::TripDirections_Maneuver_Type_kExitLeft:
+    case valhalla::odin::TripDirections_Maneuver_Type_kStayLeft:
+      return "slight left";
+    case valhalla::odin::TripDirections_Maneuver_Type_kRampRight:
+      if (Turn::GetType(GetTurnDegree(in_brg, out_brg)) == baldr::Turn::Type::kRight)
+        return "right";
+      else
+        return "slight right";
+    case valhalla::odin::TripDirections_Maneuver_Type_kRampLeft:
+      if (Turn::GetType(GetTurnDegree(in_brg, out_brg)) == baldr::Turn::Type::kLeft)
+        return "left";
+      else
+        return "slight left";
+    case valhalla::odin::TripDirections_Maneuver_Type_kMerge:
+    case valhalla::odin::TripDirections_Maneuver_Type_kRoundaboutEnter:
+    case valhalla::odin::TripDirections_Maneuver_Type_kRoundaboutExit:
+    case valhalla::odin::TripDirections_Maneuver_Type_kFerryEnter:
+    case valhalla::odin::TripDirections_Maneuver_Type_kFerryExit:
+      return turn_modifier(in_brg, out_brg);
+    default:
+      return "straight";
   }
 }
 
@@ -498,8 +550,9 @@ json::MapPtr osrm_maneuver(const valhalla::odin::TripDirections::Maneuver& maneu
 
   std::string modifier;
   if (!depart) {
-    modifier = turn_modifier(in_brg, out_brg);
-    osrm_man->emplace("modifier", modifier);
+    modifier = turn_modifier(maneuver, in_brg, out_brg);
+    if (!modifier.empty())
+      osrm_man->emplace("modifier", modifier);
   }
 
   // TODO - logic to convert maneuver types from Valhalla into OSRM maneuver types.
@@ -915,5 +968,6 @@ std::string serialize(const valhalla::odin::DirectionsOptions& directions_option
   ss << *json;
   return ss.str();
 }
+
 } // namespace osrm_serializers
 } // namespace


### PR DESCRIPTION
# Issue

The ramp turn modifiers were not being assigned properly within the osrm compat mode. Here are the before and after examples:

### OnRamp BEFORE modifier incorrect
![322_on_ramp_valhalla_osrm_compat](https://user-images.githubusercontent.com/7515853/46556092-9340d180-c8b3-11e8-9883-a77cc83d7bd7.png)

### OnRamp AFTER modifier is correct
![322_on_ramp_valhalla_osrm_compat_fixed](https://user-images.githubusercontent.com/7515853/46556095-976cef00-c8b3-11e8-8e6b-d69b578d427d.png)

----
### OffRamp BEFORE modifier incorrect
![322_off_ramp_valhalla_osrm_compat](https://user-images.githubusercontent.com/7515853/46556102-9b990c80-c8b3-11e8-9ba5-5fd144664ea7.png)

### OffRamp AFTER modifier is correct
![322_off_ramp_valhalla_osrm_compat_fixed](https://user-images.githubusercontent.com/7515853/46556106-9fc52a00-c8b3-11e8-97d0-ccf18a799b51.png)

----
## Tasklist

 - [x] Review - you must request approval to merge any PR to master
 - [x] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)
