### PR TITLE
refactor loki interface to take full costing object

### DIFF
--- a/src/loki/isochrone_action.cc
+++ b/src/loki/isochrone_action.cc
@@ -84,7 +84,7 @@ void loki_worker_t::isochrones(Api& request) {
   try {
     // correlate the various locations to the underlying graph
     auto locations = PathLocation::fromPBF(options.locations());
-    const auto projections = loki::Search(locations, *reader, edge_filter, node_filter);
+    const auto projections = loki::Search(locations, *reader, costing.get());
     for (size_t i = 0; i < locations.size(); ++i) {
       const auto& projection = projections.at(locations[i]);
       PathLocation::toPBF(projection, options.mutable_locations(i), *reader);

--- a/src/loki/locate_action.cc
+++ b/src/loki/locate_action.cc
@@ -10,22 +10,20 @@ namespace loki {
 
 void loki_worker_t::init_locate(Api& request) {
   parse_locations(request.mutable_options()->mutable_locations());
-  if (request.options().locations_size() < 1) {
+  if (request.options().locations_size() < 1)
     throw valhalla_exception_t{120};
-  }
-  if (request.options().has_costing()) {
+
+  if (request.options().has_costing())
     parse_costing(request);
-  } else {
-    edge_filter = loki::PassThroughEdgeFilter;
-    node_filter = loki::PassThroughNodeFilter;
-  }
+  else
+    costing.reset();
 }
 
 std::string loki_worker_t::locate(Api& request) {
   // correlate the various locations to the underlying graph
   init_locate(request);
   auto locations = PathLocation::fromPBF(request.options().locations());
-  auto projections = loki::Search(locations, *reader, edge_filter, node_filter);
+  auto projections = loki::Search(locations, *reader, costing.get());
   return tyr::serializeLocate(request, locations, projections, *reader);
 }
 

--- a/src/loki/matrix_action.cc
+++ b/src/loki/matrix_action.cc
@@ -89,21 +89,21 @@ void loki_worker_t::init_matrix(Api& request) {
 void loki_worker_t::matrix(Api& request) {
   init_matrix(request);
   auto& options = *request.mutable_options();
-  auto costing = Costing_Name(options.costing());
+  auto costing_name = Costing_Name(options.costing());
 
-  if (costing == "multimodal") {
+  if (costing_name == "multimodal") {
     throw valhalla_exception_t{140, Options_Action_Name(options.action())};
   };
 
   // check that location size does not exceed max.
-  auto max = max_matrix_locations.find(costing)->second;
+  auto max = max_matrix_locations.find(costing_name)->second;
   if (options.sources_size() > max || options.targets_size() > max) {
     throw valhalla_exception_t{150, std::to_string(max)};
   };
 
   // check the distances
   auto max_location_distance = std::numeric_limits<float>::min();
-  check_distance(options.sources(), options.targets(), max_matrix_distance.find(costing)->second,
+  check_distance(options.sources(), options.targets(), max_matrix_distance.find(costing_name)->second,
                  max_location_distance);
 
   // correlate the various locations to the underlying graph
@@ -115,7 +115,7 @@ void loki_worker_t::matrix(Api& request) {
   // correlate the various locations to the underlying graph
   std::unordered_map<size_t, size_t> color_counts;
   try {
-    const auto searched = loki::Search(sources_targets, *reader, edge_filter, node_filter);
+    const auto searched = loki::Search(sources_targets, *reader, costing.get());
     for (size_t i = 0; i < sources_targets.size(); ++i) {
       const auto& l = sources_targets[i];
       const auto& projection = searched.at(l);

--- a/src/loki/reach.cc
+++ b/src/loki/reach.cc
@@ -8,10 +8,9 @@ namespace loki {
 directed_reach SimpleReach(const DirectedEdge* edge,
                            uint32_t max_reach,
                            GraphReader& reader,
-                           uint8_t direction,
                            const sif::EdgeFilter& edge_filter,
-                           const sif::NodeFilter& node_filter) {
-  // TODO: harden against incomplete tile sets
+                           const sif::NodeFilter& node_filter,
+                           uint8_t direction) {
 
   // no reach to start with
   directed_reach reach{};
@@ -122,65 +121,6 @@ directed_reach SimpleReach(const DirectedEdge* edge,
 
   return reach;
 }
-
-/*
-directed_reach Reach(const DirectedEdge* edge,
-                     uint32_t max_reach,
-                     GraphReader& reader,
-                     uint8_t direction,
-                     const sif::EdgeFilter& edge_filter,
-                     const sif::NodeFilter& node_filter,
-                     reach_cache* cache) {
-  // TODO: if edge reach exists in cache for both directions, return it
-
-  directed_reach reach{};
-
-  // TODO: expand bidirectional island cache
-  // if start edge, end node and opp edge are not filtered, push them both into the bidir queue
-  // while the bidir queue is not empty and reach is < max in both directions
-  //    pop edge off the bidir queue
-  //    increment in and outbound reach
-  //    go to end node and if filtered
-  //      continue
-  //    for each edge from node
-  //      if edge and node and op edge is not filtered
-  //        add the edges to the bidir queue
-  //      else if edge is not filtered
-  //        add to outbound queue
-  //      else if opp edge is not filtered
-  //        add to inbound queue
-
-  // while outbound queue is not empty and outbound reach < max
-  //   pop edge off outbound queue
-  //   increment outbound reach
-  //   go to end node and if filtered
-  //     continue
-  //   for each edge from node
-  //     if edge is not filtered
-  //       push edge into outbound queue
-
-  // while inbound queue is not empty and inbound reach < max
-  //   pop edge off inbound queue
-  //   increment inbound reach
-  //   go to end node and if filtered
-  //     continue
-  //   for each edge from node
-  //     if opp edge is not filtered
-  //       push opp edge into inbound queue
-
-  // TODO: in the above we may push the same edges into queues at several places we need to avoid that
-  // by keeping track maybe of the nodes we visit or maybe of the edges we visit
-
-  // TODO: we also when searching only in one direction could end up back to a section of the graph
-  // that is bidirectional. in this case we should start tracking this other bidirectional island or
-  // maybe its not worth it unless a candidate shows up in there
-
-  // TODO: when the single direction search hits a bidirectional island we can immediately increment
-  // that search to include that islands size
-
-  throw std::logic_error("Optimized reach is not yet implemented");
-  return reach;
-}*/
 
 } // namespace loki
 } // namespace valhalla

--- a/src/loki/route_action.cc
+++ b/src/loki/route_action.cc
@@ -58,12 +58,12 @@ void loki_worker_t::init_route(Api& request) {
 void loki_worker_t::route(Api& request) {
   init_route(request);
   auto& options = *request.mutable_options();
-  auto costing = Costing_Name(options.costing());
-  check_locations(options.locations_size(), max_locations.find(costing)->second);
-  check_distance(options.locations(), max_distance.find(costing)->second);
+  auto costing_name = Costing_Name(options.costing());
+  check_locations(options.locations_size(), max_locations.find(costing_name)->second);
+  check_distance(options.locations(), max_distance.find(costing_name)->second);
 
   // Validate walking distances (make sure they are in the accepted range)
-  if (costing == "multimodal" || costing == "transit") {
+  if (costing_name == "multimodal" || costing_name == "transit") {
     auto* ped_opts = options.mutable_costing_options(static_cast<int>(pedestrian));
     if (!ped_opts->has_transit_start_end_max_distance())
       ped_opts->set_transit_start_end_max_distance(min_transit_walking_dis);
@@ -89,7 +89,7 @@ void loki_worker_t::route(Api& request) {
   std::unordered_map<size_t, size_t> color_counts;
   try {
     auto locations = PathLocation::fromPBF(options.locations(), true);
-    const auto projections = loki::Search(locations, *reader, edge_filter, node_filter);
+    const auto projections = loki::Search(locations, *reader, costing.get());
     for (size_t i = 0; i < locations.size(); ++i) {
       const auto& correlated = projections.at(locations[i]);
       PathLocation::toPBF(correlated, options.mutable_locations(i), *reader);

--- a/src/loki/trace_route_action.cc
+++ b/src/loki/trace_route_action.cc
@@ -184,7 +184,7 @@ void loki_worker_t::locations_from_shape(Api& request) {
 
     // Project first and last shape point onto nearest edge(s). Clear current locations list
     // and set the path locations
-    auto projections = loki::Search(locations, *reader, edge_filter, node_filter);
+    auto projections = loki::Search(locations, *reader, costing.get());
     options.clear_locations();
     PathLocation::toPBF(projections.at(locations.front()), options.mutable_locations()->Add(),
                         *reader);

--- a/src/valhalla_benchmark_loki.cc
+++ b/src/valhalla_benchmark_loki.cc
@@ -158,7 +158,7 @@ void work(const boost::property_tree::ptree& config, std::promise<results_t>& pr
       auto start = std::chrono::high_resolution_clock::now();
       try {
         // TODO: actually save the result
-        auto result = valhalla::loki::Search(job, reader, valhalla::loki::PassThroughEdgeFilter);
+        auto result = valhalla::loki::Search(job, reader);
         auto end = std::chrono::high_resolution_clock::now();
         (*r) = result_t{std::chrono::duration_cast<std::chrono::milliseconds>(end - start), true, job,
                         cached};

--- a/src/valhalla_path_comparison.cc
+++ b/src/valhalla_path_comparison.cc
@@ -103,8 +103,7 @@ void walk_edges(const std::string& shape, GraphReader& reader, cost_ptr_t cost_p
   std::vector<baldr::Location> locations;
   locations.push_back({shape_pts.front()});
   locations.push_back({shape_pts.back()});
-  const auto projections =
-      Search(locations, reader, cost_ptr->GetEdgeFilter(), cost_ptr->GetNodeFilter());
+  const auto projections = Search(locations, reader, cost_ptr.get());
   std::vector<PathLocation> path_location;
   valhalla::Options options;
   for (const auto& loc : locations) {

--- a/src/valhalla_run_isochrone.cc
+++ b/src/valhalla_run_isochrone.cc
@@ -185,7 +185,7 @@ int main(int argc, char* argv[]) {
 
   // Find locations
   std::shared_ptr<DynamicCost> cost = mode_costing[static_cast<uint32_t>(mode)];
-  const auto projections = Search(locations, reader, cost->GetEdgeFilter(), cost->GetNodeFilter());
+  const auto projections = Search(locations, reader, cost.get());
   std::vector<PathLocation> path_location;
   for (const auto& loc : locations) {
     try {
@@ -195,7 +195,7 @@ int main(int argc, char* argv[]) {
 
   // Find avoid locations
   std::vector<sif::AvoidEdge> avoid_edges;
-  const auto avoids = Search(avoid_locations, reader, cost->GetEdgeFilter(), cost->GetNodeFilter());
+  const auto avoids = Search(avoid_locations, reader, cost.get());
   for (const auto& loc : avoid_locations) {
     for (auto& e : avoids.at(loc).edges) {
       avoid_edges.push_back({e.id, e.percent_along});

--- a/src/valhalla_run_route.cc
+++ b/src/valhalla_run_route.cc
@@ -203,7 +203,7 @@ const valhalla::TripLeg* PathTest(GraphReader& reader,
     locations.back().heading_ = std::round(PointLL::HeadingAtEndOfPolyline(shape, 30.f));
 
     std::shared_ptr<DynamicCost> cost = mode_costing[static_cast<uint32_t>(mode)];
-    const auto projections = Search(locations, reader, cost->GetEdgeFilter(), cost->GetNodeFilter());
+    const auto projections = Search(locations, reader, cost.get());
     std::vector<PathLocation> path_location;
     valhalla::Options options;
     for (const auto& loc : locations) {

--- a/test/astar.cc
+++ b/test/astar.cc
@@ -383,8 +383,7 @@ void trivial_path_no_uturns(const std::string& config_file) {
   auto mode = cost->travel_mode();
   mode_costing[static_cast<uint32_t>(mode)] = cost;
 
-  const auto projections =
-      vk::Search(locations, graph_reader, cost->GetEdgeFilter(), cost->GetNodeFilter());
+  const auto projections = vk::Search(locations, graph_reader, cost.get());
   std::vector<PathLocation> path_location;
 
   for (auto loc : locations) {

--- a/test/reach.cc
+++ b/test/reach.cc
@@ -80,7 +80,7 @@ void check_all_reach() {
          edge_id.id() < tile->header()->directededgecount(); ++edge_id) {
       // use the simple method to find the reach for the edge in both directions
       const auto* edge = tile->directededge(edge_id);
-      auto reach = SimpleReach(edge, 50, reader, kInbound | kOutbound, edge_filter, node_filter);
+      auto reach = SimpleReach(edge, 50, reader, edge_filter, node_filter, kInbound | kOutbound);
 
       // shape is nice to have
       auto shape = tile->edgeinfo(edge->edgeinfo_offset()).shape();

--- a/test/search.cc
+++ b/test/search.cc
@@ -157,7 +157,7 @@ void search(valhalla::baldr::Location location,
   PathLocation::toPBF(location, &pbf, reader);
   location = PathLocation::fromPBF(pbf);
 
-  const auto results = Search({location}, reader, PassThroughEdgeFilter, PassThroughNodeFilter);
+  const auto results = Search({location}, reader);
   const auto p = results.at(location);
 
   if ((p.edges.front().begin_node() || p.edges.front().end_node()) != expected_node)
@@ -195,7 +195,7 @@ void search(valhalla::baldr::Location location, size_t result_count, int reachab
   PathLocation::toPBF(location, &pbf, reader);
   location = PathLocation::fromPBF(pbf);
 
-  const auto results = Search({location}, reader, PassThroughEdgeFilter, PassThroughNodeFilter);
+  const auto results = Search({location}, reader);
   if (results.empty() && result_count == 0)
     return;
   const auto& p = results.at(location);

--- a/valhalla/loki/reach.h
+++ b/valhalla/loki/reach.h
@@ -18,17 +18,9 @@ struct directed_reach {
 directed_reach SimpleReach(const valhalla::baldr::DirectedEdge* edge,
                            uint32_t max_reach,
                            valhalla::baldr::GraphReader& reader,
-                           uint8_t direction = kInbound | kOutbound,
-                           const sif::EdgeFilter& edge_filter = PassThroughEdgeFilter,
-                           const sif::NodeFilter& node_filter = PassThroughNodeFilter);
-/*
-directed_reach Reach(const valhalla::baldr::DirectedEdge* edge,
-                     uint32_t max_reach,
-                     valhalla::baldr::GraphReader& reader,
-                     uint8_t direction = kInbound | kOutbound,
-                     const sif::EdgeFilter& edge_filter = PassThroughEdgeFilter,
-                     const sif::NodeFilter& node_filter = PassThroughNodeFilter,
-                     reach_cache* cache = nullptr);*/
+                           const sif::EdgeFilter& edge_filter,
+                           const sif::NodeFilter& node_filter,
+                           uint8_t direction = kInbound | kOutbound);
 
 } // namespace loki
 } // namespace valhalla

--- a/valhalla/loki/search.h
+++ b/valhalla/loki/search.h
@@ -14,42 +14,21 @@ namespace valhalla {
 namespace loki {
 
 /**
- * A callable element which returns a value between 0 and 1 based on
- * how desirable the edge is for use as a location. 0 indicated the
- * edge should not be used as a location (inaccessible).
- *
- * TODO: remove the filtering of transit edges when they get proper
- * opposing edges added to the graph
- */
-const sif::EdgeFilter PassThroughEdgeFilter = [](const baldr::DirectedEdge* edge) -> float {
-  return !(edge->is_shortcut() || edge->IsTransitLine());
-};
-
-/**
- * A callable element which returns true if a node should be
- * filtered out of a graph traversal
- */
-const sif::NodeFilter PassThroughNodeFilter = [](const baldr::NodeInfo* node) { return false; };
-
-/**
  * Find an location within the route network given an input location
  * same tiled route data and a search strategy
  *
  * @param locations      the positions which need to be correlated to the route network
  * @param reader         and object used to access tiled route data TODO: switch this out for a
  * proper cache
- * @param edge_filter    a function/functor to be used in the rejection of edges. defaults to a pass
- * through filter
- * @param node_filter    a function/functor to be used in the rejection of nodes used in graph
- * traversal. defaults to a pass through filter
+ * @param edge_filter    a costing object by which we can determine which portions of the graph are
+ *                       accessable and therefor potential candidates
  * @return pathLocations the correlated data with in the tile that matches the inputs. If a
  * projection is not found, it will not have any entry in the returned value.
  */
 std::unordered_map<baldr::Location, baldr::PathLocation>
 Search(const std::vector<baldr::Location>& locations,
        baldr::GraphReader& reader,
-       const sif::EdgeFilter& edge_filter = PassThroughEdgeFilter,
-       const sif::NodeFilter& node_filter = PassThroughNodeFilter);
+       const sif::DynamicCost* costing = nullptr);
 
 } // namespace loki
 } // namespace valhalla

--- a/valhalla/loki/worker.h
+++ b/valhalla/loki/worker.h
@@ -62,8 +62,7 @@ protected:
 
   boost::property_tree::ptree config;
   sif::CostFactory<sif::DynamicCost> factory;
-  sif::EdgeFilter edge_filter;
-  sif::NodeFilter node_filter;
+  sif::cost_ptr_t costing;
   std::shared_ptr<baldr::GraphReader> reader;
   std::shared_ptr<baldr::connectivity_map_t> connectivity_map;
   std::string action_str;


### PR DESCRIPTION
exactly as the title of the pr says. in order to fully fix issues with reachability the reachability criterion must be decided using the same rules we use for path finding. to do this, the first step is to give loki full access to the costing object, so that when it does a graph expansion it has access to all the same rules thor uses when it does a graph search.