### PR TITLE
specify minimal version of gcc in README, fixes #1937

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ sudo apt-get install -y valhalla-bin
 Building from Source
 --------------------
 
-Valhalla uses CMake as build system.
+Valhalla uses CMake as build system. When compiling with gcc (GNU Compiler Collection), version 5 or newer is supported.
 
 To install on a Debian or Ubuntu system you need to install its dependencies with:
 


### PR DESCRIPTION
# Issue

Missing minimal gcc requirements, https://github.com/valhalla/valhalla/issues/1937

While it is not full-blown minimal requirements, I hope that its a helpful note to the others building from source.