### PR TITLE
Rename _finally variable to avoid clash with keywords from MSVC extensions

### DIFF
--- a/src/mjolnir/bssbuilder.cc
+++ b/src/mjolnir/bssbuilder.cc
@@ -191,7 +191,7 @@ void create_bss_node_and_edges(GraphTileBuilder& tilebuilder_local,
   // GraphTileBuilder tilebuilder_local(reader.tile_dir(), tile.header()->graphid(), true);
   auto local_level = TileHierarchy::levels().rbegin()->first;
 
-  auto _finally = make_finally([&tilebuilder_local, &tile, &lock]() {
+  auto scoped_finally = make_finally([&tilebuilder_local, &tile, &lock]() {
     LOG_INFO("Storing local tile data with bss nodes, tile id: " +
              std::to_string(tile.id().tileid()));
     std::lock_guard<std::mutex> l(lock);
@@ -414,7 +414,7 @@ void BssBuilder::Build(const boost::property_tree::ptree& pt, const std::string&
 
   auto t1 = std::chrono::high_resolution_clock::now();
 
-  auto _finally = make_finally([&t1]() {
+  auto scoped_finally = make_finally([&t1]() {
     auto t2 = std::chrono::high_resolution_clock::now();
     uint32_t secs = std::chrono::duration_cast<std::chrono::seconds>(t2 - t1).count();
     LOG_INFO("Finished - BssBuilder took " + std::to_string(secs) + " secs");


### PR DESCRIPTION
# Issue

MSVC offers extensions to C and C++ which, apparently, define `__finally`, `_finally` and `finally` as keywords.

Annoyingly, the single-underscored `_finally` somehow gets mapped to the double-underscored `__finally` causing compilation trouble:

![image](https://user-images.githubusercontent.com/80741/67709839-118c7c00-f9bf-11e9-9cb4-a3a48df2c20a.png)

Alternative could be to compile with C/C++ extensions disabled `/Za`, but that may need some tests and more fixes, as for large codebases it is not as smooth as it may seem compelling.

## Tasklist

 - [ ] Ensure all CI pass
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
