### PR TITLE
Default to no color logging if stdout isn't a TTY

### DIFF
--- a/valhalla/midgard/isatty.h
+++ b/valhalla/midgard/isatty.h
@@ -16,15 +16,15 @@
 
 #include <cstdio>
 
-namespace valhalla
-{
-namespace midgard
-{
+namespace valhalla {
+namespace midgard {
 
 // Returns true if stdout is a tty, false otherwise
 //   Useful for when you want to do something different when
 //   output is redirected to a logfile
-inline bool IsStdoutATTY() { return isatty(fileno(stdout)); }
+inline bool IsStdoutATTY() {
+  return isatty(fileno(stdout));
+}
 
 } // namespace midgard
 } // namespace valhalla

--- a/valhalla/midgard/isatty.h
+++ b/valhalla/midgard/isatty.h
@@ -1,0 +1,32 @@
+#ifndef ISATTY_HPP
+#define ISATTY_HPP
+
+// For isatty()
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#include <unistd.h>
+#else
+#ifdef WIN32
+#include <io.h>
+#define isatty _isatty
+#define fileno _fileno
+#else
+#error Unknown platform - isatty implementation required
+#endif // win32
+#endif // unix
+
+#include <cstdio>
+
+namespace valhalla
+{
+namespace midgard
+{
+
+// Returns true if stdout is a tty, false otherwise
+//   Useful for when you want to do something different when
+//   output is redirected to a logfile
+inline bool IsStdoutATTY() { return isatty(fileno(stdout)); }
+
+} // namespace midgard
+} // namespace valhalla
+
+#endif

--- a/valhalla/midgard/logging.h
+++ b/valhalla/midgard/logging.h
@@ -9,6 +9,8 @@
 #include <string>
 #include <unordered_map>
 
+#include <valhalla/midgard/isatty.h>
+
 namespace valhalla {
 namespace midgard {
 
@@ -44,7 +46,7 @@ protected:
 };
 
 // statically get a logger using the factory
-Logger& GetLogger(const LoggingConfig& config = {{"type", "std_out"}, {"color", "true"}});
+Logger& GetLogger(const LoggingConfig& config = {{"type", "std_out"}, {"color", IsStdoutATTY() ? "true" : "false" }});
 
 // statically log manually without the macros below
 void Log(const std::string&, const LogLevel);

--- a/valhalla/midgard/logging.h
+++ b/valhalla/midgard/logging.h
@@ -46,7 +46,8 @@ protected:
 };
 
 // statically get a logger using the factory
-Logger& GetLogger(const LoggingConfig& config = {{"type", "std_out"}, {"color", IsStdoutATTY() ? "true" : "false" }});
+Logger& GetLogger(const LoggingConfig& config = {{"type", "std_out"},
+                                                 {"color", IsStdoutATTY() ? "true" : "false"}});
 
 // statically log manually without the macros below
 void Log(const std::string&, const LogLevel);


### PR DESCRIPTION
# Issue

By default, Valhalla's logger defaults to emitting color codes on `stdout`.  This PR adds detection to the initialization of the logger - if `stdout` is a TTY, color is used, if it's not, ANSI color codes are not emitted.

You can still explicitly override this by providing a configuration (although no code anywhere I could find seems to actually do this).

## Tasklist

 - [ ] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
