### PR TITLE
NodeTransition - protect against missing tiles

### DIFF
--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -443,6 +443,10 @@ struct bin_handler_t {
       for (uint32_t i = 0; reaches.back() < max_reach_limit && i < node->transition_count();
            ++i, ++trans) {
         const GraphTile* tile = reader.GetGraphTile(trans->endnode());
+        if (tile == nullptr) {
+          // Protect against missing tile
+          continue;
+        }
         const NodeInfo* n = tile->node(trans->endnode());
         if (!node_filter(n)) {
           // try to mark the node

--- a/src/thor/route_matcher.cc
+++ b/src/thor/route_matcher.cc
@@ -194,6 +194,9 @@ bool expand_from_node(const std::shared_ptr<DynamicCost>* mode_costing,
     const NodeTransition* trans = tile->transition(node_info->transition_index());
     for (uint32_t i = 0; i < node_info->transition_count(); ++i, ++trans) {
       const GraphTile* end_node_tile = reader.GetGraphTile(trans->endnode());
+      if (end_node_tile == nullptr) {
+        continue;
+      }
       if (expand_from_node(mode_costing, mode, reader, shape, distances, correlated_index,
                            end_node_tile, trans->endnode(), end_nodes, prev_edge_label, elapsed_time,
                            path_infos, true, end_node, total_distance)) {

--- a/src/thor/trippathbuilder.cc
+++ b/src/thor/trippathbuilder.cc
@@ -1142,6 +1142,9 @@ TripPathBuilder::Build(const AttributesController& controller,
             // Get the end node tile and its directed edges
             GraphId endnode = trans->endnode();
             const GraphTile* endtile = graphreader.GetGraphTile(endnode);
+            if (endtile == nullptr) {
+              continue;
+            }
             const NodeInfo* nodeinfo2 = endtile->node(endnode);
             const DirectedEdge* de2 = endtile->directededge(nodeinfo2->edge_index());
             for (uint32_t idx2 = 0; idx2 < nodeinfo2->edge_count(); ++idx2, de2++) {


### PR DESCRIPTION
Protect methods that use node transitions from accessing a tile that is missing. While this should not happen since node transitions go to nodes on a different level but at the same lat,lon (so they would be in the same geographic region/extent) there could still be missing tiles due to other reasons.
