### PR TITLE
Troubleshoot autobahn reststops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
    * ADDED: Allow disabling certain neighbors in connectivity map [#2026](https://github.com/valhalla/valhalla/pull/2026)
    * ADDED: Allows routes with time-restricted edges if no time specified and notes restriction in response [#1992](https://github.com/valhalla/valhalla/issues/1992)
    * ADDED: Runtime deadend detection to timedependent a-star. [#2059](https://github.com/valhalla/valhalla/pull/2059)
+   * ADDED: Allows more complicated routes in timedependent a-star before timing out [#2068](https://github.com/valhalla/valhalla/pull/2068)
 
 ## Release Date: 2019-09-06 Valhalla 3.0.8
 * **Bug Fix**

--- a/scripts/valhalla_build_timezones
+++ b/scripts/valhalla_build_timezones
@@ -10,6 +10,11 @@ if  ! which spatialite >/dev/null; then
     exit 1
 fi
 
+if  ! which unzip >/dev/null; then
+    echo "unzip not found which is required.  Please install via:  sudo apt-get install unzip"
+    exit 1
+fi
+
 rm -rf dist
 rm -f ./timezones-with-oceans.shapefile.zip
 

--- a/src/sif/CMakeLists.txt
+++ b/src/sif/CMakeLists.txt
@@ -3,6 +3,7 @@ file(GLOB headers ${VALHALLA_SOURCE_DIR}/valhalla/sif/*.h)
 set(sources
   autocost.cc
   bicyclecost.cc
+  hierarchylimits.cc
   motorcyclecost.cc
   motorscootercost.cc
   pedestriancost.cc

--- a/src/sif/hierarchylimits.cc
+++ b/src/sif/hierarchylimits.cc
@@ -1,0 +1,7 @@
+#include "sif/hierarchylimits.h"
+
+using namespace valhalla::sif;
+
+bool HierarchyLimits::StopExpanding(const float dist) const {
+  return (dist > expansion_within_dist && up_transition_count > max_up_transitions);
+}

--- a/src/thor/timedep_forward.cc
+++ b/src/thor/timedep_forward.cc
@@ -15,7 +15,7 @@ namespace thor {
 constexpr uint64_t kInitialEdgeLabelCount = 500000;
 
 // Number of iterations to allow with no convergence to the destination
-constexpr uint32_t kMaxIterationsWithoutConvergence = 200000;
+constexpr uint32_t kMaxIterationsWithoutConvergence = 800000;
 
 // Default constructor
 TimeDepForward::TimeDepForward() : AStarPathAlgorithm() {

--- a/src/thor/timedep_reverse.cc
+++ b/src/thor/timedep_reverse.cc
@@ -15,6 +15,9 @@ namespace thor {
 // TODO - compute initial label count based on estimated route length
 constexpr uint64_t kInitialEdgeLabelCount = 500000;
 
+// Number of iterations to allow with no convergence to the destination
+constexpr uint32_t kMaxIterationsWithoutConvergence = 800000;
+
 // Default constructor
 TimeDepReverse::TimeDepReverse() : AStarPathAlgorithm() {
   mode_ = TravelMode::kDrive;
@@ -387,7 +390,7 @@ TimeDepReverse::GetBestPath(valhalla::Location& origin,
     if (dist2dest < mindist) {
       mindist = dist2dest;
       nc = 0;
-    } else if (nc++ > 50000) {
+    } else if (nc++ > kMaxIterationsWithoutConvergence) {
       if (best_path.first >= 0) {
         return {FormPath(graphreader, best_path.first)};
       } else {

--- a/src/thor/timedep_reverse.cc
+++ b/src/thor/timedep_reverse.cc
@@ -34,6 +34,11 @@ TimeDepReverse::~TimeDepReverse() {
   Clear();
 }
 
+void TimeDepReverse::Clear() {
+  AStarPathAlgorithm::Clear();
+  edgelabels_rev_.clear();
+}
+
 // Initialize prior to finding best path
 void TimeDepReverse::Init(const midgard::PointLL& origll, const midgard::PointLL& destll) {
   // Set the origin lat,lon (since this is reverse path) and cost factor

--- a/src/thor/worker.cc
+++ b/src/thor/worker.cc
@@ -356,6 +356,8 @@ void thor_worker_t::parse_filter_attributes(const Api& request, bool is_strict_f
 void thor_worker_t::cleanup() {
   astar.Clear();
   bidir_astar.Clear();
+  timedep_forward.Clear();
+  timedep_reverse.Clear();
   multi_modal_astar.Clear();
   trace.clear();
   isochrone_gen.Clear();

--- a/valhalla/sif/hierarchylimits.h
+++ b/valhalla/sif/hierarchylimits.h
@@ -65,9 +65,7 @@ struct HierarchyLimits {
    * @param  dist  Distance (meters) from the destination.
    * @return  Returns true if expansion at this hierarchy level should stop.
    */
-  bool StopExpanding(const float dist) const {
-    return (dist > expansion_within_dist && up_transition_count > max_up_transitions);
-  }
+  bool StopExpanding(const float dist) const;
 
   /**
    * Determine if expansion of a hierarchy level should be stopped once

--- a/valhalla/thor/timedep.h
+++ b/valhalla/thor/timedep.h
@@ -124,6 +124,11 @@ public:
               const sif::TravelMode mode,
               const Options& options = Options::default_instance());
 
+  /**
+   * Clear the temporary information generated during path construction.
+   */
+  virtual void Clear();
+
 protected:
   uint32_t dest_tz_index_;
   uint32_t seconds_of_week_;


### PR DESCRIPTION
# Issue

We have a set of problematic routes on the Autobahn which end with
a rest-stop on the opposite side of travel direction, thereby
requiring overshooting the destination and coming back in the
other direction.

The bidirectional a-star routes fine but the forward timedependant requires
more iterations without convergence for these routes.

## Benchmarking

We're expecting complex routes to compute for a longer time, but to actually find a route. We want to ensure that average routes don't take longer to compute. Using the `de_benchmark_routes`, this change does not seem to affect regular routes.

Thor wall-clock times for `test_requests/de_benchmark_routes.txt`
```
master
Logfile de_benchmark_routes-kMaxIterations-200000.log contains 1714 elapsed times
  p10:    263ms
  mean:   444ms
  median: 415ms
  p90:    661ms
  max:    1675ms

This PR
Logfile de_benchmark_routes-kMaxIterations-800000.log contains 1731 elapsed times
  p10:    258ms
  mean:   439ms
  median: 411ms
  p90:    650ms
  max:    1616ms
```

## Tasklist
 - [x] Verify if change is necessary in reverse a-star as well
 - [ ] ~Add tests~
 - [x] Review - you must request approval to merge any PR to master
 - [x] Add #fixes with the issue number that this PR addresses
 - [x] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)
 - [x] Update relevant [documentation](docs/README.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
