### PR TITLE
Fix mapmatch exception handling

### DIFF
--- a/src/thor/trace_attributes_action.cc
+++ b/src/thor/trace_attributes_action.cc
@@ -154,6 +154,10 @@ std::string thor_worker_t::trace_attributes(valhalla_request_t& request) {
     throw valhalla_exception_t{442};
   }
 
+  if (std::get<kTripLegIndex>(map_match_results.at(0)).empty()) {
+    throw valhalla_exception_t{442};
+  }
+
   for (const auto& trippath : std::get<kTripLegIndex>(map_match_results.at(0))) {
     if (trippath.node().size() == 0) {
       throw valhalla_exception_t{442};

--- a/src/thor/trace_route_action.cc
+++ b/src/thor/trace_route_action.cc
@@ -96,6 +96,13 @@ std::list<TripLeg> thor_worker_t::trace_route(valhalla_request_t& request) {
         auto map_match_results = map_match(request, controller);
         if (!map_match_results.empty()) {
           trip_paths = std::get<kTripLegIndex>(map_match_results.at(0));
+          if (trip_paths.empty())
+            throw std::exception{};
+          for (const auto& tp : trip_paths) {
+            if (tp.node().empty()) {
+              throw std::exception{};
+            };
+          }
         }
       } catch (...) { throw valhalla_exception_t{442}; }
       break;

--- a/src/thor/trace_route_action.cc
+++ b/src/thor/trace_route_action.cc
@@ -146,8 +146,6 @@ std::list<TripLeg> thor_worker_t::route_match(valhalla_request_t& request,
                                     path_infos.end(), *request.options.mutable_locations()->begin(),
                                     *request.options.mutable_locations()->rbegin(),
                                     std::list<valhalla::Location>{}, interrupt);
-    if (trip_path.node_size() == 0)
-      throw std::exception{};
     trip_paths.emplace_back(trip_path);
   } else {
     throw std::exception{};

--- a/src/thor/trace_route_action.cc
+++ b/src/thor/trace_route_action.cc
@@ -95,15 +95,9 @@ std::list<TripLeg> thor_worker_t::trace_route(valhalla_request_t& request) {
     // network. No shortcuts are used and detailed information at every intersection becomes
     // available.
     case ShapeMatch::walk_or_snap:
-      trip_paths = route_match(request, controller);
-      bool empty_leg = false;
-      for (const auto& tp : trip_paths) {
-        if (tp.node().empty()) {
-          empty_leg = true;
-          break;
-        };
-      }
-      if (empty_leg || trip_paths.empty()) {
+      try {
+        trip_paths = route_match(request, controller);
+      } catch (...) {
         LOG_WARN(ShapeMatch_Name(request.options.shape_match()) +
                  " algorithm failed to find exact route match; Falling back to map_match...");
         try {

--- a/src/thor/trace_route_action.cc
+++ b/src/thor/trace_route_action.cc
@@ -197,7 +197,7 @@ thor_worker_t::map_match(valhalla_request_t& request,
     // TODO - perhaps also throw exception if use_timestamps and disconnected path?
     if (request.options.action() == DirectionsOptions::trace_route &&
         (disconnected_edges.size() || path_edges.empty())) {
-      throw valhalla_exception_t{442};
+      throw std::exception{};
     };
 
     // OSRM map matching format has both the match points and the route, fill out the match points

--- a/src/thor/trace_route_action.cc
+++ b/src/thor/trace_route_action.cc
@@ -167,10 +167,6 @@ thor_worker_t::map_match(valhalla_request_t& request,
     offline_results = matcher->OfflineMatch(trace, best_paths);
   }
 
-  // This exception will be caught upstream and return a 442 error
-  if (offline_results.empty())
-    throw std::exception{};
-
   // Process each score/match result
   for (const auto& result : offline_results) {
     const auto& match_results = result.results;

--- a/test/mapmatch.cc
+++ b/test/mapmatch.cc
@@ -327,6 +327,33 @@ void test_trace_route_edge_walk_expected_error_code() {
   throw std::logic_error("Expected trace_route edge_walk exception was not found");
 }
 
+void test_trace_route_map_snap_expected_error_code() {
+  // tests expected error_code for trace_route edge_walk
+  auto expected_error_code = 442;
+  tyr::actor_t actor(conf, true);
+
+  try {
+    auto response = json_to_pt(actor.trace_route(
+        R"({"costing":"auto","shape_match":"map_snap","shape":[
+         {"lat":52.088548,"lon":5.15357,"radius":5},
+         {"lat":52.088627,"lon":5.153269,"radius":5},
+         {"lat":52.08864,"lon":5.15298,"radius":5},
+         {"lat":52.08861,"lon":5.15272,"radius":5},
+         {"lat":52.08863,"lon":5.15253,"radius":5},
+         {"lat":52.08851,"lon":5.15249,"radius":5}]})"));
+  } catch (const valhalla_exception_t& e) {
+    if (e.code != expected_error_code) {
+      throw std::logic_error("Expected error code=" + std::to_string(expected_error_code) +
+                             " | found=" + std::to_string(e.code));
+    }
+    // If we get here then all good - return
+    return;
+  }
+
+  // If we get here then throw an exception
+  throw std::logic_error("Expected trace_route map_snap exception was not found");
+}
+
 void test_trace_attributes_edge_walk_expected_error_code() {
   // tests expected error_code for trace_attributes edge_walk
   auto expected_error_code = 443;
@@ -352,6 +379,33 @@ void test_trace_attributes_edge_walk_expected_error_code() {
 
   // If we get here then throw an exception
   throw std::logic_error("Expected trace_attributes edge_walk exception was not found");
+}
+
+void test_trace_attributes_map_snap_expected_error_code() {
+  // tests expected error_code for trace_attributes edge_walk
+  auto expected_error_code = 444;
+  tyr::actor_t actor(conf, true);
+
+  try {
+    auto response = json_to_pt(actor.trace_attributes(
+        R"({"costing":"auto","shape_match":"map_snap","shape":[
+         {"lat":52.088548,"lon":5.15357,"radius":5},
+         {"lat":52.088627,"lon":5.153269,"radius":5},
+         {"lat":52.08864,"lon":5.15298,"radius":5},
+         {"lat":52.08861,"lon":5.15272,"radius":5},
+         {"lat":52.08863,"lon":5.15253,"radius":5},
+         {"lat":52.08851,"lon":5.15249,"radius":5}]})"));
+  } catch (const valhalla_exception_t& e) {
+    if (e.code != expected_error_code) {
+      throw std::logic_error("Expected error code=" + std::to_string(expected_error_code) +
+                             " | found=" + std::to_string(e.code));
+    }
+    // If we get here then all good - return
+    return;
+  }
+
+  // If we get here then throw an exception
+  throw std::logic_error("Expected trace_attributes map_snap exception was not found");
 }
 
 void test_topk_validate() {
@@ -624,7 +678,11 @@ int main(int argc, char* argv[]) {
 
   suite.test(TEST_CASE(test_trace_route_edge_walk_expected_error_code));
 
+  suite.test(TEST_CASE(test_trace_route_map_snap_expected_error_code));
+
   suite.test(TEST_CASE(test_trace_attributes_edge_walk_expected_error_code));
+
+  suite.test(TEST_CASE(test_trace_attributes_map_snap_expected_error_code));
 
   suite.test(TEST_CASE(test_topk_validate));
 


### PR DESCRIPTION
# Issue

Fixes an issue introduced in #1821 where a map_snap matching call failed to find a route but returned a non-error response. 

sample request:
```
http://localhost:8002/trace_route?json={%22costing%22:%22auto%22,%22shape_match%22:%22map_snap%22,%22shape%22:[%20{%22lat%22:52.088548,%22lon%22:5.15357,%22radius%22:5},%20{%22lat%22:52.088627,%22lon%22:5.153269,%22radius%22:5},%20{%22lat%22:52.08864,%22lon%22:5.15298,%22radius%22:5},%20{%22lat%22:52.08861,%22lon%22:5.15272,%22radius%22:5},%20{%22lat%22:52.08863,%22lon%22:5.15253,%22radius%22:5},%20{%22lat%22:52.08851,%22lon%22:5.15249,%22radius%22:5}]}
```

master:

![image](https://user-images.githubusercontent.com/5665333/58285098-1ac34e00-7d7a-11e9-8e4e-e014ed08b0ac.png)

branch:

![image](https://user-images.githubusercontent.com/5665333/58285311-7f7ea880-7d7a-11e9-8377-7bf67a1fbc03.png)



## Tasklist

 - [ ] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
