### PR TITLE
 Fixed instructions when starting on an internal edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
    * FIXED: GraphReader::AreEdgesConnected update.  If transition count == 0 return false and do not call transition function. [#1786](https://github.com/valhalla/valhalla/pull/1786)
    * FIXED: Only edge candidates that were used in the path are send to serializer: [1788](https://github.com/valhalla/valhalla/pull/1788)
    * FIXED: Added logic to prevent the removal of a destination maneuver when ending on an internal edge [#1792](https://github.com/valhalla/valhalla/pull/1792)
+   * FIXED: Fixed instructions when starting on an internal edge [#1796](https://github.com/valhalla/valhalla/pull/1796)
 
 * **Enhancement**
    * Add the ability to run valhalla_build_tiles in stages. Specify the begin_stage and end_stage as command line options. Also cleans up temporary files as the last stage in the pipeline.

--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -836,8 +836,9 @@ void ManeuversBuilder::InitializeManeuver(Maneuver& maneuver, int node_index) {
     maneuver.set_roundabout_exit_count(1);
   }
 
-  // Internal Intersection
-  if (prev_edge->internal_intersection() && !trip_path_->IsLastNodeIndex(node_index)) {
+  // Internal Intersection - excluding the first and last edges
+  if (prev_edge->internal_intersection() && !trip_path_->IsLastNodeIndex(node_index) &&
+      !trip_path_->IsFirstNodeIndex(node_index - 1)) {
     maneuver.set_internal_intersection(true);
   }
 
@@ -1536,11 +1537,13 @@ bool ManeuversBuilder::CanManeuverIncludePrevEdge(Maneuver& maneuver, int node_i
 
   /////////////////////////////////////////////////////////////////////////////
   // Process internal intersection
+  // Cannot be the first edge in the trip
   if (prev_edge->internal_intersection() && !maneuver.internal_intersection()) {
     return false;
   } else if (!prev_edge->internal_intersection() && maneuver.internal_intersection()) {
     return false;
-  } else if (prev_edge->internal_intersection() && maneuver.internal_intersection()) {
+  } else if (prev_edge->internal_intersection() && !trip_path_->IsFirstNodeIndex(node_index - 1) &&
+             maneuver.internal_intersection()) {
     return true;
   }
 


### PR DESCRIPTION
# Issue

Fixes #1794 

### Example#1
![image](https://user-images.githubusercontent.com/7515853/57314931-95c10f00-70c0-11e9-9f86-6e89fc0b2dc4.png)
``` DIFF
< BEFORE
< 1: Drive west on Snowden River Parkway.
< 2: You have arrived at Snowden River Parkway.
> AFTER
> 1: Drive northeast on Broken Land Parkway.
> 2: Turn left onto Snowden River Parkway.
> 3: You have arrived at Snowden River Parkway.
```

### Example#2
![image](https://user-images.githubusercontent.com/7515853/57315294-44fde600-70c1-11e9-9a01-bc6cdb6d42e0.png)
``` DIFF
< BEFORE
< 1: Drive southeast on Snowden River Parkway.
< 2: You have arrived at Snowden River Parkway.
> AFTER
> 1: Drive west on Snowden River Parkway.
> 2: Make a left U-turn at Broken Land Parkway to stay on Snowden River Parkway.
> 3: You have arrived at Snowden River Parkway.
```
## Tasklist

 - [x] Test
 - [x] Review - you must request approval to merge any PR to master
 - [x] Add #fixes with the issue number that this PR addresses
 - [x] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)
