### PR TITLE
Move to C++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ include(GNUInstallDirs)
 set(VALHALLA_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 list(INSERT CMAKE_MODULE_PATH 0 ${VALHALLA_SOURCE_DIR}/cmake)
 
-set(CMAKE_CXX_STANDARD 11 CACHE STRING "C++ language version to use (default is 11)")
+set(CMAKE_CXX_STANDARD 14 CACHE STRING "C++ language version to use (default is 14)")
 option(ENABLE_TOOLS "Enable Valhalla tools" ON)
 option(ENABLE_DATA_TOOLS "Enable Valhalla data tools" ON)
 option(ENABLE_SERVICES "Enable Valhalla services" ON)

--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -306,8 +306,8 @@ TileCache* TileCacheFactory::createTileCache(const boost::property_tree::ptree& 
 // Constructor using separate tile files
 GraphReader::GraphReader(const boost::property_tree::ptree& pt)
     : tile_extract_(get_extract_instance(pt)), tile_dir_(pt.get<std::string>("tile_dir", "")),
-      curlers_(midgard::make_unique<curler_pool_t>(pt.get<size_t>("max_concurrent_reader_users", 1),
-                                                   pt.get<std::string>("user_agent", ""))),
+      curlers_(std::make_unique<curler_pool_t>(pt.get<size_t>("max_concurrent_reader_users", 1),
+                                               pt.get<std::string>("user_agent", ""))),
       tile_url_(pt.get<std::string>("tile_url", "")),
       tile_url_gz_(pt.get<bool>("tile_url_gz", false)),
       cache_(TileCacheFactory::createTileCache(pt)) {

--- a/src/baldr/streetnames.cc
+++ b/src/baldr/streetnames.cc
@@ -14,7 +14,7 @@ StreetNames::StreetNames() : std::list<std::unique_ptr<StreetName>>() {
 
 StreetNames::StreetNames(const std::vector<std::pair<std::string, bool>>& names) {
   for (auto& name : names) {
-    this->emplace_back(midgard::make_unique<StreetName>(name.first, name.second));
+    this->emplace_back(std::make_unique<StreetName>(name.first, name.second));
   }
 }
 
@@ -68,10 +68,10 @@ std::string StreetNames::ToParameterString() const {
 #endif
 
 std::unique_ptr<StreetNames> StreetNames::clone() const {
-  std::unique_ptr<StreetNames> clone_street_names = midgard::make_unique<StreetNames>();
+  std::unique_ptr<StreetNames> clone_street_names = std::make_unique<StreetNames>();
   for (const auto& street_name : *this) {
     clone_street_names->emplace_back(
-        midgard::make_unique<StreetName>(street_name->value(), street_name->is_route_number()));
+        std::make_unique<StreetName>(street_name->value(), street_name->is_route_number()));
   }
 
   return clone_street_names;
@@ -79,12 +79,12 @@ std::unique_ptr<StreetNames> StreetNames::clone() const {
 
 std::unique_ptr<StreetNames>
 StreetNames::FindCommonStreetNames(const StreetNames& other_street_names) const {
-  std::unique_ptr<StreetNames> common_street_names = midgard::make_unique<StreetNames>();
+  std::unique_ptr<StreetNames> common_street_names = std::make_unique<StreetNames>();
   for (const auto& street_name : *this) {
     for (const auto& other_street_name : other_street_names) {
       if (*street_name == *other_street_name) {
         common_street_names->emplace_back(
-            midgard::make_unique<StreetName>(street_name->value(), street_name->is_route_number()));
+            std::make_unique<StreetName>(street_name->value(), street_name->is_route_number()));
         break;
       }
     }
@@ -95,7 +95,7 @@ StreetNames::FindCommonStreetNames(const StreetNames& other_street_names) const 
 
 std::unique_ptr<StreetNames>
 StreetNames::FindCommonBaseNames(const StreetNames& other_street_names) const {
-  std::unique_ptr<StreetNames> common_base_names = midgard::make_unique<StreetNames>();
+  std::unique_ptr<StreetNames> common_base_names = std::make_unique<StreetNames>();
   for (const auto& street_name : *this) {
     for (const auto& other_street_name : other_street_names) {
       if (street_name->HasSameBaseName(*other_street_name)) {
@@ -103,15 +103,15 @@ StreetNames::FindCommonBaseNames(const StreetNames& other_street_names) const {
         // thus, 'US 30 West' will be used instead of 'US 30'
         if (!street_name->GetPostCardinalDir().empty()) {
           common_base_names->emplace_back(
-              midgard::make_unique<StreetName>(street_name->value(), street_name->is_route_number()));
+              std::make_unique<StreetName>(street_name->value(), street_name->is_route_number()));
         } else if (!other_street_name->GetPostCardinalDir().empty()) {
           common_base_names->emplace_back(
-              midgard::make_unique<StreetName>(other_street_name->value(),
-                                               street_name->is_route_number()));
+              std::make_unique<StreetName>(other_street_name->value(),
+                                           street_name->is_route_number()));
           // Use street_name by default
         } else {
           common_base_names->emplace_back(
-              midgard::make_unique<StreetName>(street_name->value(), street_name->is_route_number()));
+              std::make_unique<StreetName>(street_name->value(), street_name->is_route_number()));
         }
         break;
       }
@@ -122,11 +122,11 @@ StreetNames::FindCommonBaseNames(const StreetNames& other_street_names) const {
 }
 
 std::unique_ptr<StreetNames> StreetNames::GetRouteNumbers() const {
-  std::unique_ptr<StreetNames> route_numbers = midgard::make_unique<StreetNames>();
+  std::unique_ptr<StreetNames> route_numbers = std::make_unique<StreetNames>();
   for (const auto& street_name : *this) {
     if (street_name->is_route_number()) {
       route_numbers->emplace_back(
-          midgard::make_unique<StreetName>(street_name->value(), street_name->is_route_number()));
+          std::make_unique<StreetName>(street_name->value(), street_name->is_route_number()));
     }
   }
 
@@ -134,11 +134,11 @@ std::unique_ptr<StreetNames> StreetNames::GetRouteNumbers() const {
 }
 
 std::unique_ptr<StreetNames> StreetNames::GetNonRouteNumbers() const {
-  std::unique_ptr<StreetNames> non_route_numbers = midgard::make_unique<StreetNames>();
+  std::unique_ptr<StreetNames> non_route_numbers = std::make_unique<StreetNames>();
   for (const auto& street_name : *this) {
     if (!street_name->is_route_number()) {
       non_route_numbers->emplace_back(
-          midgard::make_unique<StreetName>(street_name->value(), street_name->is_route_number()));
+          std::make_unique<StreetName>(street_name->value(), street_name->is_route_number()));
     }
   }
 

--- a/src/baldr/streetnames_factory.cc
+++ b/src/baldr/streetnames_factory.cc
@@ -14,10 +14,10 @@ std::unique_ptr<StreetNames>
 StreetNamesFactory::Create(const std::string& country_code,
                            const std::vector<std::pair<std::string, bool>>& names) {
   if (country_code == "US") {
-    return midgard::make_unique<StreetNamesUs>(names);
+    return std::make_unique<StreetNamesUs>(names);
   }
 
-  return midgard::make_unique<StreetNames>(names);
+  return std::make_unique<StreetNames>(names);
 }
 
 } // namespace baldr

--- a/src/baldr/streetnames_us.cc
+++ b/src/baldr/streetnames_us.cc
@@ -12,7 +12,7 @@ StreetNamesUs::StreetNamesUs() : StreetNames() {
 
 StreetNamesUs::StreetNamesUs(const std::vector<std::pair<std::string, bool>>& names) {
   for (auto& name : names) {
-    this->emplace_back(midgard::make_unique<StreetNameUs>(name.first, name.second));
+    this->emplace_back(std::make_unique<StreetNameUs>(name.first, name.second));
   }
 }
 
@@ -20,10 +20,10 @@ StreetNamesUs::~StreetNamesUs() {
 }
 
 std::unique_ptr<StreetNames> StreetNamesUs::clone() const {
-  std::unique_ptr<StreetNames> clone_street_names = midgard::make_unique<StreetNamesUs>();
+  std::unique_ptr<StreetNames> clone_street_names = std::make_unique<StreetNamesUs>();
   for (const auto& street_name : *this) {
     clone_street_names->emplace_back(
-        midgard::make_unique<StreetNameUs>(street_name->value(), street_name->is_route_number()));
+        std::make_unique<StreetNameUs>(street_name->value(), street_name->is_route_number()));
   }
 
   return clone_street_names;
@@ -31,12 +31,12 @@ std::unique_ptr<StreetNames> StreetNamesUs::clone() const {
 
 std::unique_ptr<StreetNames>
 StreetNamesUs::FindCommonStreetNames(const StreetNames& other_street_names) const {
-  std::unique_ptr<StreetNames> common_street_names = midgard::make_unique<StreetNamesUs>();
+  std::unique_ptr<StreetNames> common_street_names = std::make_unique<StreetNamesUs>();
   for (const auto& street_name : *this) {
     for (const auto& other_street_name : other_street_names) {
       if (*street_name == *other_street_name) {
         common_street_names->emplace_back(
-            midgard::make_unique<StreetNameUs>(street_name->value(), street_name->is_route_number()));
+            std::make_unique<StreetNameUs>(street_name->value(), street_name->is_route_number()));
         break;
       }
     }
@@ -47,7 +47,7 @@ StreetNamesUs::FindCommonStreetNames(const StreetNames& other_street_names) cons
 
 std::unique_ptr<StreetNames>
 StreetNamesUs::FindCommonBaseNames(const StreetNames& other_street_names) const {
-  std::unique_ptr<StreetNames> common_base_names = midgard::make_unique<StreetNamesUs>();
+  std::unique_ptr<StreetNames> common_base_names = std::make_unique<StreetNamesUs>();
   for (const auto& street_name : *this) {
     for (const auto& other_street_name : other_street_names) {
       if (street_name->HasSameBaseName(*other_street_name)) {
@@ -55,17 +55,15 @@ StreetNamesUs::FindCommonBaseNames(const StreetNames& other_street_names) const 
         // thus, 'US 30 West' will be used instead of 'US 30'
         if (!street_name->GetPostCardinalDir().empty()) {
           common_base_names->emplace_back(
-              midgard::make_unique<StreetNameUs>(street_name->value(),
-                                                 street_name->is_route_number()));
+              std::make_unique<StreetNameUs>(street_name->value(), street_name->is_route_number()));
         } else if (!other_street_name->GetPostCardinalDir().empty()) {
           common_base_names->emplace_back(
-              midgard::make_unique<StreetNameUs>(other_street_name->value(),
-                                                 street_name->is_route_number()));
+              std::make_unique<StreetNameUs>(other_street_name->value(),
+                                             street_name->is_route_number()));
           // Use street_name by default
         } else {
           common_base_names->emplace_back(
-              midgard::make_unique<StreetNameUs>(street_name->value(),
-                                                 street_name->is_route_number()));
+              std::make_unique<StreetNameUs>(street_name->value(), street_name->is_route_number()));
         }
         break;
       }
@@ -76,11 +74,11 @@ StreetNamesUs::FindCommonBaseNames(const StreetNames& other_street_names) const 
 }
 
 std::unique_ptr<StreetNames> StreetNamesUs::GetRouteNumbers() const {
-  std::unique_ptr<StreetNames> route_numbers = midgard::make_unique<StreetNamesUs>();
+  std::unique_ptr<StreetNames> route_numbers = std::make_unique<StreetNamesUs>();
   for (const auto& street_name : *this) {
     if (street_name->is_route_number()) {
       route_numbers->emplace_back(
-          midgard::make_unique<StreetNameUs>(street_name->value(), street_name->is_route_number()));
+          std::make_unique<StreetNameUs>(street_name->value(), street_name->is_route_number()));
     }
   }
 
@@ -88,11 +86,11 @@ std::unique_ptr<StreetNames> StreetNamesUs::GetRouteNumbers() const {
 }
 
 std::unique_ptr<StreetNames> StreetNamesUs::GetNonRouteNumbers() const {
-  std::unique_ptr<StreetNames> non_route_numbers = midgard::make_unique<StreetNamesUs>();
+  std::unique_ptr<StreetNames> non_route_numbers = std::make_unique<StreetNamesUs>();
   for (const auto& street_name : *this) {
     if (!street_name->is_route_number()) {
       non_route_numbers->emplace_back(
-          midgard::make_unique<StreetNameUs>(street_name->value(), street_name->is_route_number()));
+          std::make_unique<StreetNameUs>(street_name->value(), street_name->is_route_number()));
     }
   }
 

--- a/src/baldr/verbal_text_formatter_factory.cc
+++ b/src/baldr/verbal_text_formatter_factory.cc
@@ -12,14 +12,14 @@ std::unique_ptr<VerbalTextFormatter>
 VerbalTextFormatterFactory::Create(const std::string& country_code, const std::string& state_code) {
   if (country_code == "US") {
     if (state_code == "TX") {
-      return midgard::make_unique<VerbalTextFormatterUsTx>(country_code, state_code);
+      return std::make_unique<VerbalTextFormatterUsTx>(country_code, state_code);
     } else if (state_code == "CO") {
-      return midgard::make_unique<VerbalTextFormatterUsCo>(country_code, state_code);
+      return std::make_unique<VerbalTextFormatterUsCo>(country_code, state_code);
     }
-    return midgard::make_unique<VerbalTextFormatterUs>(country_code, state_code);
+    return std::make_unique<VerbalTextFormatterUs>(country_code, state_code);
   }
 
-  return midgard::make_unique<VerbalTextFormatter>(country_code, state_code);
+  return std::make_unique<VerbalTextFormatter>(country_code, state_code);
 }
 
 } // namespace baldr

--- a/src/odin/enhancedtrippath.cc
+++ b/src/odin/enhancedtrippath.cc
@@ -185,13 +185,13 @@ EnhancedTripLeg::EnhancedTripLeg(TripLeg& trip_path) : trip_path_(trip_path) {
 }
 
 std::unique_ptr<EnhancedTripLeg_Node> EnhancedTripLeg::GetEnhancedNode(const int node_index) {
-  return midgard::make_unique<EnhancedTripLeg_Node>(mutable_node(node_index));
+  return std::make_unique<EnhancedTripLeg_Node>(mutable_node(node_index));
 }
 
 std::unique_ptr<EnhancedTripLeg_Edge> EnhancedTripLeg::GetPrevEdge(const int node_index, int delta) {
   int index = node_index - delta;
   if (IsValidNodeIndex(index)) {
-    return midgard::make_unique<EnhancedTripLeg_Edge>(mutable_node(index)->mutable_edge());
+    return std::make_unique<EnhancedTripLeg_Edge>(mutable_node(index)->mutable_edge());
   } else {
     return nullptr;
   }
@@ -205,7 +205,7 @@ std::unique_ptr<EnhancedTripLeg_Edge> EnhancedTripLeg::GetNextEdge(const int nod
                                                                    int delta) const {
   int index = node_index + delta;
   if (IsValidNodeIndex(index) && !IsLastNodeIndex(index)) {
-    return midgard::make_unique<EnhancedTripLeg_Edge>(mutable_node(index)->mutable_edge());
+    return std::make_unique<EnhancedTripLeg_Edge>(mutable_node(index)->mutable_edge());
   } else {
     return nullptr;
   }
@@ -237,7 +237,7 @@ int EnhancedTripLeg::GetLastNodeIndex() const {
 }
 
 std::unique_ptr<EnhancedTripLeg_Admin> EnhancedTripLeg::GetAdmin(size_t index) {
-  return midgard::make_unique<EnhancedTripLeg_Admin>(mutable_admin(index));
+  return std::make_unique<EnhancedTripLeg_Admin>(mutable_admin(index));
 }
 
 std::string EnhancedTripLeg::GetCountryCode(int node_index) {
@@ -1275,7 +1275,7 @@ bool EnhancedTripLeg_Node::HasIntersectingEdgeCurrNameConsistency() const {
 
 std::unique_ptr<EnhancedTripLeg_IntersectingEdge>
 EnhancedTripLeg_Node::GetIntersectingEdge(size_t index) {
-  return midgard::make_unique<EnhancedTripLeg_IntersectingEdge>(mutable_intersecting_edge(index));
+  return std::make_unique<EnhancedTripLeg_IntersectingEdge>(mutable_intersecting_edge(index));
 }
 
 void EnhancedTripLeg_Node::CalculateRightLeftIntersectingEdgeCounts(

--- a/src/odin/maneuver.cc
+++ b/src/odin/maneuver.cc
@@ -114,10 +114,10 @@ Maneuver::Maneuver()
       tee_(false), unnamed_walkway_(false), unnamed_cycleway_(false),
       unnamed_mountain_bike_trail_(false), verbal_multi_cue_(false), to_stay_on_(false),
       drive_on_right_(true) {
-  street_names_ = midgard::make_unique<StreetNames>();
-  begin_street_names_ = midgard::make_unique<StreetNames>();
-  cross_street_names_ = midgard::make_unique<StreetNames>();
-  roundabout_exit_street_names_ = midgard::make_unique<StreetNames>();
+  street_names_ = std::make_unique<StreetNames>();
+  begin_street_names_ = std::make_unique<StreetNames>();
+  cross_street_names_ = std::make_unique<StreetNames>();
+  roundabout_exit_street_names_ = std::make_unique<StreetNames>();
 }
 
 const DirectionsLeg_Maneuver_Type& Maneuver::type() const {
@@ -145,7 +145,7 @@ const StreetNames& Maneuver::street_names() const {
 }
 
 void Maneuver::set_street_names(const std::vector<std::pair<std::string, bool>>& names) {
-  street_names_ = midgard::make_unique<StreetNamesUs>(names);
+  street_names_ = std::make_unique<StreetNamesUs>(names);
 }
 
 void Maneuver::set_street_names(std::unique_ptr<StreetNames>&& street_names) {
@@ -205,7 +205,7 @@ const StreetNames& Maneuver::begin_street_names() const {
 }
 
 void Maneuver::set_begin_street_names(const std::vector<std::pair<std::string, bool>>& names) {
-  begin_street_names_ = midgard::make_unique<StreetNamesUs>(names);
+  begin_street_names_ = std::make_unique<StreetNamesUs>(names);
 }
 
 void Maneuver::set_begin_street_names(std::unique_ptr<StreetNames>&& begin_street_names) {
@@ -225,7 +225,7 @@ const StreetNames& Maneuver::cross_street_names() const {
 }
 
 void Maneuver::set_cross_street_names(const std::vector<std::pair<std::string, bool>>& names) {
-  cross_street_names_ = midgard::make_unique<StreetNamesUs>(names);
+  cross_street_names_ = std::make_unique<StreetNamesUs>(names);
 }
 
 void Maneuver::set_cross_street_names(std::unique_ptr<StreetNames>&& cross_street_names) {
@@ -617,7 +617,7 @@ const StreetNames& Maneuver::roundabout_exit_street_names() const {
 
 void Maneuver::set_roundabout_exit_street_names(
     const std::vector<std::pair<std::string, bool>>& names) {
-  roundabout_exit_street_names_ = midgard::make_unique<StreetNamesUs>(names);
+  roundabout_exit_street_names_ = std::make_unique<StreetNamesUs>(names);
 }
 
 void Maneuver::set_roundabout_exit_street_names(

--- a/src/odin/narrative_builder_factory.cc
+++ b/src/odin/narrative_builder_factory.cc
@@ -24,21 +24,17 @@ std::unique_ptr<NarrativeBuilder> NarrativeBuilderFactory::Create(const Options&
   // if a NarrativeBuilder is derived with specific code for a particular
   // language then add logic here and return derived NarrativeBuilder
   if (phrase_dictionary->second->GetLanguageTag() == "cs-CZ") {
-    return midgard::make_unique<NarrativeBuilder_csCZ>(options, trip_path,
-                                                       *phrase_dictionary->second);
+    return std::make_unique<NarrativeBuilder_csCZ>(options, trip_path, *phrase_dictionary->second);
   } else if (phrase_dictionary->second->GetLanguageTag() == "hi-IN") {
-    return midgard::make_unique<NarrativeBuilder_hiIN>(options, trip_path,
-                                                       *phrase_dictionary->second);
+    return std::make_unique<NarrativeBuilder_hiIN>(options, trip_path, *phrase_dictionary->second);
   } else if (phrase_dictionary->second->GetLanguageTag() == "it-IT") {
-    return midgard::make_unique<NarrativeBuilder_itIT>(options, trip_path,
-                                                       *phrase_dictionary->second);
+    return std::make_unique<NarrativeBuilder_itIT>(options, trip_path, *phrase_dictionary->second);
   } else if (phrase_dictionary->second->GetLanguageTag() == "ru-RU") {
-    return midgard::make_unique<NarrativeBuilder_ruRU>(options, trip_path,
-                                                       *phrase_dictionary->second);
+    return std::make_unique<NarrativeBuilder_ruRU>(options, trip_path, *phrase_dictionary->second);
   }
 
   // otherwise just return pointer to NarrativeBuilder
-  return midgard::make_unique<NarrativeBuilder>(options, trip_path, *phrase_dictionary->second);
+  return std::make_unique<NarrativeBuilder>(options, trip_path, *phrase_dictionary->second);
 }
 
 } // namespace odin

--- a/test/enhancedtrippath.cc
+++ b/test/enhancedtrippath.cc
@@ -64,7 +64,7 @@ void TestCalculateRightLeftIntersectingEdgeCounts_Straight_Straight() {
   TripLeg_IntersectingEdge* n1_ie1 = node1.add_intersecting_edge();
   n1_ie1->set_begin_heading(355);
   n1_ie1->set_driveability(TripLeg_Traversability_kBoth);
-  TryCalculateRightLeftIntersectingEdgeCounts(0, midgard::make_unique<EnhancedTripLeg_Node>(&node1),
+  TryCalculateRightLeftIntersectingEdgeCounts(0, std::make_unique<EnhancedTripLeg_Node>(&node1),
                                               IntersectingEdgeCounts(0, 0, 0, 0, 1, 1, 1, 1));
 
   // Path straight, intersecting straight
@@ -73,7 +73,7 @@ void TestCalculateRightLeftIntersectingEdgeCounts_Straight_Straight() {
   TripLeg_IntersectingEdge* n2_ie1 = node2.add_intersecting_edge();
   n2_ie1->set_begin_heading(5);
   n2_ie1->set_driveability(TripLeg_Traversability_kForward);
-  TryCalculateRightLeftIntersectingEdgeCounts(0, midgard::make_unique<EnhancedTripLeg_Node>(&node2),
+  TryCalculateRightLeftIntersectingEdgeCounts(0, std::make_unique<EnhancedTripLeg_Node>(&node2),
                                               IntersectingEdgeCounts(1, 1, 1, 1, 0, 0, 0, 0));
 }
 
@@ -84,7 +84,7 @@ void TestCalculateRightLeftIntersectingEdgeCounts_SlightRight_Straight() {
   TripLeg_IntersectingEdge* n1_ie1 = node1.add_intersecting_edge();
   n1_ie1->set_begin_heading(0);
   n1_ie1->set_driveability(TripLeg_Traversability_kBackward);
-  TryCalculateRightLeftIntersectingEdgeCounts(0, midgard::make_unique<EnhancedTripLeg_Node>(&node1),
+  TryCalculateRightLeftIntersectingEdgeCounts(0, std::make_unique<EnhancedTripLeg_Node>(&node1),
                                               IntersectingEdgeCounts(0, 0, 0, 0, 1, 1, 0, 0));
 
   // Path slight right, intersecting straight
@@ -93,7 +93,7 @@ void TestCalculateRightLeftIntersectingEdgeCounts_SlightRight_Straight() {
   TripLeg_IntersectingEdge* n2_ie1 = node2.add_intersecting_edge();
   n2_ie1->set_begin_heading(85);
   n2_ie1->set_driveability(TripLeg_Traversability_kNone);
-  TryCalculateRightLeftIntersectingEdgeCounts(90, midgard::make_unique<EnhancedTripLeg_Node>(&node2),
+  TryCalculateRightLeftIntersectingEdgeCounts(90, std::make_unique<EnhancedTripLeg_Node>(&node2),
                                               IntersectingEdgeCounts(0, 0, 0, 0, 1, 1, 0, 0));
 }
 
@@ -102,14 +102,14 @@ void TestCalculateRightLeftIntersectingEdgeCounts_SlightLeft_Straight() {
   TripLeg_Node node1;
   node1.mutable_edge()->set_begin_heading(345);
   node1.add_intersecting_edge()->set_begin_heading(355);
-  TryCalculateRightLeftIntersectingEdgeCounts(0, midgard::make_unique<EnhancedTripLeg_Node>(&node1),
+  TryCalculateRightLeftIntersectingEdgeCounts(0, std::make_unique<EnhancedTripLeg_Node>(&node1),
                                               IntersectingEdgeCounts(1, 1, 0, 0, 0, 0, 0, 0));
 
   // Path slight left, intersecting straight
   TripLeg_Node node2;
   node2.mutable_edge()->set_begin_heading(255);
   node2.add_intersecting_edge()->set_begin_heading(275);
-  TryCalculateRightLeftIntersectingEdgeCounts(270, midgard::make_unique<EnhancedTripLeg_Node>(&node2),
+  TryCalculateRightLeftIntersectingEdgeCounts(270, std::make_unique<EnhancedTripLeg_Node>(&node2),
                                               IntersectingEdgeCounts(1, 1, 0, 0, 0, 0, 0, 0));
 }
 
@@ -123,7 +123,7 @@ void TestCalculateRightLeftIntersectingEdgeCounts_SlightLeft_Right_Left() {
   node1.add_intersecting_edge()->set_begin_heading(315);
   node1.add_intersecting_edge()->set_begin_heading(270);
   node1.add_intersecting_edge()->set_begin_heading(225);
-  TryCalculateRightLeftIntersectingEdgeCounts(0, midgard::make_unique<EnhancedTripLeg_Node>(&node1),
+  TryCalculateRightLeftIntersectingEdgeCounts(0, std::make_unique<EnhancedTripLeg_Node>(&node1),
                                               IntersectingEdgeCounts(3, 0, 0, 0, 3, 1, 0, 0));
 
   // Path slight left, intersecting right and left
@@ -135,7 +135,7 @@ void TestCalculateRightLeftIntersectingEdgeCounts_SlightLeft_Right_Left() {
   TripLeg_IntersectingEdge* n2_ie2 = node2.add_intersecting_edge();
   n2_ie2->set_begin_heading(337);
   n2_ie2->set_driveability(TripLeg_Traversability_kForward);
-  TryCalculateRightLeftIntersectingEdgeCounts(80, midgard::make_unique<EnhancedTripLeg_Node>(&node2),
+  TryCalculateRightLeftIntersectingEdgeCounts(80, std::make_unique<EnhancedTripLeg_Node>(&node2),
                                               IntersectingEdgeCounts(1, 0, 1, 0, 1, 0, 1, 0));
 }
 
@@ -148,7 +148,7 @@ void TestCalculateRightLeftIntersectingEdgeCounts_SharpRight_Right_Left() {
   node1.add_intersecting_edge()->set_begin_heading(180);
   node1.add_intersecting_edge()->set_begin_heading(90);
   node1.add_intersecting_edge()->set_begin_heading(10);
-  TryCalculateRightLeftIntersectingEdgeCounts(180, midgard::make_unique<EnhancedTripLeg_Node>(&node1),
+  TryCalculateRightLeftIntersectingEdgeCounts(180, std::make_unique<EnhancedTripLeg_Node>(&node1),
                                               IntersectingEdgeCounts(1, 1, 0, 0, 4, 0, 0, 0));
 }
 
@@ -162,7 +162,7 @@ void TestCalculateRightLeftIntersectingEdgeCounts_SharpLeft_Right_Left() {
   node1.add_intersecting_edge()->set_begin_heading(352);
   node1.add_intersecting_edge()->set_begin_heading(355);
   node1.add_intersecting_edge()->set_begin_heading(5);
-  TryCalculateRightLeftIntersectingEdgeCounts(180, midgard::make_unique<EnhancedTripLeg_Node>(&node1),
+  TryCalculateRightLeftIntersectingEdgeCounts(180, std::make_unique<EnhancedTripLeg_Node>(&node1),
                                               IntersectingEdgeCounts(5, 0, 0, 0, 1, 1, 0, 0));
 }
 
@@ -179,7 +179,7 @@ void TestHasActiveTurnLane_False() {
   edge.add_turn_lanes()->set_directions_mask(kTurnLaneLeft);
   edge.add_turn_lanes()->set_directions_mask(kTurnLaneThrough);
   edge.add_turn_lanes()->set_directions_mask(kTurnLaneRight);
-  TryHasActiveTurnLane(midgard::make_unique<EnhancedTripLeg_Edge>(&edge), false);
+  TryHasActiveTurnLane(std::make_unique<EnhancedTripLeg_Edge>(&edge), false);
 }
 
 void TestHasActiveTurnLane_True() {
@@ -190,17 +190,17 @@ void TestHasActiveTurnLane_True() {
 
   // Left active
   edge.mutable_turn_lanes(0)->set_is_active(true);
-  TryHasActiveTurnLane(midgard::make_unique<EnhancedTripLeg_Edge>(&edge), true);
+  TryHasActiveTurnLane(std::make_unique<EnhancedTripLeg_Edge>(&edge), true);
 
   // Straight active
   edge.mutable_turn_lanes(0)->set_is_active(false);
   edge.mutable_turn_lanes(1)->set_is_active(true);
-  TryHasActiveTurnLane(midgard::make_unique<EnhancedTripLeg_Edge>(&edge), true);
+  TryHasActiveTurnLane(std::make_unique<EnhancedTripLeg_Edge>(&edge), true);
 
   // Right active
   edge.mutable_turn_lanes(1)->set_is_active(false);
   edge.mutable_turn_lanes(2)->set_is_active(true);
-  TryHasActiveTurnLane(midgard::make_unique<EnhancedTripLeg_Edge>(&edge), true);
+  TryHasActiveTurnLane(std::make_unique<EnhancedTripLeg_Edge>(&edge), true);
 }
 
 void TryHasNonDirectionalTurnLane(std::unique_ptr<EnhancedTripLeg_Edge> edge, bool expected) {
@@ -216,19 +216,19 @@ void TestHasNonDirectionalTurnLane_False() {
   edge.add_turn_lanes()->set_directions_mask(kTurnLaneLeft);
   edge.add_turn_lanes()->set_directions_mask(kTurnLaneThrough);
   edge.add_turn_lanes()->set_directions_mask(kTurnLaneRight);
-  TryHasNonDirectionalTurnLane(midgard::make_unique<EnhancedTripLeg_Edge>(&edge), false);
+  TryHasNonDirectionalTurnLane(std::make_unique<EnhancedTripLeg_Edge>(&edge), false);
 }
 
 void TestHasNonDirectionalTurnLane_True() {
   TripLeg_Edge edge_1;
   edge_1.add_turn_lanes()->set_directions_mask(kTurnLaneLeft);
   edge_1.add_turn_lanes()->set_directions_mask(kTurnLaneNone);
-  TryHasNonDirectionalTurnLane(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_1), true);
+  TryHasNonDirectionalTurnLane(std::make_unique<EnhancedTripLeg_Edge>(&edge_1), true);
 
   TripLeg_Edge edge_2;
   edge_2.add_turn_lanes()->set_directions_mask(kTurnLaneEmpty);
   edge_2.add_turn_lanes()->set_directions_mask(kTurnLaneRight);
-  TryHasNonDirectionalTurnLane(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_2), true);
+  TryHasNonDirectionalTurnLane(std::make_unique<EnhancedTripLeg_Edge>(&edge_2), true);
 }
 
 void ClearActiveTurnLanes(::google::protobuf::RepeatedPtrField<::valhalla::TurnLane>* turn_lanes) {
@@ -276,49 +276,49 @@ void TestActivateTurnLanes() {
       DirectionsLeg_Maneuver_Type::DirectionsLeg_Maneuver_Type_kRight;
 
   // Reverse active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneReverse,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneReverse,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kUturnLeft,
                        next_maneuver_type, 1);
   ClearActiveTurnLanes(edge_1.mutable_turn_lanes());
 
   // Sharp left active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneSharpLeft,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneSharpLeft,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kSharpLeft,
                        next_maneuver_type, 1);
   ClearActiveTurnLanes(edge_1.mutable_turn_lanes());
 
   // Left active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneLeft,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneLeft,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kLeft, next_maneuver_type,
                        3);
   ClearActiveTurnLanes(edge_1.mutable_turn_lanes());
 
   // Slight left non-active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneSlightLeft,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneSlightLeft,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kSlightLeft,
                        next_maneuver_type, 0);
   ClearActiveTurnLanes(edge_1.mutable_turn_lanes());
 
   // Through active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneThrough,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneThrough,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kContinue,
                        next_maneuver_type, 4);
   ClearActiveTurnLanes(edge_1.mutable_turn_lanes());
 
   // Slight right non-active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneSlightRight,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneSlightRight,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kSlightRight,
                        next_maneuver_type, 0);
   ClearActiveTurnLanes(edge_1.mutable_turn_lanes());
 
   // Right active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneRight,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneRight,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kRight,
                        next_maneuver_type, 2);
   ClearActiveTurnLanes(edge_1.mutable_turn_lanes());
 
   // Sharp right active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneSharpRight,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneSharpRight,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kSharpRight,
                        next_maneuver_type, 1);
   ClearActiveTurnLanes(edge_1.mutable_turn_lanes());
@@ -335,19 +335,19 @@ void TestActivateTurnLanes() {
   edge_2.add_turn_lanes()->set_directions_mask(kTurnLaneMergeToRight);
 
   // Slight left active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_2), kTurnLaneSlightLeft,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_2), kTurnLaneSlightLeft,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kSlightLeft,
                        next_maneuver_type, 2);
   ClearActiveTurnLanes(edge_2.mutable_turn_lanes());
 
   // Through active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_2), kTurnLaneThrough,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_2), kTurnLaneThrough,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kContinue,
                        next_maneuver_type, 3);
   ClearActiveTurnLanes(edge_2.mutable_turn_lanes());
 
   // Merge-to-right active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_2), kTurnLaneMergeToRight,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_2), kTurnLaneMergeToRight,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kMergeRight,
                        next_maneuver_type, 1);
   ClearActiveTurnLanes(edge_2.mutable_turn_lanes());
@@ -364,19 +364,19 @@ void TestActivateTurnLanes() {
   edge_3.add_turn_lanes()->set_directions_mask(kTurnLaneSlightRight);
 
   // Merge-to-left active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_3), kTurnLaneMergeToLeft,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_3), kTurnLaneMergeToLeft,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kMergeLeft,
                        next_maneuver_type, 1);
   ClearActiveTurnLanes(edge_3.mutable_turn_lanes());
 
   // Through active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_3), kTurnLaneThrough,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_3), kTurnLaneThrough,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kContinue,
                        next_maneuver_type, 3);
   ClearActiveTurnLanes(edge_3.mutable_turn_lanes());
 
   // Slight right active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_3), kTurnLaneSlightRight,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_3), kTurnLaneSlightRight,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kSlightRight,
                        next_maneuver_type, 2);
   ClearActiveTurnLanes(edge_3.mutable_turn_lanes());
@@ -394,25 +394,25 @@ void TestActivateTurnLanes() {
   edge_4.add_turn_lanes()->set_directions_mask(kTurnLaneRight);
 
   // Both left turns active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_4), kTurnLaneLeft,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_4), kTurnLaneLeft,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kLeft, next_maneuver_type,
                        2);
   ClearActiveTurnLanes(edge_4.mutable_turn_lanes());
 
   // Left most turn active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_4), kTurnLaneLeft,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_4), kTurnLaneLeft,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kUturnLeft,
                        next_maneuver_type, 1);
   ClearActiveTurnLanes(edge_4.mutable_turn_lanes());
 
   // Both right turns active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_4), kTurnLaneRight,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_4), kTurnLaneRight,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kRight,
                        next_maneuver_type, 2);
   ClearActiveTurnLanes(edge_4.mutable_turn_lanes());
 
   // Right most turn active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_4), kTurnLaneRight,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_4), kTurnLaneRight,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kUturnRight,
                        next_maneuver_type, 1);
   ClearActiveTurnLanes(edge_4.mutable_turn_lanes());
@@ -439,49 +439,49 @@ void TestActivateTurnLanesShortNextRight() {
       DirectionsLeg_Maneuver_Type::DirectionsLeg_Maneuver_Type_kRight;
 
   // Reverse active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneReverse,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneReverse,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kUturnLeft,
                        next_maneuver_type, 1);
   ClearActiveTurnLanes(edge_1.mutable_turn_lanes());
 
   // Sharp left active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneSharpLeft,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneSharpLeft,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kSharpLeft,
                        next_maneuver_type, 1);
   ClearActiveTurnLanes(edge_1.mutable_turn_lanes());
 
   // Left active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneLeft,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneLeft,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kLeft, next_maneuver_type,
                        1);
   ClearActiveTurnLanes(edge_1.mutable_turn_lanes());
 
   // Slight left non-active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneSlightLeft,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneSlightLeft,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kSlightLeft,
                        next_maneuver_type, 0);
   ClearActiveTurnLanes(edge_1.mutable_turn_lanes());
 
   // Through active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneThrough,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneThrough,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kContinue,
                        next_maneuver_type, 1);
   ClearActiveTurnLanes(edge_1.mutable_turn_lanes());
 
   // Slight right non-active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneSlightRight,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneSlightRight,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kSlightRight,
                        next_maneuver_type, 0);
   ClearActiveTurnLanes(edge_1.mutable_turn_lanes());
 
   // Right active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneRight,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneRight,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kRight,
                        next_maneuver_type, 1);
   ClearActiveTurnLanes(edge_1.mutable_turn_lanes());
 
   // Sharp right active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneSharpRight,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneSharpRight,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kSharpRight,
                        next_maneuver_type, 1);
   ClearActiveTurnLanes(edge_1.mutable_turn_lanes());
@@ -498,19 +498,19 @@ void TestActivateTurnLanesShortNextRight() {
   edge_2.add_turn_lanes()->set_directions_mask(kTurnLaneMergeToRight);
 
   // Slight left active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_2), kTurnLaneSlightLeft,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_2), kTurnLaneSlightLeft,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kSlightLeft,
                        next_maneuver_type, 1);
   ClearActiveTurnLanes(edge_2.mutable_turn_lanes());
 
   // Through active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_2), kTurnLaneThrough,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_2), kTurnLaneThrough,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kContinue,
                        next_maneuver_type, 1);
   ClearActiveTurnLanes(edge_2.mutable_turn_lanes());
 
   // Merge-to-right active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_2), kTurnLaneMergeToRight,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_2), kTurnLaneMergeToRight,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kMergeRight,
                        next_maneuver_type, 1);
   ClearActiveTurnLanes(edge_2.mutable_turn_lanes());
@@ -527,19 +527,19 @@ void TestActivateTurnLanesShortNextRight() {
   edge_3.add_turn_lanes()->set_directions_mask(kTurnLaneSlightRight);
 
   // Merge-to-left active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_3), kTurnLaneMergeToLeft,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_3), kTurnLaneMergeToLeft,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kMergeLeft,
                        next_maneuver_type, 1);
   ClearActiveTurnLanes(edge_3.mutable_turn_lanes());
 
   // Through active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_3), kTurnLaneThrough,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_3), kTurnLaneThrough,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kContinue,
                        next_maneuver_type, 1);
   ClearActiveTurnLanes(edge_3.mutable_turn_lanes());
 
   // Slight right active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_3), kTurnLaneSlightRight,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_3), kTurnLaneSlightRight,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kSlightRight,
                        next_maneuver_type, 1);
   ClearActiveTurnLanes(edge_3.mutable_turn_lanes());
@@ -566,49 +566,49 @@ void TestActivateTurnLanesShortNextLeft() {
       DirectionsLeg_Maneuver_Type::DirectionsLeg_Maneuver_Type_kLeft;
 
   // Reverse active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneReverse,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneReverse,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kUturnLeft,
                        next_maneuver_type, 1);
   ClearActiveTurnLanes(edge_1.mutable_turn_lanes());
 
   // Sharp left active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneSharpLeft,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneSharpLeft,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kSharpLeft,
                        next_maneuver_type, 1);
   ClearActiveTurnLanes(edge_1.mutable_turn_lanes());
 
   // Left active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneLeft,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneLeft,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kLeft, next_maneuver_type,
                        1);
   ClearActiveTurnLanes(edge_1.mutable_turn_lanes());
 
   // Slight left non-active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneSlightLeft,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneSlightLeft,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kSlightLeft,
                        next_maneuver_type, 0);
   ClearActiveTurnLanes(edge_1.mutable_turn_lanes());
 
   // Through active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneThrough,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneThrough,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kContinue,
                        next_maneuver_type, 1);
   ClearActiveTurnLanes(edge_1.mutable_turn_lanes());
 
   // Slight right non-active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneSlightRight,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneSlightRight,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kSlightRight,
                        next_maneuver_type, 0);
   ClearActiveTurnLanes(edge_1.mutable_turn_lanes());
 
   // Right active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneRight,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneRight,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kRight,
                        next_maneuver_type, 1);
   ClearActiveTurnLanes(edge_1.mutable_turn_lanes());
 
   // Sharp right active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneSharpRight,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_1), kTurnLaneSharpRight,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kSharpRight,
                        next_maneuver_type, 1);
   ClearActiveTurnLanes(edge_1.mutable_turn_lanes());
@@ -625,19 +625,19 @@ void TestActivateTurnLanesShortNextLeft() {
   edge_2.add_turn_lanes()->set_directions_mask(kTurnLaneMergeToRight);
 
   // Slight left active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_2), kTurnLaneSlightLeft,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_2), kTurnLaneSlightLeft,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kSlightLeft,
                        next_maneuver_type, 1);
   ClearActiveTurnLanes(edge_2.mutable_turn_lanes());
 
   // Through active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_2), kTurnLaneThrough,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_2), kTurnLaneThrough,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kContinue,
                        next_maneuver_type, 1);
   ClearActiveTurnLanes(edge_2.mutable_turn_lanes());
 
   // Merge-to-right active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_2), kTurnLaneMergeToRight,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_2), kTurnLaneMergeToRight,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kMergeRight,
                        next_maneuver_type, 1);
   ClearActiveTurnLanes(edge_2.mutable_turn_lanes());
@@ -654,19 +654,19 @@ void TestActivateTurnLanesShortNextLeft() {
   edge_3.add_turn_lanes()->set_directions_mask(kTurnLaneSlightRight);
 
   // Merge-to-left active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_3), kTurnLaneMergeToLeft,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_3), kTurnLaneMergeToLeft,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kMergeLeft,
                        next_maneuver_type, 1);
   ClearActiveTurnLanes(edge_3.mutable_turn_lanes());
 
   // Through active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_3), kTurnLaneThrough,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_3), kTurnLaneThrough,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kContinue,
                        next_maneuver_type, 1);
   ClearActiveTurnLanes(edge_3.mutable_turn_lanes());
 
   // Slight right active
-  TryActivateTurnLanes(midgard::make_unique<EnhancedTripLeg_Edge>(&edge_3), kTurnLaneSlightRight,
+  TryActivateTurnLanes(std::make_unique<EnhancedTripLeg_Edge>(&edge_3), kTurnLaneSlightRight,
                        remaining_step_distance, DirectionsLeg_Maneuver_Type_kSlightRight,
                        next_maneuver_type, 1);
   ClearActiveTurnLanes(edge_3.mutable_turn_lanes());

--- a/valhalla/baldr/json.h
+++ b/valhalla/baldr/json.h
@@ -146,6 +146,15 @@ inline std::ostream& operator<<(std::ostream& stream, const fp_t& fp) {
   return stream;
 }
 
+template <typename Visitable>
+inline void applyOutputVisitor(std::ostream& stream, Visitable& visitable) {
+  // Cannot use boost::apply_visitor with C++14 due to
+  // ambiguity introduced in boost_1_58 and fixed in the latest
+  // https://lists.boost.org/boost-bugs/2015/05/41067.php
+  OstreamVisitor visitor(stream);
+  visitable.apply_visitor(visitor);
+}
+
 inline std::ostream& operator<<(std::ostream& stream, const Jmap& json) {
   stream << '{';
   bool seprator = false;
@@ -155,7 +164,7 @@ inline std::ostream& operator<<(std::ostream& stream, const Jmap& json) {
     }
     seprator = true;
     stream << '"' << key_value.first << "\":";
-    boost::apply_visitor(OstreamVisitor(stream), key_value.second);
+    applyOutputVisitor(stream, key_value.second);
   }
   stream << '}';
   return stream;
@@ -169,7 +178,7 @@ inline std::ostream& operator<<(std::ostream& stream, const Jarray& json) {
       stream << ',';
     }
     seprator = true;
-    boost::apply_visitor(OstreamVisitor(stream), element);
+    applyOutputVisitor(stream, element);
   }
   stream << ']';
   return stream;

--- a/valhalla/midgard/util.h
+++ b/valhalla/midgard/util.h
@@ -330,13 +330,6 @@ struct memory_status {
 };
 std::ostream& operator<<(std::ostream& stream, const memory_status& s);
 
-/**
- * Implement the missing make_unique for C++11.
- */
-template <typename T, typename... Args> std::unique_ptr<T> make_unique(Args&&... args) {
-  return std::unique_ptr<T>{new T{std::forward<Args>(args)...}};
-}
-
 /* circular range clamp
  */
 template <class T> T circular_range_clamp(T value, T lower, T upper) {


### PR DESCRIPTION
# Issue

The idea is to bump the required c++ standard to 14 (as it's essentially a fix for 11). It will not give a significant feature improvements (though auto in lambda params, std::shared_mutex are nice to have), but may reduce the difference when it's decided to jump to c++17 in the future.

## Tasklist

 - [ ] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)

