### PR TITLE
Serialize predicted speeds array in verbose mode

### DIFF
--- a/src/tyr/locate_serializer.cc
+++ b/src/tyr/locate_serializer.cc
@@ -16,6 +16,13 @@ json::ArrayPtr serialize_edges(const PathLocation& location, GraphReader& reader
       auto edge_info = tile->edgeinfo(directed_edge->edgeinfo_offset());
       // they want MOAR!
       if (verbose) {
+        auto predicted_speeds = json::array({});
+        if (directed_edge->has_predicted_speed()) {
+          for (auto sec = 0; sec < midgard::kSecondsPerWeek; sec += 5 * midgard::kSecPerMinute) {
+            predicted_speeds->emplace_back(
+                static_cast<uint64_t>(tile->GetSpeed(directed_edge, kPredictedFlowMask, sec)));
+          }
+        }
         array->emplace_back(json::map({
             {"correlated_lat", json::fp_t{edge.projected.lat(), 6}},
             {"correlated_lon", json::fp_t{edge.projected.lng(), 6}},
@@ -30,6 +37,7 @@ json::ArrayPtr serialize_edges(const PathLocation& location, GraphReader& reader
             {"edge_id", edge.id.json()},
             {"edge", directed_edge->json()},
             {"edge_info", edge_info.json()},
+            {"predicted_speeds", predicted_speeds},
         }));
       } // they want it lean and mean
       else {


### PR DESCRIPTION
# Issue

Outputs the array of predicted speeds for an edge in the /locate endpoint. Just for debugging purposes. 

## Tasklist

 - [ ] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
