### PR TITLE
Add missing <cctype> header to fix ambiguous std::toupper call

### DIFF
--- a/src/mjolnir/osmdata.cc
+++ b/src/mjolnir/osmdata.cc
@@ -1,3 +1,4 @@
+#include <cctype>
 #include <cstdint>
 #include <fstream>
 #include <iostream>


### PR DESCRIPTION
# Issue

Apparently, missing headers causes ambiguity between C version `std::toupper(int)` and C++ template `std::toupper(CharT ch, locale)`.

The issue occurred while compiling with VS 2017 (MSVC 19.16), but possibly happens for other versions too.

## Tasklist

- [ ] Ensure all CI pass
- [ ] Review - you must request approval to merge any PR to master
- [ ] Add #fixes with the issue number that this PR addresses
- [ ] Generally use squash merge to rebase and clean comments before merging
