### PR TITLE
fix map matching regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Release Date: Unreleased Valhalla 3.0.6
 * **Bug Fix**
-   * FIXED:  Admin name changes. [#1853](https://github.com/valhalla/valhalla/pull/1853) Ref: [#1854](https://github.com/valhalla/valhalla/issues/1854)
-   * FIXED:  valhalla_add_predicted_traffic was overcommitted while gathering stats.  Added a clear. [#1857](https://github.com/valhalla/valhalla/pull/1857)
+   * FIXED: Admin name changes. [#1853](https://github.com/valhalla/valhalla/pull/1853) Ref: [#1854](https://github.com/valhalla/valhalla/issues/1854)
+   * FIXED: valhalla_add_predicted_traffic was overcommitted while gathering stats. Added a clear. [#1857](https://github.com/valhalla/valhalla/pull/1857)
+   * FIXED: regression in map matching when moving to valhalla v3.0.0 [#1863](https://github.com/valhalla/valhalla/pull/1863)
 
 * **Enhancement**
    * ADDED: Use the same protobuf object the entire way through the request process [#1837](https://github.com/valhalla/valhalla/pull/1837)

--- a/src/meili/routing.cc
+++ b/src/meili/routing.cc
@@ -578,10 +578,10 @@ find_shortest_path(baldr::GraphReader& reader,
           if (cost.cost < max_dist && (max_time < 0 || cost.secs < max_time)) {
             // Get the end node tile and node lat,lon to compute heuristic
             const baldr::GraphTile* endtile = reader.GetGraphTile(directededge->endnode());
-            if (tile == nullptr) {
+            if (endtile == nullptr) {
               continue;
             }
-            float sortcost = cost.cost + heuristic(tile->get_node_ll(directededge->endnode()));
+            float sortcost = cost.cost + heuristic(endtile->get_node_ll(directededge->endnode()));
             labelset->put(directededge->endnode(), origin_edge.id, origin_edge.percent_along, 1.f,
                           cost, turn_cost, sortcost, label_idx, directededge, travelmode);
           }


### PR DESCRIPTION
it seems there was a copy paste fail when we updated to valhalla v3. we were using the wrong tile to get at the end nodes lat,lon. sadly we dont have any test data this is accross multiple tiles so i couldnt make a test case for this without adding new data. it might be worth getting a new utrecht extract some time soon that is just a little bigger so we can test more failures at tile boundaries without loading too much more data for the tests.

fixes #1838 