### PR TITLE
End of highway to ramps fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
    * FIXED: Enhance merge maneuver type assignment. [#1735](https://github.com/valhalla/valhalla/pull/1735)
    * FIXED: Fixed fork assignments and on ramps for OSRM compatibility mode. [#1738](https://github.com/valhalla/valhalla/pull/1738)
    * FIXED: Fixed cardinal direction on reference names when forward/backward tag is present on relations. Fixes singly digitized roads with opposing directional modifiers. [#1741](https://github.com/valhalla/valhalla/pull/1741)
-   * FIXED: Fixed fork assignment and narrattive logic when a highway ends and splits into multiple ramps. [#1742](https://github.com/valhalla/valhalla/pull/1742)
+   * FIXED: Fixed fork assignment and narrative logic when a highway ends and splits into multiple ramps. [#1742](https://github.com/valhalla/valhalla/pull/1742)
 
 * **Enhancement**
    * Add the ability to run valhalla_build_tiles in stages. Specify the begin_stage and end_stage as command line options. Also cleans up temporary files as the last stage in the pipeline.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
    * FIXED: Enhance merge maneuver type assignment. [#1735](https://github.com/valhalla/valhalla/pull/1735)
    * FIXED: Fixed fork assignments and on ramps for OSRM compatibility mode. [#1738](https://github.com/valhalla/valhalla/pull/1738)
    * FIXED: Fixed cardinal direction on reference names when forward/backward tag is present on relations. Fixes singly digitized roads with opposing directional modifiers. [#1741](https://github.com/valhalla/valhalla/pull/1741)
+   * FIXED: Fixed fork assignment and narrattive logic when a highway ends and splits into multiple ramps. [#1742](https://github.com/valhalla/valhalla/pull/1742)
+
 * **Enhancement**
    * Add the ability to run valhalla_build_tiles in stages. Specify the begin_stage and end_stage as command line options. Also cleans up temporary files as the last stage in the pipeline.
 

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -509,10 +509,15 @@ void BuildTileSet(const std::string& ways_file,
 
         // it is a fork if more than two edges and more than one driveforward edge and
         //   if all the edges are links
-        //   OR the node is a motorway_junction and none of the edges are links
-        bool fork = (((bundle.node_edges.size() > 2) && (bundle.driveforward_count > 1)) &&
-                     ((bundle.link_count == bundle.node_edges.size()) ||
-                      ((node.type() == NodeType::kMotorWayJunction) && (bundle.link_count == 0))));
+        //   OR the node is a motorway_junction
+        //      AND none of the edges are links
+        //      OR all outbound edges are links and there is only one inbound edge
+        bool fork =
+            (((bundle.node_edges.size() > 2) && (bundle.driveforward_count > 1)) &&
+             ((bundle.link_count == bundle.node_edges.size()) ||
+              ((node.type() == NodeType::kMotorWayJunction) &&
+               ((bundle.link_count == 0) || ((bundle.link_count == bundle.driveforward_count) &&
+                                             (bundle.node_edges.size() == bundle.link_count + 1))))));
 
         //////////////////////////////////////////////////////////////////////
         // Iterate over edges at node

--- a/src/odin/narrativebuilder.cc
+++ b/src/odin/narrativebuilder.cc
@@ -102,15 +102,13 @@ void NarrativeBuilder::Build(const DirectionsOptions& directions_options,
       case TripDirections_Maneuver_Type_kSharpLeft:
       case TripDirections_Maneuver_Type_kLeft: {
         // Set instruction
-        maneuver.set_instruction(FormTurnInstruction(maneuver, prev_maneuver));
+        maneuver.set_instruction(FormTurnInstruction(maneuver));
 
         // Set verbal transition alert instruction
-        maneuver.set_verbal_transition_alert_instruction(
-            FormVerbalAlertTurnInstruction(maneuver, prev_maneuver));
+        maneuver.set_verbal_transition_alert_instruction(FormVerbalAlertTurnInstruction(maneuver));
 
         // Set verbal pre transition instruction
-        maneuver.set_verbal_pre_transition_instruction(
-            FormVerbalTurnInstruction(maneuver, prev_maneuver));
+        maneuver.set_verbal_pre_transition_instruction(FormVerbalTurnInstruction(maneuver));
 
         // Set verbal post transition instruction
         maneuver.set_verbal_post_transition_instruction(
@@ -120,15 +118,13 @@ void NarrativeBuilder::Build(const DirectionsOptions& directions_options,
       case TripDirections_Maneuver_Type_kUturnRight:
       case TripDirections_Maneuver_Type_kUturnLeft: {
         // Set instruction
-        maneuver.set_instruction(FormUturnInstruction(maneuver, prev_maneuver));
+        maneuver.set_instruction(FormUturnInstruction(maneuver));
 
         // Set verbal transition alert instruction
-        maneuver.set_verbal_transition_alert_instruction(
-            FormVerbalAlertUturnInstruction(maneuver, prev_maneuver));
+        maneuver.set_verbal_transition_alert_instruction(FormVerbalAlertUturnInstruction(maneuver));
 
         // Set verbal pre transition instruction
-        maneuver.set_verbal_pre_transition_instruction(
-            FormVerbalUturnInstruction(maneuver, prev_maneuver));
+        maneuver.set_verbal_pre_transition_instruction(FormVerbalUturnInstruction(maneuver));
 
         // Set verbal post transition instruction
         maneuver.set_verbal_post_transition_instruction(
@@ -195,9 +191,7 @@ void NarrativeBuilder::Build(const DirectionsOptions& directions_options,
       case TripDirections_Maneuver_Type_kStayStraight:
       case TripDirections_Maneuver_Type_kStayRight:
       case TripDirections_Maneuver_Type_kStayLeft: {
-        if (maneuver.HasSimilarNames(prev_maneuver)) {
-          maneuver.set_to_stay_on(true);
-
+        if (maneuver.to_stay_on()) {
           // Set stay on instruction
           maneuver.set_instruction(FormKeepToStayOnInstruction(maneuver));
 
@@ -916,7 +910,7 @@ std::string NarrativeBuilder::FormVerbalContinueInstruction(Maneuver& maneuver,
   return instruction;
 }
 
-std::string NarrativeBuilder::FormTurnInstruction(Maneuver& maneuver, Maneuver* prev_maneuver) {
+std::string NarrativeBuilder::FormTurnInstruction(Maneuver& maneuver) {
   // "0": "Turn/Bear/Turn sharp <RELATIVE_DIRECTION>.",
   // "1": "Turn/Bear/Turn sharp <RELATIVE_DIRECTION> onto <STREET_NAMES>.",
   // "2": "Turn/Bear/Turn sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>. Continue on
@@ -958,8 +952,7 @@ std::string NarrativeBuilder::FormTurnInstruction(Maneuver& maneuver, Maneuver* 
   if (!begin_street_names.empty()) {
     phrase_id = 2;
   }
-  if (begin_street_names.empty() && maneuver.HasSimilarNames(prev_maneuver, true)) {
-    maneuver.set_to_stay_on(true);
+  if (maneuver.to_stay_on()) {
     phrase_id = 3;
   }
 
@@ -981,7 +974,6 @@ std::string NarrativeBuilder::FormTurnInstruction(Maneuver& maneuver, Maneuver* 
 }
 
 std::string NarrativeBuilder::FormVerbalAlertTurnInstruction(Maneuver& maneuver,
-                                                             Maneuver* prev_maneuver,
                                                              uint32_t element_max_count,
                                                              const std::string& delim) {
   // "0": "Turn/Bear/Turn sharp <RELATIVE_DIRECTION>.",
@@ -989,11 +981,10 @@ std::string NarrativeBuilder::FormVerbalAlertTurnInstruction(Maneuver& maneuver,
   // "2": "Turn/Bear/Turn sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>.",
   // "3": "Turn/Bear/Turn sharp <RELATIVE_DIRECTION> to stay on <STREET_NAMES>."
 
-  return FormVerbalTurnInstruction(maneuver, prev_maneuver, element_max_count, delim);
+  return FormVerbalTurnInstruction(maneuver, element_max_count, delim);
 }
 
 std::string NarrativeBuilder::FormVerbalTurnInstruction(Maneuver& maneuver,
-                                                        Maneuver* prev_maneuver,
                                                         uint32_t element_max_count,
                                                         const std::string& delim) {
   // "0": "Turn/Bear/Turn sharp <RELATIVE_DIRECTION>.",
@@ -1040,8 +1031,7 @@ std::string NarrativeBuilder::FormVerbalTurnInstruction(Maneuver& maneuver,
   if (!begin_street_names.empty()) {
     phrase_id = 2;
   }
-  if (begin_street_names.empty() && maneuver.HasSimilarNames(prev_maneuver, true)) {
-    maneuver.set_to_stay_on(true);
+  if (maneuver.to_stay_on()) {
     phrase_id = 3;
   }
 
@@ -1062,7 +1052,7 @@ std::string NarrativeBuilder::FormVerbalTurnInstruction(Maneuver& maneuver,
   return instruction;
 }
 
-std::string NarrativeBuilder::FormUturnInstruction(Maneuver& maneuver, Maneuver* prev_maneuver) {
+std::string NarrativeBuilder::FormUturnInstruction(Maneuver& maneuver) {
   // "0": "Make a <RELATIVE_DIRECTION> U-turn.",
   // "1": "Make a <RELATIVE_DIRECTION> U-turn onto <STREET_NAMES>.",
   // "2": "Make a <RELATIVE_DIRECTION> U-turn to stay on <STREET_NAMES>.",
@@ -1085,8 +1075,7 @@ std::string NarrativeBuilder::FormUturnInstruction(Maneuver& maneuver, Maneuver*
   uint8_t phrase_id = 0;
   if (!street_names.empty()) {
     phrase_id += 1;
-    if (maneuver.HasSameNames(prev_maneuver, true)) {
-      maneuver.set_to_stay_on(true);
+    if (maneuver.to_stay_on()) {
       phrase_id += 1;
     }
   }
@@ -1113,7 +1102,6 @@ std::string NarrativeBuilder::FormUturnInstruction(Maneuver& maneuver, Maneuver*
 }
 
 std::string NarrativeBuilder::FormVerbalAlertUturnInstruction(Maneuver& maneuver,
-                                                              Maneuver* prev_maneuver,
                                                               uint32_t element_max_count,
                                                               const std::string& delim) {
   // "0": "Make a <RELATIVE_DIRECTION> U-turn.",
@@ -1140,8 +1128,7 @@ std::string NarrativeBuilder::FormVerbalAlertUturnInstruction(Maneuver& maneuver
   uint8_t phrase_id = 0;
   if (!street_names.empty()) {
     phrase_id = 1;
-    if (maneuver.HasSameNames(prev_maneuver, true)) {
-      maneuver.set_to_stay_on(true);
+    if (maneuver.to_stay_on()) {
       phrase_id = 2;
     }
   }
@@ -1157,7 +1144,6 @@ std::string NarrativeBuilder::FormVerbalAlertUturnInstruction(Maneuver& maneuver
 }
 
 std::string NarrativeBuilder::FormVerbalUturnInstruction(Maneuver& maneuver,
-                                                         Maneuver* prev_maneuver,
                                                          uint32_t element_max_count,
                                                          const std::string& delim) {
   // "0": "Make a <RELATIVE_DIRECTION> U-turn.",
@@ -1183,8 +1169,7 @@ std::string NarrativeBuilder::FormVerbalUturnInstruction(Maneuver& maneuver,
   uint8_t phrase_id = 0;
   if (!street_names.empty()) {
     phrase_id += 1;
-    if (maneuver.HasSameNames(prev_maneuver, true)) {
-      maneuver.set_to_stay_on(true);
+    if (maneuver.to_stay_on()) {
       phrase_id += 1;
     }
   }
@@ -1794,15 +1779,23 @@ std::string NarrativeBuilder::FormKeepInstruction(Maneuver& maneuver,
   instruction.reserve(kInstructionInitialCapacity);
 
   // Assign the street names
-  std::string street_names =
-      FormStreetNames(maneuver, maneuver.street_names(),
-                      &dictionary_.keep_subset.empty_street_name_labels, true, element_max_count);
+  std::string street_names;
 
-  // If street names string is empty and the maneuver has sign branch info
-  // then assign the sign branch name to the street names string
-  if (street_names.empty() && maneuver.HasExitBranchSign()) {
+  // For ramps with branch sign info - we use the sign info to match what users are seeing
+  if (maneuver.ramp() && maneuver.HasExitBranchSign()) {
     street_names =
         maneuver.signs().GetExitBranchString(element_max_count, limit_by_consecutive_count);
+  } else {
+    street_names =
+        FormStreetNames(maneuver, maneuver.street_names(),
+                        &dictionary_.keep_subset.empty_street_name_labels, true, element_max_count);
+
+    // If street names string is empty and the maneuver has sign branch info
+    // then assign the sign branch name to the street names string
+    if (street_names.empty() && maneuver.HasExitBranchSign()) {
+      street_names =
+          maneuver.signs().GetExitBranchString(element_max_count, limit_by_consecutive_count);
+    }
   }
 
   // Determine which phrase to use

--- a/test/narrativebuilder.cc
+++ b/test/narrativebuilder.cc
@@ -678,6 +678,7 @@ void PopulateTurnManeuverList_3(std::list<Maneuver>& maneuvers,
                    Maneuver::RelativeDirection::kRight,
                    TripDirections_Maneuver_CardinalDirection_kSouth, 167, 167, 3, 4, 3, 4, 0, 0, 0, 0,
                    0, 0, 0, 0, 0, {}, {}, {}, {}, 1, 0, 0, 0, 1, 0, "", "", "", 1);
+  maneuver2.set_to_stay_on(true);
 }
 
 void PopulateSharpManeuverList_0(std::list<Maneuver>& maneuvers,
@@ -732,6 +733,7 @@ void PopulateSharpManeuverList_3(std::list<Maneuver>& maneuvers,
                    Maneuver::RelativeDirection::kRight,
                    TripDirections_Maneuver_CardinalDirection_kSouth, 167, 167, 3, 4, 3, 4, 0, 0, 0, 0,
                    0, 0, 0, 0, 0, {}, {}, {}, {}, 1, 0, 0, 0, 1, 0, "", "", "", 1);
+  maneuver2.set_to_stay_on(true);
 }
 
 void PopulateBearManeuverList_0(std::list<Maneuver>& maneuvers,
@@ -788,6 +790,7 @@ void PopulateBearManeuverList_3(std::list<Maneuver>& maneuvers,
                    TripDirections_Maneuver_CardinalDirection_kSouth, 193, 197, 187, 197, 1805, 1878,
                    0, 0, 0, 0, 0, 0, 0, 1, 0, {}, {}, {}, {}, 0, 0, 0, 0, 0, 1, "", "", "", 0, 0, 0,
                    0, 200, 0);
+  maneuver2.set_to_stay_on(true);
 }
 
 void PopulateUturnManeuverList_0(std::list<Maneuver>& maneuvers,
@@ -831,6 +834,7 @@ void PopulateUturnManeuverList_2(std::list<Maneuver>& maneuvers,
                    Maneuver::RelativeDirection::KReverse,
                    TripDirections_Maneuver_CardinalDirection_kSouth, 157, 155, 3, 4, 46, 56, 0, 0, 0,
                    0, 0, 0, 0, 0, 0, {}, {}, {}, {}, 0, 0, 0, 0, 0, 0, "", "", "", 0, 0, 0, 0, 20, 0);
+  maneuver2.set_to_stay_on(true);
 }
 
 void PopulateUturnManeuverList_3(std::list<Maneuver>& maneuvers,
@@ -875,6 +879,7 @@ void PopulateUturnManeuverList_5(std::list<Maneuver>& maneuvers,
                    TripDirections_Maneuver_CardinalDirection_kSouthWest, 212, 221, 1, 3, 1, 3, 0, 0,
                    0, 0, 0, 0, 0, 0, 0, {}, {}, {}, {}, 0, 1, 0, 0, 1, 0, "", "", "", 0, 0, 0, 0, 40,
                    0);
+  maneuver2.set_to_stay_on(true);
 }
 
 void PopulateRampStraightManeuverList_0(std::list<Maneuver>& maneuvers,
@@ -1362,6 +1367,7 @@ void PopulateKeepToStayOnManeuverList_0(std::list<Maneuver>& maneuvers,
                    TripDirections_Maneuver_CardinalDirection_kSouthWest, 219, 232, 34, 45, 380, 491,
                    0, 0, 0, 0, 0, 1, 0, 1, 0, {}, {std::make_tuple("I 95 South", 1, 0)}, {}, {}, 0, 0,
                    0, 1, 0, 0, "", "", "", 0, 0, 0, 0, 334, 0);
+  maneuver2.set_to_stay_on(true);
 }
 
 void PopulateKeepToStayOnManeuverList_1(std::list<Maneuver>& maneuvers,
@@ -1385,6 +1391,7 @@ void PopulateKeepToStayOnManeuverList_1(std::list<Maneuver>& maneuvers,
                    0, 0, 0, 0, 0, 1, 0, 1, 0, {std::make_tuple("62", 0, 0)},
                    {std::make_tuple("I 95 South", 1, 0)}, {}, {}, 0, 0, 0, 1, 0, 0, "", "", "", 0, 0,
                    0, 0, 334, 0);
+  maneuver2.set_to_stay_on(true);
 }
 
 void PopulateKeepToStayOnManeuverList_2(std::list<Maneuver>& maneuvers,
@@ -1408,6 +1415,7 @@ void PopulateKeepToStayOnManeuverList_2(std::list<Maneuver>& maneuvers,
                    0, 0, 0, 0, 0, 1, 0, 1, 0, {}, {std::make_tuple("I 95 South", 1, 0)},
                    {std::make_tuple("Baltimore", 0, 0)}, {}, 0, 0, 0, 1, 0, 0, "", "", "", 0, 0, 0, 0,
                    334, 0);
+  maneuver2.set_to_stay_on(true);
 }
 
 void PopulateKeepToStayOnManeuverList_3(std::list<Maneuver>& maneuvers,
@@ -1431,6 +1439,7 @@ void PopulateKeepToStayOnManeuverList_3(std::list<Maneuver>& maneuvers,
                    0, 0, 0, 0, 0, 1, 0, 1, 0, {std::make_tuple("62", 0, 0)},
                    {std::make_tuple("I 95 South", 1, 0)}, {std::make_tuple("Baltimore", 0, 0)}, {}, 0,
                    0, 0, 1, 0, 0, "", "", "", 0, 0, 0, 0, 334, 0);
+  maneuver2.set_to_stay_on(true);
 }
 
 void PopulateMergeManeuverList_0(std::list<Maneuver>& maneuvers,

--- a/valhalla/odin/maneuversbuilder.h
+++ b/valhalla/odin/maneuversbuilder.h
@@ -166,6 +166,13 @@ protected:
   void ProcessRoundaboutNames(std::list<Maneuver>& maneuvers);
 
   /**
+   * Iterate through the maneuvers and set the 'to stay on' attribute as needed.
+   *
+   * @param maneuvers The list of maneuvers to process.
+   */
+  void SetToStayOnAttribute(std::list<Maneuver>& maneuvers);
+
+  /**
    * Enhance a signless interchange maneuver by adding the subsequent street name
    * as a branch name.
    *

--- a/valhalla/odin/narrativebuilder.h
+++ b/valhalla/odin/narrativebuilder.h
@@ -77,29 +77,25 @@ protected:
                                             const std::string& delim = kVerbalDelim);
 
   /////////////////////////////////////////////////////////////////////////////
-  std::string FormTurnInstruction(Maneuver& maneuver, Maneuver* prev_maneuver);
+  std::string FormTurnInstruction(Maneuver& maneuver);
 
   std::string FormVerbalAlertTurnInstruction(Maneuver& maneuver,
-                                             Maneuver* prev_maneuver,
                                              uint32_t element_max_count = kVerbalAlertElementMaxCount,
                                              const std::string& delim = kVerbalDelim);
 
   std::string FormVerbalTurnInstruction(Maneuver& maneuver,
-                                        Maneuver* prev_maneuver,
                                         uint32_t element_max_count = kVerbalPreElementMaxCount,
                                         const std::string& delim = kVerbalDelim);
 
   /////////////////////////////////////////////////////////////////////////////
-  std::string FormUturnInstruction(Maneuver& maneuver, Maneuver* prev_maneuver);
+  std::string FormUturnInstruction(Maneuver& maneuver);
 
   std::string
   FormVerbalAlertUturnInstruction(Maneuver& maneuver,
-                                  Maneuver* prev_maneuver,
                                   uint32_t element_max_count = kVerbalAlertElementMaxCount,
                                   const std::string& delim = kVerbalDelim);
 
   std::string FormVerbalUturnInstruction(Maneuver& maneuver,
-                                         Maneuver* prev_maneuver,
                                          uint32_t element_max_count = kVerbalPreElementMaxCount,
                                          const std::string& delim = kVerbalDelim);
 


### PR DESCRIPTION
# Issue

Currently, when a highway would end and split into multiple ramps - the node was not marked as a fork. 
Updated data processing to mark node as a fork and updated the narrative logic and tests to form the proper instructions.

### Example 1
![image](https://user-images.githubusercontent.com/7515853/54307592-6c917000-45a2-11e9-8324-d111eb4d1f44.png)
``` diff
< BEFORE
< 6: Take exit 51A on the left onto I 81 South/US 322 West toward Carlisle/Lewistown.
>AFTER
> 6: Keep left to take exit 51A to stay on US 322 West toward Carlisle/Lewistown.
```

### Example 2
![image](https://user-images.githubusercontent.com/7515853/54307880-28eb3600-45a3-11e9-8f6c-f4c50e08b35f.png)
``` diff
< BEFORE
< 14: Take the I 695 West exit on the right toward Baltimore.
> AFTER
> 14: Keep right to take I 695 West toward Baltimore.
```

## Tasklist

 - [x] Updated tests
 - [x] Review - you must request approval to merge any PR to master
 - [x] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)
