### PR TITLE
NodeTransition index out of bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
    * FIXED: temp fix for location distance bug [#1774](https://github.com/valhalla/valhalla/pull/1774)
    * FIXED: Fix pedestrian routes using walkway_factor [#1780](https://github.com/valhalla/valhalla/pull/1780)
    * FIXED: Update the begin and end heading of short edges based on use [#1783](https://github.com/valhalla/valhalla/pull/1783)
+   * FIXED: GraphReader::AreEdgesConnected update.  If transition count == 0 return false and do not call transition function. [#1786](https://github.com/valhalla/valhalla/pull/1786)
 
 * **Enhancement**
    * Add the ability to run valhalla_build_tiles in stages. Specify the begin_stage and end_stage as command line options. Also cleans up temporary files as the last stage in the pipeline.

--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -305,6 +305,7 @@ bool GraphReader::AreEdgesConnected(const GraphId& edge1, const GraphId& edge2) 
     } else {
       const GraphTile* tile = GetGraphTile(n1);
       const NodeInfo* ni = tile->node(n1);
+      if (ni->transition_count() == 0) return false;
       const NodeTransition* trans = tile->transition(ni->transition_index());
       for (uint32_t i = 0; i < ni->transition_count(); ++i, ++trans) {
         if (trans->endnode() == n2) {

--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -305,7 +305,8 @@ bool GraphReader::AreEdgesConnected(const GraphId& edge1, const GraphId& edge2) 
     } else {
       const GraphTile* tile = GetGraphTile(n1);
       const NodeInfo* ni = tile->node(n1);
-      if (ni->transition_count() == 0) return false;
+      if (ni->transition_count() == 0)
+        return false;
       const NodeTransition* trans = tile->transition(ni->transition_index());
       for (uint32_t i = 0; i < ni->transition_count(); ++i, ++trans) {
         if (trans->endnode() == n2) {


### PR DESCRIPTION
if transition count == 0 return false and do not call transition function.

This issue was creating numerous route failures returning:
400::GraphTile NodeTransition index out of bounds: 810539,2,0 transitioncount= 0

## Tasklist

 - [x] Review - you must request approval to merge any PR to master
 - [x] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

Bug was introduced during the V3 tile refactor.  
![image](https://user-images.githubusercontent.com/2676277/57148232-29c86900-6d97-11e9-8942-806ce07a2225.png)
