### PR TITLE
add alternates to the request interface

### DIFF
--- a/proto/directions_options.proto
+++ b/proto/directions_options.proto
@@ -177,4 +177,5 @@ message DirectionsOptions {
   optional float breakage_distance = 36;                                  // Map-matching breaking distance (distance between GPS trace points)
   optional bool use_timestamps = 37 [default = false];                    // Use timestamps to compute elapsed time for trace_route and trace_attributes
   optional ShapeFormat shape_format = 38 [default = polyline6];           // Shape format (defaults to polyline6 encoding)
+  optional uint32 alternates = 39;                                        // Maximum number of alternate routes that can be returned
 }

--- a/scripts/valhalla_build_config
+++ b/scripts/valhalla_build_config
@@ -439,7 +439,7 @@ help_text = {
       'max_best_paths': 'Maximum number of best paths',
       'max_best_paths_shape': 'Maximum number of input shape points when requesting multiple paths'
     },
-    'max_avoid_locations': 'Maximum number of avoid locations to allow a request',
+    'max_avoid_locations': 'Maximum number of avoid locations to allow in a request',
     'max_reachability': 'Maximum reachability (number of nodes reachable) allowed on any one location',
     'max_radius': 'Maximum radius in meters allowed on any one location',
     'max_timedep_distance': 'Maximum b-line distance between locations to allow a time-dependent route',

--- a/scripts/valhalla_build_config
+++ b/scripts/valhalla_build_config
@@ -221,7 +221,8 @@ config = {
     'max_avoid_locations': 50,
     'max_reachability': 100,
     'max_radius': 200,
-    'max_timedep_distance': 500000
+    'max_timedep_distance': 500000,
+    'max_alternates': 2
   }
 }
 
@@ -438,10 +439,11 @@ help_text = {
       'max_best_paths': 'Maximum number of best paths',
       'max_best_paths_shape': 'Maximum number of input shape points when requesting multiple paths'
     },
-    'max_avoid_locations': 'Maximum number of avoid locations to allow in request',
+    'max_avoid_locations': 'Maximum number of avoid locations to allow a request',
     'max_reachability': 'Maximum reachability (number of nodes reachable) allowed on any one location',
     'max_radius': 'Maximum radius in meters allowed on any one location',
-    'max_timedep_distance': 'Maximum b-line distance between locations to allow a time-dependent route'
+    'max_timedep_distance': 'Maximum b-line distance between locations to allow a time-dependent route',
+    'max_alternates': 'Maximum number of alternate routes to allow in a request'
   }
 }
 

--- a/src/loki/worker.cc
+++ b/src/loki/worker.cc
@@ -146,6 +146,10 @@ void loki_worker_t::parse_costing(valhalla_request_t& request) {
       LOG_WARN("Failed to find avoid_locations");
     }
   }
+
+  // If more alternates are requested than we support we cap it
+  if (request.options.alternates() > max_alternates)
+    request.options.set_alternates(max_alternates);
 }
 
 loki_worker_t::loki_worker_t(const boost::property_tree::ptree& config,
@@ -182,7 +186,8 @@ loki_worker_t::loki_worker_t(const boost::property_tree::ptree& config,
   // Build max_locations and max_distance maps
   for (const auto& kv : config.get_child("service_limits")) {
     if (kv.first == "max_avoid_locations" || kv.first == "max_reachability" ||
-        kv.first == "max_radius" || kv.first == "max_timedep_distance") {
+        kv.first == "max_radius" || kv.first == "max_timedep_distance" ||
+        kv.first == "max_alternates") {
       continue;
     }
     if (kv.first != "skadi" && kv.first != "trace") {
@@ -236,6 +241,7 @@ loki_worker_t::loki_worker_t(const boost::property_tree::ptree& config,
   max_search_radius = config.get<float>("service_limits.trace.max_search_radius");
   max_best_paths = config.get<unsigned int>("service_limits.trace.max_best_paths");
   max_best_paths_shape = config.get<size_t>("service_limits.trace.max_best_paths_shape");
+  max_alternates = config.get<unsigned int>("service_limits.max_alternates");
 
   // Register standard edge/node costing methods
   factory.RegisterStandardCostingModels();

--- a/src/thor/worker.cc
+++ b/src/thor/worker.cc
@@ -70,7 +70,8 @@ thor_worker_t::thor_worker_t(const boost::property_tree::ptree& config,
   auto conf_algorithm = config.get<std::string>("thor.source_to_target_algorithm", "select_optimal");
   for (const auto& kv : config.get_child("service_limits")) {
     if (kv.first == "max_avoid_locations" || kv.first == "max_reachability" ||
-        kv.first == "max_radius" || kv.first == "max_timedep_distance") {
+        kv.first == "max_radius" || kv.first == "max_timedep_distance" ||
+        kv.first == "max_alternates") {
       continue;
     }
     if (kv.first != "skadi" && kv.first != "trace" && kv.first != "isochrone") {

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -838,8 +838,10 @@ void from_json(rapidjson::Document& doc, odin::DirectionsOptions& options) {
     }
   }
 
-  // how many alternates are desired, default to none
+  // how many alternates are desired, default to none and if its multi point its also none
   options.set_alternates(rapidjson::get<uint32_t>(doc, "/alternates", 0));
+  if (options.locations_size() > 2)
+    options.set_alternates(0);
 
   // force these into the output so its obvious what we did to the user
   doc.AddMember({"language", allocator}, {options.language(), allocator}, allocator);

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -838,6 +838,9 @@ void from_json(rapidjson::Document& doc, odin::DirectionsOptions& options) {
     }
   }
 
+  // how many alternates are desired, default to none
+  options.set_alternates(rapidjson::get<uint32_t>(doc, "/alternates", 0));
+
   // force these into the output so its obvious what we did to the user
   doc.AddMember({"language", allocator}, {options.language(), allocator}, allocator);
   doc.AddMember({"format", allocator},

--- a/test/actor.cc
+++ b/test/actor.cc
@@ -47,7 +47,7 @@ boost::property_tree::ptree make_conf() {
         "hov": {"max_distance": 5000000.0,"max_locations": 20,"max_matrix_distance": 400000.0,"max_matrix_locations": 50},
         "taxi": {"max_distance": 5000000.0,"max_locations": 20,"max_matrix_distance": 400000.0,"max_matrix_locations": 50},
         "isochrone": {"max_contours": 4,"max_distance": 25000.0,"max_locations": 1,"max_time": 120},
-        "max_avoid_locations": 50,"max_radius": 200,"max_reachability": 100,
+        "max_avoid_locations": 50,"max_radius": 200,"max_reachability": 100,"max_alternates":2,
         "multimodal": {"max_distance": 500000.0,"max_locations": 50,"max_matrix_distance": 0.0,"max_matrix_locations": 0},
         "pedestrian": {"max_distance": 250000.0,"max_locations": 50,"max_matrix_distance": 200000.0,"max_matrix_locations": 50,"max_transit_walking_distance": 10000,"min_transit_walking_distance": 1},
         "skadi": {"max_shape": 750000,"min_resample": 10.0},

--- a/test/bindings/nodejs/fixtures/basic_config.json
+++ b/test/bindings/nodejs/fixtures/basic_config.json
@@ -20,7 +20,7 @@
       "hov": {"max_distance": 5000000.0,"max_locations": 20,"max_matrix_distance": 400000.0,"max_matrix_locations": 50},
       "taxi": {"max_distance": 5000000.0,"max_locations": 20,"max_matrix_distance": 400000.0,"max_matrix_locations": 50},
       "isochrone": {"max_contours": 4,"max_distance": 25000.0,"max_locations": 1,"max_time": 120},
-      "max_avoid_locations": 50,"max_radius": 200,"max_reachability": 100,
+      "max_avoid_locations": 50,"max_radius": 200,"max_reachability": 100,"max_alternates": 2,
       "multimodal": {"max_distance": 500000.0,"max_locations": 50,"max_matrix_distance": 0.0,"max_matrix_locations": 0},
       "pedestrian": {"max_distance": 250000.0,"max_locations": 50,"max_matrix_distance": 200000.0,"max_matrix_locations": 50,"max_transit_walking_distance": 10000,"min_transit_walking_distance": 1},
       "skadi": {"max_shape": 750000,"min_resample": 10.0},

--- a/test/bindings/python/valhalla.json
+++ b/test/bindings/python/valhalla.json
@@ -166,6 +166,7 @@
     "max_avoid_locations": 50,
     "max_radius": 200,
     "max_reachability": 100,
+    "max_alternates": 2,
     "motor_scooter": {
       "max_distance": 500000.0,
       "max_locations": 50,

--- a/test/isochrone.cc
+++ b/test/isochrone.cc
@@ -54,7 +54,7 @@ const auto config = json_to_pt(R"({
       "hov": {"max_distance": 5000000.0,"max_locations": 20,"max_matrix_distance": 400000.0,"max_matrix_locations": 50},
       "taxi": {"max_distance": 5000000.0,"max_locations": 20,"max_matrix_distance": 400000.0,"max_matrix_locations": 50},
       "isochrone": {"max_contours": 4,"max_distance": 25000.0,"max_locations": 1,"max_time": 120},
-      "max_avoid_locations": 50,"max_radius": 200,"max_reachability": 100,
+      "max_avoid_locations": 50,"max_radius": 200,"max_reachability": 100,"max_alternates":2,
       "multimodal": {"max_distance": 500000.0,"max_locations": 50,"max_matrix_distance": 0.0,"max_matrix_locations": 0},
       "pedestrian": {"max_distance": 250000.0,"max_locations": 50,"max_matrix_distance": 200000.0,"max_matrix_locations": 50,"max_transit_walking_distance": 10000,"min_transit_walking_distance": 1},
       "skadi": {"max_shape": 750000,"min_resample": 10.0},

--- a/test/loki_service.cc
+++ b/test/loki_service.cc
@@ -363,7 +363,8 @@ void start_service() {
         "trace": { "max_best_paths": 4, "max_best_paths_shape": 100, "max_distance": 200000.0, "max_gps_accuracy": 100.0, "max_search_radius": 100, "max_shape": 16000 },
         "max_avoid_locations": 0,
         "max_reachability": 100,
-        "max_radius": 200
+        "max_radius": 200,
+        "max_alternates":2
       },
       "costing_options": { "auto": {}, "pedestrian": {} }
     })";

--- a/test/mapmatch.cc
+++ b/test/mapmatch.cc
@@ -96,7 +96,7 @@ const auto conf = json_to_pt(R"({
       "hov": {"max_distance": 5000000.0,"max_locations": 20,"max_matrix_distance": 400000.0,"max_matrix_locations": 50},
       "taxi": {"max_distance": 5000000.0,"max_locations": 20,"max_matrix_distance": 400000.0,"max_matrix_locations": 50},
       "isochrone": {"max_contours": 4,"max_distance": 25000.0,"max_locations": 1,"max_time": 120},
-      "max_avoid_locations": 50,"max_radius": 200,"max_reachability": 100,
+      "max_avoid_locations": 50,"max_radius": 200,"max_reachability": 100,"max_alternates":2,
       "multimodal": {"max_distance": 500000.0,"max_locations": 50,"max_matrix_distance": 0.0,"max_matrix_locations": 0},
       "pedestrian": {"max_distance": 250000.0,"max_locations": 50,"max_matrix_distance": 200000.0,"max_matrix_locations": 50,"max_transit_walking_distance": 10000,"min_transit_walking_distance": 1},
       "skadi": {"max_shape": 750000,"min_resample": 10.0},

--- a/test/matrix.cc
+++ b/test/matrix.cc
@@ -204,7 +204,7 @@ const auto config = json_to_pt(R"({
       "hov": {"max_distance": 5000000.0,"max_locations": 20,"max_matrix_distance": 400000.0,"max_matrix_locations": 50},
       "taxi": {"max_distance": 5000000.0,"max_locations": 20,"max_matrix_distance": 400000.0,"max_matrix_locations": 50},
       "isochrone": {"max_contours": 4,"max_distance": 25000.0,"max_locations": 1,"max_time": 120},
-      "max_avoid_locations": 50,"max_radius": 200,"max_reachability": 100,
+      "max_avoid_locations": 50,"max_radius": 200,"max_reachability": 100,"max_alternates":2,
       "multimodal": {"max_distance": 500000.0,"max_locations": 50,"max_matrix_distance": 0.0,"max_matrix_locations": 0},
       "pedestrian": {"max_distance": 250000.0,"max_locations": 50,"max_matrix_distance": 200000.0,"max_matrix_locations": 50,"max_transit_walking_distance": 10000,"min_transit_walking_distance": 1},
       "skadi": {"max_shape": 750000,"min_resample": 10.0},

--- a/test/multipoint_routes.cc
+++ b/test/multipoint_routes.cc
@@ -48,7 +48,7 @@ boost::property_tree::ptree get_conf() {
         "bus": {"max_distance": 5000000.0,"max_locations": 50,"max_matrix_distance": 400000.0,"max_matrix_locations": 50},
         "hov": {"max_distance": 5000000.0,"max_locations": 20,"max_matrix_distance": 400000.0,"max_matrix_locations": 50},
         "isochrone": {"max_contours": 4,"max_distance": 25000.0,"max_locations": 1,"max_time": 120},
-        "max_avoid_locations": 50,"max_radius": 200,"max_reachability": 100,
+        "max_avoid_locations": 50,"max_radius": 200,"max_reachability": 100,"max_alternates":2,
         "multimodal": {"max_distance": 500000.0,"max_locations": 50,"max_matrix_distance": 0.0,"max_matrix_locations": 0},
         "pedestrian": {"max_distance": 250000.0,"max_locations": 50,"max_matrix_distance": 200000.0,"max_matrix_locations": 50,"max_transit_walking_distance": 10000,"min_transit_walking_distance": 1},
         "skadi": {"max_shape": 750000,"min_resample": 10.0},

--- a/test/skadi_service.cc
+++ b/test/skadi_service.cc
@@ -213,7 +213,8 @@ void start_service(zmq::context_t& context) {
         "trace": { "max_best_paths": 4, "max_best_paths_shape": 100, "max_distance": 200000.0, "max_gps_accuracy": 100.0, "max_search_radius": 100, "max_shape": 16000 },
         "max_avoid_locations": 0,
         "max_reachability": 100,
-        "max_radius": 200
+        "max_radius": 200,
+        "max_alternates":2
       },
       "costing_options": { "auto": {}, "pedestrian": {} }
     })";

--- a/test/timedep_paths.cc
+++ b/test/timedep_paths.cc
@@ -109,7 +109,7 @@ const auto config = json_to_pt(R"({
       "hov": {"max_distance": 5000000.0,"max_locations": 20,"max_matrix_distance": 400000.0,"max_matrix_locations": 50},
       "taxi": {"max_distance": 5000000.0,"max_locations": 20,"max_matrix_distance": 400000.0,"max_matrix_locations": 50},
       "isochrone": {"max_contours": 4,"max_distance": 25000.0,"max_locations": 1,"max_time": 120},
-      "max_avoid_locations": 50,"max_radius": 200,"max_reachability": 100,
+      "max_avoid_locations": 50,"max_radius": 200,"max_reachability": 100,"max_alternates":2,
       "multimodal": {"max_distance": 500000.0,"max_locations": 50,"max_matrix_distance": 0.0,"max_matrix_locations": 0},
       "pedestrian": {"max_distance": 250000.0,"max_locations": 50,"max_matrix_distance": 200000.0,"max_matrix_locations": 50,"max_transit_walking_distance": 10000,"min_transit_walking_distance": 1},
       "skadi": {"max_shape": 750000,"min_resample": 10.0},

--- a/test/trivial_paths.cc
+++ b/test/trivial_paths.cc
@@ -102,7 +102,7 @@ const auto config = json_to_pt(R"({
       "hov": {"max_distance": 5000000.0,"max_locations": 20,"max_matrix_distance": 400000.0,"max_matrix_locations": 50},
       "taxi": {"max_distance": 5000000.0,"max_locations": 20,"max_matrix_distance": 400000.0,"max_matrix_locations": 50},
       "isochrone": {"max_contours": 4,"max_distance": 25000.0,"max_locations": 1,"max_time": 120},
-      "max_avoid_locations": 50,"max_radius": 200,"max_reachability": 100,
+      "max_avoid_locations": 50,"max_radius": 200,"max_reachability": 100,"max_alternates":2,
       "multimodal": {"max_distance": 500000.0,"max_locations": 50,"max_matrix_distance": 0.0,"max_matrix_locations": 0},
       "pedestrian": {"max_distance": 250000.0,"max_locations": 50,"max_matrix_distance": 200000.0,"max_matrix_locations": 50,"max_transit_walking_distance": 10000,"min_transit_walking_distance": 1},
       "skadi": {"max_shape": 750000,"min_resample": 10.0},

--- a/valhalla/loki/worker.h
+++ b/valhalla/loki/worker.h
@@ -95,6 +95,7 @@ protected:
   skadi::sample sample;
   size_t max_elevation_shape;
   float min_resample;
+  unsigned int max_alternates;
 };
 } // namespace loki
 } // namespace valhalla


### PR DESCRIPTION
adds alternates as a request parameter. this is part of a larger effort to add the possibility for alternate routes to the api. right now we are only concerned with adding this concept to the interface, so we will still only be returning a single route. actually returning multiple would be a breaking api change and so its out of scope at this point