### PR TITLE
temp fix for location distance bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
    * FIXED: Add leg summary and remove unused hint attribute for OSRM compatibility mode. [#1753](https://github.com/valhalla/valhalla/pull/1753)
    * FIXED: Improvements for pedestrian forks, pedestrian roundabouts, and continue maneuvers. [#1768](https://github.com/valhalla/valhalla/pull/1768)
    * FIXED: Added simplified overview for OSRM response and added use_toll logic back to truck costing. [#1765](https://github.com/valhalla/valhalla/pull/1765)
+   * FIXED: temp fix for location distance bug [#1774](https://github.com/valhalla/valhalla/pull/1774)
 
 * **Enhancement**
    * Add the ability to run valhalla_build_tiles in stages. Specify the begin_stage and end_stage as command line options. Also cleans up temporary files as the last stage in the pipeline.

--- a/src/tyr/serializers.cc
+++ b/src/tyr/serializers.cc
@@ -25,6 +25,12 @@ using namespace valhalla::baldr;
 using namespace valhalla::tyr;
 using namespace std;
 
+namespace {
+midgard::PointLL to_ll(const odin::LatLng& ll) {
+  return midgard::PointLL{ll.lng(), ll.lat()};
+}
+} // namespace
+
 namespace osrm {
 
 // Serialize a location (waypoint) in OSRM compatible format. Waypoint format is described here:
@@ -51,7 +57,10 @@ valhalla::baldr::json::MapPtr waypoint(const odin::Location& location,
 
   // Add distance in meters from the input location to the nearest
   // point on the road used in the route
-  waypoint->emplace("distance", json::fp_t{location.path_edges(0).distance(), 3});
+  // TODO: since distance was normalized in thor - need to recalculate here
+  //       in the future we shall have store separately from score
+  waypoint->emplace("distance",
+                    json::fp_t{to_ll(location.ll()).Distance(to_ll(location.path_edges(0).ll())), 3});
 
   // Add hint. Goal is for the hint returned from a locate request to be able
   // to quickly find the edge and point along the edge in a route request.


### PR DESCRIPTION
# Issue

Location distance between specified LL and snapped LL is normalized in thor - thus the returned distance is zero. Update to re-calculate distance.

## AFTER
![image](https://user-images.githubusercontent.com/7515853/56666057-34894c80-6679-11e9-9a1b-1a445f09e1c6.png)


## Tasklist

 - [x] Test
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)
