### PR TITLE
Replace default_random_engine with mt19937 (Mersenne Twister).

### DIFF
--- a/src/baldr/connectivity_map.cc
+++ b/src/baldr/connectivity_map.cc
@@ -94,7 +94,7 @@ json::MapPtr to_feature(const std::pair<size_t, polygon_t>& boundary, const std:
 template <class T>
 std::string to_feature_collection(const std::unordered_map<size_t, polygon_t>& boundaries,
                                   const std::multimap<size_t, size_t, T>& arities) {
-  std::default_random_engine generator;
+  std::mt19937 generator;
   std::uniform_int_distribution<int> distribution(64, 192);
   auto features = json::array({});
   for (const auto& arity : arities) {

--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -1223,7 +1223,7 @@ make_distributor_from_range(const ranged_default_t<float>& range) {
 void testAutoCostParams() {
   constexpr unsigned testIterations = 250;
   constexpr unsigned seed = 0;
-  std::default_random_engine generator(seed);
+  std::mt19937 generator(seed);
   std::shared_ptr<std::uniform_real_distribution<float>> distributor;
   std::shared_ptr<TestAutoCost> ctorTester;
 

--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -1017,7 +1017,7 @@ make_distributor_from_range(const ranged_default_t<float>& range) {
 void testBicycleCostParams() {
   constexpr unsigned testIterations = 250;
   constexpr unsigned seed = 0;
-  std::default_random_engine generator(seed);
+  std::mt19937 generator(seed);
   std::shared_ptr<std::uniform_real_distribution<float>> distributor;
   std::shared_ptr<TestBicycleCost> ctorTester;
 

--- a/src/sif/motorcyclecost.cc
+++ b/src/sif/motorcyclecost.cc
@@ -672,7 +672,7 @@ std::uniform_real_distribution<T>* make_distributor_from_range(const ranged_defa
 void testMotorcycleCostParams() {
   constexpr unsigned testIterations = 250;
   constexpr unsigned seed = 0;
-  std::default_random_engine generator(seed);
+  std::mt19937 generator(seed);
   std::shared_ptr<std::uniform_real_distribution<float>> distributor;
   std::shared_ptr<TestMotorcycleCost> ctorTester;
 

--- a/src/sif/motorscootercost.cc
+++ b/src/sif/motorscootercost.cc
@@ -686,7 +686,7 @@ std::uniform_int_distribution<T>* make_int_distributor_from_range(const ranged_d
 void testMotorScooterCostParams() {
   constexpr unsigned testIterations = 250;
   constexpr unsigned seed = 0;
-  std::default_random_engine generator(seed);
+  std::mt19937 generator(seed);
   std::shared_ptr<std::uniform_real_distribution<float>> fDistributor;
   std::shared_ptr<std::uniform_int_distribution<uint32_t>> iDistributor;
   std::shared_ptr<TestMotorScooterCost> ctorTester;

--- a/src/sif/pedestriancost.cc
+++ b/src/sif/pedestriancost.cc
@@ -936,7 +936,7 @@ make_distributor_from_range(const ranged_default_t<uint32_t>& range) {
 void testPedestrianCostParams() {
   constexpr unsigned testIterations = 250;
   constexpr unsigned seed = 0;
-  std::default_random_engine generator(seed);
+  std::mt19937 generator(seed);
   std::shared_ptr<std::uniform_real_distribution<float>> real_distributor;
   std::shared_ptr<std::uniform_int_distribution<uint32_t>> int_distributor;
   std::shared_ptr<TestPedestrianCost> ctorTester;

--- a/src/sif/transitcost.cc
+++ b/src/sif/transitcost.cc
@@ -787,7 +787,7 @@ make_distributor_from_range(const ranged_default_t<float>& range) {
 void testTransitCostParams() {
   constexpr unsigned testIterations = 250;
   constexpr unsigned seed = 0;
-  std::default_random_engine generator(seed);
+  std::mt19937 generator(seed);
   std::shared_ptr<std::uniform_real_distribution<float>> distributor;
   std::shared_ptr<TransitCost> ctorTester;
 

--- a/src/sif/truckcost.cc
+++ b/src/sif/truckcost.cc
@@ -752,7 +752,7 @@ make_distributor_from_range(const ranged_default_t<float>& range) {
 void testTruckCostParams() {
   constexpr unsigned testIterations = 250;
   constexpr unsigned seed = 0;
-  std::default_random_engine generator(seed);
+  std::mt19937 generator(seed);
   std::shared_ptr<std::uniform_real_distribution<float>> distributor;
   std::shared_ptr<TestTruckCost> ctorTester;
 

--- a/test/tiles.cc
+++ b/test/tiles.cc
@@ -301,7 +301,7 @@ void test_intersect_linestring() {
 
 void test_random_linestring() {
   Tiles<Point2> t(AABB2<Point2>{-10, -10, 10, 10}, 1, 5);
-  std::default_random_engine generator;
+  std::mt19937 generator;
   std::uniform_real_distribution<> distribution(-10, 10);
   for (int i = 0; i < 500; ++i) {
     std::vector<Point2> linestring;
@@ -457,7 +457,7 @@ void test_closest_first() {
     test_point(t, p);
 
   // try some randos
-  std::default_random_engine generator;
+  std::mt19937 generator;
   std::uniform_real_distribution<> distribution(0, 360);
   for (size_t i = 0; i < 25; ++i) {
     PointLL p{distribution(generator) - 180.f, distribution(generator) / 2 - 90.f};

--- a/test/util_midgard.cc
+++ b/test/util_midgard.cc
@@ -18,7 +18,7 @@ void TestRangedDefaultT() {
   constexpr float lower = -50;
   constexpr float upper = 70;
   constexpr unsigned seed = 0;
-  std::default_random_engine generator(seed);
+  std::mt19937 generator(seed);
   std::uniform_real_distribution<float> defaultDistributor(lower, upper);
   std::uniform_real_distribution<float> testDistributor(lower - 40, upper + 40);
 

--- a/test/viterbi_search.cc
+++ b/test/viterbi_search.cc
@@ -145,7 +145,7 @@ private:
 };
 
 unsigned SEED = std::chrono::system_clock::now().time_since_epoch().count();
-std::default_random_engine TRANSITION_COST_GENERATOR(SEED), EMISSION_COST_GENERATOR(SEED),
+std::mt19937 TRANSITION_COST_GENERATOR(SEED), EMISSION_COST_GENERATOR(SEED),
     COUNT_GENERATOR(SEED);
 
 Column generate_column(size_t num_states,

--- a/test/viterbi_search.cc
+++ b/test/viterbi_search.cc
@@ -145,8 +145,7 @@ private:
 };
 
 unsigned SEED = std::chrono::system_clock::now().time_since_epoch().count();
-std::mt19937 TRANSITION_COST_GENERATOR(SEED), EMISSION_COST_GENERATOR(SEED),
-    COUNT_GENERATOR(SEED);
+std::mt19937 TRANSITION_COST_GENERATOR(SEED), EMISSION_COST_GENERATOR(SEED), COUNT_GENERATOR(SEED);
 
 Column generate_column(size_t num_states,
                        std::uniform_int_distribution<int> transition_cost_distribution,


### PR DESCRIPTION
 std::default_random_engine is not consistent across all platforms.

fixes #1567
## Tasklist

 - [ ] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)
