### PR TITLE
README: Add complete git command to clone Valhalla

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,12 +115,20 @@ nvm use 10 # must use node 8.11.1 and up because of N-API
 npm install --ignore-scripts
 ```
 
-Then clone and build [`prime_server`](https://github.com/kevinkreiser/prime_server#build-and-install).
+Now, clone the Valhalla repository
+
+```bash
+git clone --recurse-submodules https://github.com/valhalla/valhalla.git
+```
+
+On Windows, you will need to run [Git 2.10.2 or later with symlinks support enabled](https://stackoverflow.com/a/11664406/151641)
+and pass `-c core.symlinks=true` to `git clone` command line.
+
+Then, build [`prime_server`](https://github.com/kevinkreiser/prime_server#build-and-install).
 
 After getting the dependencies install it with:
 
 ```bash
-git submodule update --init --recursive
 mkdir build
 cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
Show that `core.symlinks=true` is required in order to get complete and buildable clone of the repository.

------

I requested to skip the CI checks as this is a trivial change.