### PR TITLE
use the tripleg to get the locations

### DIFF
--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -1166,16 +1166,15 @@ std::string serialize(valhalla::Api& api) {
   const auto& options = api.options();
   auto json = json::map({});
 
-  // If here then the route succeeded. Set status code to OK and serialize
-  // waypoints (locations).
+  // If here then the route succeeded. Set status code to OK and serialize waypoints (locations).
   std::string status("Ok");
   json->emplace("code", status);
   switch (options.action()) {
     case valhalla::Options::trace_route:
-      json->emplace("tracepoints", osrm::waypoints(options.locations(), true));
+      json->emplace("tracepoints", osrm::waypoints(options.shape(), true));
       break;
     case valhalla::Options::route:
-      json->emplace("waypoints", osrm::waypoints(options.locations()));
+      json->emplace("waypoints", osrm::waypoints(api.trip()));
       break;
     case valhalla::Options::optimized_route:
       json->emplace("waypoints", waypoints(options.locations()));

--- a/src/tyr/serializers.cc
+++ b/src/tyr/serializers.cc
@@ -97,4 +97,13 @@ json::ArrayPtr waypoints(const google::protobuf::RepeatedPtrField<valhalla::Loca
   return waypoints;
 }
 
+json::ArrayPtr waypoints(const valhalla::Trip& trip) {
+  auto waypoints = json::array({});
+  for (const auto& route : trip.routes())
+    for (const auto& leg : route.legs())
+      for (const auto& location : leg.location())
+        waypoints->emplace_back(waypoint(location, false));
+  return waypoints;
+}
+
 } // namespace osrm

--- a/valhalla/tyr/serializers.h
+++ b/valhalla/tyr/serializers.h
@@ -117,6 +117,7 @@ valhalla::baldr::json::MapPtr waypoint(const valhalla::Location& location,
 valhalla::baldr::json::ArrayPtr
 waypoints(const google::protobuf::RepeatedPtrField<valhalla::Location>& locations,
           bool tracepoints = false);
+valhalla::baldr::json::ArrayPtr waypoints(const valhalla::Trip& locations);
 
 } // namespace osrm
 


### PR DESCRIPTION
so in #1788 i  mentioned that for some reason i thought we had already taken care of this but for some reason it wasnt working and i couldnt find the implementation. turns out the implementation is in tripleg(path)builder and it happens when we add locations to the leg, not the original locations in the options :facepalm: 

anyway this code wasnt needed. what was needed was to use the locations from the trip leg. this does that.