### PR TITLE
Removed the local ferry_factor_ inside bicycle costing.

### DIFF
--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -352,7 +352,6 @@ public:
   // We expose it within the source file for testing purposes
 
   float speedfactor_[kMaxSpeedKph + 1]; // Cost factors based on speed in kph
-  float ferry_factor_;                  // Weighting to apply to ferry edges
   float use_roads_;                     // Preference of using roads between 0 and 1
   float road_factor_;                   // Road factor based on use_roads_
   float avoid_bad_surfaces_;            // Preference of avoiding bad surfaces for the bike type


### PR DESCRIPTION
This conflicted with the ferry_factor_ in the base DynamicCost class and led to undefined behavior. Worse case is this factor was sometimes set to a negative value which led to negative costs for ferry edges. These negative costs could lead to one search direction in bidirectional halting - leaving the other search direction expanding for a potentially very long time without connecting to the other search direction. This uses up lots of memory and causes long running routes and persistent memory (allocations in edge labels for instance).
