### PR TITLE
Do not use avoid edges as origin or destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
    * FIXED: Fixed fork assignments and on ramps for OSRM compatibility mode. [#1738](https://github.com/valhalla/valhalla/pull/1738)
    * FIXED: Fixed cardinal direction on reference names when forward/backward tag is present on relations. Fixes singly digitized roads with opposing directional modifiers. [#1741](https://github.com/valhalla/valhalla/pull/1741)
    * FIXED: Fixed fork assignment and narrative logic when a highway ends and splits into multiple ramps. [#1742](https://github.com/valhalla/valhalla/pull/1742)
+   * FIXED: Do not use any avoid edges as origin or destination of a route, matrix, or isochrone. [#1745](https://github.com/valhalla/valhalla/pull/1745)
 
 * **Enhancement**
    * Add the ability to run valhalla_build_tiles in stages. Specify the begin_stage and end_stage as command line options. Also cleans up temporary files as the last stage in the pipeline.

--- a/proto/directions_options.proto
+++ b/proto/directions_options.proto
@@ -102,6 +102,11 @@ message CostingOptions {
   repeated string filter_route_ids = 54;
 }
 
+message AvoidEdge {
+  optional uint64 id = 1;
+  optional float percent_along = 2;
+}
+
 message DirectionsOptions {
 
   enum Units {
@@ -167,7 +172,7 @@ message DirectionsOptions {
   optional float turn_penalty_factor = 32;                                // The turn penalty factor associated with the suppplied trace points
   optional FilterAction filter_action = 33;                               // The trace filter action - either exclude or include
   repeated string filter_attributes = 34;                                 // The filter list for trace attributes
-  repeated uint64 avoid_edges = 35;                                       // Avoid edges for any costing - derived from avoid_locations
+  repeated AvoidEdge avoid_edges = 35;                                    // Avoid edges for any costing - derived from avoid_locations
   optional float breakage_distance = 36;                                  // Map-matching breaking distance (distance between GPS trace points)
   optional bool use_timestamps = 37 [default = false];                    // Use timestamps to compute elapsed time for trace_route and trace_attributes
   optional ShapeFormat shape_format = 38 [default = polyline6];           // Shape format (defaults to polyline6 encoding)

--- a/src/loki/worker.cc
+++ b/src/loki/worker.cc
@@ -120,7 +120,7 @@ void loki_worker_t::parse_costing(valhalla_request_t& request) {
             if (shortcut.Is_Valid()) {
               // Check if this shortcut has not been added
               auto shortcut_inserted = avoids.insert(shortcut);
-              if (inserted.second) {
+              if (shortcut_inserted.second) {
                 avoids.insert(shortcut);
 
                 // Add to pbf (with 0 percent along)

--- a/src/loki/worker.cc
+++ b/src/loki/worker.cc
@@ -97,6 +97,7 @@ void loki_worker_t::parse_costing(valhalla_request_t& request) {
     throw valhalla_exception_t{157, std::to_string(max_avoid_locations)};
   }
 
+  // Process avoid locations. Add to a list of edgeids and percent along the edge.
   if (request.options.avoid_locations_size()) {
     try {
       auto avoid_locations = PathLocation::fromPBF(request.options.avoid_locations());
@@ -105,14 +106,31 @@ void loki_worker_t::parse_costing(valhalla_request_t& request) {
       for (const auto& result : results) {
         for (const auto& edge : result.second.edges) {
           auto inserted = avoids.insert(edge.id);
-          GraphId shortcut;
-          if (inserted.second && (shortcut = reader->GetShortcut(edge.id)).Is_Valid()) {
-            avoids.insert(shortcut);
+
+          // If this edge Id was inserted add it to the request options (along with percent along)
+          // Also insert shortcut edge if one includes this edge
+          if (inserted.second) {
+            // Add edge and percent along to pbf
+            auto* avoid = request.options.add_avoid_edges();
+            avoid->set_id(edge.id);
+            avoid->set_percent_along(edge.percent_along);
+
+            // Check if a shortcut exists
+            GraphId shortcut = reader->GetShortcut(edge.id);
+            if (shortcut.Is_Valid()) {
+              // Check if this shortcut has not been added
+              auto shortcut_inserted = avoids.insert(shortcut);
+              if (inserted.second) {
+                avoids.insert(shortcut);
+
+                // Add to pbf (with 0 percent along)
+                auto* avoid = request.options.add_avoid_edges();
+                avoid->set_id(shortcut);
+                avoid->set_percent_along(0);
+              }
+            }
           }
         }
-      }
-      for (auto avoid : avoids) {
-        request.options.add_avoid_edges(avoid);
       }
     } // swallow all failures on optional avoids
     catch (...) {

--- a/src/sif/dynamiccost.cc
+++ b/src/sif/dynamiccost.cc
@@ -15,8 +15,8 @@ DynamicCost::DynamicCost(const odin::DirectionsOptions& options, const TravelMod
   }
 
   // Add avoid edges to internal set
-  for (auto& edgeid : options.avoid_edges()) {
-    user_avoid_edges_.insert(GraphId(edgeid));
+  for (auto& edge : options.avoid_edges()) {
+    user_avoid_edges_.insert({GraphId(edge.id()), edge.percent_along()});
   }
 }
 
@@ -170,9 +170,9 @@ bool DynamicCost::IsExcluded(const baldr::GraphTile*& tile, const baldr::NodeInf
 }
 
 // Adds a list of edges (GraphIds) to the user specified avoid list.
-void DynamicCost::AddUserAvoidEdges(const std::vector<GraphId>& avoid_edges) {
-  for (auto edgeid : avoid_edges) {
-    user_avoid_edges_.insert(edgeid);
+void DynamicCost::AddUserAvoidEdges(const std::vector<AvoidEdge>& avoid_edges) {
+  for (auto edge : avoid_edges) {
+    user_avoid_edges_.insert({edge.id, edge.percent_along});
   }
 }
 

--- a/src/thor/astar.cc
+++ b/src/thor/astar.cc
@@ -374,8 +374,13 @@ void AStarPathAlgorithm::SetOrigin(GraphReader& graphreader,
       continue;
     }
 
-    // Get the directed edge
+    // Disallow any user avoided edges
     GraphId edgeid(edge.graph_id());
+    if (costing_->IsUserAvoidEdge(edgeid)) {
+      continue;
+    }
+
+    // Get the directed edge
     const GraphTile* tile = graphreader.GetGraphTile(edgeid);
     const DirectedEdge* directededge = tile->directededge(edgeid);
 
@@ -474,12 +479,16 @@ uint32_t AStarPathAlgorithm::SetDestination(GraphReader& graphreader, const odin
       continue;
     }
 
-    // Keep the id and the cost to traverse the partial distance for the
-    // remainder of the edge. This cost is subtracted from the total cost
-    // up to the end of the destination edge.
-    GraphId id(edge.graph_id());
-    const GraphTile* tile = graphreader.GetGraphTile(id);
-    const DirectedEdge* directededge = tile->directededge(id);
+    // Disallow any user avoided edges
+    GraphId edgeid(edge.graph_id());
+    if (costing_->IsUserAvoidEdge(edgeid)) {
+      continue;
+    }
+
+    // Keep the cost to traverse the partial distance for the remainder of the edge. This cost
+    // is subtracted from the total cost up to the end of the destination edge.
+    const GraphTile* tile = graphreader.GetGraphTile(edgeid);
+    const DirectedEdge* directededge = tile->directededge(edgeid);
     destinations_[edge.graph_id()] = costing_->EdgeCost(directededge, tile->GetSpeed(directededge)) *
                                      (1.0f - edge.percent_along());
 

--- a/src/thor/astar.cc
+++ b/src/thor/astar.cc
@@ -374,9 +374,9 @@ void AStarPathAlgorithm::SetOrigin(GraphReader& graphreader,
       continue;
     }
 
-    // Disallow any user avoided edges
+    // Disallow any user avoid edges if the avoid location is ahead of the origin along the edge
     GraphId edgeid(edge.graph_id());
-    if (costing_->IsUserAvoidEdge(edgeid)) {
+    if (costing_->AvoidAsOriginEdge(edgeid, edge.percent_along())) {
       continue;
     }
 
@@ -479,9 +479,9 @@ uint32_t AStarPathAlgorithm::SetDestination(GraphReader& graphreader, const odin
       continue;
     }
 
-    // Disallow any user avoided edges
+    // Disallow any user avoided edges if the avoid location is behind the destination along the edge
     GraphId edgeid(edge.graph_id());
-    if (costing_->IsUserAvoidEdge(edgeid)) {
+    if (costing_->AvoidAsDestinationEdge(edgeid, edge.percent_along())) {
       continue;
     }
 

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -561,9 +561,9 @@ void BidirectionalAStar::SetOrigin(GraphReader& graphreader, odin::Location& ori
       continue;
     }
 
-    // Disallow any user avoid edges
+    // Disallow any user avoid edges if the avoid location is ahead of the origin along the edge
     GraphId edgeid(edge.graph_id());
-    if (costing_->IsUserAvoidEdge(edgeid)) {
+    if (costing_->AvoidAsOriginEdge(edgeid, edge.percent_along())) {
       continue;
     }
 
@@ -634,9 +634,9 @@ void BidirectionalAStar::SetDestination(GraphReader& graphreader, const odin::Lo
       continue;
     }
 
-    // Disallow any user avoided edges
+    // Disallow any user avoided edges if the avoid location is behind the destination along the edge
     GraphId edgeid(edge.graph_id());
-    if (costing_->IsUserAvoidEdge(edgeid)) {
+    if (costing_->AvoidAsDestinationEdge(edgeid, edge.percent_along())) {
       continue;
     }
 

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -561,8 +561,13 @@ void BidirectionalAStar::SetOrigin(GraphReader& graphreader, odin::Location& ori
       continue;
     }
 
-    // Get the directed edge
+    // Disallow any user avoid edges
     GraphId edgeid(edge.graph_id());
+    if (costing_->IsUserAvoidEdge(edgeid)) {
+      continue;
+    }
+
+    // Get the directed edge
     const GraphTile* tile = graphreader.GetGraphTile(edgeid);
     const DirectedEdge* directededge = tile->directededge(edgeid);
 
@@ -629,8 +634,13 @@ void BidirectionalAStar::SetDestination(GraphReader& graphreader, const odin::Lo
       continue;
     }
 
-    // Get the directed edge
+    // Disallow any user avoided edges
     GraphId edgeid(edge.graph_id());
+    if (costing_->IsUserAvoidEdge(edgeid)) {
+      continue;
+    }
+
+    // Get the directed edge
     const GraphTile* tile = graphreader.GetGraphTile(edgeid);
     const DirectedEdge* directededge = tile->directededge(edgeid);
 

--- a/src/thor/costmatrix.cc
+++ b/src/thor/costmatrix.cc
@@ -688,9 +688,9 @@ void CostMatrix::SetSources(GraphReader& graphreader,
         continue;
       }
 
-      // Disallow any user avoided edges
+      // Disallow any user avoid edges if the avoid location is ahead of the origin along the edge
       GraphId edgeid(edge.graph_id());
-      if (costing_->IsUserAvoidEdge(edgeid)) {
+      if (costing_->AvoidAsOriginEdge(edgeid, edge.percent_along())) {
         continue;
       }
 
@@ -765,9 +765,10 @@ void CostMatrix::SetTargets(baldr::GraphReader& graphreader,
         continue;
       }
 
-      // Disallow any user avoided edges
+      // Disallow any user avoided edges if the avoid location is behind the destination along the
+      // edge
       GraphId edgeid(edge.graph_id());
-      if (costing_->IsUserAvoidEdge(edgeid)) {
+      if (costing_->AvoidAsDestinationEdge(edgeid, edge.percent_along())) {
         continue;
       }
 

--- a/src/thor/costmatrix.cc
+++ b/src/thor/costmatrix.cc
@@ -688,8 +688,13 @@ void CostMatrix::SetSources(GraphReader& graphreader,
         continue;
       }
 
+      // Disallow any user avoided edges
+      GraphId edgeid(edge.graph_id());
+      if (costing_->IsUserAvoidEdge(edgeid)) {
+        continue;
+      }
+
       // Get the directed edge and the opposing edge Id
-      GraphId edgeid = static_cast<GraphId>(edge.graph_id());
       const GraphTile* tile = graphreader.GetGraphTile(edgeid);
       const DirectedEdge* directededge = tile->directededge(edgeid);
       GraphId oppedge = graphreader.GetOpposingEdgeId(edgeid);
@@ -760,8 +765,13 @@ void CostMatrix::SetTargets(baldr::GraphReader& graphreader,
         continue;
       }
 
+      // Disallow any user avoided edges
+      GraphId edgeid(edge.graph_id());
+      if (costing_->IsUserAvoidEdge(edgeid)) {
+        continue;
+      }
+
       // Get the directed edge
-      GraphId edgeid = static_cast<GraphId>(edge.graph_id());
       const GraphTile* tile = graphreader.GetGraphTile(edgeid);
       const DirectedEdge* directededge = tile->directededge(edgeid);
 

--- a/src/thor/isochrone.cc
+++ b/src/thor/isochrone.cc
@@ -1051,8 +1051,13 @@ void Isochrone::SetOriginLocations(
         continue;
       }
 
-      // Get the directed edge
+      // Disallow any user avoided edges
       GraphId edgeid(edge.graph_id());
+      if (costing_->IsUserAvoidEdge(edgeid)) {
+        continue;
+      }
+
+      // Get the directed edge
       const GraphTile* tile = graphreader.GetGraphTile(edgeid);
       const DirectedEdge* directededge = tile->directededge(edgeid);
 
@@ -1122,8 +1127,13 @@ void Isochrone::SetOriginLocationsMM(
         continue;
       }
 
-      // Get the directed edge
+      // Disallow any user avoided edges
       GraphId edgeid(edge.graph_id());
+      if (costing_->IsUserAvoidEdge(edgeid)) {
+        continue;
+      }
+
+      // Get the directed edge
       const GraphTile* tile = graphreader.GetGraphTile(edgeid);
       const DirectedEdge* directededge = tile->directededge(edgeid);
 

--- a/src/thor/isochrone.cc
+++ b/src/thor/isochrone.cc
@@ -1051,9 +1051,9 @@ void Isochrone::SetOriginLocations(
         continue;
       }
 
-      // Disallow any user avoided edges
+      // Disallow any user avoid edges if the avoid location is ahead of the origin along the edge
       GraphId edgeid(edge.graph_id());
-      if (costing_->IsUserAvoidEdge(edgeid)) {
+      if (costing_->AvoidAsOriginEdge(edgeid, edge.percent_along())) {
         continue;
       }
 
@@ -1127,9 +1127,9 @@ void Isochrone::SetOriginLocationsMM(
         continue;
       }
 
-      // Disallow any user avoided edges
+      // Disallow any user avoid edges if the avoid location is ahead of the origin along the edge
       GraphId edgeid(edge.graph_id());
-      if (costing_->IsUserAvoidEdge(edgeid)) {
+      if (costing_->AvoidAsOriginEdge(edgeid, edge.percent_along())) {
         continue;
       }
 

--- a/src/thor/multimodal.cc
+++ b/src/thor/multimodal.cc
@@ -556,9 +556,9 @@ void MultiModalPathAlgorithm::SetOrigin(GraphReader& graphreader,
       continue;
     }
 
-    // Disallow any user avoided edges
+    // Disallow any user avoid edges if the avoid location is ahead of the origin along the edge
     GraphId edgeid(edge.graph_id());
-    if (costing->IsUserAvoidEdge(edgeid)) {
+    if (costing->AvoidAsOriginEdge(edgeid, edge.percent_along())) {
       continue;
     }
 
@@ -664,9 +664,9 @@ uint32_t MultiModalPathAlgorithm::SetDestination(GraphReader& graphreader,
       continue;
     }
 
-    // Disallow any user avoided edges
+    // Disallow any user avoided edges if the avoid location is behind the destination along the edge
     GraphId edgeid(edge.graph_id());
-    if (costing->IsUserAvoidEdge(edgeid)) {
+    if (costing->AvoidAsDestinationEdge(edgeid, edge.percent_along())) {
       continue;
     }
 
@@ -795,8 +795,9 @@ bool MultiModalPathAlgorithm::CanReachDestination(const odin::Location& destinat
     GraphId id(edge.graph_id());
     GraphId oppedge = graphreader.GetOpposingEdgeId(id);
 
-    // Disallow user avoided edges
-    if (costing->IsUserAvoidEdge(oppedge)) {
+    // Disallow any user avoided edges if the avoid location is behind the destination along the edge
+    GraphId edgeid(edge.graph_id());
+    if (costing->AvoidAsDestinationEdge(edgeid, ratio)) {
       continue;
     }
 

--- a/src/thor/multimodal.cc
+++ b/src/thor/multimodal.cc
@@ -556,8 +556,13 @@ void MultiModalPathAlgorithm::SetOrigin(GraphReader& graphreader,
       continue;
     }
 
-    // Get the directed edge
+    // Disallow any user avoided edges
     GraphId edgeid(edge.graph_id());
+    if (costing->IsUserAvoidEdge(edgeid)) {
+      continue;
+    }
+
+    // Get the directed edge
     const GraphTile* tile = graphreader.GetGraphTile(edgeid);
     const DirectedEdge* directededge = tile->directededge(edgeid);
 
@@ -659,12 +664,16 @@ uint32_t MultiModalPathAlgorithm::SetDestination(GraphReader& graphreader,
       continue;
     }
 
-    // Keep the id and the cost to traverse the partial distance for the
-    // remainder of the edge. This cost is subtracted from the total cost
-    // up to the end of the destination edge.
-    GraphId id(edge.graph_id());
-    const GraphTile* tile = graphreader.GetGraphTile(id);
-    const DirectedEdge* dest_diredge = tile->directededge(id);
+    // Disallow any user avoided edges
+    GraphId edgeid(edge.graph_id());
+    if (costing->IsUserAvoidEdge(edgeid)) {
+      continue;
+    }
+
+    // Keep the cost to traverse the partial distance for the remainder of the edge. This cost
+    // is subtracted from the total cost up to the end of the destination edge.
+    const GraphTile* tile = graphreader.GetGraphTile(edgeid);
+    const DirectedEdge* dest_diredge = tile->directededge(edgeid);
     destinations_[edge.graph_id()] =
         costing->EdgeCost(dest_diredge, tile->GetSpeed(dest_diredge)) * (1.0f - edge.percent_along());
 
@@ -785,6 +794,12 @@ bool MultiModalPathAlgorithm::CanReachDestination(const odin::Location& destinat
     float ratio = (1.0f - edge.percent_along());
     GraphId id(edge.graph_id());
     GraphId oppedge = graphreader.GetOpposingEdgeId(id);
+
+    // Disallow user avoided edges
+    if (costing->IsUserAvoidEdge(oppedge)) {
+      continue;
+    }
+
     const GraphTile* tile = graphreader.GetGraphTile(oppedge);
     const DirectedEdge* diredge = tile->directededge(oppedge);
     uint32_t length = static_cast<uint32_t>(diredge->length()) * ratio;

--- a/src/thor/timedistancematrix.cc
+++ b/src/thor/timedistancematrix.cc
@@ -420,8 +420,13 @@ void TimeDistanceMatrix::SetOriginOneToMany(GraphReader& graphreader, const odin
       continue;
     }
 
+    // Disallow any user avoided edges
+    GraphId edgeid(edge.graph_id());
+    if (costing_->IsUserAvoidEdge(edgeid)) {
+      continue;
+    }
+
     // Get the directed edge
-    GraphId edgeid = static_cast<GraphId>(edge.graph_id());
     const GraphTile* tile = graphreader.GetGraphTile(edgeid);
     const DirectedEdge* directededge = tile->directededge(edgeid);
 
@@ -457,8 +462,13 @@ void TimeDistanceMatrix::SetOriginOneToMany(GraphReader& graphreader, const odin
 void TimeDistanceMatrix::SetOriginManyToOne(GraphReader& graphreader, const odin::Location& dest) {
   // Iterate through edges and add opposing edges to adjacency list
   for (const auto& edge : dest.path_edges()) {
+    // Disallow any user avoided edges
+    GraphId edgeid(edge.graph_id());
+    if (costing_->IsUserAvoidEdge(edgeid)) {
+      continue;
+    }
+
     // Get the directed edge
-    GraphId edgeid = static_cast<GraphId>(edge.graph_id());
     const GraphTile* tile = graphreader.GetGraphTile(edgeid);
     const DirectedEdge* directededge = tile->directededge(edgeid);
 
@@ -505,14 +515,23 @@ void TimeDistanceMatrix::SetDestinations(
   // For each destination
   uint32_t idx = 0;
   for (const auto& loc : locations) {
-    // Add a destination and get a reference to it
-    destinations_.emplace_back();
-    Destination& d = destinations_.back();
-
     // Set up the destination - consider each possible location edge.
+    bool added = false;
     for (const auto& edge : loc.path_edges()) {
-      // Keep the id and the partial distance for the
-      // remainder of the edge.
+      // Disallow user avoided edges
+      GraphId edgeid(edge.graph_id());
+      if (costing_->IsUserAvoidEdge(edgeid)) {
+        continue;
+      }
+
+      // Add a destination if this is the first allowed edge for the location
+      if (!added) {
+        destinations_.emplace_back();
+        added = true;
+      }
+
+      // Keep the id and the partial distance for the remainder of the edge.
+      Destination& d = destinations_.back();
       d.dest_edges[edge.graph_id()] = (1.0f - edge.percent_along());
 
       // Form a threshold cost (the total cost to traverse the edge)
@@ -544,19 +563,21 @@ void TimeDistanceMatrix::SetDestinationsManyToOne(
   // For each destination
   uint32_t idx = 0;
   for (const auto& loc : locations) {
-    // Add a destination and get a reference to it
-    destinations_.emplace_back();
-    Destination& d = destinations_.back();
-
     // Set up the destination - consider each possible location edge.
+    bool added = false;
     for (const auto& edge : loc.path_edges()) {
-      // Get the opposing directed edge Id - this is the edge marked as the
-      // "destination" - but the cost is based on the forward path along the
-      // initial edge.
+      // Get the opposing directed edge Id - this is the edge marked as the "destination",
+      // but the cost is based on the forward path along the initial edge.
       GraphId opp_edge_id = graphreader.GetOpposingEdgeId(static_cast<GraphId>(edge.graph_id()));
 
-      // Keep the id and the partial distance for the
-      // remainder of the edge.
+      // Add a destination if this is the first allowed edge for the location
+      if (!added) {
+        destinations_.emplace_back();
+        added = true;
+      }
+
+      // Keep the id and the partial distance for the remainder of the edge.
+      Destination& d = destinations_.back();
       d.dest_edges[opp_edge_id] = edge.percent_along();
 
       // Form a threshold cost (the total cost to traverse the edge)

--- a/src/thor/timedistancematrix.cc
+++ b/src/thor/timedistancematrix.cc
@@ -420,9 +420,9 @@ void TimeDistanceMatrix::SetOriginOneToMany(GraphReader& graphreader, const odin
       continue;
     }
 
-    // Disallow any user avoided edges
+    // Disallow any user avoid edges if the avoid location is ahead of the origin along the edge
     GraphId edgeid(edge.graph_id());
-    if (costing_->IsUserAvoidEdge(edgeid)) {
+    if (costing_->AvoidAsOriginEdge(edgeid, edge.percent_along())) {
       continue;
     }
 
@@ -462,9 +462,9 @@ void TimeDistanceMatrix::SetOriginOneToMany(GraphReader& graphreader, const odin
 void TimeDistanceMatrix::SetOriginManyToOne(GraphReader& graphreader, const odin::Location& dest) {
   // Iterate through edges and add opposing edges to adjacency list
   for (const auto& edge : dest.path_edges()) {
-    // Disallow any user avoided edges
+    // Disallow any user avoided edges if the avoid location is behind the destination along the edge
     GraphId edgeid(edge.graph_id());
-    if (costing_->IsUserAvoidEdge(edgeid)) {
+    if (costing_->AvoidAsDestinationEdge(edgeid, edge.percent_along())) {
       continue;
     }
 
@@ -518,9 +518,10 @@ void TimeDistanceMatrix::SetDestinations(
     // Set up the destination - consider each possible location edge.
     bool added = false;
     for (const auto& edge : loc.path_edges()) {
-      // Disallow user avoided edges
+      // Disallow any user avoided edges if the avoid location is behind the destination along the
+      // edge
       GraphId edgeid(edge.graph_id());
-      if (costing_->IsUserAvoidEdge(edgeid)) {
+      if (costing_->AvoidAsDestinationEdge(edgeid, edge.percent_along())) {
         continue;
       }
 

--- a/src/valhalla_run_isochrone.cc
+++ b/src/valhalla_run_isochrone.cc
@@ -190,11 +190,11 @@ int main(int argc, char* argv[]) {
   }
 
   // Find avoid locations
-  std::vector<GraphId> avoid_edges;
+  std::vector<AvoidEdge> avoid_edges;
   const auto avoids = Search(avoid_locations, reader, cost->GetEdgeFilter(), cost->GetNodeFilter());
   for (const auto& loc : avoid_locations) {
     for (auto& e : avoids.at(loc).edges) {
-      avoid_edges.push_back(e.id);
+      avoid_edges.push_back({e.id, e.percent_along});
     }
   }
   if (avoid_edges.size() > 0) {

--- a/src/valhalla_run_matrix.cc
+++ b/src/valhalla_run_matrix.cc
@@ -193,14 +193,14 @@ int main(int argc, char* argv[]) {
   // Get the max matrix distances for construction of the CostMatrix and TimeDistanceMatrix classes
   std::unordered_map<std::string, float> max_matrix_distance;
   for (const auto& kv : pt.get_child("service_limits")) {
+    // Skip over any service limits that are not for a costing method
     if (kv.first == "max_avoid_locations" || kv.first == "max_reachability" ||
-        kv.first == "max_radius") {
+        kv.first == "max_radius" || kv.first == "max_timedep_distance" || kv.first == "skadi" ||
+        kv.first == "trace" || kv.first == "isochrone") {
       continue;
     }
-    if (kv.first != "skadi" && kv.first != "trace" && kv.first != "isochrone") {
-      max_matrix_distance.emplace(kv.first, pt.get<float>("service_limits." + kv.first +
-                                                          ".max_matrix_distance"));
-    }
+    max_matrix_distance.emplace(kv.first,
+                                pt.get<float>("service_limits." + kv.first + ".max_matrix_distance"));
   }
 
   if (max_matrix_distance.empty()) {

--- a/valhalla/sif/costconstants.h
+++ b/valhalla/sif/costconstants.h
@@ -1,6 +1,8 @@
 #ifndef VALHALLA_SIF_COST_CONSTANTS_H_
 #define VALHALLA_SIF_COST_CONSTANTS_H_
 
+#include <valhalla/baldr/graphid.h>
+
 namespace valhalla {
 namespace sif {
 

--- a/valhalla/sif/costconstants.h
+++ b/valhalla/sif/costconstants.h
@@ -55,6 +55,16 @@ enum class BicycleType : uint8_t {
 //};
 
 /**
+ * Simple structure to denote edge locations to avoid. Includes the edge Id and percent
+ * along the edge. The percent along is used when checking origin and destination locations
+ * to see if the avoided location can be traveled along the "partial" edge.
+ */
+struct AvoidEdge {
+  baldr::GraphId id;
+  float percent_along;
+};
+
+/**
  * Simple structure for returning costs. Includes cost and true elapsed time
  * in seconds.
  */

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -16,7 +16,7 @@
 #include <valhalla/sif/hierarchylimits.h>
 
 #include <memory>
-#include <unordered_set>
+#include <unordered_map>
 
 namespace valhalla {
 namespace sif {
@@ -471,9 +471,9 @@ public:
    * This can be used by test programs - alternatively a list of avoid
    * edges will be passed in the property tree for the costing options
    * of a specified type.
-   * @param  avoid_edges  Set of edge Ids to avoid.
+   * @param  avoid_edges  Set of edge Ids to avoid along with the percent along the edge.
    */
-  void AddUserAvoidEdges(const std::vector<baldr::GraphId>& avoid_edges);
+  void AddUserAvoidEdges(const std::vector<AvoidEdge>& avoid_edges);
 
   /**
    * Check if the edge is in the user-specified avoid list.
@@ -484,6 +484,34 @@ public:
   bool IsUserAvoidEdge(const baldr::GraphId& edgeid) const {
     return (user_avoid_edges_.size() != 0 &&
             user_avoid_edges_.find(edgeid) != user_avoid_edges_.end());
+  }
+
+  /**
+   * Check if the edge is in the user-specified avoid list and should be avoided when used
+   * as an origin. In this case the edge is avoided if the avoid percent along is greater than
+   * the PathEdge percent along (avoid location is ahead of the origin alongn the edge).
+   * @param  edgeid  Directed edge Id.
+   * @param  pct_along Percent along the edge of the PathEdge (location).
+   * @return Returns true if the edge Id is in the user avoid edges set,
+   *         false otherwise.
+   */
+  bool AvoidAsOriginEdge(const baldr::GraphId& edgeid, const float percent_along) const {
+    auto avoid = user_avoid_edges_.find(edgeid);
+    return (avoid != user_avoid_edges_.end() && avoid->second >= percent_along);
+  }
+
+  /**
+   * Check if the edge is in the user-specified avoid list and should be avoided when used
+   * as a destinationn. In this case the edge is avoided if the avoid percent along is less than
+   * the PathEdge percent along (avoid location is behind the destination along the edge).
+   * @param  edgeid  Directed edge Id.
+   * @param  pct_along Percent along the edge of the PathEdge (location).
+   * @return Returns true if the edge Id is in the user avoid edges set,
+   *         false otherwise.
+   */
+  bool AvoidAsDestinationEdge(const baldr::GraphId& edgeid, const float percent_along) const {
+    auto avoid = user_avoid_edges_.find(edgeid);
+    return (avoid != user_avoid_edges_.end() && avoid->second <= percent_along);
   }
 
 protected:
@@ -504,8 +532,8 @@ protected:
   // Hierarchy limits.
   std::vector<HierarchyLimits> hierarchy_limits_;
 
-  // User specified edges to avoid
-  std::unordered_set<baldr::GraphId> user_avoid_edges_;
+  // User specified edges to avoid with percent along (for avoiding PathEdges of locations)
+  std::unordered_map<baldr::GraphId, float> user_avoid_edges_;
 
   // Weighting to apply to ferry edges
   float ferry_factor_;


### PR DESCRIPTION
Fixes a user submitted issue #1740. Do not use any avoided edges as origin or destination of a route, matrix, or isochrone.

Also fixed valhalla_run_matrix which had an issue reading service limits from the config file.

 - [ ] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
