### PR TITLE
fix compilation with cmake 3.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,8 +125,8 @@ if(NOT Protobuf_FOUND)
   find_package(Protobuf REQUIRED)
 endif()
 
-# TODO: remove after switching to CMake >= 3.7
-if(CMAKE_VERSION VERSION_LESS 3.7)
+# TODO: remove after switching to CMake >= 3.9
+if(CMAKE_VERSION VERSION_LESS 3.9)
   if(NOT TARGET protobuf::libprotobuf-lite)
     add_library(protobuf::libprotobuf-lite UNKNOWN IMPORTED)
     set_target_properties(protobuf::libprotobuf-lite PROPERTIES


### PR DESCRIPTION
According to the documentation, the protobuf targets appear in 3.9.

https://cmake.org/cmake/help/v3.9/module/FindProtobuf.html have
https://cmake.org/cmake/help/v3.8/module/FindProtobuf.html have not

Fix compilation on debian 9 (cmake 3.7).