### PR TITLE
Fix float to odin::DirectionsOptions::DateTimeType enum conversion

### DIFF
--- a/src/worker.cc
+++ b/src/worker.cc
@@ -590,7 +590,8 @@ void from_json(rapidjson::Document& doc, odin::DirectionsOptions& options) {
   // time type
   auto date_time_type = rapidjson::get_optional<float>(doc, "/date_time/type");
   if (date_time_type && odin::DirectionsOptions::DateTimeType_IsValid(*date_time_type)) {
-    options.set_date_time_type(static_cast<odin::DirectionsOptions::DateTimeType>(*date_time_type));
+    auto const v = static_cast<int>(*date_time_type);
+    options.set_date_time_type(static_cast<odin::DirectionsOptions::DateTimeType>(v));
   } // not specified but you want transit, then we default to current
   else if (options.has_costing() &&
            (options.costing() == odin::multimodal || options.costing() == odin::transit)) {


### PR DESCRIPTION
# Issue

MSVC 19.15 issues `error C2440: static_cast: cannot convert from T to DateTimeType` due to conversions between enumeration and floating point values are no longer allowed.

Fixes #1626

## Tasklist

 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)

## Requirements / Relations

- https://github.com/valhalla/valhalla/issues/1626#issuecomment-435913233
