### PR TITLE
The last shape point for each step geometry was missing when using the OSRM compat mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Release Date: TBD
 * **Bug Fix**
    * FIXED: Fixed the ramp turn modifiers for osrm compat [#1569](https://github.com/valhalla/valhalla/pull/1569)
+   * FIXED: Fixed the step geometry when using the osrm compat mode [#1571](https://github.com/valhalla/valhalla/pull/1571)
 
 ## Release Date: 2018-10-02 Valhalla 2.7.1
 * **Enhancement**

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -659,7 +659,8 @@ json::MapPtr osrm_maneuver(const valhalla::odin::TripDirections::Maneuver& maneu
 std::string maneuver_geometry(const uint32_t begin_idx,
                               const uint32_t end_idx,
                               const std::vector<PointLL>& shape) {
-  std::vector<PointLL> maneuver_shape(shape.begin() + begin_idx, shape.begin() + end_idx);
+  // Must add one to the end range since it is exclusive
+  std::vector<PointLL> maneuver_shape(shape.begin() + begin_idx, shape.begin() + end_idx + 1);
   return std::string(midgard::encode(maneuver_shape));
 }
 


### PR DESCRIPTION
# Issue
The last shape point for each step geometry is missing when using the OSRM compat mode.
Update the logic to include all of the shape points for each step.
The `arrive step` will have a single point - as expected

## Tasklist

 - [x] Review - you must request approval to merge any PR to master
 - [x] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)
