### PR TITLE
Fix crash for trace_route with osrm serialization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Release Date: 201?-??-?? Valhalla 3.0.2
+* **Bug Fix**
+   * FIXED: Fix crash for trace_route with osrm serialization. Was passing shape rather than locations to the waypoint method.
+
 ## Release Date: 2018-11-21 Valhalla 3.0.1
 * **Bug Fix**
    * FIXED: Fixed a rare, but serious bug with bicycle costing. ferry_factor_ in bicycle costing shadowed the data member in the base dynamic cost class, leading to an unitialized variable. Occasionally, this would lead to negative costs which caused failures. [#1663](https://github.com/valhalla/valhalla/pull/1663)

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -942,7 +942,7 @@ std::string serialize(const valhalla::odin::DirectionsOptions& directions_option
   json->emplace("code", status);
   switch (directions_options.action()) {
     case valhalla::odin::DirectionsOptions::trace_route:
-      json->emplace("tracepoints", osrm::waypoints(directions_options.shape(), true));
+      json->emplace("tracepoints", osrm::waypoints(directions_options.locations(), true));
       break;
     case valhalla::odin::DirectionsOptions::route:
       json->emplace("waypoints", osrm::waypoints(directions_options.locations()));


### PR DESCRIPTION
Was passing shape rather than locations to the waypoint method.