### PR TITLE
Fix bike_network and speed_limit in EdgeInfo

### DIFF
--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -149,6 +149,8 @@ GraphTileBuilder::GraphTileBuilder(const std::string& tile_dir,
     EdgeInfoBuilder eib;
     eib.set_wayid(ei.wayid());
     eib.set_mean_elevation(ei.mean_elevation());
+    eib.set_bike_network(ei.bike_network());
+    eib.set_speed_limit(ei.speed_limit());
     for (uint32_t nm = 0; nm < ei.name_count(); nm++) {
       NameInfo info = ei.GetNameInfo(nm);
       name_info.insert(info);


### PR DESCRIPTION
Fix bug where reading in the tile and unpacking EdgeInfo did not set the bike_network and speed_limit in the EdgeInfoBuilder. This caused incorrect data when written back out to file. These errors occurred in the GraphEnhancer stage which reads in the tile to a tile builder with serialize = true.

 - [ ] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
