### PR TITLE
Set tracepoint to null if no path_edges

### DIFF
--- a/src/tyr/serializers.cc
+++ b/src/tyr/serializers.cc
@@ -92,8 +92,10 @@ json::ArrayPtr waypoints(const google::protobuf::RepeatedPtrField<valhalla::Loca
   auto waypoints = json::array({});
   int64_t waypoint_index = -1;
   for (const auto& location : locations) {
-    if (location.type() == valhalla::Location::kBreak ||
-        location.type() == valhalla::Location::kBreakThrough) {
+    if (location.path_edges().empty()) {
+      waypoints->emplace_back(static_cast<std::nullptr_t>(nullptr));
+    } else if (location.type() == valhalla::Location::kBreak ||
+               location.type() == valhalla::Location::kBreakThrough) {
       waypoints->emplace_back(waypoint(location, is_tracepoint, false, ++waypoint_index));
     } else {
       waypoints->emplace_back(waypoint(location, is_tracepoint));


### PR DESCRIPTION
# Issue

Sets tracepoint to `null` if a location has no associated path edges. Avoids an exception when [we try to serialize waypoints without path_edges](https://github.com/valhalla/valhalla/blob/master/src/tyr/serializers.cc#L48), and more closely matches the expected OSRM output when an input location is not used for mapmatching.

## Tasklist

 - [ ] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
