### PR TITLE
check fields in protobuf2 compatible way

### DIFF
--- a/src/tyr/serializers.cc
+++ b/src/tyr/serializers.cc
@@ -92,7 +92,7 @@ json::ArrayPtr waypoints(const google::protobuf::RepeatedPtrField<valhalla::Loca
   auto waypoints = json::array({});
   int64_t waypoint_index = -1;
   for (const auto& location : locations) {
-    if (location.path_edges().empty()) {
+    if (location.path_edges().size() > 0) {
       waypoints->emplace_back(static_cast<std::nullptr_t>(nullptr));
     } else if (location.type() == valhalla::Location::kBreak ||
                location.type() == valhalla::Location::kBreakThrough) {

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -560,7 +560,7 @@ void from_json(rapidjson::Document& doc, Options& options) {
     parse_locations(doc, options, "shape", 134, false);
 
     // if no shape then try 'trace'
-    if (options.shape().empty()) {
+    if (options.shape().size() > 0) {
       parse_locations(doc, options, "trace", 135, false);
     }
   }


### PR DESCRIPTION
On protobuf 2.6, empty method is not available for RepeatedPtrField. To ensure protobuf2 compatibility, check for empty fields using size method. 

I tested Valhalla compiled with this patch on Sailfish through OSM Scout Server which links Valhalla for routing and map matching service. Will be testing new Valhalla further (just updated from 2.x), but just wanted to submit this for review.

Please feel free to reject the PR if you don't want to target Protocol Buffers 2