### PR TITLE
Fix bug in TrimShape 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
    * FIXED: Use begin street name for osrm compat mode [#1916](https://github.com/valhalla/valhalla/pull/1916)
    * FIXED: Added logic to fix missing highway cardinal directions in the US [#1917](https://github.com/valhalla/valhalla/pull/1917)
    * FIXED: Handle forward traversable significant road class intersecting edges [#1928](https://github.com/valhalla/valhalla/pull/1928)
+   * FIXED: Fixed bug with shape trimming that impacted Uturns at Via locations. [#1935](https://github.com/valhalla/valhalla/pull/1935)
 
 * **Enhancement**
    * ADDED: Caching url fetched tiles to disk [#1887](https://github.com/valhalla/valhalla/pull/1887)

--- a/src/thor/triplegbuilder.cc
+++ b/src/thor/triplegbuilder.cc
@@ -35,32 +35,38 @@ void TrimShape(std::vector<PointLL>& shape,
                const PointLL& start_vertex,
                const float end,
                const PointLL& end_vertex) {
-  // clip up to the start point
+  // clip up to the start point if the start_vertex is valid
   float along = 0.f;
   auto current = shape.begin();
-  while (current != shape.end() - 1) {
-    along += (current + 1)->Distance(*current);
-    // just crossed it
-    if ((along > start) && start_vertex.IsValid()) {
-      along = start;
-      *current = start_vertex;
-      shape.erase(shape.begin(), current);
-      break;
+  if (start_vertex.IsValid()) {
+    while (current != shape.end() - 1) {
+      along += (current + 1)->Distance(*current);
+      // just crossed it, replace the current vertex with the start position and erase
+      // shape up to the current vertex
+      if (along > start) {
+        along = start;
+        *current = start_vertex;
+        shape.erase(shape.begin(), current);
+        break;
+      }
+      ++current;
     }
-    ++current;
   }
 
-  // clip after the end point
+  // clip after the end point if the end vertex is valid
   current = shape.begin();
-  while (current != shape.end() - 1) {
-    along += (current + 1)->Distance(*current);
-    // just crossed it
-    if ((along > end) && end_vertex.IsValid()) {
-      *(++current) = end_vertex;
-      shape.erase(++current, shape.end());
-      break;
+  if (end_vertex.IsValid()) {
+    while (current != shape.end() - 1) {
+      along += (current + 1)->Distance(*current);
+      // just crossed it, replace the current vertex with the end vertex and erase
+      // shape after the current vertex
+      if (along > end) {
+        *(++current) = end_vertex;
+        shape.erase(++current, shape.end());
+        break;
+      }
+      ++current;
     }
-    ++current;
   }
 }
 


### PR DESCRIPTION
If start_vertex is not valid it never trims the start of the shape but accumulates the along distance and never resets it. This leads to erasing most of the shape when clipping after the end point. The fix is to not trim start shape if the start_vertex is not valid since it can never actually erase any of the
shape in this case. Similarly for trimming past the end shape.

# Issue

fixes #1933 

## Tasklist

 - [ ] Add tests
 - [x] Review - you must request approval to merge any PR to master
 - [x] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)
