### PR TITLE
valhalla_build_connectivity cleanup

### DIFF
--- a/src/mjolnir/valhalla_build_connectivity.cc
+++ b/src/mjolnir/valhalla_build_connectivity.cc
@@ -119,6 +119,10 @@ int main(int argc, char** argv) {
 
   uint32_t transit_level = TileHierarchy::levels().rbegin()->second.level + 1;
   for (uint32_t level = 0; level <= transit_level; level++) {
+    if (!connectivity_map.has_data(level)) {
+      continue;
+    }
+
     // Make the vector representation of it
     std::string fname = "connectivity" + std::to_string(level) + ".geojson";
     std::ofstream geojson_file(fname, std::ios::out);

--- a/valhalla/baldr/connectivity_map.h
+++ b/valhalla/baldr/connectivity_map.h
@@ -54,6 +54,16 @@ public:
    */
   std::vector<size_t> to_image(const uint32_t hierarchy_level) const;
 
+  /**
+   * Does data exist for a level.
+   * @param level Tile hierarchy level.
+   * @return Returns true if the level has data, false if it does not (no tiles present)
+   */
+  bool has_data(const uint32_t level) const {
+    auto c = colors.find(level);
+    return (c == colors.end()) ? false : c->second.size() > 0;
+  }
+
 private:
   uint32_t transit_level;
   // this is a map(tile_level, map(tile_id, tile_color))


### PR DESCRIPTION
Update valhalla_build_connectivity to not generate output if a hierarchy level does not have any tiles.

# Issue
No reported issue. Just cleanup noted when running this program. Was creating empty files/images on levels where no tiles exist).

## Tasklist

 - [ ] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)
