### PR TITLE
Protect length method used with empty containers

### DIFF
--- a/test/pointll.cc
+++ b/test/pointll.cc
@@ -47,6 +47,18 @@ void test_end(const std::vector<PointLL> l, float d, float a) {
 }
 
 void TestHeadingAlongPolyline() {
+  // Test with empty (or 1 point) polyline
+  std::vector<PointLL> empty;
+  auto r = PointLL::HeadingAlongPolyline(empty, 30.0f);
+  if (!valhalla::midgard::equal(r, 0.0f, 1.0f)) {
+    throw std::logic_error("HeadingAlongPolyline with empty polyline failed");
+  }
+  empty.emplace_back(-70.0f, 30.0f);
+  r = PointLL::HeadingAlongPolyline(empty, 30.0f);
+  if (!valhalla::midgard::equal(r, 0.0f, 1.0f)) {
+    throw std::logic_error("HeadingAlongPolyline with one point polyline failed");
+  }
+
   test_along({{-73.986392, 40.755800}, {-73.986438, 40.755819}}, 30.0f, 299);
   test_along({{-73.986438, 40.755819}, {-73.986484, 40.755681}}, 30.0f, 194);
   test_along({{-73.985777, 40.755539}, {-73.986440, 40.755820}, {-73.986617, 40.755254}}, 30.0f, 299);
@@ -91,6 +103,18 @@ void TestHeadingAlongPolyline() {
 }
 
 void TestHeadingAtEndOfPolyline() {
+  // Test with empty (or 1 point) polyline
+  std::vector<PointLL> empty;
+  auto r = PointLL::HeadingAtEndOfPolyline(empty, 30.0f);
+  if (!valhalla::midgard::equal(r, 0.0f, 1.0f)) {
+    throw std::logic_error("HeadingAtEndOfPolyline with empty polyline failed");
+  }
+  empty.emplace_back(-70.0f, 30.0f);
+  r = PointLL::HeadingAtEndOfPolyline(empty, 30.0f);
+  if (!valhalla::midgard::equal(r, 0.0f, 1.0f)) {
+    throw std::logic_error("HeadingAtEndOfPolyline with one point polyline failed");
+  }
+
   test_end({{-73.986392, 40.755800}, {-73.986438, 40.755819}}, 30.0f, 299);
   test_end({{-73.986438, 40.755819}, {-73.986484, 40.755681}}, 30.0f, 194);
   test_end({{-73.985777, 40.755539}, {-73.986440, 40.755820}, {-73.986617, 40.755254}}, 30.0f, 194);

--- a/test/util_midgard.cc
+++ b/test/util_midgard.cc
@@ -390,6 +390,18 @@ void TestTrimFront() {
   }
 }
 
+void TestLengthWithEmptyVector() {
+  std::vector<PointLL> empty;
+  if (length(empty) != 0.0f) {
+    throw std::logic_error("empty polyline returns non-zero length");
+  }
+  // Test with only 1 point, should still return 0
+  empty.emplace_back(-70.0f, 30.0f);
+  if (length(empty) != 0.0f) {
+    throw std::logic_error("one point polyline returns non-zero length");
+  }
+}
+
 void TestTangentAngle() {
   PointLL point{-122.839554f, 38.3990479f};
   std::vector<PointLL> shape{{-122.839104f, 38.3988266f},
@@ -478,6 +490,9 @@ int main() {
 
   // trim_front of a polyline
   suite.test(TEST_CASE(TestTrimFront));
+
+  // Test that length with empty container (or only 1 point) returns 0
+  suite.test(TEST_CASE(TestLengthWithEmptyVector));
 
   // tangent angle
   suite.test(TEST_CASE(TestTangentAngle));

--- a/valhalla/midgard/util.h
+++ b/valhalla/midgard/util.h
@@ -132,6 +132,9 @@ inline float normalize(const float num, const float den) {
 // Avoids having to copy the points into a polyline, polyline should really just extend
 // A container class like vector or list
 template <class container_t> float length(const container_t& pts) {
+  if (pts.size() < 2) {
+    return 0.0f;
+  }
   float length = 0.0f;
   for (auto p = std::next(pts.cbegin()); p != pts.end(); ++p) {
     length += p->Distance(*std::prev(p));


### PR DESCRIPTION
midgard util length method has segmentation fault if an empty container is passed to it. Fix by checking if the container size < 2, if so return length of 0. Add a unit test for empty and 1 point containers.

# Issue

## Tasklist

 - [x] Add tests
 - [x] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
