### PR TITLE
fix current time map matches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 commands:
   install_macos_dependencies:
     steps:
-      - run: brew install protobuf cmake libtool boost-python libspatialite pkg-config lua curl wget czmq lz4
+      - run: brew install protobuf cmake libtool boost-python libspatialite pkg-config lua curl wget czmq lz4 spatialite-bin unzip
       - run:
           name: Install Node
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 commands:
   install_macos_dependencies:
     steps:
-      - run: brew install protobuf cmake libtool boost-python libspatialite pkg-config lua curl wget czmq lz4 spatialite-bin unzip
+      - run: brew install protobuf cmake libtool boost-python libspatialite pkg-config lua curl wget czmq lz4 spatialite-tools unzip
       - run:
           name: Install Node
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ commands:
 jobs:
   lint:
     docker:
-      - image: valhalla/docker:build-2.6.1
+      - image: valhalla/docker:build-3.0.1
     steps:
       - checkout
       - run: apt-get update && apt-get -y install clang-tidy-5.0 clang-5.0 curl git nodejs
@@ -47,7 +47,7 @@ jobs:
 
   build-release-binary-linux:
     docker:
-      - image: valhalla/docker:build-2.6.1
+      - image: valhalla/docker:build-3.0.1
     steps:
       - checkout
       - run:
@@ -88,7 +88,7 @@ jobs:
 
   build-debug-binary-linux:
     docker:
-      - image: valhalla/docker:build-2.6.1
+      - image: valhalla/docker:build-3.0.1
     steps:
       - checkout
       - run:
@@ -127,7 +127,7 @@ jobs:
 
   build-debug:
     docker:
-      - image: valhalla/docker:build-2.6.1
+      - image: valhalla/docker:build-3.0.1
     steps:
       - checkout
       - run: ./scripts/format.sh && ./scripts/error_on_dirty.sh
@@ -152,7 +152,7 @@ jobs:
 
   build-release:
     docker:
-      - image: valhalla/docker:build-2.6.1
+      - image: valhalla/docker:build-3.0.1
     steps:
       - checkout
       - run: ./scripts/format.sh && ./scripts/error_on_dirty.sh
@@ -177,7 +177,7 @@ jobs:
 
   build-release-x86:
     docker:
-      - image: valhalla/docker:build-x86-3.0.0
+      - image: valhalla/docker:build-x86-3.0.1
     steps:
       - checkout
       #- run: ./scripts/format.sh && ./scripts/error_on_dirty.sh

--- a/scripts/valhalla_build_timezones
+++ b/scripts/valhalla_build_timezones
@@ -5,16 +5,6 @@ error_exit() {
   exit 1
 }
 
-if [ -z "$1" ]; then
-    echo "No config supplied.  Usage: valhalla_build_timezones /data/valhalla/mjolnir/conf/valhalla.json"
-    exit 1
-fi
-
-if  ! which jq >/dev/null; then
-    echo "jq not found which is required.  Please install via:  sudo apt-get install jq"
-    exit 1
-fi
-
 if  ! which spatialite >/dev/null; then
     echo "spatialite not found which is required.  Please install via:  sudo apt-get install spatialite-bin"
     exit 1
@@ -23,17 +13,6 @@ fi
 rm -rf dist
 rm -f ./timezones-with-oceans.shapefile.zip
 
-config=$1
-if [ ! -f $config ]; then
-    echo "Config file not found $config"
-    exit 1
-fi
-tz_file=$(jq -r '.mjolnir.timezone' $config)
-if [ ! -d $(dirname $tz_file) ]; then
-    echo "Timezone directory not found $(dirname $tz_file)"
-    exit 1
-fi
-rm -f $tz_file
 url="https://github.com/evansiroky/timezone-boundary-builder/releases/download/2018d/timezones-with-oceans.shapefile.zip"
 
 cat << EOF > alias_tz.csv
@@ -243,18 +222,21 @@ Africa/Timbuktu,Africa/Abidjan
 Atlantic/St_Helena,Africa/Abidjan
 EOF
 
-echo "downloading timezone polygon file."
+echo "downloading timezone polygon file." 1>&2 
 wget -q $url || error_exit "wget failed for " $url
-unzip ./timezones-with-oceans.shapefile.zip || error_exit "unzip failed"
-spatialite_tool -i -shp ./dist/combined-shapefile-with-oceans -d $tz_file -t tz_world -s 4326 -g geom -c UTF-8 || error_exit "spatialite_tool import failed"
-spatialite $tz_file "SELECT CreateSpatialIndex('tz_world', 'geom');" || error_exit "SpatialIndex failed" 
+unzip ./timezones-with-oceans.shapefile.zip 1>&2 || error_exit "unzip failed"
 
-spatialite $tz_file "DROP TABLE IF EXISTS "alias";" || error_exit "drop table alias failed"
-spatialite $tz_file "CREATE TABLE "alias" (alias_TZID text,alias_new_TZID text);" || error_exit "create table alias failed"
-spatialite -csv $tz_file ".import alias_tz.csv alias" || error_exit "alias table import failed"
-spatialite $tz_file "update tz_world set TZID = (select alias_new_TZID from alias where TZID = alias_TZID) where TZID in (select alias_TZID from alias);" || error_exit "updating tz_world failed"
-spatialite $tz_file "VACUUM;" || error_exit "VACUUM failed"
-spatialite $tz_file "ANALYZE;" || error_exit "ANALYZE failed"
+tz_file=$(mktemp)
+spatialite_tool -i -shp ./dist/combined-shapefile-with-oceans -d ${tz_file} -t tz_world -s 4326 -g geom -c UTF-8 1>&2 || error_exit "spatialite_tool import failed"
+spatialite ${tz_file} "SELECT CreateSpatialIndex('tz_world', 'geom');" 1>&2 || error_exit "SpatialIndex failed" 
+
+spatialite ${tz_file} "DROP TABLE IF EXISTS "alias";" 1>&2 || error_exit "drop table alias failed"
+spatialite ${tz_file} "CREATE TABLE "alias" (alias_TZID text,alias_new_TZID text);" 1>&2 || error_exit "create table alias failed"
+spatialite -csv ${tz_file} ".import alias_tz.csv alias" 1>&2 || error_exit "alias table import failed"
+spatialite ${tz_file} "update tz_world set TZID = (select alias_new_TZID from alias where TZID = alias_TZID) where TZID in (select alias_TZID from alias);" 1>&2 || error_exit "updating tz_world failed"
+spatialite ${tz_file} "VACUUM;" 1>&2 || error_exit "VACUUM failed"
+spatialite ${tz_file} "ANALYZE;" 1>&2 || error_exit "ANALYZE failed"
 
 rm -rf dist
 rm -f ./timezones-with-oceans.shapefile.zip alias_tz.csv
+cat ${tz_file}

--- a/scripts/valhalla_build_timezones
+++ b/scripts/valhalla_build_timezones
@@ -223,7 +223,7 @@ Atlantic/St_Helena,Africa/Abidjan
 EOF
 
 echo "downloading timezone polygon file." 1>&2 
-wget -q $url || error_exit "wget failed for " $url
+curl -L -s -o ./timezones-with-oceans.shapefile.zip ${url} || error_exit "wget failed for " ${url}
 unzip ./timezones-with-oceans.shapefile.zip 1>&2 || error_exit "unzip failed"
 
 tz_file=$(mktemp)

--- a/src/thor/map_matcher.cc
+++ b/src/thor/map_matcher.cc
@@ -155,14 +155,19 @@ MapMatcher::FormPath(meili::MapMatcher* matcher,
       // get the timezone
       nodeinfo = tile->node(directededge->endnode());
       const auto* tz = DateTime::get_tz_db().from_index(nodeinfo->timezone());
+      if (!tz)
+        continue;
       // if its timestamp based need to signal that out to trip leg builder
-      if (options.shape(0).time() != -1.0) {
+      if (!options.shape(0).has_date_time() && options.shape(0).time() != -1.0) {
         options.mutable_shape(0)->set_date_time(
             DateTime::seconds_to_date(options.shape(0).time(), tz, false));
       }
       // remember where we are starting
-      if (options.shape(0).has_date_time())
+      if (options.shape(0).has_date_time()) {
+        if (options.shape(0).date_time() == "current")
+          options.mutable_shape(0)->set_date_time(DateTime::iso_date_time(tz));
         origin_epoch = DateTime::seconds_since_epoch(options.shape(0).date_time(), tz);
+      }
       break;
     }
   }

--- a/src/thor/route_matcher.cc
+++ b/src/thor/route_matcher.cc
@@ -286,14 +286,19 @@ bool RouteMatcher::FormPath(const std::shared_ptr<DynamicCost>* mode_costing,
       // get the timezone
       nodeinfo = tile->node(directededge->endnode());
       const auto* tz = DateTime::get_tz_db().from_index(nodeinfo->timezone());
+      if (!tz)
+        continue;
       // if its timestamp based need to signal that out to trip leg builder
-      if (options.shape(0).time() != -1.0) {
+      if (!options.shape(0).has_date_time() && options.shape(0).time() != -1.0) {
         options.mutable_shape(0)->set_date_time(
             DateTime::seconds_to_date(options.shape(0).time(), tz, false));
       }
       // remember where we are starting
-      if (options.shape(0).has_date_time())
+      if (options.shape(0).has_date_time()) {
+        if (options.shape(0).date_time() == "current")
+          options.mutable_shape(0)->set_date_time(DateTime::iso_date_time(tz));
         origin_epoch = DateTime::seconds_since_epoch(options.shape(0).date_time(), tz);
+      }
       break;
     }
   }

--- a/src/thor/trace_route_action.cc
+++ b/src/thor/trace_route_action.cc
@@ -127,13 +127,16 @@ void thor_worker_t::route_match(Api& request) {
   // TODO - make sure the trace has timestamps..
   auto& options = *request.mutable_options();
   if (RouteMatcher::FormPath(mode_costing, mode, *reader, trace, options, m_path_infos)) {
-    // TODO: we dont support multileg here as it ignores location types
+    // TODO: we dont support multileg here as it ignores location types but...
+    // if this were a time dependent match you need to propogate the date time
+    // information to each legs origin location because triplegbuilder relies on it.
+    // form path set the first one but on the subsequent legs we will need to set them
+    // by doing time offsetting like is done in route_action.cc thor_worker_t::depart_at
 
-    // TODO: if this were a time dependent match and you werent use_timestamps
-    // you need to propogate the date information to each legs origin location
-    // because triplegbuilder relies on it. form path set the first one but
-    // on the subsequent legs we will need to set them by doing time offsetting
-    // like is done in route_action.cc thor_worker_t::depart_at
+    // For now we ignore multileg complications and just make sure the searched locations
+    // get the same data information the shape informations had
+    if (options.shape(0).has_date_time())
+      options.mutable_locations(0)->set_date_time(options.shape(0).date_time());
 
     // Form the trip path based on mode costing, origin, destination, and path edges
     auto& leg = *request.mutable_trip()->mutable_routes()->Add()->mutable_legs()->Add();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,11 +46,12 @@ endforeach()
 set_target_properties(logging PROPERTIES COMPILE_DEFINITIONS LOGGING_LEVEL_ALL)
 
 add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/test/data/utrecht_tiles/0/003/196.gph
+  COMMAND ${VALHALLA_SOURCE_DIR}/scripts/valhalla_build_timezones 2>/dev/null > test/data/utrecht_tiles/tz.sqlite
   COMMAND ${CMAKE_BINARY_DIR}/valhalla_build_tiles
-      --inline-config '{"mjolnir":{"tile_dir":"test/data/utrecht_tiles","hierarchy":true,"shortcuts":true,"concurrency":4,"logging":{"type":""}}}'
+      --inline-config '{"mjolnir":{"tile_dir":"test/data/utrecht_tiles","timezone":"test/data/utrecht_tiles/tz.sqlite","hierarchy":true,"shortcuts":true,"concurrency":4,"logging":{"type":""}}}'
       ${VALHALLA_SOURCE_DIR}/test/data/utrecht_netherlands.osm.pbf
   COMMAND ${CMAKE_BINARY_DIR}/valhalla_add_predicted_traffic
-      --inline-config '{"mjolnir":{"tile_dir":"test/data/utrecht_tiles","hierarchy":true,"shortcuts":true,"concurrency":4,"logging":{"type":""}}}'
+      --inline-config '{"mjolnir":{"tile_dir":"test/data/utrecht_tiles","concurrency":4,"logging":{"type":""}}}'
       -t ${VALHALLA_SOURCE_DIR}/test/data/traffic_tiles/
   COMMENT "Building Utrecht Tiles..."
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,7 +46,7 @@ endforeach()
 set_target_properties(logging PROPERTIES COMPILE_DEFINITIONS LOGGING_LEVEL_ALL)
 
 add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/test/data/utrecht_tiles/0/003/196.gph
-  COMMAND ${VALHALLA_SOURCE_DIR}/scripts/valhalla_build_timezones 2>/dev/null > test/data/utrecht_tiles/tz.sqlite
+  COMMAND ${VALHALLA_SOURCE_DIR}/scripts/valhalla_build_timezones > test/data/utrecht_tiles/tz.sqlite
   COMMAND ${CMAKE_BINARY_DIR}/valhalla_build_tiles
       --inline-config '{"mjolnir":{"tile_dir":"test/data/utrecht_tiles","timezone":"test/data/utrecht_tiles/tz.sqlite","hierarchy":true,"shortcuts":true,"concurrency":4,"logging":{"type":""}}}'
       ${VALHALLA_SOURCE_DIR}/test/data/utrecht_netherlands.osm.pbf

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,7 +46,8 @@ endforeach()
 set_target_properties(logging PROPERTIES COMPILE_DEFINITIONS LOGGING_LEVEL_ALL)
 
 add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/test/data/utrecht_tiles/0/003/196.gph
-  COMMAND ${VALHALLA_SOURCE_DIR}/scripts/valhalla_build_timezones > test/data/utrecht_tiles/tz.sqlite
+  COMMAND ${CMAKE_COMMAND} -E make_directory test/data/utrecht_tiles/
+  COMMAND ${VALHALLA_SOURCE_DIR}/scripts/valhalla_build_timezones 2>/dev/null > test/data/utrecht_tiles/tz.sqlite
   COMMAND ${CMAKE_BINARY_DIR}/valhalla_build_tiles
       --inline-config '{"mjolnir":{"tile_dir":"test/data/utrecht_tiles","timezone":"test/data/utrecht_tiles/tz.sqlite","hierarchy":true,"shortcuts":true,"concurrency":4,"logging":{"type":""}}}'
       ${VALHALLA_SOURCE_DIR}/test/data/utrecht_netherlands.osm.pbf

--- a/test/mapmatch.cc
+++ b/test/mapmatch.cc
@@ -733,7 +733,7 @@ int main(int argc, char* argv[]) {
     seed = std::stoi(argv[1]);
   if (argc > 2)
     bound = std::stoi(argv[2]);
-  
+
   suite.test(TEST_CASE(test32bit));
 
   suite.test(TEST_CASE(test_matcher));

--- a/test/mapmatch.cc
+++ b/test/mapmatch.cc
@@ -706,6 +706,24 @@ void test_topk_frontage_alternate() {
         "The raw score of the first result is always less than that of the second");
 }
 
+void test_now_matches() {
+  tyr::actor_t actor(conf, true);
+
+  // once with map matching
+  std::string test_case =
+      R"({"date_time":{"type":0},"shape_match":"map_snap","costing":"auto",
+         "encoded_polyline":"oeyjbBqfjwHeO~M}x@`u@wDmh@oCcd@sAiVcAaKe@cBaNe[u^qg@qH`u@cL{Tmr@c{AtTu_@xVsd@"})";
+  auto route_json = actor.trace_route(test_case);
+
+  // again with walking
+  auto route = json_to_pt(route_json);
+  auto encoded_shape = route.get_child("trip.legs").front().second.get<std::string>("shape");
+  test_case =
+      R"({"date_time":{"type":0},"shape_match":"edge_walk","costing":"auto","encoded_polyline":")" +
+      json_escape(encoded_shape) + "\"}";
+  actor.trace_route(test_case);
+}
+
 } // namespace
 
 int main(int argc, char* argv[]) {
@@ -715,7 +733,7 @@ int main(int argc, char* argv[]) {
     seed = std::stoi(argv[1]);
   if (argc > 2)
     bound = std::stoi(argv[2]);
-
+  
   suite.test(TEST_CASE(test32bit));
 
   suite.test(TEST_CASE(test_matcher));
@@ -743,6 +761,8 @@ int main(int argc, char* argv[]) {
   suite.test(TEST_CASE(test_topk_loop_alternate));
 
   suite.test(TEST_CASE(test_topk_frontage_alternate));
+
+  suite.test(TEST_CASE(test_now_matches));
 
   return suite.tear_down();
 }


### PR DESCRIPTION
in #2030 we added the ability to set a depart time for map matching what we forgot to do was properly handle when that time was set to "current" which oddly enough wont parse as a date_time :smile: 

anyway this handles that scenario in the same way the other timedependent routing algorithms handles it which is to turn it into a date_time string.