### PR TITLE
Use constrained flow speeds in bidirectional_astar.cc

### DIFF
--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -605,7 +605,7 @@ void BidirectionalAStar::SetOrigin(GraphReader& graphreader, valhalla::Location&
     // Get cost and sort cost (based on distance from endnode of this edge
     // to the destination
     nodeinfo = endtile->node(directededge->endnode());
-    Cost cost = costing_->EdgeCost(directededge, tile->GetSpeed(directededge)) *
+    Cost cost = costing_->EdgeCost(directededge, tile->GetConstrainedFlowSpeed(directededge)) *
                 (1.0f - edge.percent_along());
 
     // Store the closest node info
@@ -684,7 +684,8 @@ void BidirectionalAStar::SetDestination(GraphReader& graphreader, const valhalla
     // directed edge for costing, as this is the forward direction along the
     // destination edge. Note that the end node of the opposing edge is in the
     // same tile as the directed edge.
-    Cost cost = costing_->EdgeCost(directededge, tile->GetSpeed(directededge)) * edge.percent_along();
+    Cost cost = costing_->EdgeCost(directededge, tile->GetConstrainedFlowSpeed(directededge)) *
+                edge.percent_along();
 
     // We need to penalize this location based on its score (distance in meters from input)
     // We assume the slowest speed you could travel to cover that distance to start/end the route

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -145,7 +145,8 @@ void BidirectionalAStar::ExpandForward(GraphReader& graphreader,
 
     // Get cost. Separate out transition cost.
     Cost tc = costing_->TransitionCost(directededge, nodeinfo, pred);
-    Cost newcost = pred.cost() + tc + costing_->EdgeCost(directededge, tile->GetSpeed(directededge));
+    Cost newcost = pred.cost() + tc +
+                   costing_->EdgeCost(directededge, tile->GetConstrainedFlowSpeed(directededge));
 
     // Check if edge is temporarily labeled and this path has less cost. If
     // less cost the predecessor is updated and the sort cost is decremented
@@ -265,7 +266,8 @@ void BidirectionalAStar::ExpandReverse(GraphReader& graphreader,
     // can properly recover elapsed time on the reverse path.
     Cost tc = costing_->TransitionCostReverse(directededge->localedgeidx(), nodeinfo, opp_edge,
                                               opp_pred_edge);
-    Cost newcost = pred.cost() + costing_->EdgeCost(opp_edge, tile->GetSpeed(opp_edge));
+    Cost newcost =
+        pred.cost() + costing_->EdgeCost(opp_edge, tile->GetConstrainedFlowSpeed(opp_edge));
     newcost.cost += tc.cost;
 
     // Check if edge is temporarily labeled and this path has less cost. If

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -444,12 +444,31 @@ public:
    * @return  Returns the speed for the edge.
    */
   uint32_t GetSpeed(const DirectedEdge* de) const {
+    return GetFreeFlowSpeed(de);
+  }
+
+  /**
+   * Get the freeflow speed for an edge given the directed
+   * edge index.
+   * @param  de  Directed edge information.
+   * @return  Returns the speed for the edge.
+   */
+  uint32_t GetFreeFlowSpeed(const DirectedEdge* de) const {
     return (de->free_flow_speed() > 0) ? de->free_flow_speed() : de->speed();
   }
 
   /**
+   * Get the constrained flow speed for an edge given the directed edge index.
+   * @param  de  Directed edge information.
+   * @return  Returns the speed for the edge.
+   */
+  uint32_t GetConstrainedFlowSpeed(const DirectedEdge* de) const {
+    return (de->constrained_flow_speed() > 0) ? de->constrained_flow_speed() : de->speed();
+  }
+
+  /**
    * Convenience method to get the speed for an edge given the directed
-   * edge index.
+   * edge index and a time (seconds since midnight).
    * @param  de              Directed edge information.
    * @param  seconds_of_day  Seconds since midnight.
    * @return Returns the speed for the edge.
@@ -457,9 +476,9 @@ public:
   uint32_t GetSpeed(const DirectedEdge* de, const uint32_t seconds_of_day) const {
     // if time dependent route and we are routing between 7 AM and 7 PM local time.
     if (25200 < seconds_of_day && seconds_of_day < 68400) {
-      return (de->constrained_flow_speed() > 0) ? de->constrained_flow_speed() : de->speed();
+      return GetConstrainedFlowSpeed(de);
     } else {
-      return (de->free_flow_speed() > 0) ? de->free_flow_speed() : de->speed();
+      return GetFreeFlowSpeed(de);
     }
   }
 


### PR DESCRIPTION
# Issue

This switches bidirectional astar from using freeflow speeds to using constrained speeds.

## Tasklist

 - [ ] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
