### PR TITLE
Handle large osmid better for x86

### DIFF
--- a/test/idtable.cc
+++ b/test/idtable.cc
@@ -69,6 +69,15 @@ void TestBounds() {
     throw std::logic_error("The max id should have been increased to 181");
 }
 
+void TestX86() {
+  IdTable t(6800000000);
+  uint64_t old_max = t.max();
+
+  t.set(5528037441);
+  if (t.max() != old_max) {
+    throw std::logic_error("The max id shouldn't be changed");
+  }
+}
 int main() {
   test::suite suite("nodetable");
 
@@ -76,6 +85,7 @@ int main() {
   suite.test(TEST_CASE(TestSetGet));
   suite.test(TEST_CASE(TestRandom));
   suite.test(TEST_CASE(TestBounds));
+  suite.test(TEST_CASE(TestX86));
 
   return suite.tear_down();
 }

--- a/valhalla/mjolnir/idtable.h
+++ b/valhalla/mjolnir/idtable.h
@@ -25,7 +25,7 @@ public:
     // Create a vector to mark bits. Initialize to 0.
     bitmarkers_.resize((maxosmid / 64) + 1, 0);
     // Set this to the actual maximum as dictated by the storage
-    maxosmid_ = bitmarkers_.size() * 64 - 1;
+    maxosmid_ = bitmarkers_.size() * static_cast<uint64_t>(64) - 1;
   }
 
   /**
@@ -76,7 +76,7 @@ private:
     if (id > maxosmid_) {
       LOG_WARN("Max osmid exceeded bitset, resizing to fit id: " + std::to_string(id));
       bitmarkers_.resize(std::ceil(idx * 1.01 + 1), 0);
-      maxosmid_ = bitmarkers_.size() * 64 - 1;
+      maxosmid_ = bitmarkers_.size() * static_cast<uint64_t>(64) - 1;
     }
     return idx;
   }


### PR DESCRIPTION
# Issue

https://github.com/valhalla/valhalla/issues/2160

'size()' on x86 returns uint32_t 

## Tasklist

 - [x] Add tests


