### PR TITLE
Fix crash in AreEdgesConnected 

### DIFF
--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -343,15 +343,16 @@ bool GraphReader::AreEdgesConnected(const GraphId& edge1, const GraphId& edge2) 
 
   // Get opposing edge to de1
   const DirectedEdge* de1_opp = GetOpposingEdge(edge1, t1);
-  if (de1_opp->endnode() == de2->endnode() || is_transition(de1_opp->endnode(), de2->endnode())) {
+  if (de1_opp &&
+      (de1_opp->endnode() == de2->endnode() || is_transition(de1_opp->endnode(), de2->endnode()))) {
     return true;
   }
 
   // Get opposing edge to de2 and compare to both edge1 endnodes
   const DirectedEdge* de2_opp = GetOpposingEdge(edge2, t2);
-  if (de2_opp->endnode() == de1->endnode() || de2_opp->endnode() == de1_opp->endnode() ||
-      is_transition(de2_opp->endnode(), de1->endnode()) ||
-      is_transition(de2_opp->endnode(), de1_opp->endnode())) {
+  if (de2 && (de2_opp->endnode() == de1->endnode() || de2_opp->endnode() == de1_opp->endnode() ||
+              is_transition(de2_opp->endnode(), de1->endnode()) ||
+              is_transition(de2_opp->endnode(), de1_opp->endnode()))) {
     return true;
   }
   return false;


### PR DESCRIPTION
(called from thor get_path_algorithm)
Crashes where opposing edge is null due to end not tile not existing

May want to check other uses of GetOpposingEdge to make sure they protect against nullptr return