### PR TITLE
robustness on edge filtering

### DIFF
--- a/src/baldr/connectivity_map.cc
+++ b/src/baldr/connectivity_map.cc
@@ -268,19 +268,22 @@ std::unordered_set<size_t> connectivity_map_t::get_colors(uint32_t hierarchy_lev
     return result;
   }
   const auto& tiles = TileHierarchy::levels().find(hierarchy_level)->second.tiles;
-  for (const auto& edge : location.edges) {
-    // Get a list of tiles required within the radius of the projected point
-    const auto& ll = edge.projected;
-    DistanceApproximator approximator(ll);
-    float latdeg = (radius / kMetersPerDegreeLat);
-    float lngdeg = (radius / DistanceApproximator::MetersPerLngDegree(ll.lat()));
-    AABB2<PointLL> bbox(Point2(ll.lng() - lngdeg, ll.lat() - latdeg),
-                        Point2(ll.lng() + lngdeg, ll.lat() + latdeg));
-    std::vector<int32_t> tilelist = tiles.TileList(bbox);
-    for (auto& id : tilelist) {
-      auto color = level->second.find(id);
-      if (color != level->second.cend()) {
-        result.emplace(color->second);
+  std::vector<const decltype(location.edges)*> edge_sets{&location.edges, &location.filtered_edges};
+  for (const auto* edges : edge_sets) {
+    for (const auto& edge : *edges) {
+      // Get a list of tiles required within the radius of the projected point
+      const auto& ll = edge.projected;
+      DistanceApproximator approximator(ll);
+      float latdeg = (radius / kMetersPerDegreeLat);
+      float lngdeg = (radius / DistanceApproximator::MetersPerLngDegree(ll.lat()));
+      AABB2<PointLL> bbox(Point2(ll.lng() - lngdeg, ll.lat() - latdeg),
+                          Point2(ll.lng() + lngdeg, ll.lat() + latdeg));
+      std::vector<int32_t> tilelist = tiles.TileList(bbox);
+      for (auto& id : tilelist) {
+        auto color = level->second.find(id);
+        if (color != level->second.cend()) {
+          result.emplace(color->second);
+        }
       }
     }
   }

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -415,6 +415,11 @@ void parse_locations(const rapidjson::Document& doc,
         }
       } catch (...) { throw valhalla_exception_t{location_parse_error_code}; }
     }
+    // first and last locations get the default type of break no matter what
+    if (locations->size()) {
+      locations->Mutable(0)->set_type(odin::Location::kBreak);
+      locations->Mutable(locations->size() - 1)->set_type(odin::Location::kBreak);
+    }
     if (track) {
       midgard::logging::Log(node + "_count::" + std::to_string(request_locations->Size()),
                             " [ANALYTICS] ");

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -202,8 +202,7 @@ const std::unordered_map<unsigned, std::string> OSRM_ERRORS_CODES{
     {164,
      R"({"code":"InvalidValue","message":"The successfully parsed query parameters are invalid."})"},
 
-    {170,
-     R"({"code":"InvalidValue","message":"The successfully parsed query parameters are invalid."})"},
+    {170, R"({"code":"NoRoute","message":"Impossible route between points"})"},
     {171,
      R"({"code":"NoSegment","message":"One of the supplied input coordinates could not snap to street segment."})"},
 


### PR DESCRIPTION
this does 3 things:

* never lets a pbf location in the first or last position have a type other than break
* edge filtering happens first before falling back to putting filtered edges back in
* when we check the colors in the connectivity map we should check the filtered ones as well since we will use those in routes