### PR TITLE
Add leg summary and remove unused hint attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
    * FIXED: Fixed fork assignment and narrative logic when a highway ends and splits into multiple ramps. [#1742](https://github.com/valhalla/valhalla/pull/1742)
    * FIXED: Do not use any avoid edges as origin or destination of a route, matrix, or isochrone. [#1745](https://github.com/valhalla/valhalla/pull/1745)
    * ADDED: `remove` to `filesystem` namespace. [#1752](https://github.com/valhalla/valhalla/pull/1752)
+   * FIXED: Add leg summary and remove unused hint attribute for OSRM compatibility mode. [#1753](https://github.com/valhalla/valhalla/pull/1753)
 
 * **Enhancement**
    * Add the ability to run valhalla_build_tiles in stages. Specify the begin_stage and end_stage as command line options. Also cleans up temporary files as the last stage in the pipeline.

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -814,6 +814,10 @@ json::MapPtr annotations(valhalla::odin::EnhancedTripPath* etp) {
   return annotations;
 }
 
+// This is an initial implementation to be as good or better than the current OSRM response
+// In the future we shall use the percent of name distance as compared to the total distance
+// to determine how many named segments to display.
+// Also, might need to combine some similar named segments
 std::string summarize_leg(std::list<valhalla::odin::TripDirections>::const_iterator leg) {
   // Create a map of maneuver names to index,distance pairs
   std::unordered_map<std::string, std::pair<uint32_t, float>> maneuver_summary_map;

--- a/src/tyr/serializers.cc
+++ b/src/tyr/serializers.cc
@@ -56,7 +56,7 @@ valhalla::baldr::json::MapPtr waypoint(const odin::Location& location,
   // Add hint. Goal is for the hint returned from a locate request to be able
   // to quickly find the edge and point along the edge in a route request.
   // Defer this - not currently used in OSRM.
-  waypoint->emplace("hint", std::string("TODO"));
+  // waypoint->emplace("hint", std::string("TODO"));
 
   // If the location was used for a tracepoint we trigger extra serialization
   if (tracepoint) {


### PR DESCRIPTION
# Issue

Add logic to create the route leg `summary` (i.e. two largest named segments) for OSRM compatibility mode. Also, remove the unused `hint` attribute.

### Example 1
![image](https://user-images.githubusercontent.com/7515853/55099021-64066280-5095-11e9-8338-9c6b86e583d3.png)
``` diff
< Standard guidance
< "summary": "Pennsylvania Turnpike, Pennsylvania Turnpike"
> Shared guidance
> "summary": "I-76 West, I-99 North"
```

### Example 2
![image](https://user-images.githubusercontent.com/7515853/55099325-e2630480-5095-11e9-98ea-c1347b1e4c41.png)
``` diff
< Standard guidance
< "summary": "Veterans of Foreign Wars of the United States Memorial Highway, Baltimore-Harrisburg Expressway"
> Shared guidance
> summary": "I-83 South, I-695 East"
```

## Tasklist

 - [x] Test
 - [ ] Review - you must request approval to merge any PR to master
 - [x] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)
