### PR TITLE
match osm boundaries, ireland drives on left

### DIFF
--- a/lua/admin.lua
+++ b/lua/admin.lua
@@ -25,6 +25,7 @@ drive_on_right = {
 ["Hong Kong"] = "false",
 ["India"] = "false",
 ["Indonesia"] = "false",
+["Ireland"] = "false",
 ["Isle of Man"] = "false",
 ["Jamaica"] = "false",
 ["Japan"] = "false",


### PR DESCRIPTION
in the future we should match on country code if we can since those are not so disputable