### PR TITLE
fix trip leg builder DirectedEdge index out of bounds - #1831

### DIFF
--- a/src/thor/triplegbuilder.cc
+++ b/src/thor/triplegbuilder.cc
@@ -1180,14 +1180,16 @@ TripLegBuilder::Build(const AttributesController& controller,
     // Set the endnode of this directed edge as the startnode of the next edge.
     startnode = directededge->endnode();
 
-    // Save the opposing edge as the previous DirectedEdge (for name consistency)
-    const GraphTile* t2 =
-        directededge->leaves_tile() ? graphreader.GetGraphTile(directededge->endnode()) : graphtile;
-    if (t2 == nullptr) {
-      continue;
+    if (!directededge->IsTransitLine()) {
+      // Save the opposing edge as the previous DirectedEdge (for name consistency)
+      const GraphTile* t2 =
+          directededge->leaves_tile() ? graphreader.GetGraphTile(directededge->endnode()) : graphtile;
+      if (t2 == nullptr) {
+        continue;
+      }
+      GraphId oppedge = t2->GetOpposingEdgeId(directededge);
+      prev_de = t2->directededge(oppedge);
     }
-    GraphId oppedge = t2->GetOpposingEdgeId(directededge);
-    prev_de = t2->directededge(oppedge);
 
     // Save the index of the opposing local directed edge at the end node
     prior_opp_local_index = directededge->opp_local_idx();


### PR DESCRIPTION
# Issue

Attempt to fix random crash when building trip leg with transit data. 
Seems to fixes #1831

## Tasklist

 - [ ] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
