### PR TITLE
Add CI builds on Windows using Visual Studio 2017

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,76 @@
+# AppVeyor for Valhalla
+#
+# TODO: Build and run tests and/or tools
+#
+version: 1.0.{build}
+
+image:
+  - Visual Studio 2017
+
+environment:
+  BUILD_CFG: Release
+  BUILD_DIR: '%APPVEYOR_BUILD_FOLDER%\build'
+  VCPKG_DIR: 'C:\Tools\vcpkg'
+
+  matrix:
+    - PLATFORM: x64
+      GENERATOR: 'Visual Studio 15 2017 Win64'
+      TOOLSET: 'v141,host=x64'
+    - PLATFORM: x86
+      GENERATOR: 'Visual Studio 15 2017'
+      TOOLSET: v141
+
+cache:
+  # Invalidate vcpkg cache whenever top-level build configuration is changed
+  - C:\Tools\vcpkg -> CMakeLists.txt, .appveyor.yml
+
+clone_depth: 1
+
+install:
+  - ps: 'Write-Host "Fix symlinks to third-party .proto files" -ForegroundColor Magenta'
+  - cmd: |
+      git config core.symlinks true
+      git reset --hard
+
+  - ps: 'Write-Host "Pull submodules" -ForegroundColor Magenta'
+  - cmd: git submodule update --init --recursive
+
+  - ps: 'Write-Host "Check symlinks to third-party .proto files" -ForegroundColor Magenta'
+  - ps: |
+      Get-Content -TotalCount 1 -Path .\proto\fileformat.proto
+      Get-Content -TotalCount 1 -Path .\proto\osmformat.proto
+
+  - ps: 'Write-Host "Install vcpkg" -ForegroundColor Magenta'
+  - cmd: |
+      %VCPKG_DIR%\vcpkg.exe version
+      %VCPKG_DIR%\vcpkg.exe remove --outdated --recurse
+      cd %VCPKG_DIR% & git pull > NUL & cd ..
+      echo set(VCPKG_BUILD_TYPE release) >> %VCPKG_DIR%\triplets\x64-windows.cmake
+      call %VCPKG_DIR%\bootstrap-vcpkg.bat
+      %VCPKG_DIR%\vcpkg.exe version
+
+  - ps: 'Write-Host "Install vcpkg packages" -ForegroundColor Magenta'
+  - cmd: |
+      %VCPKG_DIR%\vcpkg.exe install protobuf zlib --triplet %PLATFORM%-windows
+      %VCPKG_DIR%\vcpkg.exe list
+      if exist %VCPKG_DIR%\downloads rmdir /S /Q %VCPKG_DIR%\downloads
+      if exist %VCPKG_DIR%\packages rmdir /S /Q %VCPKG_DIR%\packages
+
+before_build:
+  - ps: 'Write-Host "Patch .proto files of OSMPBF with syntax=proto2" -ForegroundColor Magenta'
+  - cmd: |
+      cd %APPVEYOR_BUILD_FOLDER%
+      move /Y third_party\OSM-binary\src\fileformat.proto third_party\OSM-binary\src\fileformat.proto.orig
+      move /Y third_party\OSM-binary\src\osmformat.proto third_party\OSM-binary\src\osmformat.proto.orig
+      echo syntax = "proto2"; > third_party\OSM-binary\src\fileformat.proto
+      type third_party\OSM-binary\src\fileformat.proto.orig >> third_party\OSM-binary\src\fileformat.proto
+      echo syntax = "proto2"; > third_party\OSM-binary\src\osmformat.proto
+      type third_party\OSM-binary\src\osmformat.proto.orig >> third_party\OSM-binary\src\osmformat.proto
+      del /Q third_party\OSM-binary\src\*.orig
+
+build_script:
+  - cmd: cmake --version
+  - ps: 'Write-Host "Run CMake to configure build" -ForegroundColor Magenta'
+  - cmd: cmake -H%APPVEYOR_BUILD_FOLDER% -B%BUILD_DIR% -G "%GENERATOR%" -T "%TOOLSET%" -DCMAKE_TOOLCHAIN_FILE=%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake -DVCPKG_APPLOCAL_DEPS=ON -DBOOST_ROOT=C:\Libraries\boost_1_67_0 -DENABLE_CCACHE=OFF -DENABLE_DATA_TOOLS=OFF -DENABLE_HTTP=OFF -DENABLE_NODE_BINDINGS=OFF -DENABLE_PYTHON_BINDINGS=OFF -DENABLE_SERVICES=OFF -DENABLE_TOOLS=OFF
+  - ps: 'Write-Host "Run CMake to build" -ForegroundColor Magenta'
+  - cmd: cmake --build %BUILD_DIR% --config %BUILD_CFG%

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,0 +1,74 @@
+# Azure Pipelines for Valhalla
+#
+# TODO: Shallow clone blocked by
+#       https://developercommunity.visualstudio.com/content/problem/294872/yaml-build-ignores-fetchdepth.html
+# TODO: Once CMake 3.13 is available replace -H with -S option
+#
+jobs:
+  - job: VS2017
+    displayName: 'Windows 2016 | VS2017'
+
+    pool:
+      vmImage: 'vs2017-win2016'
+
+    strategy:
+      matrix:
+        x86:
+          PLATFORM: 'x86'
+          GENERATOR: 'Visual Studio 15 2017'
+        x64:
+          PLATFORM: 'x64'
+          GENERATOR: 'Visual Studio 15 2017 Win64'
+
+    variables:
+      BUILD_CFG: 'Release'
+      BUILD_DIR: '$(Agent.WorkFolder)\build'
+      VCPKG_DIR: '$(Agent.WorkFolder)\vcpkg'
+
+    steps:
+      - script: |
+          git config core.symlinks true
+          git reset --hard
+        displayName: 'Fix symlinks to third-party .proto files'
+
+      - script: git submodule update --init --recursive
+        displayName: 'Pull submodules'
+
+      - powershell: |
+          Get-Content -TotalCount 1 -Path .\proto\fileformat.proto
+          Get-Content -TotalCount 1 -Path .\proto\osmformat.proto
+        displayName: 'Check symlinks to third-party .proto files'
+
+      - script: |
+          git clone --depth 1 https://github.com/microsoft/vcpkg %VCPKG_DIR%
+          echo.set(VCPKG_BUILD_TYPE release)>> %VCPKG_DIR%\triplets\%PLATFORM%-windows.cmake
+          call %VCPKG_DIR%\bootstrap-vcpkg.bat
+          %VCPKG_DIR%\vcpkg.exe version
+        displayName: 'Install vcpkg'
+
+      - script: |
+          %VCPKG_DIR%\vcpkg.exe install boost-algorithm boost-config boost-core boost-heap boost-lexical-cast boost-property-tree boost-variant protobuf zlib --triplet %PLATFORM%-windows
+          %VCPKG_DIR%\vcpkg.exe list
+          if exist %VCPKG_DIR%\downloads rmdir /S /Q %VCPKG_DIR%\downloads
+          if exist %VCPKG_DIR%\packages rmdir /S /Q %VCPKG_DIR%\packages
+        displayName: 'Install vcpkg packages'
+
+      - script: |
+          move /Y third_party\OSM-binary\src\fileformat.proto third_party\OSM-binary\src\fileformat.proto.orig
+          move /Y third_party\OSM-binary\src\osmformat.proto third_party\OSM-binary\src\osmformat.proto.orig
+          echo syntax = "proto2"; > third_party\OSM-binary\src\fileformat.proto
+          type third_party\OSM-binary\src\fileformat.proto.orig >> third_party\OSM-binary\src\fileformat.proto
+          echo syntax = "proto2"; > third_party\OSM-binary\src\osmformat.proto
+          type third_party\OSM-binary\src\osmformat.proto.orig >> third_party\OSM-binary\src\osmformat.proto
+          del /Q third_party\OSM-binary\src\fileformat.proto.orig
+          del /Q third_party\OSM-binary\src\osmformat.proto.orig
+        displayName: 'Patch .proto files of OSMPBF with syntax=proto2'
+
+      - script: |
+          cmake --version
+          cmake -H$(Build.SourcesDirectory) -B%BUILD_DIR% -G "%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE=%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake -DVCPKG_APPLOCAL_DEPS=ON -DENABLE_CCACHE=OFF -DENABLE_DATA_TOOLS=OFF -DENABLE_HTTP=OFF -DENABLE_NODE_BINDINGS=OFF -DENABLE_PYTHON_BINDINGS=OFF -DENABLE_SERVICES=OFF -DENABLE_TOOLS=OFF
+        displayName: 'Run CMake to configure build'
+
+      - script: |
+          cmake --build %BUILD_DIR% --config %BUILD_CFG%
+        displayName: 'Run CMake to build'


### PR DESCRIPTION
Add complete configuration files for AppVeyor and Azure Pipelines.

## Tasklist

 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Configure AppVeyor service for Valhalla using the supplied `.appveyor.yml`
 - [ ] Configure Azure Pipelines service for Valhalla using the supplied `.azure-pipelines.yml`
 - [ ] Add build status badges to [README.md](https://github.com/valhalla/valhalla/blob/master/README.md) from the configured services (for `valhalla/valhalla`, not `mloskot/valhalla`, of course)

## Requirements / Relations

- #1645

## Build Dependencies

Both configurations provided in this PR install _minimum_ dependencies required to build the library.
Both install dependencies using https://github.com/Microsoft/vcpkg

The AppVeyor is a bit faster because it uses caches `C:\Tools\vcpkg` with upgraded `vcpkg` and the installed dependencies, so subsequent builds just restore it from the cache, instead of rebuilding.
The AppVeyor cache is invalidated if `CMakeLists.txt` or `.appveyor.yml` changes.

## Build Status

The configuration has been verified on both, AppVeyor and Azure Pipelines, using my fork https://github.com/mloskot/valhalla

* [![Build status](https://ci.appveyor.com/api/projects/status/u5purpw8w581labl?svg=true)](https://ci.appveyor.com/project/mloskot/valhalla)

* [![Build Status](https://dev.azure.com/mloskot/valhalla/_apis/build/status/mloskot.valhalla?branchName=ml/azure-pipelines)](https://dev.azure.com/mloskot/valhalla/_build/latest?definitionId=4?branchName=ml/azure-pipelines)

No idea why the Azure Pipelines badge says "never built" while the two builds succeeded there.
It updates fine for two AP-enabled repos I maintain, https://github.com/mloskot/ci-test and https://github.com/boostorg/gil, so it must be some temporary issue. It's minor, we will sort it out as we go :)

## Setting up CI services

@kevinkreiser If you approve this PR and commit as it is without setting the services, nothing will happen. That is, the `.yml` files can live in the repo anyway.

To setup the services to do the builds, it takes being a member of https://github.com/valhalla/valhalla/ developers, then:

- For AppVeyor, it takes https://www.appveyor.com/docs/ and also https://www.appveyor.com/docs/team-setup/

- For Azure, it needs the free tier from https://dev.azure.com

If you will need help with setting up the services, let me know. 
