### PR TITLE
Multimodal isochrones now use an ExpandForward method

### DIFF
--- a/valhalla/thor/isochrone.h
+++ b/valhalla/thor/isochrone.h
@@ -97,6 +97,19 @@ protected:
   sif::TravelMode mode_; // Current travel mode
   uint32_t access_mode_; // Access mode used by the costing method
 
+  // For multimodal isochrones
+  bool date_set_;
+  bool date_before_tile_;
+  uint32_t date_;
+  uint32_t dow_;
+  uint32_t day_;
+  uint32_t start_time_;
+  uint32_t max_seconds_;
+  uint32_t max_transfer_distance_;
+  std::string origin_date_time_;
+  std::unordered_map<std::string, uint32_t> operators_;
+  std::unordered_set<uint32_t> processed_tiles_;
+
   // Current costing mode
   std::shared_ptr<sif::DynamicCost> costing_;
 
@@ -183,6 +196,27 @@ protected:
                      const bool from_transition,
                      uint64_t localtime,
                      int32_t seconds_of_week);
+
+  /**
+   * Expand from the node using multimodal algorithm.
+   * @param graphreader  Graph reader.
+   * @param node Graph Id of the node to expand.
+   * @param pred Edge label of the predecessor edge leading to the node.
+   * @param pred_idx Index in the edge label list of the predecessor edge.
+   * @param from_transition Boolean indicating if this expansion is from a transition edge.
+   * @param pc Pedestrian costing.
+   * @param tc Transit costing.
+   * @param mode_costing Array of all costing models.
+   * @return Returns true if the isochrone is done.
+   */
+  bool ExpandForwardMM(baldr::GraphReader& graphreader,
+                       const baldr::GraphId& node,
+                       const sif::MMEdgeLabel& pred,
+                       const uint32_t pred_idx,
+                       const bool from_transition,
+                       const std::shared_ptr<sif::DynamicCost>& pc,
+                       const std::shared_ptr<sif::DynamicCost>& tc,
+                       const std::shared_ptr<sif::DynamicCost>* mode_costing);
 
   /**
    * Updates the isotile using the edge information from the predecessor edge


### PR DESCRIPTION
Remove addition of transition edges to priority queue / adjacency list. Add an ExpandForwardMM method that is called for multimodal isochrones. This uses a similar pattern to other Expand* methods in thor. However, multimodal methods have several extra variables that need to be maintained - these now become class member variables to avoid having to pass them through methods. The ExpandForwardMM seems too long to be a lambda.

This partially addresses #1560 (leaving only the main multimodal path algorithm).