### PR TITLE
Remove const from return signature of functions

### DIFF
--- a/src/baldr/admin.cc
+++ b/src/baldr/admin.cc
@@ -42,7 +42,7 @@ uint32_t Admin::country_offset() const {
 }
 
 // country ISO3166-1
-const std::string Admin::country_iso() const {
+std::string Admin::country_iso() const {
   std::string str;
   for (int i = 0; i < kCountryIso; i++) {
     if (country_iso_[i] == '\0') {
@@ -54,7 +54,7 @@ const std::string Admin::country_iso() const {
 }
 
 // country ISO + dash + state ISO will give you ISO3166-2 for state.
-const std::string Admin::state_iso() const {
+std::string Admin::state_iso() const {
   std::string str;
   for (int i = 0; i < kStateIso; i++) {
     if (state_iso_[i] == '\0') {

--- a/src/meili/viterbi_search.cc
+++ b/src/meili/viterbi_search.cc
@@ -13,7 +13,7 @@ StateLabel::StateLabel(double costsofar, const StateId& stateid, const StateId& 
   }
 }
 
-const StateId StateLabel::id() const {
+StateId StateLabel::id() const {
   return stateid_;
 }
 
@@ -21,11 +21,11 @@ double StateLabel::costsofar() const {
   return costsofar_;
 }
 
-const StateId StateLabel::stateid() const {
+StateId StateLabel::stateid() const {
   return stateid_;
 }
 
-const StateId StateLabel::predecessor() const {
+StateId StateLabel::predecessor() const {
   return predecessor_;
 }
 // Required by SPQueue

--- a/src/odin/signs.cc
+++ b/src/odin/signs.cc
@@ -21,10 +21,10 @@ std::vector<Sign>* Signs::mutable_exit_number_list() {
   return &exit_number_list_;
 }
 
-const std::string Signs::GetExitNumberString(uint32_t max_count,
-                                             bool limit_by_consecutive_count,
-                                             std::string delim,
-                                             const VerbalTextFormatter* verbal_formatter) const {
+std::string Signs::GetExitNumberString(uint32_t max_count,
+                                       bool limit_by_consecutive_count,
+                                       std::string delim,
+                                       const VerbalTextFormatter* verbal_formatter) const {
   return ListToString(exit_number_list_, max_count, limit_by_consecutive_count, std::move(delim),
                       verbal_formatter);
 }
@@ -37,10 +37,10 @@ std::vector<Sign>* Signs::mutable_exit_branch_list() {
   return &exit_branch_list_;
 }
 
-const std::string Signs::GetExitBranchString(uint32_t max_count,
-                                             bool limit_by_consecutive_count,
-                                             std::string delim,
-                                             const VerbalTextFormatter* verbal_formatter) const {
+std::string Signs::GetExitBranchString(uint32_t max_count,
+                                       bool limit_by_consecutive_count,
+                                       std::string delim,
+                                       const VerbalTextFormatter* verbal_formatter) const {
   return ListToString(exit_branch_list_, max_count, limit_by_consecutive_count, std::move(delim),
                       verbal_formatter);
 }
@@ -53,10 +53,10 @@ std::vector<Sign>* Signs::mutable_exit_toward_list() {
   return &exit_toward_list_;
 }
 
-const std::string Signs::GetExitTowardString(uint32_t max_count,
-                                             bool limit_by_consecutive_count,
-                                             std::string delim,
-                                             const VerbalTextFormatter* verbal_formatter) const {
+std::string Signs::GetExitTowardString(uint32_t max_count,
+                                       bool limit_by_consecutive_count,
+                                       std::string delim,
+                                       const VerbalTextFormatter* verbal_formatter) const {
   return ListToString(exit_toward_list_, max_count, limit_by_consecutive_count, std::move(delim),
                       verbal_formatter);
 }
@@ -69,10 +69,10 @@ std::vector<Sign>* Signs::mutable_exit_name_list() {
   return &exit_name_list_;
 }
 
-const std::string Signs::GetExitNameString(uint32_t max_count,
-                                           bool limit_by_consecutive_count,
-                                           std::string delim,
-                                           const VerbalTextFormatter* verbal_formatter) const {
+std::string Signs::GetExitNameString(uint32_t max_count,
+                                     bool limit_by_consecutive_count,
+                                     std::string delim,
+                                     const VerbalTextFormatter* verbal_formatter) const {
   return ListToString(exit_name_list_, max_count, limit_by_consecutive_count, std::move(delim),
                       verbal_formatter);
 }
@@ -136,11 +136,11 @@ std::string Signs::ToParameterString() const {
 }
 #endif
 
-const std::string Signs::ListToString(const std::vector<Sign>& signs,
-                                      uint32_t max_count,
-                                      bool limit_by_consecutive_count,
-                                      const std::string& delim,
-                                      const VerbalTextFormatter* verbal_formatter) const {
+std::string Signs::ListToString(const std::vector<Sign>& signs,
+                                uint32_t max_count,
+                                bool limit_by_consecutive_count,
+                                const std::string& delim,
+                                const VerbalTextFormatter* verbal_formatter) const {
   std::string sign_string;
   uint32_t count = 0;
   uint32_t consecutive_count = -1;
@@ -180,7 +180,7 @@ const std::string Signs::ListToString(const std::vector<Sign>& signs,
 }
 
 #ifdef LOGGING_LEVEL_TRACE
-const std::string Signs::ListToParameterString(const std::vector<Sign>& signs) const {
+std::string Signs::ListToParameterString(const std::vector<Sign>& signs) const {
   std::string sign_string;
   std::string param_list;
 

--- a/src/valhalla_associate_segments.cc
+++ b/src/valhalla_associate_segments.cc
@@ -284,8 +284,8 @@ public:
                       const uint32_t tz_index) const;
   bool Allowed(const vb::NodeInfo* node) const;
   vs::Cost EdgeCost(const vb::DirectedEdge* edge, const uint32_t speed) const;
-  const vs::EdgeFilter GetEdgeFilter() const;
-  const vs::NodeFilter GetNodeFilter() const;
+  vs::EdgeFilter GetEdgeFilter() const;
+  vs::NodeFilter GetNodeFilter() const;
   float AStarCostFactor() const;
 };
 
@@ -330,11 +330,11 @@ vs::Cost DistanceOnlyCost::EdgeCost(const vb::DirectedEdge* edge, const uint32_t
   return {edge_len, edge_len};
 }
 
-const vs::EdgeFilter DistanceOnlyCost::GetEdgeFilter() const {
+vs::EdgeFilter DistanceOnlyCost::GetEdgeFilter() const {
   return [](const vb::DirectedEdge* edge) -> float { return allow_edge_pred(edge) ? 1.0f : 0.0f; };
 }
 
-const vs::NodeFilter DistanceOnlyCost::GetNodeFilter() const {
+vs::NodeFilter DistanceOnlyCost::GetNodeFilter() const {
   return [](const vb::NodeInfo*) -> bool { return false; };
 }
 

--- a/valhalla/baldr/admin.h
+++ b/valhalla/baldr/admin.h
@@ -34,14 +34,14 @@ public:
    * Get the country ISO3166-1 code.
    * @return  Returns the ISO country code.
    */
-  const std::string country_iso() const;
+  std::string country_iso() const;
 
   /**
    * Get the state ISO code. Country ISO + dash + state ISO will give
    * you ISO3166-2 for state.
    * @return  Returns the state ISO code.
    */
-  const std::string state_iso() const;
+  std::string state_iso() const;
 
   /**
    * Get the offset into the GraphTile text list for the state text associated

--- a/valhalla/meili/viterbi_search.h
+++ b/valhalla/meili/viterbi_search.h
@@ -29,10 +29,10 @@ public:
   StateLabel(double costsofar, const StateId& stateid, const StateId& predecessor);
 
   double costsofar() const;
-  const StateId stateid() const;
-  const StateId predecessor() const;
+  StateId stateid() const;
+  StateId predecessor() const;
   /* The following operator overloading and member functions are Required by SPQueue */
-  const StateId id() const;
+  StateId id() const;
   bool operator<(const StateLabel& rhs) const;
   bool operator>(const StateLabel& rhs) const;
   bool operator==(const StateLabel& rhs) const;

--- a/valhalla/odin/signs.h
+++ b/valhalla/odin/signs.h
@@ -23,34 +23,34 @@ public:
   const std::vector<Sign>& exit_number_list() const;
   std::vector<Sign>* mutable_exit_number_list();
 
-  const std::string GetExitNumberString(uint32_t max_count = 0,
-                                        bool limit_by_consecutive_count = false,
-                                        std::string delim = "/",
-                                        const VerbalTextFormatter* verbal_formatter = nullptr) const;
+  std::string GetExitNumberString(uint32_t max_count = 0,
+                                  bool limit_by_consecutive_count = false,
+                                  std::string delim = "/",
+                                  const VerbalTextFormatter* verbal_formatter = nullptr) const;
 
   const std::vector<Sign>& exit_branch_list() const;
   std::vector<Sign>* mutable_exit_branch_list();
 
-  const std::string GetExitBranchString(uint32_t max_count = 0,
-                                        bool limit_by_consecutive_count = false,
-                                        std::string delim = "/",
-                                        const VerbalTextFormatter* verbal_formatter = nullptr) const;
+  std::string GetExitBranchString(uint32_t max_count = 0,
+                                  bool limit_by_consecutive_count = false,
+                                  std::string delim = "/",
+                                  const VerbalTextFormatter* verbal_formatter = nullptr) const;
 
   const std::vector<Sign>& exit_toward_list() const;
   std::vector<Sign>* mutable_exit_toward_list();
 
-  const std::string GetExitTowardString(uint32_t max_count = 0,
-                                        bool limit_by_consecutive_count = false,
-                                        std::string delim = "/",
-                                        const VerbalTextFormatter* verbal_formatter = nullptr) const;
+  std::string GetExitTowardString(uint32_t max_count = 0,
+                                  bool limit_by_consecutive_count = false,
+                                  std::string delim = "/",
+                                  const VerbalTextFormatter* verbal_formatter = nullptr) const;
 
   const std::vector<Sign>& exit_name_list() const;
   std::vector<Sign>* mutable_exit_name_list();
 
-  const std::string GetExitNameString(uint32_t max_count = 0,
-                                      bool limit_by_consecutive_count = false,
-                                      std::string delim = "/",
-                                      const VerbalTextFormatter* verbal_formatter = nullptr) const;
+  std::string GetExitNameString(uint32_t max_count = 0,
+                                bool limit_by_consecutive_count = false,
+                                std::string delim = "/",
+                                const VerbalTextFormatter* verbal_formatter = nullptr) const;
 
   bool HasExit() const;
   bool HasExitNumber() const;
@@ -67,14 +67,14 @@ public:
   bool operator==(const Signs& rhs) const;
 
 protected:
-  const std::string ListToString(const std::vector<Sign>& signs,
-                                 uint32_t max_count = 0,
-                                 bool limit_by_consecutive_count = false,
-                                 const std::string& delim = "/",
-                                 const VerbalTextFormatter* verbal_formatter = nullptr) const;
+  std::string ListToString(const std::vector<Sign>& signs,
+                           uint32_t max_count = 0,
+                           bool limit_by_consecutive_count = false,
+                           const std::string& delim = "/",
+                           const VerbalTextFormatter* verbal_formatter = nullptr) const;
 
 #ifdef LOGGING_LEVEL_TRACE
-  const std::string ListToParameterString(const std::vector<Sign>& signs) const;
+  std::string ListToParameterString(const std::vector<Sign>& signs) const;
 #endif
 
   std::vector<Sign> exit_number_list_;


### PR DESCRIPTION
Removed const keyword from functions returning objects by value. const
in return type is not needed as it prevents use of rvalue/move
semantics.

#fixes #1971 

# Issue 1971
