### PR TITLE
Fix shadowed request variable

### DIFF
--- a/src/thor/worker.cc
+++ b/src/thor/worker.cc
@@ -108,7 +108,6 @@ thor_worker_t::work(const std::list<zmq::message_t>& job,
   Api request;
   try {
     // crack open the original request
-    valhalla::Api request;
     request.ParseFromArray(job.front().data(), job.front().size());
     const auto& options = request.options();
 


### PR DESCRIPTION
The `request` variable in the `try` block was being shadowed by the one above it. As a result the request in the catch handlers was a default initialized request, causing a bug where the exception handling was using the default format=json even when setting format=osrm in the request.

Is there a lint rule we can turn on to catch shadowed variables like this?