### PR TITLE
Add CMake options with defaults to CMakeSettings.json for VS

### DIFF
--- a/cmake/CMakeSettings.json
+++ b/cmake/CMakeSettings.json
@@ -4,15 +4,23 @@
     "See https://go.microsoft.com//fwlink//?linkid=834763 for more information.",
     "Usage:",
     "Copy cmake/CMkeSettings.json to top-level directory of Valhalla source tree",
-    "Then, launch Visual Studio 2017 > File > Open > CMake > select top-level CMakeLists.txt"
+    "Then, launch Visual Studio 2017 > File > Open > CMake > select top-level CMakeLists.txt",
+    "See Valhalla top-level CMakeLists.txt for complete list of options available to be passed via -D to cmake."
   ],
   "environments": [
-    {
-      "BuildDir": "${workspaceRoot}\\_build"
-    },
-    {
-      "InstallDir": "${workspaceRoot}\\_install"
-    }
+    { "BuildDir": "${workspaceRoot}\\_build" },
+    { "InstallDir": "${workspaceRoot}\\_install" },
+    { "VALHALLA_D_DEFAULT_ENABLE_CCACHE": "OFF" },
+    { "VALHALLA_D_DEFAULT_ENABLE_COVERAGE": "OFF" },
+    { "VALHALLA_D_DEFAULT_ENABLE_SANITIZER": "OFF" },
+    { "VALHALLA_D_DEFAULT_ENABLE_DATA_TOOLS": "OFF" },
+    { "VALHALLA_D_DEFAULT_ENABLE_HTTP": "OFF" },
+    { "VALHALLA_D_DEFAULT_ENABLE_NODE_BINDINGS": "OFF" },
+    { "VALHALLA_D_DEFAULT_ENABLE_PYTHON_BINDINGS": "OFF" },
+    { "VALHALLA_D_DEFAULT_ENABLE_SERVICES": "OFF" },
+    { "VALHALLA_D_DEFAULT_ENABLE_TESTS": "OFF" },
+    { "VALHALLA_D_DEFAULT_ENABLE_TOOLS": "OFF" },
+    { "VALHALLA_D_DEFAULT_LOGGING_LEVEL": "INFO" }
   ],
   "configurations": [
     {
@@ -26,13 +34,17 @@
       "buildCommandArgs": "-v",
       "ctestCommandArgs": "",
       "variables": [
-        { "name": "ENABLE_TOOLS", "value": "OFF" },
-        { "name": "ENABLE_DATA_TOOLS", "value": "OFF" },
-        { "name": "ENABLE_SERVICES", "value": "OFF" },
-        { "name": "ENABLE_HTTP", "value": "OFF" },
-        { "name": "ENABLE_PYTHON_BINDINGS", "value": "OFF" },
-        { "name": "ENABLE_NODE_BINDINGS", "value": "OFF" },
-        { "name": "ENABLE_CCACHE", "value": "OFF" }
+        { "name": "ENABLE_CCACHE", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_CCACHE}" },
+        { "name": "ENABLE_COVERAGE", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_COVERAGE}" },
+        { "name": "ENABLE_SANITIZER", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_SANITIZER}" },
+        { "name": "ENABLE_DATA_TOOLS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_DATA_TOOLS}" },
+        { "name": "ENABLE_HTTP", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_HTTP}" },
+        { "name": "ENABLE_NODE_BINDINGS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_NODE_BINDINGS}" },
+        { "name": "ENABLE_PYTHON_BINDINGS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_PYTHON_BINDINGS}" },
+        { "name": "ENABLE_SERVICES", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_SERVICES}" },
+        { "name": "ENABLE_TESTS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_TESTS}" },
+        { "name": "ENABLE_TOOLS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_TOOLS}" },
+        { "name": "LOGGING_LEVEL", "value": "${env.VALHALLA_D_DEFAULT_LOGGING_LEVEL}" }
       ]
     },
     {
@@ -46,13 +58,17 @@
       "buildCommandArgs": "-v",
       "ctestCommandArgs": "",
       "variables": [
-        { "name": "ENABLE_TOOLS", "value": "OFF" },
-        { "name": "ENABLE_DATA_TOOLS", "value": "OFF" },
-        { "name": "ENABLE_SERVICES", "value": "OFF" },
-        { "name": "ENABLE_HTTP", "value": "OFF" },
-        { "name": "ENABLE_PYTHON_BINDINGS", "value": "OFF" },
-        { "name": "ENABLE_NODE_BINDINGS", "value": "OFF" },
-        { "name": "ENABLE_CCACHE", "value": "OFF" }
+        { "name": "ENABLE_CCACHE", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_CCACHE}" },
+        { "name": "ENABLE_COVERAGE", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_COVERAGE}" },
+        { "name": "ENABLE_SANITIZER", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_SANITIZER}" },
+        { "name": "ENABLE_DATA_TOOLS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_DATA_TOOLS}" },
+        { "name": "ENABLE_HTTP", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_HTTP}" },
+        { "name": "ENABLE_NODE_BINDINGS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_NODE_BINDINGS}" },
+        { "name": "ENABLE_PYTHON_BINDINGS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_PYTHON_BINDINGS}" },
+        { "name": "ENABLE_SERVICES", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_SERVICES}" },
+        { "name": "ENABLE_TESTS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_TESTS}" },
+        { "name": "ENABLE_TOOLS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_TOOLS}" },
+        { "name": "LOGGING_LEVEL", "value": "${env.VALHALLA_D_DEFAULT_LOGGING_LEVEL}" }
       ]
     },
     {
@@ -66,13 +82,17 @@
       "buildCommandArgs": "-v",
       "ctestCommandArgs": "",
       "variables": [
-        { "name": "ENABLE_TOOLS", "value": "OFF" },
-        { "name": "ENABLE_DATA_TOOLS", "value": "OFF" },
-        { "name": "ENABLE_SERVICES", "value": "OFF" },
-        { "name": "ENABLE_HTTP", "value": "OFF" },
-        { "name": "ENABLE_PYTHON_BINDINGS", "value": "OFF" },
-        { "name": "ENABLE_NODE_BINDINGS", "value": "OFF" },
-        { "name": "ENABLE_CCACHE", "value": "OFF" }
+        { "name": "ENABLE_CCACHE", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_CCACHE}" },
+        { "name": "ENABLE_COVERAGE", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_COVERAGE}" },
+        { "name": "ENABLE_SANITIZER", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_SANITIZER}" },
+        { "name": "ENABLE_DATA_TOOLS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_DATA_TOOLS}" },
+        { "name": "ENABLE_HTTP", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_HTTP}" },
+        { "name": "ENABLE_NODE_BINDINGS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_NODE_BINDINGS}" },
+        { "name": "ENABLE_PYTHON_BINDINGS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_PYTHON_BINDINGS}" },
+        { "name": "ENABLE_SERVICES", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_SERVICES}" },
+        { "name": "ENABLE_TESTS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_TESTS}" },
+        { "name": "ENABLE_TOOLS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_TOOLS}" },
+        { "name": "LOGGING_LEVEL", "value": "${env.VALHALLA_D_DEFAULT_LOGGING_LEVEL}" }
       ]
     },
     {
@@ -86,17 +106,21 @@
       "buildCommandArgs": "-v",
       "ctestCommandArgs": "",
       "variables": [
-        { "name": "ENABLE_TOOLS", "value": "OFF" },
-        { "name": "ENABLE_DATA_TOOLS", "value": "OFF" },
-        { "name": "ENABLE_SERVICES", "value": "OFF" },
-        { "name": "ENABLE_HTTP", "value": "OFF" },
-        { "name": "ENABLE_PYTHON_BINDINGS", "value": "OFF" },
-        { "name": "ENABLE_NODE_BINDINGS", "value": "OFF" },
-        { "name": "ENABLE_CCACHE", "value": "OFF" }
+        { "name": "ENABLE_CCACHE", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_CCACHE}" },
+        { "name": "ENABLE_COVERAGE", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_COVERAGE}" },
+        { "name": "ENABLE_SANITIZER", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_SANITIZER}" },
+        { "name": "ENABLE_DATA_TOOLS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_DATA_TOOLS}" },
+        { "name": "ENABLE_HTTP", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_HTTP}" },
+        { "name": "ENABLE_NODE_BINDINGS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_NODE_BINDINGS}" },
+        { "name": "ENABLE_PYTHON_BINDINGS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_PYTHON_BINDINGS}" },
+        { "name": "ENABLE_SERVICES", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_SERVICES}" },
+        { "name": "ENABLE_TESTS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_TESTS}" },
+        { "name": "ENABLE_TOOLS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_TOOLS}" },
+        { "name": "LOGGING_LEVEL", "value": "${env.VALHALLA_D_DEFAULT_LOGGING_LEVEL}" }
       ]
     },
     {
-      "name": "x64-Debug",
+      "name": "x64-Debug-VS2017",
       "generator": "Visual Studio 15 2017 Win64",
       "configurationType": "Debug",
       "buildRoot": "${env.BuildDir}\\${name}",
@@ -105,17 +129,21 @@
       "cmakeCommandArgs": "",
       "ctestCommandArgs": "",
       "variables": [
-        { "name": "ENABLE_TOOLS", "value": "OFF" },
-        { "name": "ENABLE_DATA_TOOLS", "value": "OFF" },
-        { "name": "ENABLE_SERVICES", "value": "OFF" },
-        { "name": "ENABLE_HTTP", "value": "OFF" },
-        { "name": "ENABLE_PYTHON_BINDINGS", "value": "OFF" },
-        { "name": "ENABLE_NODE_BINDINGS", "value": "OFF" },
-        { "name": "ENABLE_CCACHE", "value": "OFF" }
+        { "name": "ENABLE_CCACHE", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_CCACHE}" },
+        { "name": "ENABLE_COVERAGE", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_COVERAGE}" },
+        { "name": "ENABLE_SANITIZER", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_SANITIZER}" },
+        { "name": "ENABLE_DATA_TOOLS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_DATA_TOOLS}" },
+        { "name": "ENABLE_HTTP", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_HTTP}" },
+        { "name": "ENABLE_NODE_BINDINGS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_NODE_BINDINGS}" },
+        { "name": "ENABLE_PYTHON_BINDINGS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_PYTHON_BINDINGS}" },
+        { "name": "ENABLE_SERVICES", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_SERVICES}" },
+        { "name": "ENABLE_TESTS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_TESTS}" },
+        { "name": "ENABLE_TOOLS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_TOOLS}" },
+        { "name": "LOGGING_LEVEL", "value": "${env.VALHALLA_D_DEFAULT_LOGGING_LEVEL}" }
       ]
     },
     {
-      "name": "x64-Release",
+      "name": "x64-Release-VS2017",
       "generator": "Visual Studio 15 2017 Win64",
       "configurationType": "Release",
       "buildRoot": "${env.BuildDir}\\${name}",
@@ -124,17 +152,21 @@
       "cmakeCommandArgs": "",
       "ctestCommandArgs": "",
       "variables": [
-        { "name": "ENABLE_TOOLS", "value": "OFF" },
-        { "name": "ENABLE_DATA_TOOLS", "value": "OFF" },
-        { "name": "ENABLE_SERVICES", "value": "OFF" },
-        { "name": "ENABLE_HTTP", "value": "OFF" },
-        { "name": "ENABLE_PYTHON_BINDINGS", "value": "OFF" },
-        { "name": "ENABLE_NODE_BINDINGS", "value": "OFF" },
-        { "name": "ENABLE_CCACHE", "value": "OFF" }
+        { "name": "ENABLE_CCACHE", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_CCACHE}" },
+        { "name": "ENABLE_COVERAGE", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_COVERAGE}" },
+        { "name": "ENABLE_SANITIZER", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_SANITIZER}" },
+        { "name": "ENABLE_DATA_TOOLS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_DATA_TOOLS}" },
+        { "name": "ENABLE_HTTP", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_HTTP}" },
+        { "name": "ENABLE_NODE_BINDINGS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_NODE_BINDINGS}" },
+        { "name": "ENABLE_PYTHON_BINDINGS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_PYTHON_BINDINGS}" },
+        { "name": "ENABLE_SERVICES", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_SERVICES}" },
+        { "name": "ENABLE_TESTS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_TESTS}" },
+        { "name": "ENABLE_TOOLS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_TOOLS}" },
+        { "name": "LOGGING_LEVEL", "value": "${env.VALHALLA_D_DEFAULT_LOGGING_LEVEL}" }
       ]
     },
     {
-      "name": "x86-Debug",
+      "name": "x86-Debug-VS2017",
       "generator": "Visual Studio 15 2017",
       "configurationType": "Debug",
       "buildRoot": "${env.BuildDir}\\${name}",
@@ -143,17 +175,21 @@
       "cmakeCommandArgs": "",
       "ctestCommandArgs": "",
       "variables": [
-        { "name": "ENABLE_TOOLS", "value": "OFF" },
-        { "name": "ENABLE_DATA_TOOLS", "value": "OFF" },
-        { "name": "ENABLE_SERVICES", "value": "OFF" },
-        { "name": "ENABLE_HTTP", "value": "OFF" },
-        { "name": "ENABLE_PYTHON_BINDINGS", "value": "OFF" },
-        { "name": "ENABLE_NODE_BINDINGS", "value": "OFF" },
-        { "name": "ENABLE_CCACHE", "value": "OFF" }
+        { "name": "ENABLE_CCACHE", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_CCACHE}" },
+        { "name": "ENABLE_COVERAGE", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_COVERAGE}" },
+        { "name": "ENABLE_SANITIZER", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_SANITIZER}" },
+        { "name": "ENABLE_DATA_TOOLS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_DATA_TOOLS}" },
+        { "name": "ENABLE_HTTP", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_HTTP}" },
+        { "name": "ENABLE_NODE_BINDINGS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_NODE_BINDINGS}" },
+        { "name": "ENABLE_PYTHON_BINDINGS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_PYTHON_BINDINGS}" },
+        { "name": "ENABLE_SERVICES", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_SERVICES}" },
+        { "name": "ENABLE_TESTS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_TESTS}" },
+        { "name": "ENABLE_TOOLS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_TOOLS}" },
+        { "name": "LOGGING_LEVEL", "value": "${env.VALHALLA_D_DEFAULT_LOGGING_LEVEL}" }
       ]
     },
     {
-      "name": "x86-Release",
+      "name": "x86-Release-VS2017",
       "generator": "Visual Studio 15 2017",
       "configurationType": "Release",
       "buildRoot": "${env.BuildDir}\\${name}",
@@ -162,13 +198,109 @@
       "cmakeCommandArgs": "",
       "ctestCommandArgs": "",
       "variables": [
-        { "name": "ENABLE_TOOLS", "value": "OFF" },
-        { "name": "ENABLE_DATA_TOOLS", "value": "OFF" },
-        { "name": "ENABLE_SERVICES", "value": "OFF" },
-        { "name": "ENABLE_HTTP", "value": "OFF" },
-        { "name": "ENABLE_PYTHON_BINDINGS", "value": "OFF" },
-        { "name": "ENABLE_NODE_BINDINGS", "value": "OFF" },
-        { "name": "ENABLE_CCACHE", "value": "OFF" }
+        { "name": "ENABLE_CCACHE", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_CCACHE}" },
+        { "name": "ENABLE_COVERAGE", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_COVERAGE}" },
+        { "name": "ENABLE_SANITIZER", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_SANITIZER}" },
+        { "name": "ENABLE_DATA_TOOLS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_DATA_TOOLS}" },
+        { "name": "ENABLE_HTTP", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_HTTP}" },
+        { "name": "ENABLE_NODE_BINDINGS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_NODE_BINDINGS}" },
+        { "name": "ENABLE_PYTHON_BINDINGS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_PYTHON_BINDINGS}" },
+        { "name": "ENABLE_SERVICES", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_SERVICES}" },
+        { "name": "ENABLE_TESTS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_TESTS}" },
+        { "name": "ENABLE_TOOLS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_TOOLS}" },
+        { "name": "LOGGING_LEVEL", "value": "${env.VALHALLA_D_DEFAULT_LOGGING_LEVEL}" }
+      ]
+    },
+    {
+      "name": "x64-Debug-VS2019",
+      "generator": "Visual Studio 16 2019 Win64",
+      "configurationType": "Debug",
+      "buildRoot": "${env.BuildDir}\\${name}",
+      "installRoot": "${env.InstallDir}\\${name}",
+      "buildCommandArgs": "-m",
+      "cmakeCommandArgs": "",
+      "ctestCommandArgs": "",
+      "variables": [
+        { "name": "ENABLE_CCACHE", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_CCACHE}" },
+        { "name": "ENABLE_COVERAGE", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_COVERAGE}" },
+        { "name": "ENABLE_SANITIZER", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_SANITIZER}" },
+        { "name": "ENABLE_DATA_TOOLS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_DATA_TOOLS}" },
+        { "name": "ENABLE_HTTP", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_HTTP}" },
+        { "name": "ENABLE_NODE_BINDINGS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_NODE_BINDINGS}" },
+        { "name": "ENABLE_PYTHON_BINDINGS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_PYTHON_BINDINGS}" },
+        { "name": "ENABLE_SERVICES", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_SERVICES}" },
+        { "name": "ENABLE_TESTS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_TESTS}" },
+        { "name": "ENABLE_TOOLS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_TOOLS}" },
+        { "name": "LOGGING_LEVEL", "value": "${env.VALHALLA_D_DEFAULT_LOGGING_LEVEL}" }
+      ]
+    },
+    {
+      "name": "x64-Release-VS2019",
+      "generator": "Visual Studio 16 2019 Win64",
+      "configurationType": "Release",
+      "buildRoot": "${env.BuildDir}\\${name}",
+      "installRoot": "${env.InstallDir}\\${name}",
+      "buildCommandArgs": "-m",
+      "cmakeCommandArgs": "",
+      "ctestCommandArgs": "",
+      "variables": [
+        { "name": "ENABLE_CCACHE", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_CCACHE}" },
+        { "name": "ENABLE_COVERAGE", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_COVERAGE}" },
+        { "name": "ENABLE_SANITIZER", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_SANITIZER}" },
+        { "name": "ENABLE_DATA_TOOLS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_DATA_TOOLS}" },
+        { "name": "ENABLE_HTTP", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_HTTP}" },
+        { "name": "ENABLE_NODE_BINDINGS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_NODE_BINDINGS}" },
+        { "name": "ENABLE_PYTHON_BINDINGS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_PYTHON_BINDINGS}" },
+        { "name": "ENABLE_SERVICES", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_SERVICES}" },
+        { "name": "ENABLE_TESTS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_TESTS}" },
+        { "name": "ENABLE_TOOLS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_TOOLS}" },
+        { "name": "LOGGING_LEVEL", "value": "${env.VALHALLA_D_DEFAULT_LOGGING_LEVEL}" }
+      ]
+    },
+    {
+      "name": "x86-Debug-VS2019",
+      "generator": "Visual Studio 16 2019",
+      "configurationType": "Debug",
+      "buildRoot": "${env.BuildDir}\\${name}",
+      "installRoot": "${env.InstallDir}\\${name}",
+      "buildCommandArgs": "-m",
+      "cmakeCommandArgs": "",
+      "ctestCommandArgs": "",
+      "variables": [
+        { "name": "ENABLE_CCACHE", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_CCACHE}" },
+        { "name": "ENABLE_COVERAGE", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_COVERAGE}" },
+        { "name": "ENABLE_SANITIZER", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_SANITIZER}" },
+        { "name": "ENABLE_DATA_TOOLS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_DATA_TOOLS}" },
+        { "name": "ENABLE_HTTP", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_HTTP}" },
+        { "name": "ENABLE_NODE_BINDINGS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_NODE_BINDINGS}" },
+        { "name": "ENABLE_PYTHON_BINDINGS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_PYTHON_BINDINGS}" },
+        { "name": "ENABLE_SERVICES", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_SERVICES}" },
+        { "name": "ENABLE_TESTS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_TESTS}" },
+        { "name": "ENABLE_TOOLS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_TOOLS}" },
+        { "name": "LOGGING_LEVEL", "value": "${env.VALHALLA_D_DEFAULT_LOGGING_LEVEL}" }
+      ]
+    },
+    {
+      "name": "x86-Release-VS2019",
+      "generator": "Visual Studio 16 2019",
+      "configurationType": "Release",
+      "buildRoot": "${env.BuildDir}\\${name}",
+      "installRoot": "${env.InstallDir}\\${name}",
+      "buildCommandArgs": "-m",
+      "cmakeCommandArgs": "",
+      "ctestCommandArgs": "",
+      "variables": [
+        { "name": "ENABLE_CCACHE", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_CCACHE}" },
+        { "name": "ENABLE_COVERAGE", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_COVERAGE}" },
+        { "name": "ENABLE_SANITIZER", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_SANITIZER}" },
+        { "name": "ENABLE_DATA_TOOLS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_DATA_TOOLS}" },
+        { "name": "ENABLE_HTTP", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_HTTP}" },
+        { "name": "ENABLE_NODE_BINDINGS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_NODE_BINDINGS}" },
+        { "name": "ENABLE_PYTHON_BINDINGS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_PYTHON_BINDINGS}" },
+        { "name": "ENABLE_SERVICES", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_SERVICES}" },
+        { "name": "ENABLE_TESTS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_TESTS}" },
+        { "name": "ENABLE_TOOLS", "value": "${env.VALHALLA_D_DEFAULT_ENABLE_TOOLS}" },
+        { "name": "LOGGING_LEVEL", "value": "${env.VALHALLA_D_DEFAULT_LOGGING_LEVEL}" }
       ]
     }
   ]


### PR DESCRIPTION
Add configurationns for Visual Studio 2019.

The cmake/CMakeSettings.json can be copied to root directory and
edited, then it serves as a cache of settings for users who look
for convenient build configuration using Visual Studio 2017/2019.

------

All CI-s skipped.