### PR TITLE
Add .tidytmp directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ scripts/gdal-2.0.0.tar.gz
 /*build*/
 /CMakeSettings.json
 /.idea
+/.tidytmp
 
 # nodejs
 node_modules


### PR DESCRIPTION
# Issue

Running clang-tidy locally creates this directory, just adding to gitignore as it should not be checked in.

## Tasklist

 - [ ] Add tests
 - [ ] Review - you must request approval to merge any PR to master
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] Update relevant [documentation](docs/README.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
