### PR TITLE
fix shape trimming to avoid single point edges

### DIFF
--- a/src/meili/candidate_search.cc
+++ b/src/meili/candidate_search.cc
@@ -32,7 +32,7 @@ CandidateQuery::WithinSquaredDistance(const midgard::PointLL& location,
                                       sif::EdgeFilter edgefilter) const {
   std::vector<baldr::PathLocation> candidates;
   std::unordered_set<baldr::GraphId> visited_nodes;
-  DistanceApproximator approximator(location);
+  midgard::projector_t projector(location);
   const baldr::GraphTile* tile = nullptr;
 
   for (auto it = edgeid_begin; it != edgeid_end; it++) {
@@ -77,7 +77,7 @@ CandidateQuery::WithinSquaredDistance(const midgard::PointLL& location,
     const bool edge_included = !edgefilter || edgefilter(edge) != 0.f;
 
     if (edge_included) {
-      std::tie(point, sq_distance, segment, offset) = helpers::Project(location, shape, approximator);
+      std::tie(point, sq_distance, segment, offset) = helpers::Project(projector, shape);
 
       if (sq_distance <= sq_search_radius) {
         const float dist = edge->forward() ? offset : 1.f - offset;
@@ -95,8 +95,7 @@ CandidateQuery::WithinSquaredDistance(const midgard::PointLL& location,
     // Correlate its opp edge
     if (oppedge_included) {
       if (!edge_included) {
-        std::tie(point, sq_distance, segment, offset) =
-            helpers::Project(location, shape, approximator);
+        std::tie(point, sq_distance, segment, offset) = helpers::Project(projector, shape);
       }
       if (sq_distance <= sq_search_radius) {
         const float dist = opp_edge->forward() ? offset : 1.f - offset;

--- a/src/meili/map_matcher.cc
+++ b/src/meili/map_matcher.cc
@@ -64,7 +64,7 @@ Interpolation InterpolateMeasurement(const MapMatcher& mapmatcher,
                                      float match_measurement_distance,
                                      float match_measurement_time) {
   const baldr::GraphTile* tile(nullptr);
-  midgard::DistanceApproximator approximator(measurement.lnglat());
+  midgard::projector_t projector(measurement.lnglat());
 
   // Route distance from each segment begin to the beginning segment
   float segment_begin_route_distance = 0.f;
@@ -88,8 +88,7 @@ Interpolation InterpolateMeasurement(const MapMatcher& mapmatcher,
 
     midgard::PointLL projected_point;
     float sq_distance, offset;
-    std::tie(projected_point, sq_distance, std::ignore, offset) =
-        helpers::Project(measurement.lnglat(), shape, approximator);
+    std::tie(projected_point, sq_distance, std::ignore, offset) = helpers::Project(projector, shape);
 
     // Find out the correct offset
     if (!directededge->forward()) {

--- a/src/thor/triplegbuilder.cc
+++ b/src/thor/triplegbuilder.cc
@@ -1063,13 +1063,14 @@ TripLegBuilder::Build(const AttributesController& controller,
       if (!directededge->forward()) {
         std::reverse(edge_shape.begin(), edge_shape.end());
       }
-      // We need to clip the shape if its at the beginning or end and is not full length
       float total = static_cast<float>(directededge->length());
-      // Trim the shape
-      TrimShape(edge_shape, is_first_edge ? start_pct * total : 0,
-                is_first_edge ? start_vrt : edge_shape.front(),
-                is_last_edge ? end_pct * total : total, is_last_edge ? end_vrt : edge_shape.back());
-      assert(edge_shape.size() > 1);
+      // Note: that this cannot be both the first and last edge, that special case is handled above
+      // Trim the shape at the front for the first edge
+      if (is_first_edge)
+        TrimShape(edge_shape, start_pct * total, start_vrt, total, edge_shape.back());
+      // And at the back if its the last edge
+      else
+        TrimShape(edge_shape, 0, edge_shape.front(), end_pct * total, end_vrt);
       // Keep the shape
       trip_shape.insert(trip_shape.end(), edge_shape.begin() + is_last_edge, edge_shape.end());
     } // Just get the shape in there in the right direction no clipping needed

--- a/valhalla/meili/geometry_helpers.h
+++ b/valhalla/meili/geometry_helpers.h
@@ -1,6 +1,5 @@
 // -*- mode: c++ -*-
-#ifndef MMP_GEOMETRY_HELPERS_H_
-#define MMP_GEOMETRY_HELPERS_H_
+#pragma once
 #include <cmath>
 
 #include <algorithm>
@@ -10,28 +9,26 @@
 #include <valhalla/midgard/constants.h>
 #include <valhalla/midgard/distanceapproximator.h>
 #include <valhalla/midgard/pointll.h>
+#include <valhalla/midgard/util.h>
 
 namespace valhalla {
 namespace meili {
 namespace helpers {
 
 // snapped point, sqaured distance, segment index, offset
-template <typename coord_t>
-std::tuple<coord_t, float, typename std::vector<coord_t>::size_type, float>
-Project(const coord_t& p,
-        const typename std::vector<coord_t>& shape,
-        const midgard::DistanceApproximator& approximator,
+inline std::tuple<midgard::PointLL, float, typename std::vector<midgard::PointLL>::size_type, float>
+Project(const midgard::projector_t& p,
+        const typename std::vector<midgard::PointLL>& shape,
         float snap_distance = 0.f) {
   if (shape.empty()) {
     throw std::invalid_argument("got empty shape");
   }
 
-  coord_t closest_point(shape.front());
-  float closest_distance = approximator.DistanceSquared(closest_point);
+  midgard::PointLL closest_point(shape.front());
+  float closest_distance = p.approx.DistanceSquared(closest_point);
   decltype(shape.size()) closest_segment = 0;
   float closest_partial_length = 0.f;
   float total_length = 0.f;
-  float lon_scale = cosf(p.lat() * midgard::kRadPerDeg);
 
   // for each segment
   for (decltype(shape.size()) i = 0; i < shape.size() - 1; ++i) {
@@ -39,28 +36,10 @@ Project(const coord_t& p,
     // and a is the origin vector to the point we are projecting, (a.b/b.b)*b
     const auto& u = shape[i];
     const auto& v = shape[i + 1];
-    auto bx = v.first - u.first;
-    auto by = v.second - u.second;
-    auto bx2 = bx * lon_scale;
-    auto sq = bx2 * bx2 + by * by;
-    const auto scale =
-        sq > 0 ? (((p.first - u.first) * lon_scale * bx2 + (p.second - u.second) * by) / sq) : 0.f;
-    // projects along the ray before u
-    if (scale <= 0.f) {
-      bx = u.first;
-      by = u.second;
-    } // projects along the ray after v
-    else if (scale >= 1.f) {
-      bx = v.first;
-      by = v.second;
-    } // projects along the ray between u and v
-    else {
-      bx = bx * scale + u.first;
-      by = by * scale + u.second;
-    }
+    auto point = p(u, v);
+
     // check if this point is better
-    coord_t point(bx, by);
-    const auto distance = approximator.DistanceSquared(point);
+    const auto distance = p.approx.DistanceSquared(point);
     if (distance < closest_distance) {
       closest_point = std::move(point);
       closest_distance = distance;
@@ -79,15 +58,15 @@ Project(const coord_t& p,
   float offset = total_length > 0.f ? static_cast<float>(closest_partial_length / total_length) : 0.f;
   offset = std::max(0.f, std::min(offset, 1.f));
 
-  // Snapp to vertices if it's close
+  // Snap to vertices if it's close
   if (total_length * offset <= snap_distance) {
     closest_point = shape.front();
-    closest_distance = approximator.DistanceSquared(closest_point);
+    closest_distance = p.approx.DistanceSquared(closest_point);
     closest_segment = 0;
     offset = 0.f;
   } else if (total_length * (1.f - offset) <= snap_distance) {
     closest_point = shape.back();
-    closest_distance = approximator.DistanceSquared(closest_point);
+    closest_distance = p.approx.DistanceSquared(closest_point);
     closest_segment = shape.size() - 1;
     offset = 1.f;
   }
@@ -98,4 +77,3 @@ Project(const coord_t& p,
 } // namespace helpers
 } // namespace meili
 } // namespace valhalla
-#endif // MMP_GEOMETRY_HELPERS_H_


### PR DESCRIPTION
in some scenarios the partial shape trimming for the beginning and end of the route can lead to an edge with a single point, this causes many problems downstream for guidance and eventually on the client side as well. i'll annotate the PR with the series of things going on to address that in this PR.