### PR TITLE
Update the begin and end heading of short edges based on use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
    * FIXED: Added simplified overview for OSRM response and added use_toll logic back to truck costing. [#1765](https://github.com/valhalla/valhalla/pull/1765)
    * FIXED: temp fix for location distance bug [#1774](https://github.com/valhalla/valhalla/pull/1774)
    * FIXED: Fix pedestrian routes using walkway_factor [#1780](https://github.com/valhalla/valhalla/pull/1780)
+   * FIXED: Update the begin and end heading of short edges based on use [#1783](https://github.com/valhalla/valhalla/pull/1783)
 
 * **Enhancement**
    * Add the ability to run valhalla_build_tiles in stages. Specify the begin_stage and end_stage as command line options. Also cleans up temporary files as the last stage in the pipeline.

--- a/src/odin/directionsbuilder.cc
+++ b/src/odin/directionsbuilder.cc
@@ -12,8 +12,10 @@
 #include <valhalla/proto/tripdirections.pb.h>
 
 namespace {
-// Minimum edge length (~10 feet)
-constexpr auto kMinEdgeLength = 0.003f;
+// Minimum drive edge length (~10 feet)
+constexpr auto kMinDriveEdgeLength = 0.003f;
+// Minimum pedestrian/bicycle edge length (~1 foot)
+constexpr auto kMinPedestrianBicycleEdgeLength = 0.0003f;
 
 } // namespace
 
@@ -101,23 +103,41 @@ TripDirections DirectionsBuilder::Build(const DirectionsOptions& directions_opti
 
 // Update the heading of ~0 length edges.
 void DirectionsBuilder::UpdateHeading(EnhancedTripPath* etp) {
+  auto is_walkway = [](TripPath_Use use) -> bool {
+    return ((use == TripPath_Use_kSidewalkUse) || (use == TripPath_Use_kFootwayUse) ||
+            (use == TripPath_Use_kStepsUse) || (use == TripPath_Use_kPathUse) ||
+            (use == TripPath_Use_kPedestrianUse) || (use == TripPath_Use_kBridlewayUse));
+  };
+
+  auto is_bikeway = [](TripPath_Use use) -> bool {
+    return ((use == TripPath_Use_kCyclewayUse) || (use == TripPath_Use_kMountainBikeUse));
+  };
+
   for (size_t x = 0; x < etp->node_size(); ++x) {
     auto* prev_edge = etp->GetPrevEdge(x);
     auto* curr_edge = etp->GetCurrEdge(x);
     auto* next_edge = etp->GetNextEdge(x);
-    if (curr_edge && (curr_edge->length() < kMinEdgeLength)) {
+
+    // Set the minimum edge length based on use
+    auto min_edge_length = kMinDriveEdgeLength;
+    if (curr_edge && !curr_edge->roundabout() &&
+        (is_walkway(curr_edge->use()) || is_bikeway(curr_edge->use()))) {
+      min_edge_length = kMinPedestrianBicycleEdgeLength;
+    }
+
+    if (curr_edge && (curr_edge->length() < min_edge_length)) {
 
       // Set the current begin heading
-      if (prev_edge && (prev_edge->length() >= kMinEdgeLength)) {
+      if (prev_edge && (prev_edge->length() >= min_edge_length)) {
         curr_edge->set_begin_heading(prev_edge->end_heading());
-      } else if (next_edge && (next_edge->length() >= kMinEdgeLength)) {
+      } else if (next_edge && (next_edge->length() >= min_edge_length)) {
         curr_edge->set_begin_heading(next_edge->begin_heading());
       }
 
       // Set the current end heading
-      if (next_edge && (next_edge->length() >= kMinEdgeLength)) {
+      if (next_edge && (next_edge->length() >= min_edge_length)) {
         curr_edge->set_end_heading(next_edge->begin_heading());
-      } else if (prev_edge && (prev_edge->length() >= kMinEdgeLength)) {
+      } else if (prev_edge && (prev_edge->length() >= min_edge_length)) {
         curr_edge->set_end_heading(prev_edge->end_heading());
       }
     }

--- a/src/odin/directionsbuilder.cc
+++ b/src/odin/directionsbuilder.cc
@@ -104,9 +104,7 @@ TripDirections DirectionsBuilder::Build(const DirectionsOptions& directions_opti
 // Update the heading of ~0 length edges.
 void DirectionsBuilder::UpdateHeading(EnhancedTripPath* etp) {
   auto is_walkway = [](TripPath_Use use) -> bool {
-    return ((use == TripPath_Use_kSidewalkUse) || (use == TripPath_Use_kFootwayUse) ||
-            (use == TripPath_Use_kStepsUse) || (use == TripPath_Use_kPathUse) ||
-            (use == TripPath_Use_kPedestrianUse) || (use == TripPath_Use_kBridlewayUse));
+    return ((use >= TripPath_Use_kSidewalkUse) && (use <= TripPath_Use_kBridlewayUse));
   };
 
   auto is_bikeway = [](TripPath_Use use) -> bool {

--- a/test_requests/pedestrian_routes.txt
+++ b/test_requests/pedestrian_routes.txt
@@ -34,3 +34,7 @@
 -j '{"locations":[{"lat":37.333054,"lon":-121.894478,"name":"The Almaden"},{"lat":37.329918,"lon":-121.902328,"name":"San Jose Diridon Station"}],"costing":"pedestrian","directions_options":{"units":"miles"}}'
 -j '{"locations":[{"lat":43.646835,"lon":-79.377213,"name":"Hockey Hall of Fame"},{"lat":43.652077,"lon":-79.383278,"name":"Nathan Phillips Square"}],"costing":"pedestrian","directions_options":{"units":"miles"}}'
 -j '{"locations":[{"lat":43.652077,"lon":-79.383278,"name":"Nathan Phillips Square"},{"lat":43.646835,"lon":-79.377213,"name":"Hockey Hall of Fame"}],"costing":"pedestrian","directions_options":{"units":"miles"}}'
+-j '{"locations":[{"lat":40.042545,"lon":-76.299072,"street":"East Fulton Street"},{"lat":40.038799,"lon":-76.305710,"street":"88 Chinese Express"}],"costing":"pedestrian","directions_options":{"units":"miles"}}'
+-j '{"locations":[{"lat":40.038799,"lon":-76.305710,"street":"88 Chinese Express"},{"lat":40.042545,"lon":-76.299072,"street":"East Fulton Street"}],"costing":"pedestrian","directions_options":{"units":"miles"}}'
+-j '{"locations":[{"lat":40.042534,"lon":-76.299171,"street":"East Fulton Street"},{"lat":40.041744,"lon":-76.308380,"street":"Roburrito's"}],"costing":"pedestrian","directions_options":{"units":"miles"}}'
+-j '{"locations":[{"lat":40.041744,"lon":-76.308380,"street":"Roburrito's"},{"lat":40.042534,"lon":-76.299171,"street":"East Fulton Street"}],"costing":"pedestrian","directions_options":{"units":"miles"}}'


### PR DESCRIPTION
# Issue

Some very short walkway edges had invalid headings which resulted in a missing turn instruction.
Improve the `UpdateHeading` method by setting different distance thresholds based on edge use.
Prior to this update - maneuver#4 in the following example was missing:
![missing_man4](https://user-images.githubusercontent.com/7515853/57058125-edecb100-6c7b-11e9-9fca-f5ec29b1bc3c.png)

## Tasklist

 - [x] Test
 - [x] Review - you must request approval to merge any PR to master
 - [x] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)
