### PR TITLE
Return geojson route geometry in osrm serializer

### DIFF
--- a/proto/options.proto
+++ b/proto/options.proto
@@ -28,6 +28,7 @@ enum DirectionsType {
 enum ShapeFormat {
   polyline5 = 0;
   polyline6 = 1;
+  geojson = 2;
 }
 
 enum Costing {

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -620,6 +620,8 @@ void from_json(rapidjson::Document& doc, Options& options) {
       options.set_shape_format(polyline6);
     } else if (*shape_format == "polyline5") {
       options.set_shape_format(polyline5);
+    } else if (*shape_format == "geojson") {
+      options.set_shape_format(geojson);
     } else {
       // Throw an error if shape format is invalid
       throw valhalla_exception_t{164};


### PR DESCRIPTION
# Issue

Adds support for `shape_format: geojson` in the osrm serialized response. 

## Tasklist

 - [ ] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
