### PR TITLE
Fixed the destinations assignment for exit names in OSRM compatibility mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
    * FIXED: Fixed the osrm maneuver type when a maneuver has the to_stay_on attribute set.  [#1714](https://github.com/valhalla/valhalla/pull/1714)
    * FIXED: Fixed osrm compatibility mode attributes.  [#1716](https://github.com/valhalla/valhalla/pull/1716)
    * FIXED: Fixed rotary/roundabout issues in Valhalla OSRM compatibility.  [#1727](https://github.com/valhalla/valhalla/pull/1727)
+   * FIXED: Fixed the destinations assignment for exit names in OSRM compatibility mode. [#1732](https://github.com/valhalla/valhalla/pull/1732)
 * **Enhancement**
    * Add the ability to run valhalla_build_tiles in stages. Specify the begin_stage and end_stage as command line options. Also cleans up temporary files as the last stage in the pipeline.
 

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -443,8 +443,11 @@ std::string destinations(const valhalla::odin::TripDirections_Maneuver_Sign& sig
   // Get the towards nonrefs
   std::string toward_nonrefs = get_sign_element_nonrefs(sign.exit_toward_locations());
 
-  // Get the name nonrefs
-  std::string name_nonrefs = get_sign_element_nonrefs(sign.exit_names());
+  // Get the name nonrefs only if the others are empty
+  std::string name_nonrefs;
+  if (branch_nonrefs.empty() && toward_nonrefs.empty()) {
+    name_nonrefs = get_sign_element_nonrefs(sign.exit_names());
+  }
 
   // Create nonrefs by combining the branch, toward, name nonref lists
   std::string nonrefs = branch_nonrefs;


### PR DESCRIPTION
# Issue

Exit names should only be used if exit branch and exit toward records are empty. Fixed the destinations assignment for the OSRM compatibility mode.

## Tasklist

 - [x] Review - you must request approval to merge any PR to master
 - [x] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)

In the following example - `Bedford` should not be part of the `destinations`

## Before
![destinations_name_before](https://user-images.githubusercontent.com/7515853/53667603-7c729100-3c3f-11e9-91bc-ab93c077edf7.png)

## After
![destinations_name_after](https://user-images.githubusercontent.com/7515853/53667619-83999f00-3c3f-11e9-9e6c-81cae21ec514.png)
