### PR TITLE
dont keep path edges we didnt use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Release Date: 2019-04-22 Valhalla 3.0.3
+## Release Date: UNRELEASED Valhalla 3.0.3
 * **Bug Fix**
    * FIXED: Fixed a rare loop condition in route matcher (edge walking to match a trace).
    * FIXED: Fixed VACUUM ANALYZE syntax issue.  [#1704](https://github.com/valhalla/valhalla/pull/1704)
@@ -18,6 +18,7 @@
    * FIXED: Fix pedestrian routes using walkway_factor [#1780](https://github.com/valhalla/valhalla/pull/1780)
    * FIXED: Update the begin and end heading of short edges based on use [#1783](https://github.com/valhalla/valhalla/pull/1783)
    * FIXED: GraphReader::AreEdgesConnected update.  If transition count == 0 return false and do not call transition function. [#1786](https://github.com/valhalla/valhalla/pull/1786)
+   * FIXED: Only edge candidates that were used in the path are send to serializer: [1788](https://github.com/valhalla/valhalla/pull/1788)
 
 * **Enhancement**
    * Add the ability to run valhalla_build_tiles in stages. Specify the begin_stage and end_stage as command line options. Also cleans up temporary files as the last stage in the pipeline.

--- a/src/thor/route_action.cc
+++ b/src/thor/route_action.cc
@@ -129,11 +129,38 @@ std::list<valhalla::odin::TripPath> thor_worker_t::route(valhalla_request_t& req
   parse_locations(request);
   auto costing = parse_costing(request);
 
+  // get all the legs
+  auto* locations = request.options.mutable_locations();
   auto trippaths = (request.options.has_date_time_type() &&
                     request.options.date_time_type() == odin::DirectionsOptions::arrive_by)
-                       ? path_arrive_by(*request.options.mutable_locations(), costing)
-                       : path_depart_at(*request.options.mutable_locations(), costing);
+                       ? path_arrive_by(*locations, costing)
+                       : path_depart_at(*locations, costing);
 
+  // TODO: this wont be needed once we do the block comment above
+  // cull unused edges
+  auto path = trippaths.begin();
+  GraphId left, right;
+  for (auto l = locations->begin(); l < locations->end(); ++l) {
+    // the edge on the right side of this node
+    right = GraphId(path != trippaths.end() ? static_cast<uint64_t>(path->node(0).edge().id())
+                                            : kInvalidGraphId);
+    // remove edges that we didnt use
+    auto end = std::partition(l->mutable_path_edges()->begin(), l->mutable_path_edges()->end(),
+                              [&left, &right](const valhalla::odin::Location::PathEdge& e) {
+                                return e.graph_id() == left || e.graph_id() == right;
+                              });
+    auto shrink_to_size = end - l->mutable_path_edges()->begin();
+    while (l->path_edges_size() > shrink_to_size)
+      l->mutable_path_edges()->RemoveLast();
+
+    // next leg
+    left = GraphId(path != trippaths.end()
+                       ? static_cast<uint64_t>(path->node(path->node_size() - 2).edge().id())
+                       : kInvalidGraphId);
+    ++path;
+  }
+
+  // log admin areas
   if (!request.options.do_not_track()) {
     for (const auto& tp : trippaths) {
       log_admin(tp);


### PR DESCRIPTION
I'm not sure why I thought this but, I thought that after we computed a given leg of the route, we went back to the input locations and removed all of the edge candidates that didnt end up getting used in the route. I must have been dreaming but I swore this code already existed. Anyway... I've added this code so that when we go to serialize this information out, we only have the edge candidate that actually got used.

In the future we will marry this code with the code in the individual depart/arrive functions by handling both break and non break stop types using the commented out chunk of code at the top of `thor/route_action.cc`