### PR TITLE
add valhalla/valhalla.h.in check to the releasing doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ var hersheyRequest = '{"locations":[{"lat":40.546115,"lon":-76.385076,"type":"br
 var route = valhalla.route(hersheyRequest); // returns a string, other actions also available
 ```
 
-Please see the releasing docs for information on releasing a new version.
+Please see the [releasing docs](docs/releasing.md) for information on releasing a new version.
 
 Tests
 -----

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -43,12 +43,13 @@ We may introduce forward-compatible changes: query parameters and response prope
 2. Make sure `CHANGELOG.md` is up to date.
 3. Make sure the `package.json` on branch `x.y` has been committed.
 4. Make sure all tests are passing (e.g. Circle CI gives you a :green_apple:)
-5. Use an annotated tag to mark the release: `git tag x.y.z -a` Body of the tag description should be the changelog entries.
-6. Push tags and commits: `git push; git push --tags`
-7. On https://github.com/valhalla/valhalla/releases press `Draft a new release`,
+5. Make sure the [`valhalla/valhalla.h.in`](../valhalla/valhalla.h.in) has been updated.
+6. Use an annotated tag to mark the release: `git tag x.y.z -a` Body of the tag description should be the changelog entries.
+7. Push tags and commits: `git push; git push --tags`
+8. On https://github.com/valhalla/valhalla/releases press `Draft a new release`,
    write the release tag `x.y.z` in the `Tag version` field, write the changelog entries in the `Describe this release` field
    and press `Publish release`.
-8. If you are publishing to npm:
+9. If you are publishing to npm:
     - your binaries will get published to s3 by circle when you push a tag that matches the package.json version
     - Locally you can now test binaries. Cleanup, re-install, and run the tests like:
        ```


### PR DESCRIPTION
# Issue

minor documentation suggestion in the "releasing doc";
related to the old issues about updating the versions in the ` valhalla/valhalla.h.in` 
* https://github.com/valhalla/valhalla/issues/1836
* https://github.com/valhalla/valhalla/issues/1797


## Tasklist

 - [ ] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
 - [x ] Update relevant [documentation](docs/README.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
