### PR TITLE
Initialise current_time=0 as origin.has_date_time() may report false

### DIFF
--- a/src/thor/triplegbuilder.cc
+++ b/src/thor/triplegbuilder.cc
@@ -803,7 +803,7 @@ TripLegBuilder::Build(const AttributesController& controller,
       }
     }
 
-    double current_time;
+    double current_time = 0;
     if (origin.has_date_time()) {
       current_time = DateTime::seconds_from_midnight(origin.date_time());
       current_time += elapsedtime;


### PR DESCRIPTION
# Issue

This is a general hygiene and consistent predictability of `current_time` value used during route calculation.

It also helps to avoid annoyance of Visual C++ check: `Runtime Check Failure #3 - Variable is not initiliazed`.

## Tasklist

 - [ ] Review - you must request approval to merge any PR to master
 - [x] CI builds pass

## Requirements / Relations

Somewhat related/similar change is https://github.com/valhalla/valhalla/commit/14bb758cb644ac0566319c5d03226c067d504638