### PR TITLE
Added logic to detect if user is to merge to the left or right

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Release Date: UNRELEASED Valhalla 3.0.8
+* **Bug Fix**
+   * FIXED: Added logic to detect if user is to merge to the left or right [#1892](https://github.com/valhalla/valhalla/pull/1892)
+
 ## Release Date: 2019-7-18 Valhalla 3.0.7
 * **Bug Fix**
    * FIXED: Fix pedestrian fork [#1886](https://github.com/valhalla/valhalla/pull/1886)

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -728,10 +728,10 @@ std::string turn_modifier(const valhalla::DirectionsLeg::Maneuver& maneuver,
     case valhalla::DirectionsLeg_Maneuver_Type_kDestination:
       return "";
     case valhalla::DirectionsLeg_Maneuver_Type_kSlightRight:
+    case valhalla::DirectionsLeg_Maneuver_Type_kStayRight:
     case valhalla::DirectionsLeg_Maneuver_Type_kExitRight:
       return "slight right";
     case valhalla::DirectionsLeg_Maneuver_Type_kRight:
-    case valhalla::DirectionsLeg_Maneuver_Type_kStayRight:
     case valhalla::DirectionsLeg_Maneuver_Type_kStartRight:
     case valhalla::DirectionsLeg_Maneuver_Type_kDestinationRight:
       return "right";
@@ -746,11 +746,11 @@ std::string turn_modifier(const valhalla::DirectionsLeg::Maneuver& maneuver,
     case valhalla::DirectionsLeg_Maneuver_Type_kSharpLeft:
       return "sharp left";
     case valhalla::DirectionsLeg_Maneuver_Type_kLeft:
-    case valhalla::DirectionsLeg_Maneuver_Type_kStayLeft:
     case valhalla::DirectionsLeg_Maneuver_Type_kStartLeft:
     case valhalla::DirectionsLeg_Maneuver_Type_kDestinationLeft:
       return "left";
     case valhalla::DirectionsLeg_Maneuver_Type_kSlightLeft:
+    case valhalla::DirectionsLeg_Maneuver_Type_kStayLeft:
     case valhalla::DirectionsLeg_Maneuver_Type_kExitLeft:
       return "slight left";
     case valhalla::DirectionsLeg_Maneuver_Type_kRampRight:


### PR DESCRIPTION
# Issue

The OSRM compatibility mode expects `merge` maneuvers to have an associated modifier. The modifier indicates if the user should merge to the left or to the right.
Fixes #1730 

## Examples of before vs. after - these were in the issue
![merge_1_before_vs_after](https://user-images.githubusercontent.com/7515853/61794866-2077f700-adf0-11e9-9320-2d9c56390ca1.png)

![image](https://user-images.githubusercontent.com/7515853/61795266-f96df500-adf0-11e9-9367-d1e4f77cb295.png)

## Another Example before vs. after
![image](https://user-images.githubusercontent.com/7515853/61796138-cf1d3700-adf2-11e9-8c3a-08f172b0a9e4.png)
![image](https://user-images.githubusercontent.com/7515853/61796249-04c22000-adf3-11e9-8158-ef0337d0440a.png)


## Tasklist

 - [ ] Test
 - [ ] Review - you must request approval to merge any PR to master
 - [x] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)
