### PR TITLE
Fix osrm maneuver type for to_stay_on steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * **Bug Fix**
    * FIXED: Fixed a rare loop condition in route matcher (edge walking to match a trace).
    * FIXED: Fixed VACUUM ANALYZE syntax issue.  [#1704](https://github.com/valhalla/valhalla/pull/1704)
+   * FIXED: Fixed the osrm maneuver type when a maneuver has the to_stay_on attribute set.  [#1714](https://github.com/valhalla/valhalla/pull/1714)
 * **Enhancement**
    * Add the ability to run valhalla_build_tiles in stages. Specify the begin_stage and end_stage as command line options. Also cleans up temporary files as the last stage in the pipeline.
 

--- a/proto/tripdirections.proto
+++ b/proto/tripdirections.proto
@@ -162,6 +162,7 @@ message TripDirections {
     optional TransitType transit_type = 28;
     optional uint32 begin_path_index = 29;                   // Index in TripPath for first node of maneuver
     optional uint32 end_path_index = 30;                     // Index in TripPath for last node of maneuver
+    optional bool to_stay_on = 31;                           // True if same name as previous maneuver
   }
   
   optional uint64 trip_id = 1;

--- a/src/odin/directionsbuilder.cc
+++ b/src/odin/directionsbuilder.cc
@@ -297,6 +297,11 @@ TripDirections DirectionsBuilder::PopulateTripDirections(const DirectionsOptions
       trip_maneuver->set_verbal_multi_cue(maneuver.verbal_multi_cue());
     }
 
+    // To stay on
+    if (maneuver.to_stay_on()) {
+      trip_maneuver->set_to_stay_on(maneuver.to_stay_on());
+    }
+
     // Travel mode
     trip_maneuver->set_travel_mode(translate_travel_mode.find(maneuver.travel_mode())->second);
 

--- a/src/odin/maneuver.cc
+++ b/src/odin/maneuver.cc
@@ -110,7 +110,7 @@ Maneuver::Maneuver()
       transit_connection_(false), rail_(false), bus_(false), fork_(false),
       begin_intersecting_edge_name_consistency_(false), intersecting_forward_edge_(false),
       tee_(false), unnamed_walkway_(false), unnamed_cycleway_(false),
-      unnamed_mountain_bike_trail_(false), verbal_multi_cue_(false) {
+      unnamed_mountain_bike_trail_(false), verbal_multi_cue_(false), to_stay_on_(false) {
   street_names_ = midgard::make_unique<StreetNames>();
   begin_street_names_ = midgard::make_unique<StreetNames>();
   cross_street_names_ = midgard::make_unique<StreetNames>();
@@ -573,6 +573,14 @@ bool Maneuver::verbal_multi_cue() const {
 
 void Maneuver::set_verbal_multi_cue(bool verbal_multi_cue) {
   verbal_multi_cue_ = verbal_multi_cue;
+}
+
+bool Maneuver::to_stay_on() const {
+  return to_stay_on_;
+}
+
+void Maneuver::set_to_stay_on(bool to_stay_on) {
+  to_stay_on_ = to_stay_on;
 }
 
 TripPath_TravelMode Maneuver::travel_mode() const {

--- a/src/odin/narrativebuilder.cc
+++ b/src/odin/narrativebuilder.cc
@@ -196,6 +196,8 @@ void NarrativeBuilder::Build(const DirectionsOptions& directions_options,
       case TripDirections_Maneuver_Type_kStayRight:
       case TripDirections_Maneuver_Type_kStayLeft: {
         if (maneuver.HasSimilarNames(prev_maneuver)) {
+          maneuver.set_to_stay_on(true);
+
           // Set stay on instruction
           maneuver.set_instruction(FormKeepToStayOnInstruction(maneuver));
 
@@ -918,7 +920,8 @@ std::string NarrativeBuilder::FormTurnInstruction(Maneuver& maneuver, Maneuver* 
   // "0": "Turn/Bear/Turn sharp <RELATIVE_DIRECTION>.",
   // "1": "Turn/Bear/Turn sharp <RELATIVE_DIRECTION> onto <STREET_NAMES>.",
   // "2": "Turn/Bear/Turn sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>. Continue on
-  // <STREET_NAMES>.", "3": "Turn/Bear/Turn sharp <RELATIVE_DIRECTION> to stay on <STREET_NAMES>."
+  // <STREET_NAMES>.",
+  // "3": "Turn/Bear/Turn sharp <RELATIVE_DIRECTION> to stay on <STREET_NAMES>."
   const TurnSubset* subset = nullptr;
   switch (maneuver.type()) {
     case TripDirections_Maneuver_Type_kSlightRight:
@@ -956,6 +959,7 @@ std::string NarrativeBuilder::FormTurnInstruction(Maneuver& maneuver, Maneuver* 
     phrase_id = 2;
   }
   if (begin_street_names.empty() && maneuver.HasSimilarNames(prev_maneuver, true)) {
+    maneuver.set_to_stay_on(true);
     phrase_id = 3;
   }
 
@@ -1037,6 +1041,7 @@ std::string NarrativeBuilder::FormVerbalTurnInstruction(Maneuver& maneuver,
     phrase_id = 2;
   }
   if (begin_street_names.empty() && maneuver.HasSimilarNames(prev_maneuver, true)) {
+    maneuver.set_to_stay_on(true);
     phrase_id = 3;
   }
 
@@ -1081,6 +1086,7 @@ std::string NarrativeBuilder::FormUturnInstruction(Maneuver& maneuver, Maneuver*
   if (!street_names.empty()) {
     phrase_id += 1;
     if (maneuver.HasSameNames(prev_maneuver, true)) {
+      maneuver.set_to_stay_on(true);
       phrase_id += 1;
     }
   }
@@ -1135,6 +1141,7 @@ std::string NarrativeBuilder::FormVerbalAlertUturnInstruction(Maneuver& maneuver
   if (!street_names.empty()) {
     phrase_id = 1;
     if (maneuver.HasSameNames(prev_maneuver, true)) {
+      maneuver.set_to_stay_on(true);
       phrase_id = 2;
     }
   }
@@ -1177,6 +1184,7 @@ std::string NarrativeBuilder::FormVerbalUturnInstruction(Maneuver& maneuver,
   if (!street_names.empty()) {
     phrase_id += 1;
     if (maneuver.HasSameNames(prev_maneuver, true)) {
+      maneuver.set_to_stay_on(true);
       phrase_id += 1;
     }
   }

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -691,7 +691,7 @@ json::MapPtr osrm_maneuver(const valhalla::odin::TripDirections::Maneuver& maneu
       } else if (false_node && new_name) {
         maneuver_type = "new name";
       } else {
-        if (modifier != "uturn") {
+        if ((modifier != "uturn") && (!maneuver.to_stay_on())) {
           maneuver_type = "turn";
         } else {
           maneuver_type = "continue";

--- a/test/narrativebuilder.cc
+++ b/test/narrativebuilder.cc
@@ -3297,6 +3297,7 @@ void TestBuildTurnInstructions_0_miles_en_US() {
                                   "Continue for a half mile.");
 
   TryBuild(directions_options, maneuvers, expected_maneuvers);
+  VerifyToStayOn(maneuvers.back(), false);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3325,6 +3326,7 @@ void TestBuildTurnInstructions_1_miles_en_US() {
                                   "Turn left onto Middletown Road.", "Continue for 1.2 miles.");
 
   TryBuild(directions_options, maneuvers, expected_maneuvers);
+  VerifyToStayOn(maneuvers.back(), false);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3440,6 +3442,7 @@ void TestBuildTurnInstructions_2_miles_en_US() {
       "Continue on Maryland 9 24 for a half mile.");
 
   TryBuild(directions_options, maneuvers, expected_maneuvers);
+  VerifyToStayOn(maneuvers.back(), false);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/test/narrativebuilder.cc
+++ b/test/narrativebuilder.cc
@@ -337,6 +337,13 @@ void TryBuild(const DirectionsOptions& directions_options,
   }
 }
 
+void VerifyToStayOn(const Maneuver& maneuver, bool expected_to_stay_on) {
+
+  // Check to stay on attribute
+  if (maneuver.to_stay_on() != expected_to_stay_on)
+    throw std::runtime_error("Incorrect 'to stay on' attribute");
+}
+
 void PopulateStartManeuverList_0(std::list<Maneuver>& maneuvers,
                                  const std::string& country_code,
                                  const std::string& state_code) {
@@ -3465,6 +3472,7 @@ void TestBuildTurnInstructions_3_miles_en_US() {
                                   "Turn right to stay on Sunstone Drive.", "Continue for 100 feet.");
 
   TryBuild(directions_options, maneuvers, expected_maneuvers);
+  VerifyToStayOn(maneuvers.back(), true);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3585,6 +3593,7 @@ void TestBuildSharpInstructions_3_miles_en_US() {
                                   "Continue for 100 feet.");
 
   TryBuild(directions_options, maneuvers, expected_maneuvers);
+  VerifyToStayOn(maneuvers.back(), true);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3702,6 +3711,7 @@ void TestBuildBearInstructions_3_miles_en_US() {
                                   "Bear left to stay on U.S. 15 South.", "Continue for 2.6 miles.");
 
   TryBuild(directions_options, maneuvers, expected_maneuvers);
+  VerifyToStayOn(maneuvers.back(), true);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3792,6 +3802,7 @@ void TestBuildUturnInstructions_2_miles_en_US() {
                                   "Continue for 2 tenths of a mile.");
 
   TryBuild(directions_options, maneuvers, expected_maneuvers);
+  VerifyToStayOn(maneuvers.back(), true);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3885,6 +3896,7 @@ void TestBuildUturnInstructions_5_miles_en_US() {
       "Continue for 200 feet.");
 
   TryBuild(directions_options, maneuvers, expected_maneuvers);
+  VerifyToStayOn(maneuvers.back(), true);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4924,6 +4936,7 @@ void TestBuildKeepToStayOn_0_miles_en_US() {
                                   "Continue for 5.1 miles.");
 
   TryBuild(directions_options, maneuvers, expected_maneuvers);
+  VerifyToStayOn(maneuvers.back(), true);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4958,6 +4971,7 @@ void TestBuildKeepToStayOn_1_miles_en_US() {
                                   "Continue for 5.1 miles.");
 
   TryBuild(directions_options, maneuvers, expected_maneuvers);
+  VerifyToStayOn(maneuvers.back(), true);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4992,6 +5006,7 @@ void TestBuildKeepToStayOn_2_miles_en_US() {
                                   "Continue for 5.1 miles.");
 
   TryBuild(directions_options, maneuvers, expected_maneuvers);
+  VerifyToStayOn(maneuvers.back(), true);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5026,6 +5041,7 @@ void TestBuildKeepToStayOn_3_miles_en_US() {
       "Continue for 5.1 miles.");
 
   TryBuild(directions_options, maneuvers, expected_maneuvers);
+  VerifyToStayOn(maneuvers.back(), true);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/valhalla/odin/maneuver.h
+++ b/valhalla/odin/maneuver.h
@@ -194,6 +194,9 @@ public:
   bool verbal_multi_cue() const;
   void set_verbal_multi_cue(bool verbal_multi_cue);
 
+  bool to_stay_on() const;
+  void set_to_stay_on(bool to_stay_on);
+
   TripPath_TravelMode travel_mode() const;
   void set_travel_mode(TripPath_TravelMode travel_mode);
 
@@ -310,6 +313,7 @@ protected:
   bool unnamed_cycleway_;
   bool unnamed_mountain_bike_trail_;
   bool verbal_multi_cue_;
+  bool to_stay_on_;
 
   ////////////////////////////////////////////////////////////////////////////
   // Transit support


### PR DESCRIPTION
# Issue

Currently, the osrm maneuver type is set to `turn` instead of `continue` for a `to_stay_on` step.

## Tasklist

 - [x] Update logic to properly assign the `continue` maneuver type
 - [x] Add tests
 - [x] Review - you must request approval to merge any PR to master
 - [x] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)

## Before
![before_to_stay_on](https://user-images.githubusercontent.com/7515853/52490947-ef826d80-2b93-11e9-805f-9f639457bc96.png)

## After
![after_to_stay_on](https://user-images.githubusercontent.com/7515853/52490959-f6a97b80-2b93-11e9-8a75-c1ffaf36bb79.png)

