### PR TITLE
Add max_timedep_distance config variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Release Date: TBD
+* **Enhancement**
+   * UPDATED: Added a configuration variable for max_timedep_distance. This is used in selecting the path algorithm and provides the maximum distance between locations when choosing a time dependent path algorithm (other than multi modal). Above this distance, bidirectional A* is used with no time dependencies.
 * **Bug Fix**
    * FIXED: Fixed the ramp turn modifiers for osrm compat [#1569](https://github.com/valhalla/valhalla/pull/1569)
    * FIXED: Fixed the step geometry when using the osrm compat mode [#1571](https://github.com/valhalla/valhalla/pull/1571)

--- a/scripts/valhalla_build_config
+++ b/scripts/valhalla_build_config
@@ -207,7 +207,8 @@ config = {
     },
     'max_avoid_locations': 50,
     'max_reachability': 100,
-    'max_radius': 200
+    'max_radius': 200,
+    'max_timedep_distance': 500000
   }
 }
 
@@ -413,7 +414,8 @@ help_text = {
     },
     'max_avoid_locations': 'Maximum number of avoid locations to allow in request',
     'max_reachability': 'Maximum reachability (number of nodes reachable) allowed on any one location',
-    'max_radius': 'Maximum radius in meters allowed on any one location'
+    'max_radius': 'Maximum radius in meters allowed on any one location',
+    'max_timedep_distance': 'Maximum b-line distance between locations to allow a time-dependent route'
   }
 }
 

--- a/src/loki/worker.cc
+++ b/src/loki/worker.cc
@@ -155,7 +155,7 @@ loki_worker_t::loki_worker_t(const boost::property_tree::ptree& config,
   // Build max_locations and max_distance maps
   for (const auto& kv : config.get_child("service_limits")) {
     if (kv.first == "max_avoid_locations" || kv.first == "max_reachability" ||
-        kv.first == "max_radius") {
+        kv.first == "max_radius" || kv.first == "max_timedep_distance") {
       continue;
     }
     if (kv.first != "skadi" && kv.first != "trace") {

--- a/src/thor/route_action.cc
+++ b/src/thor/route_action.cc
@@ -20,12 +20,6 @@ using namespace valhalla::thor;
 namespace valhalla {
 namespace thor {
 
-// Maximum distance allowed for time dependent routes. Since these use
-// single direction A* there may be performance issues allowing very long
-// routes. Also, for long routes the accuracy of predicted time along the
-// route starts to become suspect (due to user breaks and other factors).
-constexpr float kMaxTimeDependentDistance = 500000.0f; // 500 km
-
 // Threshold for running a second pass pedestrian route with adjusted A*. The first
 // pass for pedestrian routes is run with an aggressive A* threshold based on walking
 // speed. If ferries are included in the path the A* heuristic rules can be violated
@@ -63,7 +57,7 @@ thor::PathAlgorithm* thor_worker_t::get_path_algorithm(const std::string& routet
   if (origin.has_date_time()) {
     PointLL ll1(origin.ll().lng(), origin.ll().lat());
     PointLL ll2(destination.ll().lng(), destination.ll().lat());
-    if (ll1.Distance(ll2) < kMaxTimeDependentDistance) {
+    if (ll1.Distance(ll2) < max_timedep_distance) {
       timedep_forward.set_interrupt(interrupt);
       return &timedep_forward;
     }
@@ -74,7 +68,7 @@ thor::PathAlgorithm* thor_worker_t::get_path_algorithm(const std::string& routet
   if (destination.has_date_time()) {
     PointLL ll1(origin.ll().lng(), origin.ll().lat());
     PointLL ll2(destination.ll().lng(), destination.ll().lat());
-    if (ll1.Distance(ll2) < kMaxTimeDependentDistance) {
+    if (ll1.Distance(ll2) < max_timedep_distance) {
       timedep_reverse.set_interrupt(interrupt);
       return &timedep_reverse;
     }

--- a/src/thor/timedep_forward.cc
+++ b/src/thor/timedep_forward.cc
@@ -67,7 +67,6 @@ void TimeDepForward::ExpandForward(GraphReader& graphreader,
   }
 
   // Expand from end node.
-  uint32_t max_shortcut_length = static_cast<uint32_t>(pred.distance() * 0.5f);
   GraphId edgeid(node.tileid(), node.level(), nodeinfo->edge_index());
   EdgeStatusInfo* es = edgestatus_.GetPtr(edgeid, tile);
   const DirectedEdge* directededge = tile->directededge(nodeinfo->edge_index());

--- a/src/thor/timedep_reverse.cc
+++ b/src/thor/timedep_reverse.cc
@@ -96,7 +96,6 @@ void TimeDepReverse::ExpandReverse(GraphReader& graphreader,
   }
 
   // Expand from end node.
-  uint32_t max_shortcut_length = static_cast<uint32_t>(pred.distance() * 0.5f);
   GraphId edgeid(node.tileid(), node.level(), nodeinfo->edge_index());
   EdgeStatusInfo* es = edgestatus_.GetPtr(edgeid, tile);
   const DirectedEdge* directededge = tile->directededge(nodeinfo->edge_index());

--- a/src/thor/worker.cc
+++ b/src/thor/worker.cc
@@ -25,7 +25,7 @@ using namespace valhalla::thor;
 
 namespace {
 
-// Maximum distance allowed for time dependent routes. Since these use
+// Default maximum distance allowed for time dependent routes. Since these use
 // single direction A* there may be performance issues allowing very long
 // routes. Also, for long routes the accuracy of predicted time along the
 // route starts to become suspect (due to user breaks and other factors).
@@ -86,7 +86,8 @@ thor_worker_t::thor_worker_t(const boost::property_tree::ptree& config,
     source_to_target_algorithm = SELECT_OPTIMAL;
   }
 
-  max_timedep_distance = config.get<float>("service_limits.max_timedep_distance", kDefaultMaxTimeDependentDistance);
+  max_timedep_distance =
+      config.get<float>("service_limits.max_timedep_distance", kDefaultMaxTimeDependentDistance);
 }
 
 thor_worker_t::~thor_worker_t() {

--- a/src/valhalla_run_route.cc
+++ b/src/valhalla_run_route.cc
@@ -49,6 +49,10 @@ using namespace valhalla::meili;
 namespace bpo = boost::program_options;
 
 namespace {
+
+// Default maximum distance between locations to choose a time dependent path algorithm
+const float kDefaultMaxTimeDependentDistance = 500000.0f;
+
 class PathStatistics {
   std::pair<float, float> origin;
   std::pair<float, float> destination;
@@ -526,6 +530,10 @@ int main(int argc, char* argv[]) {
   // Get something we can use to fetch tiles
   valhalla::baldr::GraphReader reader(pt.get_child("mjolnir"));
 
+  // Get the maximum distance for time dependent routes
+  float max_timedep_distance =
+      pt.get<float>("service_limits.max_timedep_distance", kDefaultMaxTimeDependentDistance);
+
   auto t0 = std::chrono::high_resolution_clock::now();
 
   // Construct costing
@@ -577,6 +585,9 @@ int main(int argc, char* argv[]) {
     valhalla::odin::Location origin = directions_options.locations(i);
     valhalla::odin::Location dest = directions_options.locations(i + 1);
 
+    PointLL ll1(origin.ll().lng(), origin.ll().lat());
+    PointLL ll2(dest.ll().lng(), dest.ll().lat());
+
     // Choose path algorithm
     PathAlgorithm* pathalgorithm;
     if (routetype == "multimodal") {
@@ -585,11 +596,12 @@ int main(int argc, char* argv[]) {
       // Use time dependent algorithms if date time is present
       // TODO - this isn't really correct for multipoint routes but should allow
       // simple testing.
-      if (directions_options.has_date_time() &&
+      if (directions_options.has_date_time() && ll1.Distance(ll2) < max_timedep_distance &&
           (directions_options.date_time_type() == DirectionsOptions_DateTimeType_depart_at ||
            directions_options.date_time_type() == DirectionsOptions_DateTimeType_current)) {
         pathalgorithm = &timedep_forward;
-      } else if (directions_options.date_time_type() == DirectionsOptions_DateTimeType_arrive_by) {
+      } else if (directions_options.date_time_type() == DirectionsOptions_DateTimeType_arrive_by &&
+                 ll1.Distance(ll2) < max_timedep_distance) {
         pathalgorithm = &timedep_reverse;
       } else {
         // Use bidirectional except for possible trivial cases

--- a/valhalla/midgard/openlr.h
+++ b/valhalla/midgard/openlr.h
@@ -206,7 +206,7 @@ struct LineLocation {
     append3(decimal2integer(longitude));
     append3(decimal2integer(latitude));
     result.push_back(((first.frc & 0x7) << 3) | (first.fow & 0x7));
-    result.push_back(((first.lfrcnp & 0x7) << 5) | bearing2integer(first.bearing) & 0x1f);
+    result.push_back(((first.lfrcnp & 0x7) << 5) | (bearing2integer(first.bearing) & 0x1f));
     result.push_back(distance2integer(first.distance));
 
     for (const auto& lrp : intermediate) {
@@ -214,7 +214,7 @@ struct LineLocation {
       append2(static_cast<std::int32_t>(std::round(100000 * (lrp.longitude - longitude))));
       append2(static_cast<std::int32_t>(std::round(100000 * (lrp.latitude - latitude))));
       result.push_back(((lrp.frc & 0x7) << 3) | (lrp.fow & 0x7));
-      result.push_back(((lrp.lfrcnp & 0x7) << 5) | bearing2integer(lrp.bearing) & 0x1f);
+      result.push_back(((lrp.lfrcnp & 0x7) << 5) | (bearing2integer(lrp.bearing) & 0x1f));
       result.push_back(distance2integer(lrp.distance));
 
       longitude = lrp.longitude;
@@ -227,7 +227,7 @@ struct LineLocation {
     append2(static_cast<std::int32_t>(std::round(100000 * (last.longitude - longitude))));
     append2(static_cast<std::int32_t>(std::round(100000 * (last.latitude - latitude))));
     result.push_back(((last.frc & 0x7) << 3) | (last.fow & 0x7));
-    result.push_back((pofff << 6) | (nofff << 5) | bearing2integer(last.bearing) & 0x1f);
+    result.push_back((pofff << 6) | (nofff << 5) | (bearing2integer(last.bearing) & 0x1f));
 
     // Offsets
     if (pofff) {

--- a/valhalla/thor/worker.h
+++ b/valhalla/thor/worker.h
@@ -97,6 +97,7 @@ protected:
   Isochrone isochrone_gen;
   std::shared_ptr<meili::MapMatcher> matcher;
   float long_request;
+  float max_timedep_distance;
   std::unordered_map<std::string, float> max_matrix_distance;
   SOURCE_TO_TARGET_ALGORITHM source_to_target_algorithm;
   meili::MapMatcherFactory matcher_factory;


### PR DESCRIPTION
Add max_timedep_distance for time dependent (not multi-modal) routes to config file. Added to the script that generates the config file. This variable is used to select the path algorithm when a date_time is provided - above this configured distance bidirectional A* is used. This replaces a constant variable to now allow configuration changes rather than code changes when increasing or decreasing the maximum value. This is also used in valhalla_run_route (in addition to valhalla_service) to get compatible behavior.

fixes #1565
 - [ ] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
