### PR TITLE
Fix search_cutoff check in loki correlate_node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 * **Bug Fix**
    * FIXED: Changed reachability computation to consider both directions of travel wrt candidate edges [#1965](https://github.com/valhalla/valhalla/pull/1965)
    * FIXED: toss ways where access=private and highway=service and service != driveway. [#1960](https://github.com/valhalla/valhalla/pull/1960)
-   
+   * FIXED: Fix search_cutoff check in loki correlate_node. [#2023](https://github.com/valhalla/valhalla/pull/2023)
+
 * **Enhancement**
    * ADDED: Establish pinpoint test pattern [#1969](https://github.com/valhalla/valhalla/pull/1969)
    * ADDED: Suppress relative direction in ramp/exit instructions if it matches driving side of street [#1990](https://github.com/valhalla/valhalla/pull/1990)

--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -243,6 +243,9 @@ struct bin_handler_t {
                       const candidate_t& candidate,
                       PathLocation& correlated,
                       std::vector<PathLocation::PathEdge>& filtered) {
+    // the search cutoff is a hard filter so skip any outside of that
+    if (candidate.point.Distance(location.latlng_) > location.search_cutoff_)
+      return;
     // we need this because we might need to go to different levels
     float distance = std::numeric_limits<float>::lowest();
     std::function<void(const GraphId& node_id, bool transition)> crawl;
@@ -259,9 +262,6 @@ struct bin_handler_t {
       // cache the distance
       if (distance == std::numeric_limits<float>::lowest())
         distance = node_ll.Distance(location.latlng_);
-      // the search cutoff is a hard filter so skip any outside of that
-      if (distance > location.search_cutoff_)
-        return;
       // add edges entering/leaving this node
       for (const auto* edge = start_edge; edge < end_edge; ++edge) {
         // get some info about this edge and the opposing

--- a/test/search.cc
+++ b/test/search.cc
@@ -230,6 +230,18 @@ void test_edge_search() {
              PE{{t, l, 0}, 1, d.second, 0, S::NONE}, PE{{t, l, 3}, 1, d.second, 0, S::NONE},
              PE{{t, l, 6}, 1, d.second, 0, S::NONE} // arriving edges
          });
+
+  // regression test for #2023, displace the point beyond search_cutoff but within node_snap_tolerance
+  Location near_node{a.second};
+  near_node.latlng_.second += 0.00001; // 1.11 meters
+  near_node.search_cutoff_ = 1.0;
+  near_node.node_snap_tolerance_ = 2.0;
+  search(near_node, true, a.second,
+         {PE{{t, l, 2}, 0, a.second, 0, S::NONE}, PE{{t, l, 3}, 0, a.second, 0, S::NONE},
+          PE{{t, l, 4}, 0, a.second, 0, S::NONE}, PE{{t, l, 1}, 1, a.second, 0, S::NONE},
+          PE{{t, l, 8}, 1, a.second, 0, S::NONE}, PE{{t, l, 5}, 1, a.second, 0, S::NONE}},
+         true);
+
   // snap to node as through location should be all edges
   Location x{a.second, Location::StopType::THROUGH};
   search(x, true, a.second,


### PR DESCRIPTION
# Issue

Previously, the correlate_node check in loki was incorrectly filtering out candidate edges that were outside the node_snap_tolerance but within the search_cutoff. We were measuring the wrong distance for cutoff, from the correlated node to the input location rather than from the edge to the input location. This would result in no edges being found even if the location was directly on an edge.

@kevinkreiser any thoughts on how I might implement a regression test for this case?

## Tasklist

 - [ ] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
