### PR TITLE
fix unique_ptr usage for GEOS 3.7

### DIFF
--- a/src/mjolnir/valhalla_build_admins.cc
+++ b/src/mjolnir/valhalla_build_admins.cc
@@ -144,7 +144,7 @@ std::vector<std::string> GetWkts(std::unique_ptr<Geometry>& mline) {
   std::vector<std::string> wkts;
 
 #if 3 == GEOS_VERSION_MAJOR && 6 <= GEOS_VERSION_MINOR
-  GeometryFactory::unique_ptr gf = GeometryFactory::create();
+  auto gf = GeometryFactory::create();
 #else
   std::unique_ptr<GeometryFactory> gf(new GeometryFactory());
 #endif


### PR DESCRIPTION
# Issue
GeometryFactory::unique_ptr does not exist in GeometryFactory.h in GEOS 3.7:
https://github.com/libgeos/geos/blob/3.7/include/geos/geom/GeometryFactory.h#L80

Fixes #1570 (already had the correctly proposed fix in the issue)

## Tasklist

 - [ ] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [X] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)
