### PR TITLE
Fix transition penalties for bicycle costing.

### DIFF
--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -769,7 +769,7 @@ Cost BicycleCost::TransitionCost(const baldr::DirectedEdge* edge,
   penalty *= (bike_accom * avoid_roads) + use_roads_;
 
   // Return cost (time and penalty)
-  c.cost += (seconds * (turn_stress + 1.0f));
+  c.cost += (seconds * (turn_stress + 1.0f)) + penalty;
   c.secs += seconds;
   return c;
 }
@@ -850,7 +850,7 @@ Cost BicycleCost::TransitionCostReverse(const uint32_t idx,
   penalty *= (bike_accom * avoid_roads) + use_roads_;
 
   // Return cost (time and penalty)
-  c.cost += (seconds * (turn_stress + 1.0f));
+  c.cost += (seconds * (turn_stress + 1.0f)) + penalty;
   c.secs += seconds;
   return c;
 }


### PR DESCRIPTION
Missed adding penalty when ported to return a Cost structure.

Fixes #1631 

Note, since bicycle costing now uses the base transition costs it will apply destination only penalties to the parking area (shown as the prior bike route). With these destination only penalties the route does not turn around inside the parking area (which is marked as destination only).

![image](https://user-images.githubusercontent.com/1838768/48153139-85f07b80-e293-11e8-99e9-867b516aa810.png)

 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 