### PR TITLE
suggested changes to intersection map matching

### DIFF
--- a/src/meili/candidate_search.cc
+++ b/src/meili/candidate_search.cc
@@ -107,12 +107,15 @@ CandidateQuery::WithinSquaredDistance(const midgard::PointLL& location,
       }
     }
 
+    // We found some edge candidates within the distance cut off
     if (correlated.edges.size()) {
-      // Add back if it is an edge correlated or it's a node correlated
-      // but it's not added yet. By only allow one snapped_node per intersection match
-      // we are including one edge candidate that starts/ends on the snapped node.
-      // by the time we recover the route from edge candidates, the logic need to adjust
-      // the this edge candidate accordingly to the edge transition consistancy.
+      // If the candidates are not at a node we just add them if they are at a node
+      // we avoid adding them multiple times by remembering the node we snapped to
+      // this has two consequences:
+      // 1. it allows us to keep the number of edge candidates low which keeps the search fast
+      // 2. it may use one edge for the route segment going into a state (at 100% along the edge)
+      //    and then use the opposing edge (at 0% along the edge) to start the route segment which
+      //    leaves that state. we fix this case later inside of find match result
       if (!snapped_node.Is_Valid() || visited_nodes.insert(snapped_node).second) {
         candidates.emplace_back(std::move(correlated));
       }

--- a/src/meili/candidate_search.cc
+++ b/src/meili/candidate_search.cc
@@ -113,9 +113,9 @@ CandidateQuery::WithinSquaredDistance(const midgard::PointLL& location,
       // we avoid adding them multiple times by remembering the node we snapped to
       // this has two consequences:
       // 1. it allows us to keep the number of edge candidates low which keeps the search fast
-      // 2. it may use one edge for the route segment going into a state (at 100% along the edge)
-      //    and then use the opposing edge (at 0% along the edge) to start the route segment which
-      //    leaves that state. we fix this case later inside of find match result
+      // 2. in routing.cc we will find a route to the node, ie not the candidate edge, which means
+      //    the route may not end or begin with the candidates we store here, we will need to
+      //    handle this case inside of FindMatchResult which expects a candidate to be used
       if (!snapped_node.Is_Valid() || visited_nodes.insert(snapped_node).second) {
         candidates.emplace_back(std::move(correlated));
       }


### PR DESCRIPTION
in reviewing #2114 i had a couple of changes i'd like to suggest. ive made the bulk of them here but i think the most important thing is still left to do. specifically, in the case we are at an intersection, we need to potentially use which are not candidates on the state but are other edges leaving or entering the same node the edge candidates do.

i think the trick will be to say, for the previous route segment going into the state, if the last edge is 0% along, we need to get the edge before that and use it at 100% along.

if its the frist segment in the route and there is no previous route segment, then we can say if the first edge of the next segment is 100% along, then we need the edge after that and  use it at 0% along.

i havent added that logic to this PR but i think the above is what we need to do.