### PR TITLE
Use A* if edges are connected. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * **Bug Fix**
    * FIXED: Fix crash for trace_route with osrm serialization. Was passing shape rather than locations to the waypoint method.
    * FIXED: Properly set driving_side based on data set in TripPath.
+   * FIXED: A bad bicycle route exposed an issue with bidirectional A* when the origin and destination edges are connected. Use A* in these cases to avoid requiring a high cost threshold in BD A*.
 
 ## Release Date: 2018-11-21 Valhalla 3.0.1
 * **Bug Fix**

--- a/src/thor/route_action.cc
+++ b/src/thor/route_action.cc
@@ -74,12 +74,14 @@ thor::PathAlgorithm* thor_worker_t::get_path_algorithm(const std::string& routet
     }
   }
 
-  // Use A* if any origin and destination edges are the same - otherwise
-  // use bidirectional A*. Bidirectional A* does not handle trivial cases
-  // with oneways.
+  // Use A* if any origin and destination edges are the same or are connected - otherwise
+  // use bidirectional A*. Bidirectional A* does not handle trivial cases with oneways and
+  // has issues when cost of origin or destination edge is high (needs a high threshold to
+  // find the proper connection).
   for (auto& edge1 : origin.path_edges()) {
     for (auto& edge2 : destination.path_edges()) {
-      if (edge1.graph_id() == edge2.graph_id()) {
+      if (edge1.graph_id() == edge2.graph_id() ||
+          reader->AreEdgesConnected(GraphId(edge1.graph_id()), GraphId(edge2.graph_id()))) {
         astar.set_interrupt(interrupt);
         return &astar;
       }

--- a/src/valhalla_run_route.cc
+++ b/src/valhalla_run_route.cc
@@ -604,11 +604,12 @@ int main(int argc, char* argv[]) {
                  ll1.Distance(ll2) < max_timedep_distance) {
         pathalgorithm = &timedep_reverse;
       } else {
-        // Use bidirectional except for possible trivial cases
+        // Use bidirectional except for trivial cases (same edge or connected edges)
         pathalgorithm = &bd;
         for (auto& edge1 : origin.path_edges()) {
           for (auto& edge2 : dest.path_edges()) {
-            if (edge1.graph_id() == edge2.graph_id()) {
+            if (edge1.graph_id() == edge2.graph_id() ||
+                reader.AreEdgesConnected(GraphId(edge1.graph_id()), GraphId(edge2.graph_id()))) {
               pathalgorithm = &astar;
             }
           }


### PR DESCRIPTION
Bidirectional A* has issues when cost of origin or destination edge is high (needs a high threshold to find the proper connection).

fixes #1671 

 - [ ] Add tests
 - [x] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [x] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)