### PR TITLE
Add zlib target and dirent header location to mjolnir targets for MSVC

### DIFF
--- a/src/mjolnir/CMakeLists.txt
+++ b/src/mjolnir/CMakeLists.txt
@@ -66,6 +66,7 @@ valhalla_module(NAME mjolnir
       ${VALHALLA_SOURCE_DIR}
       ${VALHALLA_SOURCE_DIR}/valhalla
       ${VALHALLA_SOURCE_DIR}/third_party/date/include
+      $<$<BOOL:${MSVC}>:${VALHALLA_SOURCE_DIR}/third_party/dirent/include>
       ${PROTOBUF_INCLUDE_DIR}
    PRIVATE
       ${CMAKE_CURRENT_BINARY_DIR}
@@ -79,4 +80,5 @@ valhalla_module(NAME mjolnir
     Spatialite::Spatialite
     SQLite3::SQLite3
     Lua::Lua
-    Threads::Threads)
+    Threads::Threads
+    ZLIB::ZLIB)


### PR DESCRIPTION
# Issue

The `src\mjolnir\osmpbfparser.cc` includes `zlib.h`, so it requires the target.

The custom [filesystem.hpp](https://github.com/valhalla/valhalla/blob/9f07205f58ab2d4b85bcd33d2f9e621f7c62c5bc/valhalla/filesystem.h#L12) requires `dirent.h`, so for MSVC it needs to be specified from the third_party implementation.

## Tasklist

 - [ ] Ensure all CI builds pass
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Generally use squash merge to rebase and clean comments before merging
