### PR TITLE
Remove OSMLR submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "rapidjson"]
 	path = third_party/rapidjson
 	url = https://github.com/miloyip/rapidjson
-[submodule "proto"]
-	path = third_party/OSMLR
-	url = https://github.com/valhalla/osmlr-tile-spec.git
 [submodule "third_party/dirent"]
 	path = third_party/dirent
 	url = https://github.com/tronkko/dirent

--- a/proto/segment.proto
+++ b/proto/segment.proto
@@ -1,1 +1,0 @@
-../third_party/OSMLR/segment.proto

--- a/proto/tile.proto
+++ b/proto/tile.proto
@@ -1,1 +1,0 @@
-../third_party/OSMLR/tile.proto


### PR DESCRIPTION
OSMLR use was removed internally with PR #1599.
This PR removes the submodule.

