### PR TITLE
Add missing boost::filesystem dependency to baldr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,9 +204,9 @@ if(ENABLE_DATA_TOOLS)
 ## Top level executables
 elseif(ENABLE_TOOLS)
   find_package(Boost 1.51 REQUIRED COMPONENTS filesystem system program_options)
-## Header only boost for the library without mjolnir
+## Boost for the library without mjolnir
 elseif(NOT Boost_FOUND)
-  find_package(Boost 1.51 REQUIRED)
+  find_package(Boost 1.51 REQUIRED COMPONENTS filesystem)
 endif()
 add_definitions(-DBOOST_NO_CXX11_SCOPED_ENUMS)
 

--- a/src/baldr/CMakeLists.txt
+++ b/src/baldr/CMakeLists.txt
@@ -108,5 +108,6 @@ valhalla_module(NAME baldr
     valhalla::proto
     ${valhalla_protobuf_targets}
     Boost::boost
+    Boost::filesystem
     CURL::CURL
     ZLIB::ZLIB)


### PR DESCRIPTION
This PR addresses issue #2065 by adding Boost::filesystem to baldr dependencies. 

Dependency is induced by graphtile.cc