### PR TITLE
[build] Build node bindings with c++14 as well (missed in e21b3160b2)

### DIFF
--- a/src/bindings/node/CMakeLists.txt
+++ b/src/bindings/node/CMakeLists.txt
@@ -14,7 +14,7 @@ nodejs_init()
 message(STATUS "Configuring node_valhalla bindings for NodeJs ${NODEJS_VERSION}")
 
 add_nodejs_module(node_valhalla node.cc)
-set_target_properties(node_valhalla PROPERTIES CXX_STANDARD 11)
+set_target_properties(node_valhalla PROPERTIES CXX_STANDARD 14)
 target_link_libraries(node_valhalla valhalla)
 
 # Include N-API wrappers


### PR DESCRIPTION
Part of  #2022 (transition to C++14)

