### PR TITLE
Add support for polyline5 encoding 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
    * FIXED: x86 tests were failing due mostly to floating point issues and the aforementioned structure misalignment.
 * **Enhancement**
    * Add a durations list (delta time between each pair of trace points), a begin_time and a use_timestamp flag to trace_route requests. This allows using the input trace timestamps or durations plus the begin_time to compute elapsed time at each edge in the matched path (rather than using costing methods).
+   * Add support for polyline5 encoding for OSRM formatted output.
 * **Note**
    * Isochrones and openlr are both noted as not working with release builds for x86 (32bit) platforms. We'll look at getting this fixed in a future release
 

--- a/proto/directions_options.proto
+++ b/proto/directions_options.proto
@@ -25,6 +25,11 @@ enum DirectionsType {
   instructions = 2;
 }
 
+enum ShapeFormat {
+  polyline5 = 0;
+  polyline6 = 1;
+}
+
 enum Costing {
   auto_ = 0;
   auto_shorter = 1;
@@ -165,4 +170,5 @@ message DirectionsOptions {
   repeated uint64 avoid_edges = 35;                                       // Avoid edges for any costing - derived from avoid_locations
   optional float breakage_distance = 36;                                  // Map-matching breaking distance (distance between GPS trace points)
   optional bool use_timestamps = 37;                                      // Use timestamps to compute elapsed time for trace_route and trace_attributes
+  optional ShapeFormat shape_format = 38 [default = polyline6];           // Shape format (defaults to polyline6 encoding)
 }

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -822,9 +822,9 @@ json::ArrayPtr serialize_legs(const std::list<valhalla::odin::TripDirections>& l
       // name change
 
       // Add geometry for this maneuver
-      step->emplace("geometry", maneuver_geometry(maneuver.begin_shape_index(),
-                                                  maneuver.end_shape_index(), shape,
-                                                  directions_options));
+      step->emplace("geometry",
+                    maneuver_geometry(maneuver.begin_shape_index(), maneuver.end_shape_index(), shape,
+                                      directions_options));
 
       // Add mode, driving side, weight, distance, duration, name
       float distance = maneuver.length() * (imperial ? 1609.34f : 1000.0f);

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -169,10 +169,10 @@ void route_summary(json::MapPtr& route,
 // Generate full shape of the route. TODO - different encodings, generalization
 std::string full_shape(const std::list<valhalla::odin::TripDirections>& legs,
                        const valhalla::odin::DirectionsOptions& directions_options) {
+  // TODO - support generalization
 
-  // TODO - support 5 digit encoding, support generalization
-
-  if (legs.size() == 1) {
+  // If just one leg and it we want polyline6 then we just return the encoded leg shape
+  if (legs.size() == 1 && directions_options.shape_format() == odin::polyline6) {
     return legs.front().shape();
   }
 
@@ -188,7 +188,8 @@ std::string full_shape(const std::list<valhalla::odin::TripDirections>& legs,
     decoded.insert(decoded.end(), decoded.size() ? decoded_leg.begin() + 1 : decoded_leg.begin(),
                    decoded_leg.end());
   }
-  return midgard::encode(decoded);
+  int prec = directions_options.shape_format() == odin::polyline6 ? 6 : 5;
+  return midgard::encode(decoded, prec);
 }
 
 // Serialize waypoints for optimized route. Note that OSRM retains the
@@ -707,10 +708,12 @@ json::MapPtr osrm_maneuver(const valhalla::odin::TripDirections::Maneuver& maneu
 // TODO - encoding options
 std::string maneuver_geometry(const uint32_t begin_idx,
                               const uint32_t end_idx,
-                              const std::vector<PointLL>& shape) {
+                              const std::vector<PointLL>& shape,
+                              const valhalla::odin::DirectionsOptions& directions_options) {
   // Must add one to the end range since maneuver end shape index is exclusive
   std::vector<PointLL> maneuver_shape(shape.begin() + begin_idx, shape.begin() + end_idx + 1);
-  return midgard::encode(maneuver_shape);
+  int prec = directions_options.shape_format() == odin::polyline6 ? 6 : 5;
+  return midgard::encode(maneuver_shape, prec);
 }
 
 // Get the mode
@@ -790,7 +793,8 @@ json::MapPtr annotations(std::list<odin::TripPath>::const_iterator path_leg) {
 // Serialize each leg
 json::ArrayPtr serialize_legs(const std::list<valhalla::odin::TripDirections>& legs,
                               const std::list<odin::TripPath>& path_legs,
-                              bool imperial) {
+                              bool imperial,
+                              const valhalla::odin::DirectionsOptions& directions_options) {
   auto output_legs = json::array({});
 
   // TODO: verify that path_legs is same size as legs
@@ -819,7 +823,8 @@ json::ArrayPtr serialize_legs(const std::list<valhalla::odin::TripDirections>& l
 
       // Add geometry for this maneuver
       step->emplace("geometry", maneuver_geometry(maneuver.begin_shape_index(),
-                                                  maneuver.end_shape_index(), shape));
+                                                  maneuver.end_shape_index(), shape,
+                                                  directions_options));
 
       // Add mode, driving side, weight, distance, duration, name
       float distance = maneuver.length() * (imperial ? 1609.34f : 1000.0f);
@@ -972,7 +977,7 @@ std::string serialize(const valhalla::odin::DirectionsOptions& directions_option
     route_summary(route, legs, imperial);
 
     // Serialize route legs
-    route->emplace("legs", serialize_legs(legs, path_legs, imperial));
+    route->emplace("legs", serialize_legs(legs, path_legs, imperial, directions_options));
 
     routes->emplace_back(route);
   }

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -188,8 +188,8 @@ std::string full_shape(const std::list<valhalla::odin::TripDirections>& legs,
     decoded.insert(decoded.end(), decoded.size() ? decoded_leg.begin() + 1 : decoded_leg.begin(),
                    decoded_leg.end());
   }
-  int prec = directions_options.shape_format() == odin::polyline6 ? 6 : 5;
-  return midgard::encode(decoded, prec);
+  int precision = directions_options.shape_format() == odin::polyline6 ? 1e6 : 1e5;
+  return midgard::encode(decoded, precision);
 }
 
 // Serialize waypoints for optimized route. Note that OSRM retains the
@@ -712,8 +712,8 @@ std::string maneuver_geometry(const uint32_t begin_idx,
                               const valhalla::odin::DirectionsOptions& directions_options) {
   // Must add one to the end range since maneuver end shape index is exclusive
   std::vector<PointLL> maneuver_shape(shape.begin() + begin_idx, shape.begin() + end_idx + 1);
-  int prec = directions_options.shape_format() == odin::polyline6 ? 6 : 5;
-  return midgard::encode(maneuver_shape, prec);
+  int precision = directions_options.shape_format() == odin::polyline6 ? 1e6 : 1e5;
+  return midgard::encode(maneuver_shape, precision);
 }
 
 // Get the mode

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -555,6 +555,21 @@ void from_json(rapidjson::Document& doc, odin::DirectionsOptions& options) {
     }
   }
 
+  // Set the output precision for shape/geometry (polyline encoding). Defaults to polyline6
+  // TODO - is this just for OSRM compatibility?
+  options.set_shape_format(odin::polyline6);
+  auto shape_format = rapidjson::get_optional<std::string>(doc, "/shape_format");
+  if (shape_format) {
+    if (*shape_format == "polyline6") {
+      options.set_shape_format(odin::polyline6);
+    } else if (*shape_format == "polyline5") {
+      options.set_shape_format(odin::polyline5);
+    } else {
+      ; // TODO - error or just ignore?
+    }
+  }
+
+
   // TODO: remove this?
   options.set_do_not_track(rapidjson::get_optional<bool>(doc, "/healthcheck").get_value_or(false));
 

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -569,7 +569,6 @@ void from_json(rapidjson::Document& doc, odin::DirectionsOptions& options) {
     }
   }
 
-
   // TODO: remove this?
   options.set_do_not_track(rapidjson::get_optional<bool>(doc, "/healthcheck").get_value_or(false));
 

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -95,7 +95,7 @@ const std::unordered_map<unsigned, unsigned> ERROR_TO_STATUS{
     {150, 400}, {151, 400}, {152, 400}, {153, 400}, {154, 400}, {155, 400}, {156, 400},
     {157, 400}, {158, 400}, {159, 400},
 
-    {160, 400}, {161, 400}, {162, 400}, {163, 400},
+    {160, 400}, {161, 400}, {162, 400}, {163, 400}, {164, 400},
 
     {170, 400}, {171, 400}, {172, 400},
 
@@ -197,6 +197,8 @@ const std::unordered_map<unsigned, std::string> OSRM_ERRORS_CODES{
     {162,
      R"({"code":"InvalidValue","message":"The successfully parsed query parameters are invalid."})"},
     {163,
+     R"({"code":"InvalidValue","message":"The successfully parsed query parameters are invalid."})"},
+    {164,
      R"({"code":"InvalidValue","message":"The successfully parsed query parameters are invalid."})"},
 
     {170,
@@ -565,7 +567,8 @@ void from_json(rapidjson::Document& doc, odin::DirectionsOptions& options) {
     } else if (*shape_format == "polyline5") {
       options.set_shape_format(odin::polyline5);
     } else {
-      ; // TODO - error or just ignore?
+      // Throw an error if shape format is invalid
+      throw valhalla_exception_t{164};
     }
   }
 

--- a/test/encode.cc
+++ b/test/encode.cc
@@ -12,11 +12,12 @@ namespace {
 
 using container_t = std::vector<std::pair<double, double>>;
 
-bool appx_equal(const container_t& a, const container_t& b) {
+bool appx_equal(const container_t& a, const container_t& b, const float epsilon = 0.00001f) {
   if (a.size() != b.size())
     return false;
   for (size_t i = 0; i < a.size(); ++i) {
-    if (!equal(a[i].first, b[i].first) || !equal(a[i].second, b[i].second))
+    if (!equal<float>(a[i].first, b[i].first, epsilon) ||
+        !equal<float>(a[i].second, b[i].second, epsilon))
       return false;
   }
   return true;
@@ -51,12 +52,46 @@ void do_polyline_pair(const container_t& points, const std::string& encoded) {
     throw std::runtime_error("Nested polyline decoding of an encoding failed");*/
 }
 
+void do_polyline_pair5(const container_t& points, const std::string& encoded) {
+  auto enc_answer = encode<container_t>(points, 5);
+  if (enc_answer != encoded)
+    throw std::runtime_error("Simple polyline encoding failed. Expected: " + encoded +
+                             " Got: " + enc_answer);
+
+  // Decode the answer, use a lower epsilon when comparing
+  auto dec_answer = decode<container_t>(enc_answer, 5);
+  if (!appx_equal(dec_answer, points, 0.00005f))
+    throw std::runtime_error("Simple polyline decoding failed. Expected: " + to_string(points) +
+                             " Got: " + to_string(dec_answer));
+}
+
 void do_varint_pair(const container_t& points) {
   auto enc_answer = encode7<container_t>(points);
   auto dec_answer = decode7<container_t>(enc_answer);
   if (!appx_equal(dec_answer, points))
     throw std::runtime_error("Simple varint encode decode loop failed. Expected: " +
                              to_string(points) + " Got: " + to_string(dec_answer));
+}
+
+void test_polyline5() {
+  // check an easy case first just to be sure its working
+  auto encoded = encode<container_t>({{-76.3002, 40.0433}, {-76.3036, 40.043}}, 5);
+  if (encoded != "s}ksFfkupMz@fT")
+    throw std::runtime_error("Expected: s}ksFfkupMz@fT but got: " + encoded);
+
+  do_polyline_pair5({{41.37084, -5.03016}, {76.8342, 42.01251}}, "pmu]wfo{Fw_c~G_mmwE");
+
+  do_polyline_pair5(
+      {{-9.42372, 152.03805},
+       {-1.82375, 116.05687},
+       {-71.41203, -66.66489},
+       {65.64729, 68.17239},
+       {34.2284, -77.90916},
+       {-72.90402, -47.25247},
+       {-78.55439, -25.28158},
+       {-31.92992, 103.20477},
+       {58.26482, -169.02219}},
+      "y|}~[fqox@jqrzEyjkm@~yfza@vmvgL}k~uXwkpcYrprzZ`ow~DisbzDrh{lSaebeCxqna@u~eoW}iq{Gnip|r@cdoeP");
 }
 
 void test_polyline() {
@@ -601,6 +636,7 @@ int main() {
   test::suite suite("encode_decode");
 
   suite.test(TEST_CASE(test_polyline));
+  suite.test(TEST_CASE(test_polyline5));
   suite.test(TEST_CASE(test_varint));
 
   return suite.tear_down();

--- a/test/encode.cc
+++ b/test/encode.cc
@@ -53,13 +53,13 @@ void do_polyline_pair(const container_t& points, const std::string& encoded) {
 }
 
 void do_polyline_pair5(const container_t& points, const std::string& encoded) {
-  auto enc_answer = encode<container_t>(points, 5);
+  auto enc_answer = encode<container_t>(points, 1e5);
   if (enc_answer != encoded)
     throw std::runtime_error("Simple polyline encoding failed. Expected: " + encoded +
                              " Got: " + enc_answer);
 
   // Decode the answer, use a lower epsilon when comparing
-  auto dec_answer = decode<container_t>(enc_answer, 5);
+  auto dec_answer = decode<container_t>(enc_answer, 1e-5);
   if (!appx_equal(dec_answer, points, 0.00005f))
     throw std::runtime_error("Simple polyline decoding failed. Expected: " + to_string(points) +
                              " Got: " + to_string(dec_answer));
@@ -75,7 +75,7 @@ void do_varint_pair(const container_t& points) {
 
 void test_polyline5() {
   // check an easy case first just to be sure its working
-  auto encoded = encode<container_t>({{-76.3002, 40.0433}, {-76.3036, 40.043}}, 5);
+  auto encoded = encode<container_t>({{-76.3002, 40.0433}, {-76.3036, 40.043}}, 1e5);
   if (encoded != "s}ksFfkupMz@fT")
     throw std::runtime_error("Expected: s}ksFfkupMz@fT but got: " + encoded);
 

--- a/valhalla/midgard/encoded.h
+++ b/valhalla/midgard/encoded.h
@@ -16,8 +16,8 @@ template <class container_t, class ShapeDecoder = Shape5Decoder<typename contain
 typename std::enable_if<
     std::is_same<std::vector<typename container_t::value_type>, container_t>::value,
     container_t>::type
-decode(const char* encoded, size_t length) {
-  ShapeDecoder shape(encoded, length);
+decode(const char* encoded, size_t length, const int precision = 6) {
+  ShapeDecoder shape(encoded, length, precision);
   container_t c;
   c.reserve(length / 4);
   while (!shape.empty()) {
@@ -31,8 +31,8 @@ template <class container_t, class ShapeDecoder = Shape5Decoder<typename contain
 typename std::enable_if<
     !std::is_same<std::vector<typename container_t::value_type>, container_t>::value,
     container_t>::type
-decode(const char* encoded, size_t length) {
-  ShapeDecoder shape(encoded, length);
+decode(const char* encoded, size_t length, const int precision = 6) {
+  ShapeDecoder shape(encoded, length, precision);
   container_t c;
   while (!shape.empty()) {
     c.emplace_back(shape.pop());
@@ -47,12 +47,14 @@ decode(const char* encoded, size_t length) {
  * @return points   the container of points
  */
 template <class container_t, class ShapeDecoder = Shape5Decoder<typename container_t::value_type>>
-container_t decode(const std::string& encoded) {
-  return decode<container_t, ShapeDecoder>(encoded.c_str(), encoded.length());
+container_t decode(const std::string& encoded, const int precision = 6) {
+  return decode<container_t, ShapeDecoder>(encoded.c_str(), encoded.length(), precision);
 }
 
-template <class container_t> container_t decode7(const char* encoded, size_t length) {
-  return decode<container_t, Shape7Decoder<typename container_t::value_type>>(encoded, length);
+template <class container_t>
+container_t decode7(const char* encoded, size_t length, const int precision = 7) {
+  return decode<container_t, Shape7Decoder<typename container_t::value_type>>(encoded, length,
+                                                                              precision);
 }
 
 /**

--- a/valhalla/midgard/encoded.h
+++ b/valhalla/midgard/encoded.h
@@ -71,9 +71,11 @@ template <class container_t> container_t decode7(const std::string& encoded) {
  * which allows displaying simplified versions of the encoded linestring
  *
  * @param points    the list of points to encode
+ * @param precision Precision of the encoded polyline. Defaults to 6 digit precision, but also
+ *                  supports 5. (TODO - are any others really needed?)
  * @return string   the encoded container of points
  */
-template <class container_t> std::string encode(const container_t& points) {
+template <class container_t> std::string encode(const container_t& points, const int precision = 6) {
   // a place to keep the output
   std::string output;
   // unless the shape is very course you should probably only need about 3 bytes
@@ -95,13 +97,16 @@ template <class container_t> std::string encode(const container_t& points) {
     output.push_back(static_cast<char>(number));
   };
 
+  // Set precision - only allows 5 or 6. If any other value we go back to the default (6).
+  int prec = (precision == 5) ? 1e5 : 1e6;
+
   // this is an offset encoding so we remember the last point we saw
   int last_lon = 0, last_lat = 0;
   // for each point
   for (const auto& p : points) {
     // shift the decimal point 5 places to the right and truncate
-    int lon = static_cast<int>(floor(static_cast<double>(p.first) * 1e6));
-    int lat = static_cast<int>(floor(static_cast<double>(p.second) * 1e6));
+    int lon = static_cast<int>(floor(static_cast<double>(p.first) * prec));
+    int lat = static_cast<int>(floor(static_cast<double>(p.second) * prec));
     // encode each coordinate, lat first for some reason
     serialize(lat - last_lat);
     serialize(lon - last_lon);

--- a/valhalla/midgard/shape_decoder.h
+++ b/valhalla/midgard/shape_decoder.h
@@ -8,7 +8,8 @@ namespace midgard {
 
 template <typename Point> class Shape7Decoder {
 public:
-  Shape7Decoder(const char* begin, const size_t size) : begin(begin), end(begin + size) {
+  Shape7Decoder(const char* begin, const size_t size, const int precision = 7)
+      : begin(begin), end(begin + size) {
   }
   Point pop() noexcept(false) {
     lat = next(lat);
@@ -45,13 +46,15 @@ private:
 
 template <typename Point> class Shape5Decoder {
 public:
-  Shape5Decoder(const char* begin, const size_t size) : begin(begin), end(begin + size) {
+  Shape5Decoder(const char* begin, const size_t size, const int precision = 6)
+      : begin(begin), end(begin + size) {
+    prec = precision == 5 ? 1e-5 : 1e-6;
   }
   Point pop() noexcept(false) {
     lat = next(lat);
     lon = next(lon);
-    return Point(typename Point::first_type(double(lon) * 1e-6),
-                 typename Point::second_type(double(lat) * 1e-6));
+    return Point(typename Point::first_type(double(lon) * prec),
+                 typename Point::second_type(double(lat) * prec));
   }
   bool empty() const {
     return begin == end;
@@ -62,6 +65,7 @@ private:
   const char* end;
   int32_t lat = 0;
   int32_t lon = 0;
+  double prec;
 
   int32_t next(const int32_t previous) noexcept(false) {
     // grab each 5 bits and mask it in where it belongs using the shift

--- a/valhalla/midgard/shape_decoder.h
+++ b/valhalla/midgard/shape_decoder.h
@@ -46,9 +46,8 @@ private:
 
 template <typename Point> class Shape5Decoder {
 public:
-  Shape5Decoder(const char* begin, const size_t size, const int precision = 6)
-      : begin(begin), end(begin + size) {
-    prec = precision == 5 ? 1e-5 : 1e-6;
+  Shape5Decoder(const char* begin, const size_t size, const double precision = 1e-6)
+      : begin(begin), end(begin + size), prec(precision) {
   }
   Point pop() noexcept(false) {
     lat = next(lat);

--- a/valhalla/worker.h
+++ b/valhalla/worker.h
@@ -82,6 +82,7 @@ const std::unordered_map<unsigned, std::string>
                 {161, "Date and time required for destination for date_type of arrive by"},
                 {162, "Date and time is invalid.  Format is YYYY-MM-DDTHH:MM"},
                 {163, "Invalid date_type"},
+                {164, "Invalid shape format"},
 
                 {170, "Locations are in unconnected regions. Go check/edit the map at osm.org"},
                 {171, "No suitable edges near location"},


### PR DESCRIPTION
Default to polyline6. For now only support polyline5 for OSRM output format.

## Tasklist

 - [x] Add tests
 - [x] Review - you must request approval to merge any PR to master
 - [x] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)
