### PR TITLE
Handle forward traversable significant road class intersecting edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
    * FIXED: Added missing motorway fork instruction [#1914](https://github.com/valhalla/valhalla/pull/1914)
    * FIXED: Use begin street name for osrm compat mode [#1916](https://github.com/valhalla/valhalla/pull/1916)
    * FIXED: Added logic to fix missing highway cardinal directions in the US [#1917](https://github.com/valhalla/valhalla/pull/1917)
+   * FIXED: Handle forward traversable significant road class intersecting edges [#1928](https://github.com/valhalla/valhalla/pull/1928)
 
 * **Enhancement**
    * ADDED: Caching url fetched tiles to disk [#1887](https://github.com/valhalla/valhalla/pull/1887)

--- a/src/odin/enhancedtrippath.cc
+++ b/src/odin/enhancedtrippath.cc
@@ -19,6 +19,7 @@ using namespace valhalla::baldr;
 
 namespace {
 constexpr float kShortRemainingDistanceThreshold = 0.402f; // Kilometers (~quarter mile)
+constexpr int kSignificantRoadClassThreshold = 2;          // Max lower road class delta
 
 const std::string& TripLeg_RoadClass_Name(int v) {
   static const std::unordered_map<int, std::string> values{
@@ -1357,6 +1358,25 @@ bool EnhancedTripLeg_Node::HasForwardTraversableIntersectingEdge(
   for (int i = 0; i < intersecting_edge_size(); ++i) {
     if (is_forward(GetTurnDegree(from_heading, intersecting_edge(i).begin_heading())) &&
         GetIntersectingEdge(i)->IsTraversableOutbound(travel_mode)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool EnhancedTripLeg_Node::HasForwardTraversableSignificantRoadClassXEdge(
+    uint32_t from_heading,
+    const TripLeg_TravelMode travel_mode,
+    TripLeg_RoadClass path_road_class) {
+
+  for (int i = 0; i < intersecting_edge_size(); ++i) {
+    auto xedge = GetIntersectingEdge(i);
+    // if the intersecting edge is forward
+    // and is traversable based on mode
+    // and is a significant road class as compared to the path road class
+    if (is_forward(GetTurnDegree(from_heading, intersecting_edge(i).begin_heading())) &&
+        xedge->IsTraversableOutbound(travel_mode) &&
+        ((xedge->road_class() - path_road_class) <= kSignificantRoadClassThreshold)) {
       return true;
     }
   }

--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -2029,12 +2029,13 @@ bool ManeuversBuilder::IsIntersectingForwardEdge(int node_index,
       return true;
     }
     // if path edge is forward
-    // and forward traversable intersecting edge exists
+    // and forward traversable significant road class intersecting edge exists
     // and path edge is not the straightest
     // then return true
     else if (curr_edge->IsForward(turn_degree) &&
-             node->HasForwardTraversableIntersectingEdge(prev_edge->end_heading(),
-                                                         prev_edge->travel_mode()) &&
+             node->HasForwardTraversableSignificantRoadClassXEdge(prev_edge->end_heading(),
+                                                                  prev_edge->travel_mode(),
+                                                                  prev_edge->road_class()) &&
              !curr_edge->IsStraightest(turn_degree,
                                        node->GetStraightestTraversableIntersectingEdgeTurnDegree(
                                            prev_edge->end_heading(), prev_edge->travel_mode()))) {

--- a/test_requests/lower_road_class_xedge_routes.txt
+++ b/test_requests/lower_road_class_xedge_routes.txt
@@ -1,0 +1,6 @@
+-j '{"locations":[{"lat":16.384245,"lon":120.517128,"street":"208"},{"lat":16.385538,"lon":120.516861,"street":"208"}],"costing":"auto","units":"miles"}'
+-j '{"locations":[{"lat":40.282242,"lon":-76.659195,"street":"West Chocolate Avenue"},{"lat":40.279373,"lon":-76.663582,"street":"US 422"}],"costing":"auto","units":"miles"}'
+-j '{"locations":[{"lat":40.799229,"lon":-73.468132,"street":"Sunnyside Boulevard"},{"lat":40.799580,"lon":-73.470741,"street":"Sunnyside Boulevard"}],"costing":"auto","units":"miles"}'
+-j '{"locations":[{"lat":40.648800,"lon":-73.976547,"street":"East 5th Street"},{"lat":40.647732,"lon":-73.974312,"street":"Caton Avenue"}],"costing":"auto","units":"miles"}'
+-j '{"locations":[{"lat":40.045902,"lon":-76.297455,"street":"New Holland Avenue"},{"lat":40.044231,"lon":-76.298088,"street":"North Plum Street"}],"costing":"auto","units":"miles"}'
+-j '{"locations":[{"lat":39.943272,"lon":-76.087372,"street":"Georgetown Road"},{"lat":39.935886,"lon":-76.075653,"street":"Georgetown Road"}],"costing":"auto","units":"miles"}'

--- a/valhalla/odin/enhancedtrippath.h
+++ b/valhalla/odin/enhancedtrippath.h
@@ -587,6 +587,10 @@ public:
   bool HasForwardTraversableIntersectingEdge(uint32_t from_heading,
                                              const TripLeg_TravelMode travel_mode);
 
+  bool HasForwardTraversableSignificantRoadClassXEdge(uint32_t from_heading,
+                                                      const TripLeg_TravelMode travel_mode,
+                                                      TripLeg_RoadClass path_road_class);
+
   bool HasWiderForwardTraversableIntersectingEdge(uint32_t from_heading,
                                                   const TripLeg_TravelMode travel_mode);
 


### PR DESCRIPTION
# Issue

Currently, the forward intersecting edge logic considers all intersecting edge road classes when processing an intersection. This leads to extraneous instructions that can confuse the user.

### Before
![image](https://user-images.githubusercontent.com/7515853/64258953-23d5c680-cef6-11e9-800f-af3679d170fe.png)

### After 
![image](https://user-images.githubusercontent.com/7515853/64259221-b1191b00-cef6-11e9-9818-04732511e4c5.png)

## Tasklist

 - [x] Add tests
 - [x] Review - you must request approval to merge any PR to master
 - [x] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)
