### PR TITLE
fix typo icp -> ipc for the configuration file check in valhalla service main function

### DIFF
--- a/src/valhalla_service.cc
+++ b/src/valhalla_service.cc
@@ -46,7 +46,7 @@ int main(int argc, char** argv) {
 
   // check the server endpoint
   if (listen.find("tcp://") != 0) {
-    if (listen.find("icp://") != 0) {
+    if (listen.find("ipc://") != 0) {
       LOG_ERROR("You must listen on either tcp://ip:port or ipc://some_socket_file");
       return EXIT_FAILURE;
     } else {


### PR DESCRIPTION

# Issue

With the current configuration check, there is an option to start the valhalla service with the configuration:

```
{
  ...
  "httpd": {
    "service": {
...
      "listen": "**icp**:///tmp/valhalla",
....
    }
  },
...
}
```

It produces error : `libc++abi.dylib: terminating with uncaught exception of type std::runtime_error: Protocol not supported`

If I change the socket protocol to the correct name 

```
{
  ...
  "httpd": {
    "service": {
...
      "listen": "**ipc**:///tmp/valhalla",
....
    }
  },
...
}
```

The valhalla service main's function configuration check fails with the error: `You must listen on either tcp://ip:port or ipc://some_socket_file`


