### PR TITLE
Add OSMAdminData

### DIFF
--- a/src/mjolnir/pbfadminparser.cc
+++ b/src/mjolnir/pbfadminparser.cc
@@ -36,8 +36,8 @@ public:
   virtual ~admin_callback() {
   }
   // Construct PBFAdminParser based on properties file and input PBF extract
-  admin_callback(const boost::property_tree::ptree& pt, OSMData& osmdata)
-      : shape_(kMaxOSMNodeId), members_(kMaxOSMNodeId), osmdata_(osmdata),
+  admin_callback(const boost::property_tree::ptree& pt, OSMAdminData& osmdata)
+      : shape_(kMaxOSMNodeId), members_(kMaxOSMNodeId), osm_admin_data_(osmdata),
         lua_(std::string(lua_admin_lua, lua_admin_lua + lua_admin_lua_len)) {
   }
 
@@ -48,12 +48,12 @@ public:
       return;
     }
 
-    ++osmdata_.osm_node_count;
+    ++osm_admin_data_.osm_node_count;
 
-    osmdata_.shape_map.emplace(osmid, PointLL(lng, lat));
+    osm_admin_data_.shape_map.emplace(osmid, PointLL(lng, lat));
 
-    if (osmdata_.shape_map.size() % 500000 == 0) {
-      LOG_INFO("Processed " + std::to_string(osmdata_.shape_map.size()) + " nodes on ways");
+    if (osm_admin_data_.shape_map.size() % 500000 == 0) {
+      LOG_INFO("Processed " + std::to_string(osm_admin_data_.shape_map.size()) + " nodes on ways");
     }
   }
 
@@ -67,12 +67,12 @@ public:
     }
 
     for (const auto node : nodes) {
-      ++osmdata_.node_count;
+      ++osm_admin_data_.node_count;
       // Mark the nodes that we will care about when processing nodes
       shape_.set(node);
     }
 
-    osmdata_.way_map.emplace(osmid, std::list<uint64_t>(nodes.begin(), nodes.end()));
+    osm_admin_data_.way_map.emplace(osmid, std::list<uint64_t>(nodes.begin(), nodes.end()));
   }
 
   virtual void relation_callback(const uint64_t osmid,
@@ -89,15 +89,15 @@ public:
     for (const auto& tag : results) {
       // TODO:  Store multiple all the names
       if (tag.first == "name" && !tag.second.empty()) {
-        admin.set_name_index(osmdata_.name_offset_map.index(tag.second));
+        admin.set_name_index(osm_admin_data_.name_offset_map.index(tag.second));
       } else if (tag.first == "name:en" && !tag.second.empty()) {
-        admin.set_name_en_index(osmdata_.name_offset_map.index(tag.second));
+        admin.set_name_en_index(osm_admin_data_.name_offset_map.index(tag.second));
       } else if (tag.first == "admin_level") {
         admin.set_admin_level(std::stoi(tag.second));
       } else if (tag.first == "drive_on_right") {
         admin.set_drive_on_right(tag.second == "true" ? true : false);
       } else if (tag.first == "iso_code" && !tag.second.empty()) {
-        admin.set_iso_code_index(osmdata_.name_offset_map.index(tag.second));
+        admin.set_iso_code_index(osm_admin_data_.name_offset_map.index(tag.second));
       }
     }
 
@@ -108,7 +108,7 @@ public:
       if (member.member_type == OSMPBF::Relation::MemberType::Relation_MemberType_WAY) {
         members_.set(member.member_id);
         member_ids.push_back(member.member_id);
-        ++osmdata_.osm_way_count;
+        ++osm_admin_data_.osm_way_count;
       }
     }
 
@@ -118,11 +118,11 @@ public:
 
     admin.set_ways(member_ids);
 
-    osmdata_.admins_.push_back(std::move(admin));
+    osm_admin_data_.admins_.push_back(std::move(admin));
   }
 
   virtual void changeset_callback(const uint64_t changeset_id) override {
-    osmdata_.max_changeset_id_ = std::max(osmdata_.max_changeset_id_, changeset_id);
+    osm_admin_data_.max_changeset_id_ = std::max(osm_admin_data_.max_changeset_id_, changeset_id);
   }
 
   // Lua Tag Transformation class
@@ -132,7 +132,7 @@ public:
   IdTable shape_, members_;
 
   // Pointer to all the OSM data (for use by callbacks)
-  OSMData& osmdata_;
+  OSMAdminData& osm_admin_data_;
 };
 
 } // namespace
@@ -140,11 +140,11 @@ public:
 namespace valhalla {
 namespace mjolnir {
 
-OSMData PBFAdminParser::Parse(const boost::property_tree::ptree& pt,
-                              const std::vector<std::string>& input_files) {
+OSMAdminData PBFAdminParser::Parse(const boost::property_tree::ptree& pt,
+                                   const std::vector<std::string>& input_files) {
   // Create OSM data. Set the member pointer so that the parsing callback
   // methods can use it.
-  OSMData osmdata{};
+  OSMAdminData osmdata{};
   admin_callback callback(pt, osmdata);
 
   LOG_INFO("Parsing files: " + boost::algorithm::join(input_files, ", "));

--- a/src/mjolnir/valhalla_build_admins.cc
+++ b/src/mjolnir/valhalla_build_admins.cc
@@ -4,8 +4,6 @@
 
 #include "baldr/graphconstants.h"
 #include "mjolnir/adminconstants.h"
-#include "mjolnir/graphbuilder.h"
-#include "mjolnir/hierarchybuilder.h"
 #include "mjolnir/osmpbfparser.h"
 #include "mjolnir/pbfadminparser.h"
 
@@ -33,6 +31,15 @@
 #include <geos/opLinemerge.h>
 #include <geos/util/GEOSException.h>
 
+#include <boost/filesystem/operations.hpp>
+#include <boost/optional.hpp>
+#include <boost/program_options.hpp>
+#include <boost/property_tree/ptree.hpp>
+
+#include "baldr/rapidjson_utils.h"
+#include "midgard/logging.h"
+#include "midgard/util.h"
+
 using namespace geos::geom;
 using namespace geos::io;
 using namespace geos::util;
@@ -41,15 +48,6 @@ using namespace geos::operation::linemerge;
 // For OSM pbf reader
 using namespace valhalla::mjolnir;
 using namespace valhalla::baldr;
-
-#include "baldr/rapidjson_utils.h"
-#include <boost/filesystem/operations.hpp>
-#include <boost/optional.hpp>
-#include <boost/program_options.hpp>
-#include <boost/property_tree/ptree.hpp>
-#include <ostream>
-
-#include "midgard/logging.h"
 
 namespace bpo = boost::program_options;
 using namespace valhalla::midgard;
@@ -261,7 +259,7 @@ void BuildAdminFromPBF(const boost::property_tree::ptree& pt,
 
   // Read the OSM protocol buffer file. Callbacks for nodes, ways, and
   // relations are defined within the PBFParser class
-  OSMData osmdata = PBFAdminParser::Parse(pt, input_files);
+  OSMAdminData osm_admin_data = PBFAdminParser::Parse(pt, input_files);
 
   // done with the protobuffer library, cant use it again after this
   OSMPBF::Parser::free();
@@ -430,7 +428,7 @@ void BuildAdminFromPBF(const boost::property_tree::ptree& pt,
 
   try {
 
-    for (const auto& admin : osmdata.admins_) {
+    for (const auto& admin : osm_admin_data.admins_) {
 
       std::unique_ptr<Geometry> geom;
       std::unique_ptr<std::vector<Geometry*>> lines(new std::vector<Geometry*>);
@@ -438,11 +436,11 @@ void BuildAdminFromPBF(const boost::property_tree::ptree& pt,
 
       for (const auto memberid : admin.ways()) {
 
-        auto itr = osmdata.way_map.find(memberid);
+        auto itr = osm_admin_data.way_map.find(memberid);
 
         // A relation may be included in an extract but it's members may not.
         // Example:  PA extract can contain a NY relation.
-        if (itr == osmdata.way_map.end()) {
+        if (itr == osm_admin_data.way_map.end()) {
           has_data = false;
           break;
         }
@@ -453,7 +451,7 @@ void BuildAdminFromPBF(const boost::property_tree::ptree& pt,
 
         for (const auto ref_id : itr->second) {
 
-          const PointLL ll = osmdata.shape_map.at(ref_id);
+          const PointLL ll = osm_admin_data.shape_map.at(ref_id);
 
           Coordinate c;
           c.x = ll.lng();
@@ -484,7 +482,7 @@ void BuildAdminFromPBF(const boost::property_tree::ptree& pt,
           sqlite3_bind_int(stmt, 1, admin.admin_level());
 
           if (admin.iso_code_index()) {
-            iso = osmdata.name_offset_map.name(admin.iso_code_index());
+            iso = osm_admin_data.name_offset_map.name(admin.iso_code_index());
             sqlite3_bind_text(stmt, 2, iso.c_str(), iso.length(), SQLITE_STATIC);
           } else {
             sqlite3_bind_null(stmt, 2);
@@ -492,11 +490,11 @@ void BuildAdminFromPBF(const boost::property_tree::ptree& pt,
 
           sqlite3_bind_null(stmt, 3);
 
-          name = osmdata.name_offset_map.name(admin.name_index());
+          name = osm_admin_data.name_offset_map.name(admin.name_index());
           sqlite3_bind_text(stmt, 4, name.c_str(), name.length(), SQLITE_STATIC);
 
           if (admin.name_en_index()) {
-            name_en = osmdata.name_offset_map.name(admin.name_en_index());
+            name_en = osm_admin_data.name_offset_map.name(admin.name_en_index());
             sqlite3_bind_text(stmt, 5, name_en.c_str(), name_en.length(), SQLITE_STATIC);
           } else {
             sqlite3_bind_null(stmt, 5);
@@ -510,8 +508,10 @@ void BuildAdminFromPBF(const boost::property_tree::ptree& pt,
             continue;
           }
           LOG_ERROR("sqlite3_step() error: " + std::string(sqlite3_errmsg(db_handle)));
-          LOG_ERROR("sqlite3_step() Name: " + osmdata.name_offset_map.name(admin.name_index()));
-          LOG_ERROR("sqlite3_step() Name:en: " + osmdata.name_offset_map.name(admin.name_en_index()));
+          LOG_ERROR("sqlite3_step() Name: " +
+                    osm_admin_data.name_offset_map.name(admin.name_index()));
+          LOG_ERROR("sqlite3_step() Name:en: " +
+                    osm_admin_data.name_offset_map.name(admin.name_en_index()));
           LOG_ERROR("sqlite3_step() Admin Level: " + std::to_string(admin.admin_level()));
           LOG_ERROR("sqlite3_step() Drive on Right: " + std::to_string(admin.drive_on_right()));
         }

--- a/valhalla/mjolnir/osmadmindata.h
+++ b/valhalla/mjolnir/osmadmindata.h
@@ -1,0 +1,44 @@
+#ifndef VALHALLA_MJOLNIR_OSMADMINDATA_H
+#define VALHALLA_MJOLNIR_OSMADMINDATA_H
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+#include <valhalla/mjolnir/osmadmin.h>
+#include <valhalla/mjolnir/uniquenames.h>
+
+namespace valhalla {
+namespace mjolnir {
+
+using OSMWayMap = std::unordered_map<uint64_t, std::list<uint64_t>>;
+using OSMShapeMap = std::unordered_map<uint64_t, PointLL>;
+
+/**
+ * Simple container for OSM data used by admin processing.
+ * Populated by the PBF admin parser and sent into valhalla_build_admins.
+ */
+struct OSMAdminData {
+  uint64_t max_changeset_id_; // The largest/newest changeset id encountered when parsing OSM data
+  size_t osm_node_count;      // Count of osm nodes
+  size_t osm_way_count;       // Count of osm ways
+  size_t node_count;          // Count of all nodes
+
+  // Unique names used by admin areas
+  UniqueNames name_offset_map;
+
+  // Map used in admins to store the shape of the nodes.
+  OSMShapeMap shape_map;
+
+  // Map used in admins to store the ways.
+  OSMWayMap way_map;
+
+  // Vector of admins.
+  std::vector<OSMAdmin> admins_;
+};
+
+} // namespace mjolnir
+} // namespace valhalla
+
+#endif // VALHALLA_MJOLNIR_OSMADMINDATA_H

--- a/valhalla/mjolnir/osmdata.h
+++ b/valhalla/mjolnir/osmdata.h
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include <valhalla/mjolnir/osmaccessrestriction.h>
-#include <valhalla/mjolnir/osmadmin.h>
 #include <valhalla/mjolnir/osmnode.h>
 #include <valhalla/mjolnir/osmrestriction.h>
 #include <valhalla/mjolnir/osmway.h>
@@ -40,9 +39,6 @@ using AccessRestrictionsMultiMap = std::unordered_multimap<uint64_t, OSMAccessRe
 using BikeMultiMap = std::unordered_multimap<uint64_t, OSMBike>;
 
 using OSMStringMap = std::unordered_map<uint64_t, std::string>;
-
-using OSMShapeMap = std::unordered_map<uint64_t, PointLL>;
-using OSMWayMap = std::unordered_map<uint64_t, std::list<uint64_t>>;
 
 using OSMLaneConnectivityMultiMap = std::unordered_multimap<uint32_t, OSMLaneConnectivity>;
 
@@ -104,17 +100,8 @@ struct OSMData {
   // Backward turn lane strings
   UniqueNames bwd_turn_lanes_map;
 
-  // Map used in admins to store the shape of the nodes.
-  OSMShapeMap shape_map;
-
-  // Map used in admins to store the ways.
-  OSMWayMap way_map;
-
   // Lane connectivity, index by the to way Id
   OSMLaneConnectivityMultiMap lane_connectivity_map;
-
-  // Vector of admins.
-  std::vector<OSMAdmin> admins_;
 };
 
 } // namespace mjolnir

--- a/valhalla/mjolnir/pbfadminparser.h
+++ b/valhalla/mjolnir/pbfadminparser.h
@@ -6,7 +6,7 @@
 #include <string>
 #include <vector>
 
-#include <valhalla/mjolnir/osmdata.h>
+#include <valhalla/mjolnir/osmadmindata.h>
 
 namespace valhalla {
 namespace mjolnir {
@@ -19,8 +19,8 @@ public:
   /**
    * Loads given input files
    */
-  static OSMData Parse(const boost::property_tree::ptree& pt,
-                       const std::vector<std::string>& input_files);
+  static OSMAdminData Parse(const boost::property_tree::ptree& pt,
+                            const std::vector<std::string>& input_files);
 };
 
 } // namespace mjolnir


### PR DESCRIPTION
This is a new class that includes data parsed from OSM needed for admin data creation.

This removes several data members from the OSMData structure. This is a good first step before
starting to split OSM parsing from Valhalla tile building stages.