### PR TITLE
[map matching] Interpolate trace points with no candidate edges

### DIFF
--- a/scripts/valhalla_build_config
+++ b/scripts/valhalla_build_config
@@ -85,7 +85,7 @@ config = {
       'max_route_distance_factor': 5,
       'max_route_time_factor': 5,
       'max_search_radius': 100,
-      'breakage_distance': 50,
+      'breakage_distance': 2000,
       'interpolation_distance': 10,
       'search_radius': 50,
       'geometry': False,

--- a/scripts/valhalla_build_config
+++ b/scripts/valhalla_build_config
@@ -85,7 +85,7 @@ config = {
       'max_route_distance_factor': 5,
       'max_route_time_factor': 5,
       'max_search_radius': 100,
-      'breakage_distance': 2000,
+      'breakage_distance': 50,
       'interpolation_distance': 10,
       'search_radius': 50,
       'geometry': False,

--- a/src/meili/map_matcher.cc
+++ b/src/meili/map_matcher.cc
@@ -536,7 +536,8 @@ std::vector<MatchResults> MapMatcher::OfflineMatch(const std::vector<Measurement
   bool found_broken_path = false;
 
   // Separate the measurements we are using for matching from the ones we'll just interpolate
-  auto interpolated = AppendMeasurements(measurements);
+  std::unordered_map<StateId::Time, std::vector<Measurement>> interpolated;
+  AppendMeasurements(measurements, interpolated);
 
   // For k paths
   while (best_paths.size() < k && !found_broken_path) {
@@ -652,15 +653,15 @@ std::vector<MatchResults> MapMatcher::OfflineMatch(const std::vector<Measurement
   return best_paths;
 }
 
-std::unordered_map<StateId::Time, std::vector<Measurement>>
-MapMatcher::AppendMeasurements(const std::vector<Measurement>& measurements) {
+void MapMatcher::AppendMeasurements(
+    const std::vector<Measurement>& measurements,
+    std::unordered_map<StateId::Time, std::vector<Measurement>>& interpolated) {
   const float max_search_radius = config_.get<float>("max_search_radius"),
-              sq_max_search_radius = max_search_radius * max_search_radius,
               interpolation_distance = config_.get<float>("interpolation_distance"),
-              sq_interpolation_distance = interpolation_distance * interpolation_distance,
               breakage_distance = config_.get<float>("breakage_distance"),
+              sq_max_search_radius = max_search_radius * max_search_radius,
+              sq_interpolation_distance = interpolation_distance * interpolation_distance,
               sq_breakage_distance = breakage_distance * breakage_distance;
-  std::unordered_map<StateId::Time, std::vector<Measurement>> interpolated;
 
   auto last = measurements.cbegin() - 1;
   uint32_t time;
@@ -719,9 +720,6 @@ MapMatcher::AppendMeasurements(const std::vector<Measurement>& measurements) {
       interpolated_epoch_time = m->epoch_time();
     }
   }
-
-  // return just the interpolated measurements
-  return interpolated;
 }
 
 } // namespace meili

--- a/src/meili/map_matcher.cc
+++ b/src/meili/map_matcher.cc
@@ -677,7 +677,7 @@ void MapMatcher::AppendMeasurements(
     // Do not interpolate this point if:
     // - it's far enough away from the last uninterpolated measurement,
     // - it's closer to the last uninterpolated measurement than the max breakage distance,
-    // - but always match the last measurement
+    // - and never interpolate the last measurement
     if ((sq_distance >= sq_interpolation_distance && sq_distance < sq_breakage_distance) ||
         std::next(m) == measurements.end()) {
       // If there were interpolated points between these two points with time information

--- a/src/meili/map_matcher.cc
+++ b/src/meili/map_matcher.cc
@@ -660,13 +660,18 @@ MapMatcher::AppendMeasurements(const std::vector<Measurement>& measurements) {
               sq_interpolation_distance = interpolation_distance * interpolation_distance;
   std::unordered_map<StateId::Time, std::vector<Measurement>> interpolated;
 
-  // Always match the first measurement
-  auto last = measurements.cbegin();
-  auto time = AppendMeasurement(*last, sq_max_search_radius);
+  auto last = measurements.cbegin() - 1;
+  uint32_t time;
   double interpolated_epoch_time = -1;
   for (auto m = std::next(last); m != measurements.end(); ++m) {
-    const auto sq_distance = GreatCircleDistanceSquared(*last, *m);
-    // Always match the last measurement and if its far enough away
+    if (interrupt_) {
+      (*interrupt_)();
+    }
+    std::vector<baldr::PathLocation> candidates;
+    const auto sq_distance = m == measurements.cbegin()
+                                 ? sq_interpolation_distance + 1 // Always match the first measurement
+                                 : GreatCircleDistanceSquared(*last, *m);
+    // Always match the last measurement and if its far enough away to not interpolate
     if (sq_interpolation_distance < sq_distance || std::next(m) == measurements.end()) {
       // If there were interpolated points between these two points with time information
       if (interpolated_epoch_time != -1) {
@@ -680,15 +685,38 @@ MapMatcher::AppendMeasurements(const std::vector<Measurement>& measurements) {
           container_.SetMeasurementLeaveTime(time, interpolated_epoch_time);
         }
       }
-      // This one isnt interpolated so we make room for its state
-      time = AppendMeasurement(*m, sq_max_search_radius);
+
+      // Get the edge candidates for this measurement within a radius
+      auto sq_radius =
+          std::min(sq_max_search_radius, std::max(m->sq_search_radius(), m->sq_gps_accuracy()));
+      candidates = candidatequery_.Query(m->lnglat(), sq_radius, costing()->GetEdgeFilter());
+    }
+
+    if (!candidates.empty()) {
+      time = container_.AppendMeasurement(*m);
+
+      //  std::string fsep = "";
+      //  std::cout << std::endl << "Candidates at time " << time << std::endl <<
+      //  R"({"type":"FeatureCollection","features":[)";
+      for (const auto& candidate : candidates) {
+        const auto& stateid = container_.AppendCandidate(candidate);
+        vs_.AddStateId(stateid);
+
+        //    std::cout << fsep << container_.geojson(stateid);
+        //    fsep = ",";
+      }
+      //  std::cout << R"(]})" << std::endl;
       last = m;
       interpolated_epoch_time = -1;
-    } // TODO: if its the last measurement and it wants to be interpolated
+    }
+    // TODO: if its the last measurement and it wants to be interpolated
     // then what we need to do is make last match interpolated
     // and copy its epoch_time into the last measurements epoch time
     // else if(std::next(measurement) == measurements.end()) { }
     // This one is so close to the last match that we will just interpolate it
+
+    // If within interpolation distance, or if no edge candidates were found within a radius
+    // treat this as an interpolated measurement
     else {
       interpolated[time].push_back(*m);
       interpolated_epoch_time = m->epoch_time();

--- a/src/meili/match_route.cc
+++ b/src/meili/match_route.cc
@@ -241,6 +241,7 @@ ConstructRoute(const MapMatcher& mapmatcher, match_iterator_t begin, match_itera
       // get the route between the two states by walking edge labels backwards
       // then reverse merge the segments together which are on the same edge so we have a
       // minimum number of segments. in this case we could at minimum end up with 1 segment
+      // if there is a valid route between states, otherwise we get 0 segments
       std::vector<EdgeSegment> segments;
       MergeRoute(segments, prev_state, state);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -105,10 +105,7 @@ endif()
 
 add_dependencies(run-sample test_directories)
 if(ENABLE_DATA_TOOLS)
-  ## TODO: fix apple tests!
-  if(NOT APPLE)
-    add_dependencies(run-mapmatch utrecht_tiles)
-  endif()
+  add_dependencies(run-mapmatch utrecht_tiles)
   add_dependencies(run-isochrone utrecht_tiles)
   add_dependencies(run-matrix utrecht_tiles)
   add_dependencies(run-timedep_paths utrecht_tiles)

--- a/test/mapmatch.cc
+++ b/test/mapmatch.cc
@@ -258,8 +258,25 @@ void test_trace_route_breaks() {
           {"lat":52.09110,"lon":5.09806},
           {"lat":52.09050,"lon":5.09769},
           {"lat":52.09098,"lon":5.09679}]})",
+      R"({"costing":"auto","shape_match":"map_snap","shape":[
+          {"lat":52.1021061,"lon":5.1185333},
+          {"lat":52.1023218,"lon":5.1188399},
+          {"lat":52.1020414,"lon":5.1189351}]})",
+      R"({"costing":"auto","shape_match":"map_snap","shape":[
+          {"lat":52.1022584,"lon":5.1187390},
+          {"lat":52.1020775,"lon":5.1187256},
+          {"lat":52.1020414,"lon":5.1189351}]})",
+      R"({"costing":"auto","shape_match":"map_snap","shape":[
+          {"lat":52.1021000,"lon":5.1185625},
+          {"lat":52.1020775,"lon":5.1187256},
+          {"lat":52.1022038,"lon":5.1189493}]})",
       R"({"costing":"auto","shape_match":"map_snap","encoded_polyline":"quijbBqpnwHfJxc@bBdJrDfSdAzFX|AHd@bG~[|AnIdArGbAo@z@m@`EuClO}MjE}E~NkPaAuC"})"};
-  std::vector<size_t> test_answers = {2, 1, 1, 1};
+  std::vector<size_t> test_answers = {2, 1, 1, 1, 1, 1, 1};
+
+  if (test_cases.size() != test_answers.size())
+    throw std::logic_error("Number of test_cases and test_answers must be equal " +
+                           std::to_string(test_cases.size()) +
+                           "!=" + std::to_string(test_answers.size()));
 
   tyr::actor_t actor(conf, true);
   for (size_t i = 0; i < test_cases.size(); ++i) {
@@ -267,7 +284,8 @@ void test_trace_route_breaks() {
     const auto& legs = matched.get_child("trip.legs");
     if (legs.size() != test_answers[i])
       throw std::logic_error("Expected " + std::to_string(test_answers[i]) + " legs but got " +
-                             std::to_string(legs.size()));
+                             std::to_string(legs.size()) + " for test_cases[" + std::to_string(i) +
+                             "]");
 
     for (const auto& leg : legs) {
       auto decoded_match =

--- a/test/mapmatch.cc
+++ b/test/mapmatch.cc
@@ -328,7 +328,7 @@ void test_trace_route_edge_walk_expected_error_code() {
 }
 
 void test_trace_route_map_snap_expected_error_code() {
-  // tests expected error_code for trace_route edge_walk
+  // tests expected error_code for trace_route map_snap
   auto expected_error_code = 442;
   tyr::actor_t actor(conf, true);
 

--- a/test/mapmatch.cc
+++ b/test/mapmatch.cc
@@ -339,7 +339,7 @@ void test_trace_route_map_snap_expected_error_code() {
          {"lat":52.088627,"lon":5.153269,"radius":5},
          {"lat":52.08864,"lon":5.15298,"radius":5},
          {"lat":52.08861,"lon":5.15272,"radius":5},
-         {"lat":52.08863,"lon":5.15253,"radius":5},
+         {"lat":52.08860,"lon":5.15257,"radius":5},
          {"lat":52.08851,"lon":5.15249,"radius":5}]})"));
   } catch (const valhalla_exception_t& e) {
     if (e.code != expected_error_code) {
@@ -382,7 +382,7 @@ void test_trace_attributes_edge_walk_expected_error_code() {
 }
 
 void test_trace_attributes_map_snap_expected_error_code() {
-  // tests expected error_code for trace_attributes edge_walk
+  // tests expected error_code for trace_attributes map_snap
   auto expected_error_code = 444;
   tyr::actor_t actor(conf, true);
 
@@ -393,7 +393,7 @@ void test_trace_attributes_map_snap_expected_error_code() {
          {"lat":52.088627,"lon":5.153269,"radius":5},
          {"lat":52.08864,"lon":5.15298,"radius":5},
          {"lat":52.08861,"lon":5.15272,"radius":5},
-         {"lat":52.08863,"lon":5.15253,"radius":5},
+         {"lat":52.08860,"lon":5.15257,"radius":5},
          {"lat":52.08851,"lon":5.15249,"radius":5}]})"));
   } catch (const valhalla_exception_t& e) {
     if (e.code != expected_error_code) {

--- a/valhalla/meili/map_matcher.h
+++ b/valhalla/meili/map_matcher.h
@@ -82,8 +82,6 @@ private:
   std::unordered_map<StateId::Time, std::vector<Measurement>>
   AppendMeasurements(const std::vector<Measurement>& measurements);
 
-  StateId::Time AppendMeasurement(const Measurement& measurement, const float sq_max_search_radius);
-
   void RemoveRedundancies(const std::vector<StateId>& result);
   // void RemoveRedundancies(const MatchResults& path, std::vector<StateId>& result);
 

--- a/valhalla/meili/map_matcher.h
+++ b/valhalla/meili/map_matcher.h
@@ -79,8 +79,8 @@ public:
   }
 
 private:
-  std::unordered_map<StateId::Time, std::vector<Measurement>>
-  AppendMeasurements(const std::vector<Measurement>& measurements);
+  void AppendMeasurements(const std::vector<Measurement>& measurements,
+                          std::unordered_map<StateId::Time, std::vector<Measurement>>& interpolated);
 
   void RemoveRedundancies(const std::vector<StateId>& result);
   // void RemoveRedundancies(const MatchResults& path, std::vector<StateId>& result);


### PR DESCRIPTION


**WIP**. This PR makes map matching more permissive by allowing the match to continue beyond where an outlier trace point would break the match.

Here's a made-up example where this helps produce a more complete match:

Before (master)
![image](https://user-images.githubusercontent.com/5665333/60549691-97d7d080-9cf3-11e9-9e88-a3c6ee12cd22.png)


After (this branch)
![image](https://user-images.githubusercontent.com/5665333/60549403-c4d7b380-9cf2-11e9-93f2-bf7033fda66f.png)

Point 3 has no candidate edges within the specified radius of 2m, but the match proceeds to point 4 where a valid destination was found. This change means the algorithm will try hard to connect points with a valid route between them, even if many of the intervening points could not be matched. 

The maximum distance between uninterpolated points can be set with the `breakage_distance` config, currently set to 2000m.


## Tasklist

 - [ ] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
