### PR TITLE
Heading filter fix for node search

### DIFF
--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -303,8 +303,10 @@ struct bin_handler_t {
                                            PathLocation::NONE,
                                            reach.outbound,
                                            reach.inbound};
-          auto index = other_edge->forward() ? 0 : info.shape().size() - 2;
-          if (heading_filter(other_edge, tile->edgeinfo(edge->edgeinfo_offset()), location,
+          // index is opposite the logic above, plus we need to use the edgeinfo and shape
+          // from the other tile since we use the other_edge forward flag
+          auto index = other_edge->forward() ? info.shape().size() - 2 : 0;
+          if (heading_filter(other_edge, other_tile->edgeinfo(other_edge->edgeinfo_offset()), location,
                              candidate.point, index)) {
             filtered.emplace_back(std::move(path_edge));
           } else if (correlated_edges.insert(path_edge.id).second) {


### PR DESCRIPTION
Fix logic for shape index on the opposing (other) edge in the node heading filter. Need to use opposite logic and make sure the tile and edgeinfo for the opposing edge is used in case it was from a different tile and the forward flag is the same as the current edge.

# Issue

fixes #2057 

## Tasklist

 - [ ] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
