### PR TITLE
filesystem: Fix make_to_type return type for non-POSIX systems

### DIFF
--- a/valhalla/filesystem.h
+++ b/valhalla/filesystem.h
@@ -144,7 +144,10 @@ private:
       entry_->d_type = mode_to_type(s.st_mode);
     }
   }
-  unsigned char mode_to_type(decltype(stat::st_mode) mode) {
+
+  // On POXIX, d_type is char.
+  // On Windows, d_type is int (values are larger than 8-bit integer).
+  decltype(::dirent::d_type) mode_to_type(decltype(::stat::st_mode) mode) {
     if (S_ISREG(mode))
       return DT_REG;
     else if (S_ISDIR(mode))


### PR DESCRIPTION
# Issue

On POXIX, `d_type` is char.
On Windows, `d_type` is int and values are **larger than 8-bit integer** which will never fit the `d_type` leading to invalid values breaking most of the filesystem operations.

## Tasklist

 - [ ] Ensure all CI builds pass.
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
