### PR TITLE
path expansion endpoint

### DIFF
--- a/proto/options.proto
+++ b/proto/options.proto
@@ -131,6 +131,7 @@ message Options {
     trace_attributes = 10;
     height = 11;
     transit_available = 12;
+    expansion = 13;
   }
 
   enum DateTimeType {

--- a/src/bindings/node/node.cc
+++ b/src/bindings/node/node.cc
@@ -218,6 +218,12 @@ private:
                               -> std::string { return actor.transit_available(request); });
   }
 
+  Napi::Value Expansion(const Napi::CallbackInfo& info) {
+    return generic_action(info,
+                          [](valhalla::tyr::actor_t& actor, const std::string& request)
+                              -> std::string { return actor.expansion(request); });
+  }
+
   valhalla::tyr::actor_t actor;
 };
 

--- a/src/bindings/python/python.cc
+++ b/src/bindings/python/python.cc
@@ -62,6 +62,7 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(trace_route_overloads, trace_route, 1, 1)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(trace_attributes_overloads, trace_attributes, 1, 1);
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(height_overloads, height, 1, 1);
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(transit_available_overloads, transit_available, 1, 1);
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(expansion_overloads, expansion, 1, 1);
 } // namespace
 
 BOOST_PYTHON_MODULE(valhalla) {
@@ -83,6 +84,7 @@ BOOST_PYTHON_MODULE(valhalla) {
       .def("TraceAttributes", &valhalla::tyr::actor_t::route, trace_attributes_overloads())
       .def("Height", &valhalla::tyr::actor_t::route, height_overloads())
       .def("TransitAvailable", &valhalla::tyr::actor_t::route, transit_available_overloads())
+      .def("Expansion", &valhalla::tyr::actor_t::route, expansion_overloads())
 
       ;
 }

--- a/src/loki/worker.cc
+++ b/src/loki/worker.cc
@@ -268,6 +268,7 @@ loki_worker_t::work(const std::list<zmq::message_t>& job,
     // do request specific processing
     switch (options.action()) {
       case Options::route:
+      case Options::expansion:
         route(request);
         result.messages.emplace_back(request.SerializeAsString());
         break;

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -183,7 +183,7 @@ void BidirectionalAStar::ExpandForward(GraphReader& graphreader,
     *es = {EdgeSet::kTemporary, idx};
 
     // setting this edge as reached
-    TrackExpansion(graphreader, edgeid, "reached");
+    TrackExpansion(graphreader, edgeid, "r");
   }
 
   // Handle transitions - expand from the end node of each transition
@@ -295,7 +295,7 @@ void BidirectionalAStar::ExpandReverse(GraphReader& graphreader,
     *es = {EdgeSet::kTemporary, idx};
 
     // setting this edge as reached, sending the opposing because this is the reverse tree
-    TrackExpansion(graphreader, oppedge, "reached");
+    TrackExpansion(graphreader, oppedge, "r");
   }
 
   // Handle transitions - expand from the end node of each transition
@@ -435,8 +435,7 @@ BidirectionalAStar::GetBestPath(valhalla::Location& origin,
       edgestatus_forward_.Update(fwd_pred.edgeid(), EdgeSet::kPermanent);
 
       // setting this edge as settled
-
-      TrackExpansion(graphreader, fwd_pred.edgeid(), "settled");
+      TrackExpansion(graphreader, fwd_pred.edgeid(), "s");
 
       // Prune path if predecessor is not a through edge or if the maximum
       // number of upward transitions has been exceeded on this hierarchy level.
@@ -456,7 +455,7 @@ BidirectionalAStar::GetBestPath(valhalla::Location& origin,
       edgestatus_reverse_.Update(rev_pred.edgeid(), EdgeSet::kPermanent);
 
       // setting this edge as settled, sending the opposing because this is the reverse tree
-      TrackExpansion(graphreader, rev_pred.opp_edgeid(), "settled");
+      TrackExpansion(graphreader, rev_pred.opp_edgeid(), "s");
 
       // Prune path if predecessor is not a through edge
       if ((rev_pred.not_thru() && rev_pred.not_thru_pruning()) ||
@@ -518,7 +517,7 @@ bool BidirectionalAStar::SetForwardConnection(GraphReader& graphreader, const BD
   }
 
   // setting this edge as connected
-  TrackExpansion(graphreader, pred.edgeid(), "connected");
+  TrackExpansion(graphreader, pred.edgeid(), "c");
 
   return true;
 }
@@ -564,8 +563,7 @@ bool BidirectionalAStar::SetReverseConnection(GraphReader& graphreader, const BD
   }
 
   // setting this edge as connected, sending the opposing because this is the reverse tree
-
-  TrackExpansion(graphreader, oppedge, "connected");
+  TrackExpansion(graphreader, oppedge, "c");
 
   return true;
 }
@@ -632,7 +630,7 @@ void BidirectionalAStar::SetOrigin(GraphReader& graphreader, valhalla::Location&
     adjacencylist_forward_->add(idx);
 
     // setting this edge as reached
-    TrackExpansion(graphreader, edgeid, "reached");
+    TrackExpansion(graphreader, edgeid, "r");
 
     // Set the initial not_thru flag to false. There is an issue with not_thru
     // flags on small loops. Set this to false here to override this for now.
@@ -706,7 +704,7 @@ void BidirectionalAStar::SetDestination(GraphReader& graphreader, const valhalla
     adjacencylist_reverse_->add(idx);
 
     // setting this edge as settled, sending the opposing because this is the reverse tree
-    TrackExpansion(graphreader, edgeid, "reached");
+    TrackExpansion(graphreader, edgeid, "r");
 
     // Set the initial not_thru flag to false. There is an issue with not_thru
     // flags on small loops. Set this to false here to override this for now.

--- a/src/thor/route_action.cc
+++ b/src/thor/route_action.cc
@@ -134,7 +134,11 @@ std::string thor_worker_t::expansion(Api& request) {
   expansion_->SetObject();
   rapidjson::Pointer("/type").Set(*expansion_, "FeatureCollection");
   rapidjson::Pointer("/properties/algorithm").Set(*expansion_, "none");
-  rapidjson::Pointer("/features").Create(*expansion_).SetArray();
+  rapidjson::Pointer("/features/0/type").Set(*expansion_, "Feature");
+  rapidjson::Pointer("/features/0/geometry/type").Set(*expansion_, "MultiLineString");
+  rapidjson::Pointer("/features/0/geometry/coordinates").Create(*expansion_).SetArray();
+  rapidjson::Pointer("/features/0/properties/edge_ids").Create(*expansion_).SetArray();
+  rapidjson::Pointer("/features/0/properties/statuses").Create(*expansion_).SetArray();
   // fill it out
   route(request);
   // serialize it

--- a/src/thor/worker.cc
+++ b/src/thor/worker.cc
@@ -108,7 +108,6 @@ thor_worker_t::work(const std::list<zmq::message_t>& job,
   Api request;
   try {
     // crack open the original request
-    valhalla::Api request;
     request.ParseFromArray(job.front().data(), job.front().size());
     const auto& options = request.options();
 

--- a/src/thor/worker.cc
+++ b/src/thor/worker.cc
@@ -148,6 +148,11 @@ thor_worker_t::work(const std::list<zmq::message_t>& job,
         result = to_response_json(trace_attributes(request), info, request);
         denominator = trace.size() / 1100;
         break;
+      case Options::expansion: {
+        result = to_response_json(expansion(request), info, request);
+        denominator = options.locations_size();
+        break;
+      }
       default:
         throw valhalla_exception_t{400}; // this should never happen
     }

--- a/src/tyr/actor.cc
+++ b/src/tyr/actor.cc
@@ -50,6 +50,7 @@ std::string actor_t::route(const std::string& request_str, const std::function<v
   ParseApi(request_str, Options::route, request);
   // check the request and locate the locations in the graph
   pimpl->loki_worker.route(request);
+  // route between the locations in the graph to find the best path
   pimpl->thor_worker.route(request);
   // get some directions back from them
   pimpl->odin_worker.narrate(request);
@@ -214,6 +215,7 @@ std::string actor_t::expansion(const std::string& request_str,
   ParseApi(request_str, Options::expansion, request);
   // check the request and locate the locations in the graph
   pimpl->loki_worker.route(request);
+  // route between the locations in the graph to find the best path
   auto json = pimpl->thor_worker.expansion(request);
   // if they want you do to do the cleanup automatically
   if (auto_cleanup) {

--- a/src/tyr/actor.cc
+++ b/src/tyr/actor.cc
@@ -205,5 +205,22 @@ std::string actor_t::transit_available(const std::string& request_str,
   return json;
 }
 
+std::string actor_t::expansion(const std::string& request_str,
+                               const std::function<void()>& interrupt) {
+  // set the interrupts
+  pimpl->set_interrupts(interrupt);
+  // parse the request
+  Api request;
+  ParseApi(request_str, Options::expansion, request);
+  // check the request and locate the locations in the graph
+  pimpl->loki_worker.route(request);
+  auto json = pimpl->thor_worker.expansion(request);
+  // if they want you do to do the cleanup automatically
+  if (auto_cleanup) {
+    cleanup();
+  }
+  return json;
+}
+
 } // namespace tyr
 } // namespace valhalla

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -893,6 +893,7 @@ bool Options_Action_Parse(const std::string& action, Options::Action* a) {
       {"trace_attributes", Options::trace_attributes},
       {"height", Options::height},
       {"transit_available", Options::transit_available},
+      {"expansion", Options::expansion},
   };
   auto i = actions.find(action);
   if (i == actions.cend())
@@ -913,6 +914,7 @@ const std::string& Options_Action_Name(const Options::Action action) {
       {Options::trace_attributes, "trace_attributes"},
       {Options::height, "height"},
       {Options::transit_available, "transit_available"},
+      {Options::expansion, "expansion"},
   };
   auto i = actions.find(action);
   return i == actions.cend() ? empty : i->second;

--- a/valhalla/baldr/rapidjson_utils.h
+++ b/valhalla/baldr/rapidjson_utils.h
@@ -28,9 +28,12 @@
 
 namespace rapidjson {
 
-template <typename T> inline std::string to_string(const T& document_or_value) {
+template <typename T>
+inline std::string to_string(const T& document_or_value, int decimal_places = -1) {
   rapidjson::StringBuffer buffer;
   rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+  if (decimal_places >= 0)
+    writer.SetMaxDecimalPlaces(decimal_places);
   document_or_value.Accept(writer);
   return std::string(buffer.GetString(), buffer.GetSize());
 }

--- a/valhalla/thor/bidirectional_astar.h
+++ b/valhalla/thor/bidirectional_astar.h
@@ -154,7 +154,7 @@ protected:
    * @param  pred  Edge label of the predecessor.
    * @return Returns true if a connection was set, false if not (if on a complex restriction).
    */
-  bool SetForwardConnection(const sif::BDEdgeLabel& pred);
+  bool SetForwardConnection(baldr::GraphReader& graphreader, const sif::BDEdgeLabel& pred);
 
   /**
    * The edge on the reverse search connects to a reached edge on the forward
@@ -163,7 +163,7 @@ protected:
    * @param  pred  Edge label of the predecessor.
    * @return Returns true if a connection was set, false if not (if on a complex restriction).
    */
-  bool SetReverseConnection(const sif::BDEdgeLabel& pred);
+  bool SetReverseConnection(baldr::GraphReader& graphreader, const sif::BDEdgeLabel& pred);
 
   /**
    * Form the path from the adjacency lists. Recovers the path from the

--- a/valhalla/thor/pathalgorithm.h
+++ b/valhalla/thor/pathalgorithm.h
@@ -163,26 +163,27 @@ protected:
       if (!full_shape && shape.size() > 2)
         shape.erase(shape.begin() + 1, shape.end() - 1);
 
-      // make the feature
-      auto& a = expansion->GetAllocator();
-      auto* features = rapidjson::Pointer("/features").Get(*expansion);
-      features->GetArray().PushBack(rapidjson::Value(rapidjson::kObjectType), a);
-      auto& feature = (*features)[features->Size() - 1];
-      rapidjson::Pointer("/type").Set(feature, "Feature", a);
-
       // make the geom
-      rapidjson::Pointer("/geometry/type").Set(feature, "LineString", a);
-      auto& coords = rapidjson::Pointer("/geometry/coordinates").Create(feature, a).SetArray();
+      auto& a = expansion->GetAllocator();
+      auto* coords = rapidjson::Pointer("/features/0/geometry/coordinates").Get(*expansion);
+      coords->GetArray().PushBack(rapidjson::Value(rapidjson::kArrayType), a);
+      auto& linestring = (*coords)[coords->Size() - 1];
       for (const auto& p : shape) {
-        coords.GetArray().PushBack(rapidjson::Value(rapidjson::kArrayType), a);
-        auto point = coords[coords.Size() - 1].GetArray();
+        linestring.GetArray().PushBack(rapidjson::Value(rapidjson::kArrayType), a);
+        auto point = linestring[linestring.Size() - 1].GetArray();
         point.PushBack(p.first, a);
         point.PushBack(p.second, a);
       }
 
       // make the properties
-      rapidjson::Pointer("/properties/edge").Set(feature, static_cast<uint64_t>(edgeid), a);
-      rapidjson::Pointer("/properties/status").Set(feature, status, a);
+      rapidjson::Pointer("/features/0/properties/edge_ids")
+          .Get(*expansion)
+          ->GetArray()
+          .PushBack(static_cast<uint64_t>(edgeid), a);
+      rapidjson::Pointer("/features/0/properties/statuses")
+          .Get(*expansion)
+          ->GetArray()
+          .PushBack(rapidjson::Value{}.SetString(status, a), a);
     }
   }
 };

--- a/valhalla/thor/pathalgorithm.h
+++ b/valhalla/thor/pathalgorithm.h
@@ -1,5 +1,4 @@
-#ifndef VALHALLA_THOR_PATHALGORITHM_H_
-#define VALHALLA_THOR_PATHALGORITHM_H_
+#pragma once
 
 #include <functional>
 #include <map>
@@ -13,6 +12,9 @@
 #include <valhalla/proto/api.pb.h>
 #include <valhalla/sif/dynamiccost.h>
 #include <valhalla/thor/pathinfo.h>
+
+#include <rapidjson/document.h>
+#include <rapidjson/pointer.h>
 
 namespace valhalla {
 namespace thor {
@@ -29,7 +31,10 @@ public:
   /**
    * Constructor
    */
-  PathAlgorithm() : interrupt(nullptr), has_ferry_(false) {
+  PathAlgorithm() : interrupt(nullptr), has_ferry_(false), track_expansion_(false) {
+    expansion_.SetObject();
+    rapidjson::Pointer("/type").Set(expansion_, "FeatureCollection");
+    rapidjson::Pointer("/features").Create(expansion_).SetArray();
   }
 
   /**
@@ -79,10 +84,32 @@ public:
     return has_ferry_;
   }
 
+  /**
+   * Returns a geojson feature collection where each feature represents
+   * and edge that was visited by the algorithm. The order of the features
+   * is the same order in which the edges were visited. Each feature/edge
+   * will have properties describing the edge's id as well as the current
+   * state (reached, settled, connected) so that one can replay the expansion
+   * as a time series and visually inspect what the algorithm is doing.
+   *
+   * This method will return a feature collection after a call to GetBestPath.
+   * If the underlying path algorithm doesn't implement this or GetBestPath
+   * has not been called an empty feature collection is returned.
+   *
+   * @return the feature collection
+   */
+  const rapidjson::Document& GetPathExpansionHistory() const {
+    return expansion_;
+  }
+
 protected:
   const std::function<void()>* interrupt;
 
   bool has_ferry_; // Indicates whether the path has a ferry
+
+  // for tracking the expansion of the algorithm visually
+  bool track_expansion_;
+  rapidjson::Document expansion_;
 
   /**
    * Check for path completion along the same edge. Edge ID in question
@@ -119,9 +146,47 @@ protected:
     const baldr::GraphTile* tile = graphreader.GetGraphTile(node);
     return (tile == nullptr) ? 0 : tile->node(node)->timezone();
   }
+
+  /**
+   * Adds an edge to the expansion history of the current pass of the algorithm
+   * There is no schema for the status, but loosely you should pass one of:
+   * reached, settled, connected so the person using this geojson can style accordingly
+   */
+  virtual void TrackExpansion(baldr::GraphReader& reader,
+                              baldr::GraphId edgeid,
+                              const char* status,
+                              bool full_shape = false) {
+    // full shape might be overkill but meh, its trace
+    const auto* tile = reader.GetGraphTile(edgeid);
+    const auto* edge = tile->directededge(edgeid);
+    auto shape = tile->edgeinfo(edge->edgeinfo_offset()).shape();
+    if (!edge->forward())
+      std::reverse(shape.begin(), shape.end());
+    if (!full_shape && shape.size() > 2)
+      shape.erase(shape.begin() + 1, shape.end() - 1);
+
+    // make the feature
+    auto& a = expansion_.GetAllocator();
+    auto* features = rapidjson::Pointer("/features").Get(expansion_);
+    features->GetArray().PushBack(rapidjson::Value(rapidjson::kObjectType), a);
+    auto& feature = (*features)[features->Size() - 1];
+    rapidjson::Pointer("/type").Set(feature, "Feature", a);
+
+    // make the geom
+    rapidjson::Pointer("/geometry/type").Set(feature, "LineString", a);
+    auto& coords = rapidjson::Pointer("/geometry/coordinates").Create(feature, a).SetArray();
+    for (const auto& p : shape) {
+      coords.GetArray().PushBack(rapidjson::Value(rapidjson::kArrayType), a);
+      auto point = coords[coords.Size() - 1].GetArray();
+      point.PushBack(p.first, a);
+      point.PushBack(p.second, a);
+    }
+
+    // make the properties
+    rapidjson::Pointer("/properties/edge").Set(feature, static_cast<uint64_t>(edgeid), a);
+    rapidjson::Pointer("/properties/status").Set(feature, status, a);
+  }
 };
 
 } // namespace thor
 } // namespace valhalla
-
-#endif // VALHALLA_THOR_PATHALGORITHM_H_

--- a/valhalla/thor/pathalgorithm.h
+++ b/valhalla/thor/pathalgorithm.h
@@ -31,10 +31,7 @@ public:
   /**
    * Constructor
    */
-  PathAlgorithm() : interrupt(nullptr), has_ferry_(false), track_expansion_(false) {
-    expansion_.SetObject();
-    rapidjson::Pointer("/type").Set(expansion_, "FeatureCollection");
-    rapidjson::Pointer("/features").Create(expansion_).SetArray();
+  PathAlgorithm() : interrupt(nullptr), has_ferry_(false), expansion_() {
   }
 
   /**
@@ -85,7 +82,7 @@ public:
   }
 
   /**
-   * Returns a geojson feature collection where each feature represents
+   * Sets the geojson feature collection where each feature represents
    * and edge that was visited by the algorithm. The order of the features
    * is the same order in which the edges were visited. Each feature/edge
    * will have properties describing the edge's id as well as the current
@@ -98,8 +95,8 @@ public:
    *
    * @return the feature collection
    */
-  const rapidjson::Document& GetPathExpansionHistory() const {
-    return expansion_;
+  void set_expansion(const std::shared_ptr<rapidjson::Document>& expansion) {
+    expansion_ = expansion;
   }
 
 protected:
@@ -108,8 +105,7 @@ protected:
   bool has_ferry_; // Indicates whether the path has a ferry
 
   // for tracking the expansion of the algorithm visually
-  bool track_expansion_;
-  rapidjson::Document expansion_;
+  std::weak_ptr<rapidjson::Document> expansion_;
 
   /**
    * Check for path completion along the same edge. Edge ID in question
@@ -152,39 +148,42 @@ protected:
    * There is no schema for the status, but loosely you should pass one of:
    * reached, settled, connected so the person using this geojson can style accordingly
    */
-  virtual void TrackExpansion(baldr::GraphReader& reader,
-                              baldr::GraphId edgeid,
-                              const char* status,
-                              bool full_shape = false) {
-    // full shape might be overkill but meh, its trace
-    const auto* tile = reader.GetGraphTile(edgeid);
-    const auto* edge = tile->directededge(edgeid);
-    auto shape = tile->edgeinfo(edge->edgeinfo_offset()).shape();
-    if (!edge->forward())
-      std::reverse(shape.begin(), shape.end());
-    if (!full_shape && shape.size() > 2)
-      shape.erase(shape.begin() + 1, shape.end() - 1);
+  virtual inline void TrackExpansion(baldr::GraphReader& reader,
+                                     baldr::GraphId edgeid,
+                                     const char* status,
+                                     bool full_shape = false) {
+    // only do this if someone is looking for this on the outside
+    if (auto expansion = expansion_.lock()) {
+      // full shape might be overkill but meh, its trace
+      const auto* tile = reader.GetGraphTile(edgeid);
+      const auto* edge = tile->directededge(edgeid);
+      auto shape = tile->edgeinfo(edge->edgeinfo_offset()).shape();
+      if (!edge->forward())
+        std::reverse(shape.begin(), shape.end());
+      if (!full_shape && shape.size() > 2)
+        shape.erase(shape.begin() + 1, shape.end() - 1);
 
-    // make the feature
-    auto& a = expansion_.GetAllocator();
-    auto* features = rapidjson::Pointer("/features").Get(expansion_);
-    features->GetArray().PushBack(rapidjson::Value(rapidjson::kObjectType), a);
-    auto& feature = (*features)[features->Size() - 1];
-    rapidjson::Pointer("/type").Set(feature, "Feature", a);
+      // make the feature
+      auto& a = expansion->GetAllocator();
+      auto* features = rapidjson::Pointer("/features").Get(*expansion);
+      features->GetArray().PushBack(rapidjson::Value(rapidjson::kObjectType), a);
+      auto& feature = (*features)[features->Size() - 1];
+      rapidjson::Pointer("/type").Set(feature, "Feature", a);
 
-    // make the geom
-    rapidjson::Pointer("/geometry/type").Set(feature, "LineString", a);
-    auto& coords = rapidjson::Pointer("/geometry/coordinates").Create(feature, a).SetArray();
-    for (const auto& p : shape) {
-      coords.GetArray().PushBack(rapidjson::Value(rapidjson::kArrayType), a);
-      auto point = coords[coords.Size() - 1].GetArray();
-      point.PushBack(p.first, a);
-      point.PushBack(p.second, a);
+      // make the geom
+      rapidjson::Pointer("/geometry/type").Set(feature, "LineString", a);
+      auto& coords = rapidjson::Pointer("/geometry/coordinates").Create(feature, a).SetArray();
+      for (const auto& p : shape) {
+        coords.GetArray().PushBack(rapidjson::Value(rapidjson::kArrayType), a);
+        auto point = coords[coords.Size() - 1].GetArray();
+        point.PushBack(p.first, a);
+        point.PushBack(p.second, a);
+      }
+
+      // make the properties
+      rapidjson::Pointer("/properties/edge").Set(feature, static_cast<uint64_t>(edgeid), a);
+      rapidjson::Pointer("/properties/status").Set(feature, status, a);
     }
-
-    // make the properties
-    rapidjson::Pointer("/properties/edge").Set(feature, static_cast<uint64_t>(edgeid), a);
-    rapidjson::Pointer("/properties/status").Set(feature, status, a);
   }
 };
 

--- a/valhalla/thor/worker.h
+++ b/valhalla/thor/worker.h
@@ -12,7 +12,6 @@
 #include <valhalla/baldr/graphreader.h>
 #include <valhalla/baldr/graphtile.h>
 #include <valhalla/baldr/location.h>
-#include <valhalla/baldr/rapidjson_utils.h>
 #include <valhalla/meili/map_matcher_factory.h>
 #include <valhalla/proto/options.pb.h>
 #include <valhalla/proto/trip.pb.h>
@@ -102,7 +101,6 @@ protected:
   meili::MapMatcherFactory matcher_factory;
   std::shared_ptr<baldr::GraphReader> reader;
   AttributesController controller;
-  std::shared_ptr<rapidjson::Document> expansion_;
 };
 
 } // namespace thor

--- a/valhalla/thor/worker.h
+++ b/valhalla/thor/worker.h
@@ -12,6 +12,7 @@
 #include <valhalla/baldr/graphreader.h>
 #include <valhalla/baldr/graphtile.h>
 #include <valhalla/baldr/location.h>
+#include <valhalla/baldr/rapidjson_utils.h>
 #include <valhalla/meili/map_matcher_factory.h>
 #include <valhalla/proto/options.pb.h>
 #include <valhalla/proto/trip.pb.h>
@@ -54,6 +55,7 @@ public:
   std::string isochrones(Api& request);
   void trace_route(Api& request);
   std::string trace_attributes(Api& request);
+  std::string expansion(Api& request);
 
 protected:
   std::vector<std::vector<thor::PathInfo>> get_path(PathAlgorithm* path_algorithm,
@@ -100,6 +102,7 @@ protected:
   meili::MapMatcherFactory matcher_factory;
   std::shared_ptr<baldr::GraphReader> reader;
   AttributesController controller;
+  std::shared_ptr<rapidjson::Document> expansion_;
 };
 
 } // namespace thor

--- a/valhalla/tyr/actor.h
+++ b/valhalla/tyr/actor.h
@@ -30,6 +30,8 @@ public:
                      const std::function<void()>& interrupt = []() -> void {});
   std::string transit_available(const std::string& request_str,
                                 const std::function<void()>& interrupt = []() -> void {});
+  std::string expansion(const std::string& request_str,
+                        const std::function<void()>& interrupt = []() -> void {});
 
 protected:
   struct pimpl_t;


### PR DESCRIPTION
this adds a new endpoint to valhalla called `/expansion` which takes a normal `/route` style request but returns geojson. the geojson is a time-series dataset of which edges of the routing graph were touched by the path algorithm (only bidirectional a* implemented so far) in the order they were touched and what type of label was assigned to them.

the geojson is a small as possible (for such a verbose format). it returns only a single feature which has a geometry of type `MultiLineString`. Each `LineString` represents the beginning and end points (so only two coordinates) of each edge the algorithm touched.

the properties of the feature contain two parallel arrays (which match the number of edges/linestrings in the geometry). the first array is a list of the edge_ids and the second array is a list of the statuses. the statuses can be one of `r` (reached), `s` (settled) or `c` (connected).

this should work for multileg routes as well but there is no signifier of when one legs expansion history ends and the next one begins.

there should be little to no performance impact on the `/route` endpoint as the function that tracks this data is both `inline`d and wrapped in an `if` that says don't track this if we werent called from the `/expansion` action/endpont.