### PR TITLE
Admin name change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Release Date: Unreleased Valhalla 3.0.6
 * **Bug Fix**
-   *
+   * FIXED:  Admin name changes. [#1853](https://github.com/valhalla/valhalla/pull/1853) Ref: [#1854](https://github.com/valhalla/valhalla/issues/1854)
 
 * **Enhancement**
    * ADDED: Use the same protobuf object the entire way through the request process [#1837](https://github.com/valhalla/valhalla/pull/1837)

--- a/src/mjolnir/valhalla_build_admins.cc
+++ b/src/mjolnir/valhalla_build_admins.cc
@@ -634,7 +634,8 @@ void BuildAdminFromPBF(const boost::property_tree::ptree& pt,
       continue;
     }
     LOG_ERROR("sqlite3_step() error: " + std::string(sqlite3_errmsg(db_handle)) +
-              ".  Ignore if not using a planet extract.");
+              ".  Ignore if not using a planet extract or check if there was a name change for " +
+              access.first.c_str());
   }
 
   sqlite3_finalize(stmt);

--- a/valhalla/mjolnir/adminconstants.h
+++ b/valhalla/mjolnir/adminconstants.h
@@ -82,7 +82,7 @@ const std::unordered_map<std::string, std::vector<int>>
                      (kAutoAccess | kTruckAccess | kBusAccess | kHOVAccess | kTaxiAccess |
                       kMotorcycleAccess),
                      -1, -1, -1, -1, -1, -1, -1}},
-                   {"The Netherlands",
+                   {"Netherlands",
                     {(kAutoAccess | kTruckAccess | kBusAccess | kHOVAccess | kTaxiAccess |
                       kMotorcycleAccess),
                      (kAutoAccess | kTruckAccess | kBusAccess | kHOVAccess | kTaxiAccess |
@@ -129,7 +129,7 @@ const std::unordered_map<std::string, std::vector<int>>
                    {"United Kingdom",
                     {-1, -1, -1, -1, -1, (kPedestrianAccess | kWheelchairAccess | kBicycleAccess),
                      (kPedestrianAccess | kWheelchairAccess | kBicycleAccess), -1, -1}},
-                   {"United States of America",
+                   {"United States",
                     {-1, -1, -1, -1, (kPedestrianAccess | kWheelchairAccess | kBicycleAccess),
                      (kPedestrianAccess | kWheelchairAccess | kBicycleAccess),
                      (kPedestrianAccess | kWheelchairAccess | kBicycleAccess),


### PR DESCRIPTION
# Issue

`United States of America` was changed to `United States` and `The Netherlands` was changed to `Netherlands` in OSM for the country polygon.

## Tasklist

 - [x] Review - you must request approval to merge any PR to master
 - [x] Add #fixes with the issue number that this PR addresses
 - [x] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

Fixes #1708
Ref #1854