### PR TITLE
Nit: Removes a disparity between forward and reverse astar-search

### DIFF
--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -455,7 +455,7 @@ inline bool BidirectionalAStar::ExpandReverseInner(GraphReader& graphreader,
   // Check if edge is temporarily labeled and this path has less cost. If
   // less cost the predecessor is updated and the sort cost is decremented
   // by the difference in real cost (A* heuristic doesn't change)
-  if (meta.edge_status->set() != EdgeSet::kUnreached) {
+  if (meta.edge_status->set() == EdgeSet::kTemporary) {
     BDEdgeLabel& lab = edgelabels_reverse_[meta.edge_status->index()];
     if (newcost.cost < lab.cost().cost) {
       float newsortcost = lab.sortcost() - (lab.cost().cost - newcost.cost);


### PR DESCRIPTION
Difference was introduced mistakenly but with no impact on logic
since any `kPermanent` values are already filtered out earlier in the
code.

See https://github.com/valhalla/valhalla/commit/54b6fa980d75cb4dff49f0e000cbb53720a94f48#r35813426

## Tasklist

 - [ ] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
