### PR TITLE
Enhance merge maneuver type assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
    * FIXED: Fixed osrm compatibility mode attributes.  [#1716](https://github.com/valhalla/valhalla/pull/1716)
    * FIXED: Fixed rotary/roundabout issues in Valhalla OSRM compatibility.  [#1727](https://github.com/valhalla/valhalla/pull/1727)
    * FIXED: Fixed the destinations assignment for exit names in OSRM compatibility mode. [#1732](https://github.com/valhalla/valhalla/pull/1732)
+   * FIXED: Enhance merge maneuver type assignment. [#1735](https://github.com/valhalla/valhalla/pull/1735)
 * **Enhancement**
    * Add the ability to run valhalla_build_tiles in stages. Specify the begin_stage and end_stage as command line options. Also cleans up temporary files as the last stage in the pipeline.
 

--- a/src/odin/enhancedtrippath.cc
+++ b/src/odin/enhancedtrippath.cc
@@ -967,6 +967,15 @@ bool EnhancedTripPath_Node::HasIntersectingEdgeNameConsistency() const {
   return false;
 }
 
+bool EnhancedTripPath_Node::HasIntersectingEdgeCurrNameConsistency() const {
+  for (const auto& xedge : intersecting_edge()) {
+    if (xedge.curr_name_consistency()) {
+      return true;
+    }
+  }
+  return false;
+}
+
 EnhancedTripPath_IntersectingEdge* EnhancedTripPath_Node::GetIntersectingEdge(size_t index) {
   return static_cast<EnhancedTripPath_IntersectingEdge*>(mutable_intersecting_edge(index));
 }

--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -1238,7 +1238,7 @@ void ManeuversBuilder::SetManeuverType(Maneuver& maneuver, bool none_type_allowe
     }
   }
   // Process merge
-  else if (curr_edge->IsHighway() && prev_edge && prev_edge->IsRampUse()) {
+  else if (IsMergeManeuverType(prev_edge, curr_edge)) {
     maneuver.set_type(TripDirections_Maneuver_Type_kMerge);
     LOG_TRACE("ManeuverType=MERGE");
   }
@@ -1652,6 +1652,21 @@ bool ManeuversBuilder::IncludeUnnamedPrevEdge(int node_index,
                                                     curr_edge->begin_heading()),
                                       node->GetStraightestIntersectingEdgeTurnDegree(
                                           prev_edge->end_heading()))) {
+    return true;
+  }
+
+  return false;
+}
+
+bool ManeuversBuilder::IsMergeManeuverType(EnhancedTripPath_Edge* prev_edge,
+                                           EnhancedTripPath_Edge* curr_edge) const {
+
+  if (prev_edge && prev_edge->IsRampUse() && !curr_edge->IsRampUse() &&
+      (curr_edge->IsHighway() ||
+       (((curr_edge->road_class() == TripPath_RoadClass_kTrunk) ||
+         (curr_edge->road_class() == TripPath_RoadClass_kPrimary)) &&
+        curr_edge->IsOneway() &&
+        curr_edge->IsForward(GetTurnDegree(prev_edge->end_heading(), curr_edge->begin_heading()))))) {
     return true;
   }
 

--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -1238,7 +1238,7 @@ void ManeuversBuilder::SetManeuverType(Maneuver& maneuver, bool none_type_allowe
     }
   }
   // Process merge
-  else if (IsMergeManeuverType(prev_edge, curr_edge)) {
+  else if (IsMergeManeuverType(maneuver, prev_edge, curr_edge)) {
     maneuver.set_type(TripDirections_Maneuver_Type_kMerge);
     LOG_TRACE("ManeuverType=MERGE");
   }
@@ -1658,15 +1658,16 @@ bool ManeuversBuilder::IncludeUnnamedPrevEdge(int node_index,
   return false;
 }
 
-bool ManeuversBuilder::IsMergeManeuverType(EnhancedTripPath_Edge* prev_edge,
+bool ManeuversBuilder::IsMergeManeuverType(Maneuver& maneuver,
+                                           EnhancedTripPath_Edge* prev_edge,
                                            EnhancedTripPath_Edge* curr_edge) const {
-
+  auto* node = trip_path_->GetEnhancedNode(maneuver.begin_node_index());
   if (prev_edge && prev_edge->IsRampUse() && !curr_edge->IsRampUse() &&
       (curr_edge->IsHighway() ||
        (((curr_edge->road_class() == TripPath_RoadClass_kTrunk) ||
          (curr_edge->road_class() == TripPath_RoadClass_kPrimary)) &&
-        curr_edge->IsOneway() &&
-        curr_edge->IsForward(GetTurnDegree(prev_edge->end_heading(), curr_edge->begin_heading()))))) {
+        curr_edge->IsOneway() && curr_edge->IsForward(maneuver.turn_degree()) &&
+        node->HasIntersectingEdgeCurrNameConsistency()))) {
     return true;
   }
 

--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -1662,6 +1662,10 @@ bool ManeuversBuilder::IsMergeManeuverType(Maneuver& maneuver,
                                            EnhancedTripPath_Edge* prev_edge,
                                            EnhancedTripPath_Edge* curr_edge) const {
   auto* node = trip_path_->GetEnhancedNode(maneuver.begin_node_index());
+  // Previous edge is ramp and current edge is not a ramp
+  // Current edge is a highway OR
+  // Current edge is a trunk or primary, oneway, forward turn degree, and
+  // consistent name with intersecting edge
   if (prev_edge && prev_edge->IsRampUse() && !curr_edge->IsRampUse() &&
       (curr_edge->IsHighway() ||
        (((curr_edge->road_class() == TripPath_RoadClass_kTrunk) ||

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -643,11 +643,7 @@ json::MapPtr osrm_maneuver(const valhalla::odin::TripDirections::Maneuver& maneu
                     maneuver.type() == odin::TripDirections_Maneuver_Type_kBecomes;
     bool ramp = curr_edge->use() == odin::TripPath_Use_kRampUse;
     bool fork = etp->node(idx).fork();
-    bool merge = prev_edge->use() == odin::TripPath_Use_kRampUse &&
-                 curr_edge->use() == odin::TripPath_Use_kRoadUse &&
-                 (curr_edge->road_class() == odin::TripPath_RoadClass_kMotorway ||
-                  curr_edge->road_class() == odin::TripPath_RoadClass_kTrunk);
-    if (merge) {
+    if (maneuver.type() == odin::TripDirections_Maneuver_Type_kMerge) {
       maneuver_type = "merge";
     } else if (fork) {
       maneuver_type = "fork";

--- a/valhalla/odin/enhancedtrippath.h
+++ b/valhalla/odin/enhancedtrippath.h
@@ -190,6 +190,8 @@ public:
 
   bool HasIntersectingEdgeNameConsistency() const;
 
+  bool HasIntersectingEdgeCurrNameConsistency() const;
+
   EnhancedTripPath_IntersectingEdge* GetIntersectingEdge(size_t index);
 
   void CalculateRightLeftIntersectingEdgeCounts(uint32_t from_heading,

--- a/valhalla/odin/maneuversbuilder.h
+++ b/valhalla/odin/maneuversbuilder.h
@@ -88,7 +88,9 @@ protected:
                               EnhancedTripPath_Edge* prev_edge,
                               EnhancedTripPath_Edge* curr_edge) const;
 
-  bool IsMergeManeuverType(EnhancedTripPath_Edge* prev_edge, EnhancedTripPath_Edge* curr_edge) const;
+  bool IsMergeManeuverType(Maneuver& maneuver,
+                           EnhancedTripPath_Edge* prev_edge,
+                           EnhancedTripPath_Edge* curr_edge) const;
 
   bool
   IsFork(int node_index, EnhancedTripPath_Edge* prev_edge, EnhancedTripPath_Edge* curr_edge) const;

--- a/valhalla/odin/maneuversbuilder.h
+++ b/valhalla/odin/maneuversbuilder.h
@@ -88,6 +88,8 @@ protected:
                               EnhancedTripPath_Edge* prev_edge,
                               EnhancedTripPath_Edge* curr_edge) const;
 
+  bool IsMergeManeuverType(EnhancedTripPath_Edge* prev_edge, EnhancedTripPath_Edge* curr_edge) const;
+
   bool
   IsFork(int node_index, EnhancedTripPath_Edge* prev_edge, EnhancedTripPath_Edge* curr_edge) const;
 


### PR DESCRIPTION
# Issue

While testing the OSRM compatibility mode - noticed some inconsistent assignments for the merge maneuver type. Added logic to provide consistent assignments.

``` diff
Example 1
< BEFORE
< Continue on 17th Street.
> AFTER
> Merge onto 17th Street.

Example 2
< BEFORE
< Continue on PA 743 North.
> AFTER
> Merge onto PA 743 North.

Example 3
< BEFORE
< Merge left onto US 220 Business
> AFTER
> Turn left onto US 220 Business
```
## Tasklist

 - [x] Test
 - [x] Review - you must request approval to merge any PR to master
 - [x] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)

