### PR TITLE
Fix timezone shape filename in valhalla_build_timezones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
    * FIXED: Moved complex restrictions building to before validate. [#1805](https://github.com/valhalla/valhalla/pull/1805)
    * FIXED: Fix bicycle edge filter whan avoid_bad_surfaces = 1.0 [#1806](https://github.com/valhalla/valhalla/pull/1806)
    * FIXED: Replace the EnhancedTripPath class inheritance with aggregation [#1807](https://github.com/valhalla/valhalla/pull/1807)
+   * FIXED: Replace the old timezone shape zip file every time valhalla_build_timezones is ran [#1817](https://github.com/valhalla/valhalla/pull/1817)
 
 ## Release Date: 2019-05-08 Valhalla 3.0.3
 * **Bug Fix**

--- a/scripts/valhalla_build_timezones
+++ b/scripts/valhalla_build_timezones
@@ -21,7 +21,7 @@ if  ! which spatialite >/dev/null; then
 fi
 
 rm -rf dist
-rm -f ./timezones.shapefile.zip
+rm -f ./timezones-with-oceans.shapefile.zip
 
 config=$1
 if [ ! -f $config ]; then


### PR DESCRIPTION
Fix the filename of the shape zip file so it removes the old file and replaces it with the new one.

# Issue

Fixes #1816

## Tasklist

 - [ ] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [x] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)
