### PR TITLE
Fixes to make batch.sh run correctly

### DIFF
--- a/run_route_scripts/batch.sh
+++ b/run_route_scripts/batch.sh
@@ -45,14 +45,19 @@ for arg in $(valhalla_run_route --help | grep -o '\-[a-z\-]\+' | sort | uniq); d
     sed -i -e "s/^${arg}[ ]\+/${arg}|/g" "${TMP}"
     sed -i -e "s/[ ]\+${arg}[ ]\+/|${arg}|/g" "${TMP}"
 done
-sed -i -e "s;$;|--config|${CONF};g" -e "s/\([^\\]\)'|/\1|/g" -e "s/|'/|/g" "${TMP}"
+# Strip single-quotes from json string (arg to -j option in INPUT} to keep
+# valhalla's json parser happy
+sed -i -e "s/'//g" "${TMP}"
 
 #run all of the paths, make sure to cut off the timestamps
 #from the log messages otherwise every line will be a diff
 #TODO: add leading zeros to output files so they sort nicely
 echo -e "\x1b[32;1mWriting routes from ${INPUT} with a concurrency of ${CONCURRENCY} into ${RESULTS_OUTDIR}\x1b[0m"
-cat "${TMP}" | parallel --progress -k -C '\|' -P "${CONCURRENCY}" "valhalla_run_route {} 2>&1 | tee -a ${RESULTS_OUTDIR}/{#}.tmp | grep -F NARRATIVE | sed -e 's/^[^\[]*\[NARRATIVE\] //' &> ${RESULTS_OUTDIR}/{#}.txt; grep -F STATISTICS ${RESULTS_OUTDIR}/{#}.tmp | sed -e 's/^[^\[]*\[STATISTICS\] //' &>> ${RESULTS_OUTDIR}/{#}_statistics.csv; rm -f ${RESULTS_OUTDIR}/{#}.tmp"
-rm -f "${TMP}"
+cat "${TMP}" | parallel --progress -k -P "${CONCURRENCY}" "valhalla_run_route {} --config ${CONF} 2>&1 | tee -a ${RESULTS_OUTDIR}/{#}.tmp | grep -F NARRATIVE | sed -e 's/^[^\[]*\[NARRATIVE\] //' &> ${RESULTS_OUTDIR}/{#}.txt; grep -F STATISTICS ${RESULTS_OUTDIR}/{#}.tmp | sed -e 's/^[^\[]*\[STATISTICS\] //' &>> ${RESULTS_OUTDIR}/{#}_statistics.csv; rm -f ${RESULTS_OUTDIR}/{#}.tmp"
+# On macos, sed inline replace (-i opt) ends up creating a backup file with
+# "-e" suffix, even though -i arg is empty. The wildcard below will ensure that
+# that file is deleted as well.
+rm -f ${TMP}*
 echo "orgLat, orgLng, destLat, destLng, result, #Passes, runtime, trip time, length, arcDistance, #Manuevers" > ${RESULTS_OUTDIR}/statistics.csv
 cat `ls -1v ${RESULTS_OUTDIR}/*_statistics.csv` >> ${RESULTS_OUTDIR}/statistics.csv
 rm -f ${RESULTS_OUTDIR}/*_statistics.csv

--- a/run_route_scripts/batch.sh
+++ b/run_route_scripts/batch.sh
@@ -53,7 +53,7 @@ sed -i -e "s/'//g" "${TMP}"
 #from the log messages otherwise every line will be a diff
 #TODO: add leading zeros to output files so they sort nicely
 echo -e "\x1b[32;1mWriting routes from ${INPUT} with a concurrency of ${CONCURRENCY} into ${RESULTS_OUTDIR}\x1b[0m"
-cat "${TMP}" | parallel --progress -k -P "${CONCURRENCY}" "valhalla_run_route {} --config ${CONF} 2>&1 | tee -a ${RESULTS_OUTDIR}/{#}.tmp | grep -F NARRATIVE | sed -e 's/^[^\[]*\[NARRATIVE\] //' &> ${RESULTS_OUTDIR}/{#}.txt; grep -F STATISTICS ${RESULTS_OUTDIR}/{#}.tmp | sed -e 's/^[^\[]*\[STATISTICS\] //' &>> ${RESULTS_OUTDIR}/{#}_statistics.csv; rm -f ${RESULTS_OUTDIR}/{#}.tmp"
+cat "${TMP}" | parallel --progress -k -C '\|' -P "${CONCURRENCY}" "valhalla_run_route {} --config ${CONF} 2>&1 | tee -a ${RESULTS_OUTDIR}/{#}.tmp | grep -F NARRATIVE | sed -e 's/^[^\[]*\[NARRATIVE\] //' &> ${RESULTS_OUTDIR}/{#}.txt; grep -F STATISTICS ${RESULTS_OUTDIR}/{#}.tmp | sed -e 's/^[^\[]*\[STATISTICS\] //' &>> ${RESULTS_OUTDIR}/{#}_statistics.csv; rm -f ${RESULTS_OUTDIR}/{#}.tmp"
 # On macos, sed inline replace (-i opt) ends up creating a backup file with
 # "-e" suffix, even though -i arg is empty. The wildcard below will ensure that
 # that file is deleted as well.


### PR DESCRIPTION
# Issue

The last sed command in this script was creating a malformed json. It
was stripping the trailing single-quote of the json string but not the
leading one.

Changed the sed expression to remove single quotes from the json string.
Also moved adding the "--config" option to the place where parallel is
invoking valhalla_run_route. Since the arg to this option is fixed for
all runs of parallel, I find it easier to read if placed in the same
place where the executable is being called. This also limits the sed
expression to whats needed.

Tested by running batch.sh as follows:
$ ./batch.sh ../test_requests/demo_routes.txt ../build/valhalla.json
and verifying that guidance instructions are generated in results/ dir.

Fixes #2139 

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)