### PR TITLE
Switches to ninja instead of make in CI for faster builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
 
   build-release-binary-linux:
     docker:
-      - image: valhalla/docker:build-3.0.1
+      - image: valhalla/docker:build-3.0.2
     steps:
       - checkout
       - run:
@@ -67,7 +67,7 @@ jobs:
 
   build-debug-binary-linux:
     docker:
-      - image: valhalla/docker:build-3.0.1
+      - image: valhalla/docker:build-3.0.2
     steps:
       - checkout
       - run:
@@ -106,7 +106,7 @@ jobs:
 
   lint-build-debug:
     docker:
-      - image: valhalla/docker:build-3.0.1
+      - image: valhalla/docker:build-3.0.2
     steps:
       - checkout
       - run: ./scripts/format.sh && ./scripts/error_on_dirty.sh
@@ -132,7 +132,7 @@ jobs:
 
   build-release:
     docker:
-      - image: valhalla/docker:build-3.0.1
+      - image: valhalla/docker:build-3.0.2
     steps:
       - checkout
       - run: ./scripts/format.sh && ./scripts/error_on_dirty.sh
@@ -157,7 +157,7 @@ jobs:
 
   build-release-x86:
     docker:
-      - image: valhalla/docker:build-x86-3.0.1
+      - image: valhalla/docker:build-x86-3.0.2
     steps:
       - checkout
       #- run: ./scripts/format.sh && ./scripts/error_on_dirty.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,9 +48,9 @@ jobs:
       - run: |
           cd build && cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=Off -DENABLE_PYTHON_BINDINGS=On \
           -DCPACK_GENERATOR=DEB -DCPACK_PACKAGE_VERSION_SUFFIX="-0ubuntu1-$(lsb_release -sc)" -DENABLE_SERVICES=OFF
-      - run: ninja -C build
-      - run: ninja -C build install
-      - run: ninja -C build package
+      - run: ninja -j 3 -C build
+      - run: ninja -j 3 -C build install
+      - run: ninja -j 3 -C build package
       - run:
           command: |
             export PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")
@@ -89,9 +89,9 @@ jobs:
       - run: |
           cd build && cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=Off -DENABLE_PYTHON_BINDINGS=On \
           -DCPACK_GENERATOR=DEB -DCPACK_PACKAGE_VERSION_SUFFIX="-0ubuntu1-$(lsb_release -sc)" -DENABLE_SERVICES=OFF
-      - run: ninja -C build
-      - run: ninja -C build install
-      - run: ninja -C build package
+      - run: ninja -j 3 -C build
+      - run: ninja -j 3 -C build install
+      - run: ninja -j 3 -C build package
       - run:
           command: |
             export PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")
@@ -118,12 +118,12 @@ jobs:
       - run: mkdir build
       - run: cd build && cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=On -DCPACK_GENERATOR=DEB -DENABLE_COMPILER_WARNINGS=On -DCMAKE_EXPORT_COMPILE_COMMANDS=On
       - run: scripts/clang-tidy-only-diff.sh
-      - run: ninja -C build
-      - run: ninja -C build tests
-      - run: ninja -C build check
-      - run: ninja -C build install
-      - run: ninja -C build package
-      - run: ninja -C build coverage
+      - run: ninja -j 3 -C build
+      - run: ninja -j 3 -C build tests
+      - run: ninja -j 3 -C build check
+      - run: ninja -j 3 -C build install
+      - run: ninja -j 3 -C build package
+      - run: ninja -j 3 -C build coverage
       - run: /bin/bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
       - save_cache:
           key: ccache
@@ -145,11 +145,11 @@ jobs:
       - run: |
           cd build && cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=On -DENABLE_PYTHON_BINDINGS=On \
           -DCPACK_GENERATOR=DEB -DCPACK_PACKAGE_VERSION_SUFFIX="-0ubuntu1-$(lsb_release -sc)"
-      - run: ninja -C build
-      - run: ninja -C build tests
-      - run: ninja -C build check
-      - run: ninja -C build install
-      - run: ninja -C build package
+      - run: ninja -j 3 -C build
+      - run: ninja -j 3 -C build tests
+      - run: ninja -j 3 -C build check
+      - run: ninja -j 3 -C build install
+      - run: ninja -j 3 -C build package
       - save_cache:
           key: ccache
           paths:
@@ -169,9 +169,9 @@ jobs:
       - run: mkdir build
       - run: |
           cd build && cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release -DENABLE_NODE_BINDINGS=Off
-      - run: ninja -C build
-      - run: ninja -C build tests
-      - run: ninja -C build check
+      - run: ninja -j 3 -C build
+      - run: ninja -j 3 -C build tests
+      - run: ninja -j 3 -C build check
       - save_cache:
           key: ccache
           paths:
@@ -192,9 +192,9 @@ jobs:
       - run: npm install --ignore-scripts
       - run: mkdir -p build
       - run: cd build && cmake .. -GNinja -DENABLE_PYTHON_BINDINGS=Off
-      - run: ninja -C build
-      - run: ninja -C build tests
-      - run: ninja -C build check
+      - run: ninja -j 3 -C build
+      - run: ninja -j 3 -C build tests
+      - run: ninja -j 3 -C build check
       - save_cache:
           key: ccache
           paths:
@@ -210,7 +210,7 @@ jobs:
       - run: npm install --ignore-scripts
       - run: mkdir -p build
       - run: cd build && cmake .. -GNinja -DBUILD_SHARED_LIBS=Off -DENABLE_PYTHON_BINDINGS=Off -DENABLE_DATA_TOOLS=OFF -DENABLE_SERVICES=OFF -DBoost_USE_STATIC_LIBS=ON -DProtobuf_USE_STATIC_LIBS=ON -DLZ4_USE_STATIC_LIBS=ON
-      - run: ninja -C build
+      - run: ninja -j 3 -C build
       - run:
           command: |
             export PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")
@@ -229,7 +229,7 @@ jobs:
       - run: npm install --ignore-scripts
       - run: mkdir -p build
       - run: cd build && cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug -DENABLE_PYTHON_BINDINGS=Off -DBUILD_SHARED_LIBS=Off -DENABLE_DATA_TOOLS=OFF -DENABLE_SERVICES=OFF -DBoost_USE_STATIC_LIBS=ON -DProtobuf_USE_STATIC_LIBS=ON -DLZ4_USE_STATIC_LIBS=ON
-      - run: ninja -C build
+      - run: ninja -j 3 -C build
       - run:
           command: |
             export PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 commands:
   install_macos_dependencies:
     steps:
-      - run: brew install protobuf cmake libtool boost-python libspatialite pkg-config lua curl wget czmq lz4 spatialite-tools unzip
+      - run: brew install protobuf cmake libtool boost-python libspatialite pkg-config lua curl wget czmq lz4 spatialite-tools unzip ninja
       - run:
           name: Install Node
           command: |
@@ -46,11 +46,11 @@ jobs:
       - run: npm install --ignore-scripts
       - run: mkdir build
       - run: |
-          cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=Off -DENABLE_PYTHON_BINDINGS=On \
+          cd build && cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=Off -DENABLE_PYTHON_BINDINGS=On \
           -DCPACK_GENERATOR=DEB -DCPACK_PACKAGE_VERSION_SUFFIX="-0ubuntu1-$(lsb_release -sc)" -DENABLE_SERVICES=OFF
-      - run: make -C build -j4
-      - run: make -C build install
-      - run: make -C build package
+      - run: ninja -C build
+      - run: ninja -C build install
+      - run: ninja -C build package
       - run:
           command: |
             export PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")
@@ -87,11 +87,11 @@ jobs:
       - run: npm install --ignore-scripts
       - run: mkdir build
       - run: |
-          cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=Off -DENABLE_PYTHON_BINDINGS=On \
+          cd build && cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=Off -DENABLE_PYTHON_BINDINGS=On \
           -DCPACK_GENERATOR=DEB -DCPACK_PACKAGE_VERSION_SUFFIX="-0ubuntu1-$(lsb_release -sc)" -DENABLE_SERVICES=OFF
-      - run: make -C build -j4
-      - run: make -C build install
-      - run: make -C build package
+      - run: ninja -C build
+      - run: ninja -C build install
+      - run: ninja -C build package
       - run:
           command: |
             export PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")
@@ -116,14 +116,14 @@ jobs:
             - ccache
       - run: npm install --ignore-scripts
       - run: mkdir build
-      - run: cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=On -DCPACK_GENERATOR=DEB -DENABLE_COMPILER_WARNINGS=On -DCMAKE_EXPORT_COMPILE_COMMANDS=On
+      - run: cd build && cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=On -DCPACK_GENERATOR=DEB -DENABLE_COMPILER_WARNINGS=On -DCMAKE_EXPORT_COMPILE_COMMANDS=On
       - run: scripts/clang-tidy-only-diff.sh
-      - run: make -C build -j4
-      - run: make -C build -j4 tests
-      - run: make -C build -j2 check
-      - run: make -C build install
-      - run: make -C build package
-      - run: make -C build coverage
+      - run: ninja -C build
+      - run: ninja -C build tests
+      - run: ninja -C build check
+      - run: ninja -C build install
+      - run: ninja -C build package
+      - run: ninja -C build coverage
       - run: /bin/bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
       - save_cache:
           key: ccache
@@ -143,13 +143,13 @@ jobs:
       - run: npm install --ignore-scripts
       - run: mkdir build
       - run: |
-          cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=On -DENABLE_PYTHON_BINDINGS=On \
+          cd build && cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=On -DENABLE_PYTHON_BINDINGS=On \
           -DCPACK_GENERATOR=DEB -DCPACK_PACKAGE_VERSION_SUFFIX="-0ubuntu1-$(lsb_release -sc)"
-      - run: make -C build -j4
-      - run: make -C build -j4 tests
-      - run: make -C build -j2 check
-      - run: make -C build install
-      - run: make -C build package
+      - run: ninja -C build
+      - run: ninja -C build tests
+      - run: ninja -C build check
+      - run: ninja -C build install
+      - run: ninja -C build package
       - save_cache:
           key: ccache
           paths:
@@ -168,10 +168,10 @@ jobs:
       - run: npm install --ignore-scripts
       - run: mkdir build
       - run: |
-          cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DENABLE_NODE_BINDINGS=Off
-      - run: make -C build -j4
-      - run: make -C build -j4 tests
-      - run: make -C build -j2 check
+          cd build && cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release -DENABLE_NODE_BINDINGS=Off
+      - run: ninja -C build
+      - run: ninja -C build tests
+      - run: ninja -C build check
       - save_cache:
           key: ccache
           paths:
@@ -191,10 +191,10 @@ jobs:
       - run: brew install --build-from-source ./prime_server.rb
       - run: npm install --ignore-scripts
       - run: mkdir -p build
-      - run: cd build && cmake .. -DENABLE_PYTHON_BINDINGS=Off
-      - run: make -C build -j4
-      - run: make -C build -j4 tests
-      - run: make -C build -j2 check
+      - run: cd build && cmake .. -GNinja -DENABLE_PYTHON_BINDINGS=Off
+      - run: ninja -C build
+      - run: ninja -C build tests
+      - run: ninja -C build check
       - save_cache:
           key: ccache
           paths:
@@ -209,8 +209,8 @@ jobs:
       - run: git submodule sync && git submodule update --init
       - run: npm install --ignore-scripts
       - run: mkdir -p build
-      - run: cd build && cmake .. -DBUILD_SHARED_LIBS=Off -DENABLE_PYTHON_BINDINGS=Off -DENABLE_DATA_TOOLS=OFF -DENABLE_SERVICES=OFF -DBoost_USE_STATIC_LIBS=ON -DProtobuf_USE_STATIC_LIBS=ON -DLZ4_USE_STATIC_LIBS=ON
-      - run: make -C build -j4
+      - run: cd build && cmake .. -GNinja -DBUILD_SHARED_LIBS=Off -DENABLE_PYTHON_BINDINGS=Off -DENABLE_DATA_TOOLS=OFF -DENABLE_SERVICES=OFF -DBoost_USE_STATIC_LIBS=ON -DProtobuf_USE_STATIC_LIBS=ON -DLZ4_USE_STATIC_LIBS=ON
+      - run: ninja -C build
       - run:
           command: |
             export PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")
@@ -228,8 +228,8 @@ jobs:
       - run: git submodule sync && git submodule update --init
       - run: npm install --ignore-scripts
       - run: mkdir -p build
-      - run: cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_PYTHON_BINDINGS=Off -DBUILD_SHARED_LIBS=Off -DENABLE_DATA_TOOLS=OFF -DENABLE_SERVICES=OFF -DBoost_USE_STATIC_LIBS=ON -DProtobuf_USE_STATIC_LIBS=ON -DLZ4_USE_STATIC_LIBS=ON
-      - run: make -C build -j4
+      - run: cd build && cmake .. -GNinja -DCMAKE_BUILD_TYPE=Debug -DENABLE_PYTHON_BINDINGS=Off -DBUILD_SHARED_LIBS=Off -DENABLE_DATA_TOOLS=OFF -DENABLE_SERVICES=OFF -DBoost_USE_STATIC_LIBS=ON -DProtobuf_USE_STATIC_LIBS=ON -DLZ4_USE_STATIC_LIBS=ON
+      - run: ninja -C build
       - run:
           command: |
             export PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -86,6 +86,7 @@ add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/test/data/roma_tiles/1/047/352.gph
   DEPENDS valhalla_build_tiles ${VALHALLA_SOURCE_DIR}/test/data/via_montebello_roma_italy.osm.pbf)
 add_custom_target(roma_tiles DEPENDS ${CMAKE_BINARY_DIR}/test/data/roma_tiles/1/047/352.gph)
 
+file(GLOB locales "${VALHALLA_SOURCE_DIR}/locales/*.json")
 add_custom_command(OUTPUT .locales.timestamp
   COMMAND /bin/bash -c "for loc in $(jq --raw-output .posix_locale *.json); do \
        $<$<NOT:$<BOOL:${APPLE}>>:  localedef -i $\{loc\%.\*\} -f $\{loc\#\#\*.\} ./$\{loc\}   ; > \
@@ -93,7 +94,7 @@ add_custom_command(OUTPUT .locales.timestamp
      done \
      && touch ${CMAKE_CURRENT_BINARY_DIR}/.locales.timestamp"
   WORKING_DIRECTORY ${VALHALLA_SOURCE_DIR}/locales
-  DEPENDS ${VALHALLA_SOURCE_DIR}/locales/*.json
+  DEPENDS ${locales}
   COMMENT "Compile locale definition files..."
   VERBATIM)
 add_custom_target(localedef DEPENDS .locales.timestamp)


### PR DESCRIPTION
Using ninja speeds up a full build by 36% on my desktop, while not
seeing much of a speedup on incremental builds.

```md
Full build:       36% speedup
  ninja:          real 151.07
  make -j$(nproc) real 234.78

Incremental (touched bidirectional): 1% speedup
  ninja:          real 15.31
  make -j$(nproc) real 15.54
```

# Issue

What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.

## Tasklist

 - [ ] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
