### PR TITLE
Fix bicycle edge filter whan avoid_bad_surfaces = 1.0

### DIFF
--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -388,9 +388,11 @@ protected:
    */
   virtual const EdgeFilter GetEdgeFilter() const {
     // Throw back a lambda that checks the access for this type of costing
-    return [](const baldr::DirectedEdge* edge) {
+    Surface s = worst_allowed_surface_;
+    float a = avoid_bad_surfaces_;
+    return [s, a](const baldr::DirectedEdge* edge) {
       if (edge->is_shortcut() || !(edge->forwardaccess() & kBicycleAccess) ||
-          edge->use() == Use::kSteps) {
+          edge->use() == Use::kSteps || (a == 1.0f && edge->surface() > s)) {
         return 0.0f;
       } else {
         // TODO - use classification/use to alter the factor


### PR DESCRIPTION
This updates PR #1800 which removed the check for surfaces in the edge filter, but was not quite right.  If avoid_bad_surfaces = 1.0 then bad surfaces are to be totally avoided (not just penalized) as the documentation states. So the surface comparison is required when avoid_bad_surfaces = 1.0.

# Issue

What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.

## Tasklist

 - [ ] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
