### PR TITLE
Fixed fork assignments and on ramps for OSRM compatibility mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
    * FIXED: Fixed rotary/roundabout issues in Valhalla OSRM compatibility.  [#1727](https://github.com/valhalla/valhalla/pull/1727)
    * FIXED: Fixed the destinations assignment for exit names in OSRM compatibility mode. [#1732](https://github.com/valhalla/valhalla/pull/1732)
    * FIXED: Enhance merge maneuver type assignment. [#1735](https://github.com/valhalla/valhalla/pull/1735)
+   * FIXED: Fixed fork assignments and on ramps for OSRM compatibility mode. [#1738](https://github.com/valhalla/valhalla/pull/1738)
 * **Enhancement**
    * Add the ability to run valhalla_build_tiles in stages. Specify the begin_stage and end_stage as command line options. Also cleans up temporary files as the last stage in the pipeline.
 

--- a/proto/tripdirections.proto
+++ b/proto/tripdirections.proto
@@ -164,6 +164,7 @@ message TripDirections {
     optional uint32 end_path_index = 30;                     // Index in TripPath for last node of maneuver
     optional bool to_stay_on = 31;                           // True if same name as previous maneuver
     repeated StreetName roundabout_exit_street_names = 32;   // Outbound street names from roundabout
+    optional uint32 turn_degree = 33;                        // Turn degree of maneuver
   }
   
   optional uint64 trip_id = 1;

--- a/src/odin/directionsbuilder.cc
+++ b/src/odin/directionsbuilder.cc
@@ -165,6 +165,7 @@ TripDirections DirectionsBuilder::PopulateTripDirections(const DirectionsOptions
     trip_maneuver->set_time(maneuver.time());
     trip_maneuver->set_begin_cardinal_direction(maneuver.begin_cardinal_direction());
     trip_maneuver->set_begin_heading(maneuver.begin_heading());
+    trip_maneuver->set_turn_degree(maneuver.turn_degree());
     trip_maneuver->set_begin_shape_index(maneuver.begin_shape_index());
     trip_maneuver->set_end_shape_index(maneuver.end_shape_index());
     if (maneuver.portions_toll()) {

--- a/src/odin/enhancedtrippath.cc
+++ b/src/odin/enhancedtrippath.cc
@@ -1110,6 +1110,19 @@ uint32_t EnhancedTripPath_Node::GetStraightestTraversableIntersectingEdgeTurnDeg
   return staightest_turn_degree;
 }
 
+bool EnhancedTripPath_Node::IsStraightestTraversableIntersectingEdgeReversed(
+    uint32_t from_heading,
+    const TripPath_TravelMode travel_mode) {
+  uint32_t straightest_traversable_xedge_turn_degree =
+      GetStraightestTraversableIntersectingEdgeTurnDegree(from_heading, travel_mode);
+  // Determine if the straightest intersecting edge is in the reversed direction
+  if ((straightest_traversable_xedge_turn_degree > 124) &&
+      (straightest_traversable_xedge_turn_degree < 236)) {
+    return true;
+  }
+  return false;
+}
+
 uint32_t EnhancedTripPath_Node::GetStraightestIntersectingEdgeTurnDegree(uint32_t from_heading) {
 
   uint32_t staightest_turn_degree = 180; // Initialize to reverse turn degree

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -551,26 +551,22 @@ std::string turn_modifier(const valhalla::odin::TripDirections::Maneuver& maneuv
   }
 }
 
-// Ramp cases - off ramp transitions from a motorway. On ramp ends
-// in a motorway.
-// TODO are we able to use the TripDirections_Maneuver_Type ramp/exit classification
-std::string ramp_type(valhalla::odin::EnhancedTripPath_Edge* prev_edge,
-                      const uint32_t idx,
-                      valhalla::odin::EnhancedTripPath* etp) {
-  if (prev_edge->use() == odin::TripPath_Use_kRoadUse) {
-    if (prev_edge->road_class() == odin::TripPath_RoadClass_kMotorway) {
-      return std::string("off ramp");
-    } else if (prev_edge->road_class() != odin::TripPath_RoadClass_kMotorway) {
-      // Check that next road is a motorway
-      for (uint32_t i = idx + 1; i < (etp->node_size() - 1); ++i) {
-        auto* curr_edge = etp->GetCurrEdge(i);
-        if (curr_edge->use() == odin::TripPath_Use_kRoadUse) {
-          if (curr_edge->road_class() == odin::TripPath_RoadClass_kMotorway) {
-            return std::string("on ramp");
-          }
-          break;
-        }
-      }
+// Ramp cases - off ramp transitions from a motorway.
+// On ramp ends in a motorway.
+std::string ramp_type(const valhalla::odin::TripDirections::Maneuver& maneuver) {
+  if ((maneuver.type() == TripDirections_Maneuver_Type_kExitRight) ||
+      (maneuver.type() == TripDirections_Maneuver_Type_kExitLeft)) {
+    return "off ramp";
+  } else if ((maneuver.type() == TripDirections_Maneuver_Type_kRampStraight) ||
+             (maneuver.type() == TripDirections_Maneuver_Type_kRampRight) ||
+             (maneuver.type() == TripDirections_Maneuver_Type_kRampLeft)) {
+
+    // If slight turn
+    uint32_t turn_degree = maneuver.turn_degree();
+    if ((turn_degree > 329) || (turn_degree < 31)) {
+      return "on ramp";
+    } else {
+      return "turn";
     }
   }
   return "";
@@ -641,14 +637,20 @@ json::MapPtr osrm_maneuver(const valhalla::odin::TripDirections::Maneuver& maneu
     auto* curr_edge = etp->GetCurrEdge(idx);
     bool new_name = maneuver.type() == odin::TripDirections_Maneuver_Type_kContinue ||
                     maneuver.type() == odin::TripDirections_Maneuver_Type_kBecomes;
-    bool ramp = curr_edge->use() == odin::TripPath_Use_kRampUse;
-    bool fork = etp->node(idx).fork();
+    bool ramp = ((maneuver.type() == TripDirections_Maneuver_Type_kRampStraight) ||
+                 (maneuver.type() == TripDirections_Maneuver_Type_kRampRight) ||
+                 (maneuver.type() == TripDirections_Maneuver_Type_kRampLeft) ||
+                 (maneuver.type() == TripDirections_Maneuver_Type_kExitRight) ||
+                 (maneuver.type() == TripDirections_Maneuver_Type_kExitLeft));
+    bool fork = ((maneuver.type() == TripDirections_Maneuver_Type_kStayStraight) ||
+                 (maneuver.type() == TripDirections_Maneuver_Type_kStayRight) ||
+                 (maneuver.type() == TripDirections_Maneuver_Type_kStayLeft));
     if (maneuver.type() == odin::TripDirections_Maneuver_Type_kMerge) {
       maneuver_type = "merge";
     } else if (fork) {
       maneuver_type = "fork";
     } else if (ramp) {
-      maneuver_type = ramp_type(prev_edge, idx, etp);
+      maneuver_type = ramp_type(maneuver);
     } else if (new_name) {
       maneuver_type = "new name";
     }

--- a/valhalla/odin/enhancedtrippath.h
+++ b/valhalla/odin/enhancedtrippath.h
@@ -210,6 +210,9 @@ public:
   uint32_t GetStraightestTraversableIntersectingEdgeTurnDegree(uint32_t from_heading,
                                                                const TripPath_TravelMode travel_mode);
 
+  bool IsStraightestTraversableIntersectingEdgeReversed(uint32_t from_heading,
+                                                        const TripPath_TravelMode travel_mode);
+
   // Type
   bool IsStreetIntersection() const;
   bool IsGate() const;


### PR DESCRIPTION
# Issue

Update fork assignment to call out right/left at bifurcation. Fixes #140
Update ramp logic so we do not call out a maneuver when transitioning from a one way ramp to a bidirectional ramp and the reverse case too. Fixes #703
Update `on ramp` assignment to call out turn vs. take. Fixes #1733 

### Example 1
![image](https://user-images.githubusercontent.com/7515853/54132617-ec74da00-43ea-11e9-95a9-4f2d12a39baf.png)
``` diff
< BEFORE
< 3: Keep straight to take PA 743 South toward Elizabethtown.
> AFTER
> 3: Keep right to take PA 743 South toward Elizabethtown.
```

### Example 2
![image](https://user-images.githubusercontent.com/7515853/54132794-3c53a100-43eb-11e9-8a43-c0c5d7e6385d.png)
``` diff
< BEFORE
< 2: Take exit 24 on the right onto PA 238 toward Emigsville.
< 3: Keep straight toward Emigsville.
< 4: Turn right onto Church Road/PA 238.
> AFTER
> 2: Take exit 24 on the right onto PA 238 toward Emigsville.
> 3: Turn right onto Church Road/PA 238.
```

### Example 3
![image](https://user-images.githubusercontent.com/7515853/54133164-f3e8b300-43eb-11e9-876f-cbe07fd46691.png)
Standard guidance and shared guidance are now the same
![image](https://user-images.githubusercontent.com/7515853/54133251-1c70ad00-43ec-11e9-9d6b-274bb7fce3f4.png)

## Tasklist

 - [x] Test
 - [x] Review - you must request approval to merge any PR to master
 - [x] Add #fixes with the issue number that this PR addresses
 - [x] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)
