### PR TITLE
updated wayids to be uint32_t instead of uint64_t for relations

### DIFF
--- a/src/mjolnir/osmrestriction.cc
+++ b/src/mjolnir/osmrestriction.cc
@@ -74,22 +74,22 @@ uint32_t OSMRestriction::modes() const {
 }
 
 // Set the from way id
-void OSMRestriction::set_from(uint64_t from) {
+void OSMRestriction::set_from(uint32_t from) {
   from_ = from;
 }
 
 // Get the from way id
-uint64_t OSMRestriction::from() const {
+uint32_t OSMRestriction::from() const {
   return from_;
 }
 
 // Set the to way id
-void OSMRestriction::set_to(uint64_t to) {
+void OSMRestriction::set_to(uint32_t to) {
   to_ = to;
 }
 
 // Get the to way id
-uint64_t OSMRestriction::to() const {
+uint32_t OSMRestriction::to() const {
   return to_;
 }
 

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -1114,7 +1114,7 @@ public:
     OSMRestriction restriction{};
     OSMRestriction to_restriction{};
 
-    uint64_t from_way_id = 0;
+    uint32_t from_way_id = 0;
     bool isRestriction = false, isTypeRestriction = false, hasRestriction = false;
     bool isRoad = false, isRoute = false, isBicycle = false, isConnectivity = false;
     bool isConditional = false, has_multiple_times = false;
@@ -1303,8 +1303,8 @@ public:
       }
     } else if (isConnectivity && (!to_lanes.empty() || !to.empty()) &&
                (!from_lanes.empty() || !from.empty())) {
-      uint64_t from_way_id = 0;
-      uint64_t to_way_id = 0;
+      uint32_t from_way_id = 0;
+      uint32_t to_way_id = 0;
       for (const auto& member : members) {
         // from and to must be of type 1(way).
         if (member.role == "from" &&

--- a/valhalla/mjolnir/osmdata.h
+++ b/valhalla/mjolnir/osmdata.h
@@ -29,13 +29,13 @@ struct OSMBike {
 };
 
 struct OSMLaneConnectivity {
-  uint64_t to_way_id;
-  uint64_t from_way_id;
+  uint32_t to_way_id;
+  uint32_t from_way_id;
   std::string to_lanes;
   std::string from_lanes;
 };
 
-using RestrictionsMultiMap = std::unordered_multimap<uint64_t, OSMRestriction>;
+using RestrictionsMultiMap = std::unordered_multimap<uint32_t, OSMRestriction>;
 
 using ViaSet = std::unordered_set<uint64_t>;
 
@@ -48,7 +48,7 @@ using OSMStringMap = std::unordered_map<uint64_t, std::string>;
 using OSMShapeMap = std::unordered_map<uint64_t, PointLL>;
 using OSMWayMap = std::unordered_map<uint64_t, std::list<uint64_t>>;
 
-using OSMLaneConnectivityMultiMap = std::unordered_multimap<uint64_t, OSMLaneConnectivity>;
+using OSMLaneConnectivityMultiMap = std::unordered_multimap<uint32_t, OSMLaneConnectivity>;
 
 enum class OSMType : uint8_t { kNode, kWay, kRelation };
 

--- a/valhalla/mjolnir/osmrestriction.h
+++ b/valhalla/mjolnir/osmrestriction.h
@@ -70,22 +70,22 @@ struct OSMRestriction {
   /**
    * Set the from way id
    */
-  void set_from(uint64_t from);
+  void set_from(uint32_t from);
 
   /**
    * Get the from way id
    */
-  uint64_t from() const;
+  uint32_t from() const;
 
   /**
    * Set the to way id
    */
-  void set_to(uint64_t to);
+  void set_to(uint32_t to);
 
   /**
    * Get the to way id
    */
-  uint64_t to() const;
+  uint32_t to() const;
 
   /**
    * Set the time domain
@@ -129,7 +129,10 @@ struct OSMRestriction {
   }
 
   // from is a way - uses OSM way Id.
-  uint64_t from_;
+  uint32_t from_;
+
+  // to is a way - uses OSM way Id.
+  uint32_t to_;
 
   // Via is a node. When parsing OSM this is stored as an OSM node Id.
   // It later gets changed into a GraphId.
@@ -143,9 +146,6 @@ struct OSMRestriction {
 
   // fixed size of vias.
   uint64_t vias_[valhalla::baldr::kMaxViasPerRestriction];
-
-  // to is a way - uses OSM way Id.
-  uint64_t to_;
 
   // timed restriction information
   uint64_t time_domain_;


### PR DESCRIPTION
updated wayids to be uint32_t instead of uint64_t in order to reduce the sequence file size.

# Issue

closes #1653

## Tasklist

 - [x] RAD test
 - [x] Review - you must request approval to merge any PR to master
 - [x] Add #fixes with the issue number that this PR addresses
 - [x] Generally use squash merge to rebase and clean comments before merging
