### PR TITLE
Add durations to allow trace_route to compute elapsed times using the trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 * **Bug Fix**
    * FIXED: Fix crash for trace_route with osrm serialization. Was passing shape rather than locations to the waypoint method.
 * **Enhancement**
-   * Add a durations list ((delta time between each pair of trace points), a begin_time and a use_timestamp flag to trace_route requests. This allows using the input trace timestamps or durations plus the begin_time to compute elapsed time at each edge in the matched path (rather than using costing methods).
+   * Add a durations list (delta time between each pair of trace points), a begin_time and a use_timestamp flag to trace_route requests. This allows using the input trace timestamps or durations plus the begin_time to compute elapsed time at each edge in the matched path (rather than using costing methods).
 
 ## Release Date: 2018-11-21 Valhalla 3.0.1
 * **Bug Fix**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Release Date: 201?-??-?? Valhalla 3.0.2
 * **Bug Fix**
    * FIXED: Fix crash for trace_route with osrm serialization. Was passing shape rather than locations to the waypoint method.
+* **Enhancement**
+   * Add a durations list ((delta time between each pair of trace points) and a use_timestamp flag to trace_route requests. This allows using the input trace timestamps or durations to compute elapsed time at each edge in the matched path (rather than using costing methods).
 
 ## Release Date: 2018-11-21 Valhalla 3.0.1
 * **Bug Fix**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Release Date: 201?-??-?? Valhalla 3.0.2
+* **Bug Fix**
+   * FIXED: Fix crash for trace_route with osrm serialization. Was passing shape rather than locations to the waypoint method.
+
 ## Release Date: 2018-11-21 Valhalla 3.0.1
 * **Bug Fix**
    * FIXED: Fixed a rare, but serious bug with bicycle costing. ferry_factor_ in bicycle costing shadowed the data member in the base dynamic cost class, leading to an unitialized variable. Occasionally, this would lead to negative costs which caused failures. [#1663](https://github.com/valhalla/valhalla/pull/1663)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 * **Bug Fix**
    * FIXED: Fix crash for trace_route with osrm serialization. Was passing shape rather than locations to the waypoint method.
 * **Enhancement**
-   * Add a durations list ((delta time between each pair of trace points) and a use_timestamp flag to trace_route requests. This allows using the input trace timestamps or durations to compute elapsed time at each edge in the matched path (rather than using costing methods).
+   * Add a durations list ((delta time between each pair of trace points), a begin_time and a use_timestamp flag to trace_route requests. This allows using the input trace timestamps or durations plus the begin_time to compute elapsed time at each edge in the matched path (rather than using costing methods).
 
 ## Release Date: 2018-11-21 Valhalla 3.0.1
 * **Bug Fix**

--- a/docs/api/map-matching/api-reference.md
+++ b/docs/api/map-matching/api-reference.md
@@ -47,6 +47,12 @@ Costing for `multimodal` is not supported for map matching because it would be d
 
 You can also set `directions_options` to specify output units, language, and whether or not to return directions in a narrative form. Refer to the [route options](/turn-by-turn/api-reference.md#directions-options) documentation for examples.
 
+`trace_route` has additional options that allow using timestamps from trace points to be used when computing elapsed time along the matched path. These options are:
+| Option | Description |
+| :--------- | :---------- |
+| `durations` | List of durations (seconds) between each successive pair of input trace points. This allows trace points to be supplied as an encoded polyline and timestamps to be supplied by using a separate array of "delta" times.
+| `use_timestamps` | A boolean value indicating whether the input timestamps or durations should be used when computing elapsed time at each edge along the matched path. If true, timestamps are used. If false (default), internal costing is applied to compute elapsed times. |
+
 ### Attribute filters (`trace_attributes` only)
 
 The `trace_attributes` action allows you to apply filters to `include` or `exclude` specific attribute filter keys in your response. These filters are optional and can be added to the action string inside of the `filters` object.

--- a/docs/api/map-matching/api-reference.md
+++ b/docs/api/map-matching/api-reference.md
@@ -50,7 +50,8 @@ You can also set `directions_options` to specify output units, language, and whe
 `trace_route` has additional options that allow using timestamps from trace points to be used when computing elapsed time along the matched path. These options are:
 | Option | Description |
 | :--------- | :---------- |
-| `durations` | List of durations (seconds) between each successive pair of input trace points. This allows trace points to be supplied as an encoded polyline and timestamps to be supplied by using a separate array of "delta" times.
+| `begin_time` | Begin timestamp for the trace. This is used along with the `durations` so that timestamps can be specified for a trace that is specified using an encoded polyline.
+| `durations` | List of durations (seconds) between each successive pair of input trace points. This allows trace points to be supplied as an encoded polyline and timestamps to be created by using this list of "delta" times along with the `begin_time` of the trace.
 | `use_timestamps` | A boolean value indicating whether the input timestamps or durations should be used when computing elapsed time at each edge along the matched path. If true, timestamps are used. If false (default), internal costing is applied to compute elapsed times. |
 
 ### Attribute filters (`trace_attributes` only)

--- a/proto/directions_options.proto
+++ b/proto/directions_options.proto
@@ -164,4 +164,5 @@ message DirectionsOptions {
   repeated string filter_attributes = 34;                                 // The filter list for trace attributes
   repeated uint64 avoid_edges = 35;                                       // Avoid edges for any costing - derived from avoid_locations
   optional float breakage_distance = 36;                                  // Map-matching breaking distance (distance between GPS trace points)
+  optional bool use_timestamps = 37;                                      // Use timestamps to compute elapsed time for trace_route and trace_attributes
 }

--- a/src/thor/map_matcher.cc
+++ b/src/thor/map_matcher.cc
@@ -11,6 +11,115 @@ using namespace valhalla::sif;
 namespace valhalla {
 namespace thor {
 
+struct interpolation_t {
+  baldr::GraphId edge;   // edge id
+  float total_distance;  // distance along the path
+  float edge_distance;   // ratio of the distance along the edge
+  size_t original_index; // index into the original measurements
+  double epoch_time;     // seconds from epoch
+};
+
+std::list<std::vector<interpolation_t>>
+interpolate_matches(const std::vector<meili::MatchResult>& matches,
+                    const std::vector<meili::EdgeSegment>& edges,
+                    meili::MapMatcher* matcher) {
+  // TODO: backtracking could have happened. maybe it really happened but maybe there were
+  // positional inaccuracies. for now we should detect when there are backtracks and give up
+  // otherwise the the timing reported here might be suspect
+  // find each set of continuous edges
+  std::list<std::vector<interpolation_t>> interpolations;
+  size_t idx = 0;
+  for (auto begin_edge = edges.cbegin(), end_edge = edges.cbegin() + 1; begin_edge != edges.cend();
+       begin_edge = end_edge, end_edge += 1) {
+    // find the end of the this block
+    while (end_edge != edges.cend()) {
+      if (!matcher->graphreader().AreEdgesConnectedForward(std::prev(end_edge)->edgeid,
+                                                           end_edge->edgeid)) {
+        break;
+      }
+      ++end_edge;
+    }
+
+    // go through each edge and each match keeping the distance each point is along the entire trace
+    std::vector<interpolation_t> interpolated;
+    size_t last_idx = idx;
+    for (auto segment = begin_edge; segment != end_edge; ++segment) {
+      float edge_length = matcher->graphreader()
+                              .GetGraphTile(segment->edgeid)
+                              ->directededge(segment->edgeid)
+                              ->length();
+      float total_length = segment == begin_edge ? -edges.front().source * edge_length
+                                                 : interpolated.back().total_distance;
+      // get the distance and match result for the begin node of the edge
+      interpolated.emplace_back(interpolation_t{segment->edgeid, total_length, 0.f, last_idx, -1});
+
+      // add distances for all the match points that happened on this edge
+      for (; idx < matches.size(); ++idx) {
+        // skip unroutable ones, we dont know what edge they were on
+        if (!matches[idx].edgeid.Is_Valid()) {
+          continue;
+          // if its a valid one that doesnt match we move on
+        } else if (matches[idx].edgeid != segment->edgeid) {
+          break;
+        }
+        // it was the right thing we were looking for
+        interpolated.emplace_back(
+            interpolation_t{segment->edgeid, matches[idx].distance_along * edge_length + total_length,
+                            matches[idx].distance_along, idx, matches[idx].epoch_time});
+        last_idx = idx;
+      }
+      // add the end node of the edge
+      interpolated.emplace_back(
+          interpolation_t{segment->edgeid, edge_length + total_length, 1.f, last_idx, -1});
+    }
+
+    // finally backfill the time information for those points that dont have it
+    auto backfill = interpolated.begin();
+    while (backfill != interpolated.end()) {
+      // this one is done already
+      if (backfill->epoch_time != -1) {
+        ++backfill;
+        continue;
+      }
+      // find the range that have values (or the ends of the range
+      auto left = backfill != interpolated.begin() ? std::prev(backfill) : backfill;
+      auto right = std::next(backfill);
+      for (; right != interpolated.end() && right->epoch_time == -1; ++right) {
+        ;
+      }
+      // backfill between left and right
+      while (backfill != right) {
+        // if both indices are valid we interpolate
+        if (left != interpolated.begin() && right != interpolated.end()) {
+          double time_diff = right->epoch_time - left->epoch_time;
+          float distance_diff = right->total_distance - left->total_distance;
+          float distance_ratio =
+              distance_diff > 0 ? (backfill->total_distance - left->total_distance) / distance_diff
+                                : 0.f;
+          backfill->epoch_time = left->epoch_time + distance_ratio * time_diff;
+        } // if left index is valid we carry it forward if we can
+        else if (left != interpolated.begin() && backfill->total_distance == left->total_distance) {
+          backfill->epoch_time = left->epoch_time;
+          backfill->original_index = left->original_index;
+        }
+        // right index is valid we carry it forward if we can
+        else if (right != interpolated.end() && backfill->total_distance == right->total_distance) {
+          backfill->epoch_time = right->epoch_time;
+          backfill->original_index = right->original_index;
+        }
+        // next backfill
+        ++backfill;
+      }
+    }
+
+    // keep this set of interpolations
+    interpolations.emplace_back(std::move(interpolated));
+  }
+
+  // give back the distances and updated match results
+  return interpolations;
+}
+
 // Form the path from the map-matching results. This path gets sent to
 // TripPathBuilder.
 std::vector<PathInfo>
@@ -19,9 +128,11 @@ MapMatcher::FormPath(meili::MapMatcher* matcher,
                      const std::vector<meili::EdgeSegment>& edge_segments,
                      const std::shared_ptr<sif::DynamicCost>* mode_costing,
                      const sif::TravelMode mode,
-                     std::vector<std::pair<GraphId, GraphId>>& disconnected_edges) {
-  // Set the mode and costing
+                     std::vector<std::pair<GraphId, GraphId>>& disconnected_edges,
+                     const bool use_timestamps) {
+  // Set costing based on the mode
   const auto& costing = mode_costing[static_cast<uint32_t>(mode)];
+
   // Iterate through the matched path. Form PathInfo - populate elapsed time
   // Return an empty path (or throw exception) if path is not connected.
   float elapsed_time = 0;
@@ -30,6 +141,20 @@ MapMatcher::FormPath(meili::MapMatcher* matcher,
   const NodeInfo* nodeinfo = nullptr;
   const DirectedEdge* directededge;
   EdgeLabel pred;
+
+  // Interpolate match results if using timestamps for elapsed time
+  bool use_costing = !use_timestamps;
+  std::list<std::vector<interpolation_t>> interpolations;
+  size_t interpolated_index = 0;
+  size_t last_interp_index = 0;
+  if (use_timestamps) {
+    interpolations = interpolate_matches(results, edge_segments, matcher);
+    if (interpolations.size() > 1) {
+      // This means there is a discontinuity. If so, fallback to using costing
+      use_costing = true;
+    }
+    last_interp_index = interpolations.front().back().original_index;
+  }
 
   for (const auto& edge_segment : edge_segments) {
 
@@ -48,20 +173,34 @@ MapMatcher::FormPath(meili::MapMatcher* matcher,
       disconnected_edges.emplace_back(prior_edge, edge_id);
     }
 
-    // TODO: slight difference in time between route and trace_route
-    if (nodeinfo) {
-      // Get transition cost
-      elapsed_time += costing->TransitionCost(directededge, nodeinfo, pred).secs;
-
-      // Get time along the edge, handling partial distance along
-      // the first and last edge
-      elapsed_time += costing->EdgeCost(directededge, tile->GetSpeed(directededge)).secs *
-                      (edge_segment.target - edge_segment.source);
+    if (use_costing) {
+      // TODO: slight difference in time between route and trace_route
+      if (nodeinfo) {
+        // Get time along the edge, handling partial distance along the first and last edge.
+        // Add the transition cost at the begin node.
+        elapsed_time += costing->EdgeCost(directededge, tile->GetSpeed(directededge)).secs *
+                        (edge_segment.target - edge_segment.source) +
+                        costing->TransitionCost(directededge, nodeinfo, pred).secs;
+      } else {
+        // Get time along the edge, handling partial distance along the first and last edge
+        elapsed_time += costing->EdgeCost(directededge, tile->GetSpeed(directededge)).secs *
+                        (edge_segment.target - edge_segment.source);
+      }
     } else {
-      // Get time along the edge, handling partial distance along
-      // the first and last edge
-      elapsed_time += costing->EdgeCost(directededge, tile->GetSpeed(directededge)).secs *
-                      (edge_segment.target - edge_segment.source);
+      // Use timestamps to update elapsed time. Use the timestamp at the interpolation
+      // that no longer matches the edge_id (or the last interpolation if the edge id
+      // matches the rest of the interpolations).
+      size_t idx = last_interp_index;
+      for (size_t i = interpolated_index; i < interpolations.front().size(); ++i) {
+        if (interpolations.front()[i].edge != edge_id) {
+          // Set the index into the match results, update the interpolated index to
+          // start search for next edge id
+          idx = interpolations.front()[i].original_index;
+          interpolated_index = i;
+          break;
+        }
+      }
+      elapsed_time = results[idx].epoch_time - results[0].epoch_time;
     }
 
     // Update the prior_edge and nodeinfo. TODO (protect against invalid tile)

--- a/src/thor/map_matcher.cc
+++ b/src/thor/map_matcher.cc
@@ -179,7 +179,7 @@ MapMatcher::FormPath(meili::MapMatcher* matcher,
         // Get time along the edge, handling partial distance along the first and last edge.
         // Add the transition cost at the begin node.
         elapsed_time += costing->EdgeCost(directededge, tile->GetSpeed(directededge)).secs *
-                        (edge_segment.target - edge_segment.source) +
+                            (edge_segment.target - edge_segment.source) +
                         costing->TransitionCost(directededge, nodeinfo, pred).secs;
       } else {
         // Get time along the edge, handling partial distance along the first and last edge

--- a/src/thor/route_matcher.cc
+++ b/src/thor/route_matcher.cc
@@ -91,6 +91,7 @@ bool expand_from_node(const std::shared_ptr<DynamicCost>* mode_costing,
                       GraphReader& reader,
                       const std::vector<meili::Measurement>& shape,
                       const std::vector<float>& distances,
+                      const bool use_timestamps,
                       size_t& correlated_index,
                       const GraphTile* tile,
                       const GraphId& node,
@@ -159,13 +160,14 @@ bool expand_from_node(const std::shared_ptr<DynamicCost>* mode_costing,
       // Found a match if shape equals directed edge LL within tolerance
       if (shape.at(index).lnglat().ApproximatelyEqual(de_end_ll) &&
           de->length() < length_comparison(length, true)) {
-        // Update the elapsed time based on transition cost
-        elapsed_time +=
-            mode_costing[static_cast<int>(mode)]->TransitionCost(de, node_info, prev_edge_label).secs;
-
-        // Update the elapsed time based on edge cost
-        elapsed_time +=
-            mode_costing[static_cast<int>(mode)]->EdgeCost(de, end_node_tile->GetSpeed(de)).secs;
+        if (use_timestamps) {
+          elapsed_time = shape[index].epoch_time() - shape[0].epoch_time();
+        } else {
+          // Update the elapsed time based on transition cost and edge cost
+          auto& costing = mode_costing[static_cast<int>(mode)];
+          elapsed_time += costing->TransitionCost(de, node_info, prev_edge_label).secs +
+                          costing->EdgeCost(de, end_node_tile->GetSpeed(de)).secs;
+        }
 
         // Add edge and update correlated index
         path_infos.emplace_back(mode, elapsed_time, edge_id, 0);
@@ -174,9 +176,9 @@ bool expand_from_node(const std::shared_ptr<DynamicCost>* mode_costing,
         prev_edge_label = {kInvalidLabel, edge_id, de, {}, 0, 0, mode, 0};
 
         // Continue walking shape to find the end edge...
-        if (expand_from_node(mode_costing, mode, reader, shape, distances, index, end_node_tile,
-                             de->endnode(), end_nodes, prev_edge_label, elapsed_time, path_infos,
-                             false, end_node, total_distance)) {
+        if (expand_from_node(mode_costing, mode, reader, shape, distances, use_timestamps, index,
+                             end_node_tile, de->endnode(), end_nodes, prev_edge_label, elapsed_time,
+                             path_infos, false, end_node, total_distance)) {
           return true;
         } else {
           // Match failed along this edge, pop the last entry off path_infos
@@ -197,9 +199,10 @@ bool expand_from_node(const std::shared_ptr<DynamicCost>* mode_costing,
       if (end_node_tile == nullptr) {
         continue;
       }
-      if (expand_from_node(mode_costing, mode, reader, shape, distances, correlated_index,
-                           end_node_tile, trans->endnode(), end_nodes, prev_edge_label, elapsed_time,
-                           path_infos, true, end_node, total_distance)) {
+      if (expand_from_node(mode_costing, mode, reader, shape, distances, use_timestamps,
+                           correlated_index, end_node_tile, trans->endnode(), end_nodes,
+                           prev_edge_label, elapsed_time, path_infos, true, end_node,
+                           total_distance)) {
         return true;
       }
     }
@@ -214,6 +217,7 @@ bool RouteMatcher::FormPath(const std::shared_ptr<DynamicCost>* mode_costing,
                             const sif::TravelMode& mode,
                             GraphReader& reader,
                             const std::vector<meili::Measurement>& shape,
+                            const bool use_timestamps,
                             const google::protobuf::RepeatedPtrField<odin::Location>& correlated,
                             std::vector<PathInfo>& path_infos) {
   // Form distances between shape points
@@ -272,11 +276,14 @@ bool RouteMatcher::FormPath(const std::shared_ptr<DynamicCost>* mode_costing,
       // Check if shape is within tolerance at the end node
       if (shape.at(index).lnglat().ApproximatelyEqual(de_end_ll) &&
           de_remaining_length < length_comparison(length, true)) {
-
-        // Update the elapsed time edge cost at begin edge
-        elapsed_time +=
-            mode_costing[static_cast<int>(mode)]->EdgeCost(de, end_node_tile->GetSpeed(de)).secs *
-            (1 - edge.percent_along());
+        if (use_timestamps) {
+          elapsed_time = shape[index].epoch_time() - shape[0].epoch_time();
+        } else {
+          // Update the elapsed time edge cost at begin edge
+          elapsed_time +=
+              mode_costing[static_cast<int>(mode)]->EdgeCost(de, end_node_tile->GetSpeed(de)).secs *
+              (1 - edge.percent_along());
+        }
 
         // Add begin edge
         path_infos.emplace_back(mode, elapsed_time, graphid, 0);
@@ -286,9 +293,9 @@ bool RouteMatcher::FormPath(const std::shared_ptr<DynamicCost>* mode_costing,
 
         // Continue walking shape to find the end node
         GraphId end_node;
-        if (expand_from_node(mode_costing, mode, reader, shape, distances, index, end_node_tile,
-                             de->endnode(), end_nodes, prev_edge_label, elapsed_time, path_infos,
-                             false, end_node, total_distance)) {
+        if (expand_from_node(mode_costing, mode, reader, shape, distances, use_timestamps, index,
+                             end_node_tile, de->endnode(), end_nodes, prev_edge_label, elapsed_time,
+                             path_infos, false, end_node, total_distance)) {
           // If node equals stop node then when are done expanding - get
           // the matching end edge
           auto n = end_nodes.find(end_node);
@@ -312,16 +319,16 @@ bool RouteMatcher::FormPath(const std::shared_ptr<DynamicCost>* mode_costing,
           }
           const DirectedEdge* end_de = end_edge_tile->directededge(end_edge_graphid);
 
-          // Update the elapsed time based on transition cost
-          elapsed_time += mode_costing[static_cast<int>(mode)]
-                              ->TransitionCost(end_de, end_edge_tile->node(n->first), prev_edge_label)
-                              .secs;
-
-          // Update the elapsed time based on edge cost
-          elapsed_time += mode_costing[static_cast<int>(mode)]
-                              ->EdgeCost(end_de, end_edge_tile->GetSpeed(end_de))
-                              .secs *
-                          end_edge.percent_along();
+          if (use_timestamps) {
+            elapsed_time = shape.back().epoch_time() - shape[0].epoch_time();
+          } else {
+            // Update the elapsed time based on transition cost and edge cost
+            auto& costing = mode_costing[static_cast<int>(mode)];
+            elapsed_time +=
+                costing->TransitionCost(end_de, end_edge_tile->node(n->first), prev_edge_label).secs +
+                costing->EdgeCost(end_de, end_edge_tile->GetSpeed(end_de)).secs *
+                    end_edge.percent_along();
+          }
 
           // Add end edge
           path_infos.emplace_back(mode, elapsed_time, end_edge_graphid, 0);
@@ -339,10 +346,14 @@ bool RouteMatcher::FormPath(const std::shared_ptr<DynamicCost>* mode_costing,
     // end is along the same edge.
     for (const auto& end : end_nodes) {
       if (end.second.first.graph_id() == edge.graph_id()) {
-        // Update the elapsed time based on edge cost
-        elapsed_time +=
-            mode_costing[static_cast<int>(mode)]->EdgeCost(de, end_node_tile->GetSpeed(de)).secs *
-            (end.second.first.percent_along() - edge.percent_along());
+        if (use_timestamps) {
+          elapsed_time = shape.back().epoch_time() - shape[0].epoch_time();
+        } else {
+          // Update the elapsed time based on edge cost
+          elapsed_time +=
+              mode_costing[static_cast<int>(mode)]->EdgeCost(de, end_node_tile->GetSpeed(de)).secs *
+              (end.second.first.percent_along() - edge.percent_along());
+        }
 
         // Add end edge
         path_infos.emplace_back(mode, elapsed_time, GraphId(edge.graph_id()), 0);

--- a/src/thor/trace_route_action.cc
+++ b/src/thor/trace_route_action.cc
@@ -120,8 +120,11 @@ odin::TripPath thor_worker_t::route_match(valhalla_request_t& request,
                                           const AttributesController& controller) {
   odin::TripPath trip_path;
   std::vector<PathInfo> path_infos;
-  if (RouteMatcher::FormPath(mode_costing, mode, *reader, trace, request.options.locations(),
-                             path_infos)) {
+
+  // TODO - make sure the trace has timestamps..
+  bool use_timestamps = request.options.use_timestamps();
+  if (RouteMatcher::FormPath(mode_costing, mode, *reader, trace, use_timestamps,
+                             request.options.locations(), path_infos)) {
     // Form the trip path based on mode costing, origin, destination, and path edges
     trip_path = thor::TripPathBuilder::Build(controller, *reader, mode_costing, path_infos,
                                              *request.options.mutable_locations()->begin(),

--- a/src/thor/trace_route_action.cc
+++ b/src/thor/trace_route_action.cc
@@ -167,9 +167,10 @@ thor_worker_t::map_match(valhalla_request_t& request,
     std::vector<std::pair<GraphId, GraphId>> disconnected_edges;
     std::vector<PathInfo> path_edges =
         MapMatcher::FormPath(matcher.get(), match_results, edge_segments, mode_costing, mode,
-                             disconnected_edges);
+                             disconnected_edges, request.options.use_timestamps());
 
-    // Throw exception if not trace attributes action and disconnected path
+    // Throw exception if not trace attributes action and disconnected path.
+    // TODO - perhaps also throw exception if use_timestamps and disconnected path?
     if (request.options.action() == odin::DirectionsOptions::trace_route &&
         disconnected_edges.size()) {
       throw valhalla_exception_t{442};

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -942,7 +942,7 @@ std::string serialize(const valhalla::odin::DirectionsOptions& directions_option
   json->emplace("code", status);
   switch (directions_options.action()) {
     case valhalla::odin::DirectionsOptions::trace_route:
-      json->emplace("tracepoints", osrm::waypoints(directions_options.shape(), true));
+      json->emplace("tracepoints", osrm::waypoints(directions_options.locations(), true));
       break;
     case valhalla::odin::DirectionsOptions::route:
       json->emplace("waypoints", osrm::waypoints(directions_options.locations()));

--- a/src/valhalla_path_comparison.cc
+++ b/src/valhalla_path_comparison.cc
@@ -116,7 +116,7 @@ void walk_edges(const std::string& shape, GraphReader& reader, cost_ptr_t cost_p
 
   std::vector<PathInfo> path_infos;
   std::vector<PathLocation> correlated;
-  bool rtn = RouteMatcher::FormPath(mode_costing, mode, reader, measurements,
+  bool rtn = RouteMatcher::FormPath(mode_costing, mode, reader, measurements, false,
                                     directions_options.locations(), path_infos);
   if (!rtn) {
     std::cerr << "ERROR: RouteMatcher returned false - did not match complete shape." << std::endl;

--- a/src/valhalla_run_route.cc
+++ b/src/valhalla_run_route.cc
@@ -197,7 +197,7 @@ TripPath PathTest(GraphReader& reader,
                           reader);
     }
     std::vector<PathInfo> path;
-    bool ret = RouteMatcher::FormPath(mode_costing, mode, reader, trace,
+    bool ret = RouteMatcher::FormPath(mode_costing, mode, reader, trace, false,
                                       directions_options.locations(), path);
     if (ret) {
       LOG_INFO("RouteMatcher succeeded");

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -501,6 +501,7 @@ void from_json(rapidjson::Document& doc, odin::DirectionsOptions& options) {
     }
   }
 
+  // Use durations to set time
   auto durations = rapidjson::get_optional<rapidjson::Value::ConstArray>(doc, "/durations");
   if (durations) {
     // Set the elasped time to 0 at the first shape point
@@ -517,6 +518,10 @@ void from_json(rapidjson::Document& doc, odin::DirectionsOptions& options) {
       ++index;
     }
   }
+
+  // Option to use timestamps when computing elapsed time for matched routes
+  options.set_use_timestamps(
+      rapidjson::get_optional<bool>(doc, "/use_timestamps").get_value_or(false));
 
   // TODO: remove this?
   options.set_do_not_track(rapidjson::get_optional<bool>(doc, "/healthcheck").get_value_or(false));

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -501,6 +501,23 @@ void from_json(rapidjson::Document& doc, odin::DirectionsOptions& options) {
     }
   }
 
+  auto durations = rapidjson::get_optional<rapidjson::Value::ConstArray>(doc, "/durations");
+  if (durations) {
+    // Set the elasped time to 0 at the first shape point
+    double elapsed_time = 0.0;
+    options.mutable_shape()->Mutable(0)->set_time(elapsed_time);
+
+    // Iterate through the durations and add to elapsed time - set this on successive shape
+    // points. (TODO - what if the number of durations is not equal to shape size - 1)
+    int index = 1;
+    for (const auto& dur : *durations) {
+      auto duration = dur.GetDouble();
+      elapsed_time += duration;
+      options.mutable_shape()->Mutable(index)->set_time(elapsed_time);
+      ++index;
+    }
+  }
+
   // TODO: remove this?
   options.set_do_not_track(rapidjson::get_optional<bool>(doc, "/healthcheck").get_value_or(false));
 

--- a/valhalla/thor/map_matcher.h
+++ b/valhalla/thor/map_matcher.h
@@ -28,7 +28,8 @@ public:
            const std::vector<meili::EdgeSegment>& edge_segments,
            const std::shared_ptr<sif::DynamicCost>* mode_costing,
            const sif::TravelMode mode,
-           std::vector<std::pair<baldr::GraphId, baldr::GraphId>>& disconnected_edges);
+           std::vector<std::pair<baldr::GraphId, baldr::GraphId>>& disconnected_edges,
+           const bool use_timestamps);
 };
 
 } // namespace thor

--- a/valhalla/thor/route_matcher.h
+++ b/valhalla/thor/route_matcher.h
@@ -23,10 +23,23 @@ namespace thor {
 
 class RouteMatcher {
 public:
+  /**
+   * Form a path by matching shape with graph edges (edge walking).
+   * @param mode_costing Dynamic costing methods used to determine allowed edges and costs.
+   * @param mode Travel mode (indexes the costing methods).
+   * @param reader Graph reader.
+   * @param shape Shape used to match edges. Can include timestamps.
+   * @param use_timestamps If true the timestamps will be used to compute elapsed time,
+   *                       otherwise costing methods determine elapsed time along the path.
+   * @param correlated Correlated locations (generally the first and last shape point).
+   * @param path_infos Returns PathInfo - list of edges and elapsed times.
+   * @return Returns true if the edge walk forms a path, false if shape does not match.
+   */
   static bool FormPath(const std::shared_ptr<sif::DynamicCost>* mode_costing,
                        const sif::TravelMode& mode,
                        baldr::GraphReader& reader,
                        const std::vector<meili::Measurement>& shape,
+                       const bool use_timestamps,
                        const google::protobuf::RepeatedPtrField<odin::Location>& correlated,
                        std::vector<PathInfo>& path_infos);
 };

--- a/valhalla/worker.h
+++ b/valhalla/worker.h
@@ -60,6 +60,7 @@ const std::unordered_map<unsigned, std::string>
                 {133, "Failed to parse avoid"},
                 {134, "Failed to parse shape"},
                 {135, "Failed to parse trace"},
+                {136, "durations size not compatible with trace size"},
 
                 {140, "Action does not support multimodal costing"},
                 {141, "Arrive by for multimodal not implemented yet"},
@@ -75,6 +76,7 @@ const std::unordered_map<unsigned, std::string>
                 {156, "Outside the valid walking distance between stops of a multimodal route"},
                 {157, "Exceeded max avoid locations"},
                 {158, "Input trace option is out of bounds"},
+                {159, "use_timestamps set with no timestamps present"},
 
                 {160, "Date and time required for origin for date_type of depart at"},
                 {161, "Date and time required for destination for date_type of arrive by"},


### PR DESCRIPTION
Add durations for between each pair of shape points. Also add a use_timestamps flag that specifies whether timestamps/durations are to be used for computing elapsed times or whether the mde costng methods should be used to computed elapsed time. This is one way to get elapsed times (timestamps) set at each shape point for trace_route or trace_attributes. 

Also made changes in trace_route (for both edge walking and map matching) to use the timestamps, or more precisely the difference between a timestamp at a node or end of an edge and the initial timestamp (or 0 if only durations are present).

Added some error checking to make sure that if use_timestamps is set to true and no durations or timestamps are present an exception is thrown. Also checks to make sure the size of the durations array matches the size of the trace points list (-1 since durations are for each trace point pair).

 - [ ] Add tests
 - [x] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [x] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)
 - [x] Update relevant [documentation](docs/README.md)
