### PR TITLE
fix to the distance shape bug

### DIFF
--- a/src/meili/map_matcher.cc
+++ b/src/meili/map_matcher.cc
@@ -235,10 +235,10 @@ MatchResult FindMatchResult(const MapMatcher& mapmatcher,
   }
 
   // If we failed to get a valid edge or can't find it
-  // At least we know which point it matches
+  // At least we know which point it matches. we set distance_along
+  // to 1 which will match the last valid edge's end
   const auto& edge = state.candidate().edges.front();
-  return {edge.projected,     std::sqrt(edge.distance), edgeid,
-          edge.percent_along, measurement.epoch_time(), stateid};
+  return {edge.projected, std::sqrt(edge.distance), edgeid, 1, measurement.epoch_time(), stateid};
 }
 
 // Find the corresponding match results of a list of states


### PR DESCRIPTION
# Issue

when map_matcher could not find an edge for the match results, it assigns the last valid edgeid to it and also set pct_along to 0. It tricks the leg builder to build leg on such matching results. Thus a buggy shape shows up. Also, the trimming logic fails on under flow. 
<img width="1431" alt="Screen Shot 2019-12-10 at 12 26 55 PM" src="https://user-images.githubusercontent.com/16877918/70582259-b9749800-1b6e-11ea-9b8a-56f22d3f5147.png">


