### PR TITLE
fix broken optional arg setting in config builder

### DIFF
--- a/scripts/valhalla_build_config
+++ b/scripts/valhalla_build_config
@@ -4,18 +4,22 @@ import argparse
 import json
 import pprint
 
+class optional:
+  def __init__(self, t=None):
+    self.type = t
+
 #global default configuration
 config = {
   'mjolnir': {
     'max_cache_size': 1000000000,
-    'tile_url': None,
-    'tile_url_gz': None,
+    'tile_url': optional(str),
+    'tile_url_gz': optional(bool),
     'tile_dir': '/data/valhalla',
     'tile_extract': '/data/valhalla/tiles.tar',
     'admin': '/data/valhalla/admin.sqlite',
     'timezone': '/data/valhalla/tz_world.sqlite',
     'transit_dir': '/data/valhalla/transit',
-    'transit_bounding_box': None,
+    'transit_bounding_box': optional(str),
     'hierarchy': True,
     'shortcuts': True,
     'include_driveways': True,
@@ -477,9 +481,9 @@ def add_leaf_args(path, tree, leaves, parser):
     h = help_text
     for k in keys:
       h = h[k]
-    t = comma_separated_list if type(tree) == type([]) else type(tree)
+    t = comma_separated_list if type(tree) == type([]) else (type(tree) if type(tree) != type(optional()) else tree.type)
     arg = '--' + path.replace('_', '-').replace('\0', '-')
-    parser.add_argument(arg, type = t if t != type(False) else parse_bool, help=h, default=tree)
+    parser.add_argument(arg, type = t if t != type(bool()) else parse_bool, help=h, default=tree)
     leaves.append(path)
 
 #entry point to program
@@ -499,7 +503,7 @@ if __name__ == '__main__':
     for k in keys[:-1]:
       v = v[k]
     v[keys[-1]] = getattr(args, leaf.replace('\0', '_'))
-    if v[keys[-1]] is None:
+    if isinstance(v[keys[-1]], type(optional())):
       del v[keys[-1]]
 
   #show the config


### PR DESCRIPTION
args that were marked as `None` because they were optional did not actually allow you to set them via the command arguments. in fact if you tried to, it would raise an exception and fail. this was because their type was `None` and argparse correctly says you have to have the right type when specificing args. the fix was to make a new type `optional` that allows you to both signify that the type is optional and should be excluded from the config if not provided but also if provided what the proper type should be. i couldnt think of a more pythonic way to specify this optionality so i made a quick class specifically for it. if a more pythonic way springs to mind we can change it down the road.