### PR TITLE
Expose interpolation_distance as a query parameter

### DIFF
--- a/docs/api/map-matching/api-reference.md
+++ b/docs/api/map-matching/api-reference.md
@@ -2,7 +2,7 @@
 
 With the Mapbox Map Matching service, you can match coordinates, such as GPS locations, to roads and paths that have been mapped in OpenStreetMap. By doing this, you can turn a path into a route with narrative instructions and also get the attribute values from that matched line.
 
-You can view an [interactive demo](http://valhalla.github.io/demos/map_matching/) or use [Mobility Explorer](https://github.com/transitland/mobility-explorer). 
+You can view an [interactive demo](http://valhalla.github.io/demos/map_matching/) or use [Mobility Explorer](https://github.com/transitland/mobility-explorer).
 
 There are two separate Map Matching calls that perform different operations on an input set of latitude,longitude coordinates. The `trace_route` action returns the shape snapped to the road network and narrative directions, while `trace_attributes` returns detailed attribution along the portion of the route.
 
@@ -52,6 +52,11 @@ You can also set `directions_options` to specify output units, language, and whe
 | `begin_time` | Begin timestamp for the trace. This is used along with the `durations` so that timestamps can be specified for a trace that is specified using an encoded polyline. |
 | `durations` | List of durations (seconds) between each successive pair of input trace points. This allows trace points to be supplied as an encoded polyline and timestamps to be created by using this list of "delta" times along with the `begin_time` of the trace. |
 | `use_timestamps` | A boolean value indicating whether the input timestamps or durations should be used when computing elapsed time at each edge along the matched path. If true, timestamps are used. If false (default), internal costing is applied to compute elapsed times. |
+| `trace_options` | Additional options. |
+| `trace_options.search_radius` | Search radius in meters associated with supplied trace points. |
+| `trace_options.gps_accuracy` | GPS accuracy in meters associated with supplied trace points. |
+| `trace_options.breakage_distance` | Breaking distance in meters between trace points. |
+| `trace_options.interpolation_distance` | Interpolation distance in meters beyond which trace points are merged together. |
 
 ### Attribute filters (`trace_attributes` only)
 
@@ -271,7 +276,7 @@ Follow these guidelines to improve the Map Matching results.
 * Have each trace represent one continuous path.
 * Verify that there is a corresponding match with the OpenStreetMap network.
 
-You can use certain parameters to tune the response. Unless otherwise noted, each of these options is specified within a root-level `trace_options` object. 
+You can use certain parameters to tune the response. Unless otherwise noted, each of these options is specified within a root-level `trace_options` object.
 
 * Use `turn_penalty_factor` to penalize turns from one road segment to next. For a pedestrian `trace_route`, you may see a back-and-forth motion along the streets of your path. Try increasing the turn penalty factor to 500 to smooth out jittering of points. Note that if GPS accuracy is already good, increasing this will have a negative affect on your results.
 * Set the `gps_accuracy` to indicate the accuracy in meters.

--- a/proto/options.proto
+++ b/proto/options.proto
@@ -169,9 +169,9 @@ message Options {
   repeated Location trace = 27;                                           // Trace points for map matching
   optional ShapeMatch shape_match = 28 [default = walk_or_snap];          // The matching algorithm based on the type of input
   optional uint32 best_paths = 29 [default = 1];                          // The number of top k paths
-  optional float gps_accuracy = 30;                                       // The gps accuracy associated with the suppplied trace points
-  optional float search_radius = 31;                                      // The search radius associated with the suppplied trace points
-  optional float turn_penalty_factor = 32;                                // The turn penalty factor associated with the suppplied trace points
+  optional float gps_accuracy = 30;                                       // The gps accuracy associated with the supplied trace points
+  optional float search_radius = 31;                                      // The search radius associated with the supplied trace points
+  optional float turn_penalty_factor = 32;                                // The turn penalty factor associated with the supplied trace points
   optional FilterAction filter_action = 33;                               // The trace filter action - either exclude or include
   repeated string filter_attributes = 34;                                 // The filter list for trace attributes
   repeated AvoidEdge avoid_edges = 35;                                    // Avoid edges for any costing - derived from avoid_locations
@@ -179,4 +179,5 @@ message Options {
   optional bool use_timestamps = 37 [default = false];                    // Use timestamps to compute elapsed time for trace_route and trace_attributes
   optional ShapeFormat shape_format = 38 [default = polyline6];           // Shape format (defaults to polyline6 encoding)
   optional uint32 alternates = 39;                                        // Maximum number of alternate routes that can be returned
+  optional float interpolation_distance = 40;                             // Map-matching interpolation distance beyond which trace points are merged
 }

--- a/scripts/valhalla_build_config
+++ b/scripts/valhalla_build_config
@@ -76,7 +76,7 @@ config = {
   },
   'meili': {
     'mode': 'auto',
-    'customizable': ['mode', 'search_radius', 'turn_penalty_factor', 'gps_accuracy', 'sigma_z', 'beta', 'max_route_distance_factor', 'max_route_time_factor'],
+    'customizable': ['mode', 'search_radius', 'turn_penalty_factor', 'gps_accuracy', 'interpolation_distance', 'sigma_z', 'beta', 'max_route_distance_factor', 'max_route_time_factor'],
     'verbose': False,
     'default': {
       'sigma_z': 4.07,

--- a/src/meili/map_matcher_factory.cc
+++ b/src/meili/map_matcher_factory.cc
@@ -68,8 +68,6 @@ boost::property_tree::ptree MapMatcherFactory::MergeConfig(const Options& option
   }
 
   // Check for overrides of matcher related directions options. Override these values in config.
-  // TODO - there are several options listed as customizable that are not documented
-  // in the interface...either add them and document or remove them from config?
   if (options.search_radius() && customizable.find("search_radius") != customizable.end()) {
     config.put<float>("search_radius", options.search_radius());
   }
@@ -82,6 +80,10 @@ boost::property_tree::ptree MapMatcherFactory::MergeConfig(const Options& option
   }
   if (options.breakage_distance() && customizable.find("breakage_distance") != customizable.end()) {
     config.put<float>("breakage_distance", options.breakage_distance());
+  }
+  if (options.interpolation_distance() &&
+      customizable.find("interpolation_distance") != customizable.end()) {
+    config.put<float>("interpolation_distance", options.interpolation_distance());
   }
 
   // Give it back

--- a/src/meili/map_matcher_factory.cc
+++ b/src/meili/map_matcher_factory.cc
@@ -81,7 +81,7 @@ boost::property_tree::ptree MapMatcherFactory::MergeConfig(const Options& option
   if (options.breakage_distance() && customizable.find("breakage_distance") != customizable.end()) {
     config.put<float>("breakage_distance", options.breakage_distance());
   }
-  if (options.interpolation_distance() &&
+  if (options.has_interpolation_distance() &&
       customizable.find("interpolation_distance") != customizable.end()) {
     config.put<float>("interpolation_distance", options.interpolation_distance());
   }

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -851,6 +851,12 @@ void from_json(rapidjson::Document& doc, Options& options) {
     options.set_breakage_distance(*breakage_distance);
   }
 
+  // if specified, get the interpolation_distance value in there
+  auto interpolation_distance =
+      rapidjson::get_optional<float>(doc, "/trace_options/interpolation_distance");
+  if (interpolation_distance) {
+    options.set_interpolation_distance(*interpolation_distance);
+  }
   // if specified, get the filter_action value in there
   auto filter_action_str = rapidjson::get_optional<std::string>(doc, "/filters/action");
   FilterAction filter_action;


### PR DESCRIPTION
# Issue

Adds `trace_options.interpolation_distance` as a request-time parameter for map matching. Also documents the other existing trace_options parameters for completeness. Please let me know if the documentation I've added makes sense!

## Tasklist

 - [ ] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
