### PR TITLE
Tc internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
    * ADDED: Allows more complicated routes in timedependent a-star before timing out [#2068](https://github.com/valhalla/valhalla/pull/2068)
    * ADDED: Guide signs and junction names [#2096](https://github.com/valhalla/valhalla/pull/2096)
    * ADDED: Added a bool to the config indicating whether to use commercially set attributes.  Added logic to not call IsIntersectionInternal if this is a commercial data set.  [#2132](https://github.com/valhalla/valhalla/pull/2132)
+   * ADDED: Removed commerical data set bool to the config and added more knobs for data.  Added infer_internal_intersections, infer_turn_channels, apply_country_overrides, and use_admin_db.  [#2173](https://github.com/valhalla/valhalla/pull/2173)
 
 ## Release Date: 2019-11-21 Valhalla 3.0.9
 * **Bug Fix**

--- a/scripts/valhalla_build_config
+++ b/scripts/valhalla_build_config
@@ -25,7 +25,6 @@ config = {
     'transit_bounding_box': optional(str),
     'hierarchy': True,
     'shortcuts': True,
-    'commercial_data': optional(bool),
     'include_driveways': True,
     'include_bicycle': True,
     'include_pedestrian': True,
@@ -33,6 +32,12 @@ config = {
     'import_bike_share_stations': False,
     'global_synchronized_cache': False,
     'max_concurrent_reader_users' : 1,
+    'data_processing': {
+      'infer_internal_intersections': True,
+      'infer_turn_channels': True,
+      'apply_country_overrides': True,
+      'use_admin_db': True
+    },
     'logging': {
       'type': 'std_out',
       'color': True,
@@ -254,7 +259,6 @@ help_text = {
     'transit_bounding_box': 'Add comma separated bounding box values to only download transit data inside the given bounding box',
     'hierarchy': 'bool indicating whether road hierarchy is to be built - default to True',
     'shortcuts': 'bool indicating whether shortcuts are to be built - default to True',
-    'commercial_data': 'bool indicating whether to use commercially set attributes',
     'include_driveways': 'bool indicating whether private driveways are included - default to True',
     'include_bicycle': 'bool indicating whether cycling only ways are included - default to True',
     'include_pedestrian': 'bool indicating whether pedestrian only ways are included - default to True',
@@ -262,6 +266,12 @@ help_text = {
     'import_bike_share_stations': 'bool indicating whether importing bike share stations(BSS). Set to True when using multimodal - default to False',
     'global_synchronized_cache': 'bool indicating whether global_synchronized_cache is used - default to False',
     'max_concurrent_reader_users' : 'number of threads in the threadpool which can be used to fetch tiles over the network via curl',
+    'data_processing': {
+      'infer_internal_intersections': 'bool indicating whether or not to infer internal intersections during the graph enhancer phase or use the internal_intersection key from the pbf',
+      'infer_turn_channels': 'bool indicating whether or not to infer turn channels during the graph enhancer phase or use the turn_channel key from the pbf',
+      'apply_country_overrides': 'bool indicating whether or not to apply country overrides during the graph enhancer phase',
+      'use_admin_db': 'bool indicating whether or not to use the administrative database during the graph enhancer phase or use the admin keys from the pbf that are set on the way'
+    },
     'logging': {
       'type': 'Type of logger either std_out or file',
       'color': 'User colored log level in std_out logger',

--- a/src/mjolnir/graphenhancer.cc
+++ b/src/mjolnir/graphenhancer.cc
@@ -859,7 +859,7 @@ bool IsNextEdgeInternal(const DirectedEdge directededge,
                         GraphTileBuilder& tilebuilder,
                         GraphReader& reader,
                         std::mutex& lock,
-                        bool infer_turn_channels) {
+                        bool infer_internal_intersections) {
   // Get the tile at the startnode
   GraphTileBuilder tile = tilebuilder;
   // Get the tile at the end node. and find inbound heading of the candidate
@@ -899,7 +899,7 @@ bool IsNextEdgeInternal(const DirectedEdge directededge,
     if (tilebuilder.edgeinfo(directededge.edgeinfo_offset()).wayid() ==
         tile.edgeinfo(diredge.edgeinfo_offset()).wayid()) {
 
-      if (!infer_turn_channels)
+      if (!infer_internal_intersections)
         return diredge.internal();
       else
         return IsIntersectionInternal(&tile, reader, lock, directededge.endnode(), nodeinfo, diredge,
@@ -1399,7 +1399,7 @@ void enhance(const boost::property_tree::ptree& pt,
   sequence<OSMAccess> access_tags(access_file, false);
 
   auto database = pt.get_optional<std::string>("admin");
-  bool infer_turn_channels = pt.get<bool>("data_processing.infer_turn_channels", true);
+  bool infer_internal_intersections = pt.get<bool>("data_processing.infer_internal_intersections", true);
   bool apply_country_overrides = pt.get<bool>("data_processing.apply_country_overrides", true);
 
   // Initialize the admin DB (if it exists)
@@ -1713,7 +1713,7 @@ void enhance(const boost::property_tree::ptree& pt,
           // find the edge that has the same wayid as the current DE
           // if it is internal, then add turn lanes for this edge and not the internal one
           // if not internal, then do not add turn lanes for this DE and leave them on the next one.
-          if (!IsNextEdgeInternal(directededge, tilebuilder, reader, lock, infer_turn_channels)) {
+          if (!IsNextEdgeInternal(directededge, tilebuilder, reader, lock, infer_internal_intersections)) {
             directededge.set_turnlanes(false);
           }
         }
@@ -1723,7 +1723,7 @@ void enhance(const boost::property_tree::ptree& pt,
 
         // Test if an internal intersection edge. Must do this after setting
         // opposing edge index
-        if (infer_turn_channels && IsIntersectionInternal(&tilebuilder, reader, lock, startnode,
+        if (infer_internal_intersections && IsIntersectionInternal(&tilebuilder, reader, lock, startnode,
                                                           nodeinfo, directededge, j)) {
           directededge.set_internal(true);
         }

--- a/src/mjolnir/graphenhancer.cc
+++ b/src/mjolnir/graphenhancer.cc
@@ -859,7 +859,7 @@ bool IsNextEdgeInternal(const DirectedEdge directededge,
                         GraphTileBuilder& tilebuilder,
                         GraphReader& reader,
                         std::mutex& lock,
-                        bool commercial_data) {
+                        bool infer_turn_channels) {
   // Get the tile at the startnode
   GraphTileBuilder tile = tilebuilder;
   // Get the tile at the end node. and find inbound heading of the candidate
@@ -899,7 +899,7 @@ bool IsNextEdgeInternal(const DirectedEdge directededge,
     if (tilebuilder.edgeinfo(directededge.edgeinfo_offset()).wayid() ==
         tile.edgeinfo(diredge.edgeinfo_offset()).wayid()) {
 
-      if (commercial_data)
+      if (!infer_turn_channels)
         return diredge.internal();
       else
         return IsIntersectionInternal(&tile, reader, lock, directededge.endnode(), nodeinfo, diredge,
@@ -1399,7 +1399,8 @@ void enhance(const boost::property_tree::ptree& pt,
   sequence<OSMAccess> access_tags(access_file, false);
 
   auto database = pt.get_optional<std::string>("admin");
-  bool commercial_data = pt.get<bool>("commercial_data", false);
+  bool infer_turn_channels = pt.get<bool>("data_processing.infer_turn_channels", true);
+  bool apply_country_overrides = pt.get<bool>("data_processing.apply_country_overrides", true);
 
   // Initialize the admin DB (if it exists)
   sqlite3* admin_db_handle = database ? GetDBHandle(*database) : nullptr;
@@ -1584,8 +1585,7 @@ void enhance(const boost::property_tree::ptree& pt,
         }
 
         // only process country access logic if the iso country codes match.
-        if (country_code == end_node_code) {
-
+        if (apply_country_overrides && country_code == end_node_code) {
           // country access logic.
           // if the (auto, bike, foot, etc) tag flag is set in the OSMAccess
           // struct, then this means that it has been set by a user of the
@@ -1713,7 +1713,7 @@ void enhance(const boost::property_tree::ptree& pt,
           // find the edge that has the same wayid as the current DE
           // if it is internal, then add turn lanes for this edge and not the internal one
           // if not internal, then do not add turn lanes for this DE and leave them on the next one.
-          if (!IsNextEdgeInternal(directededge, tilebuilder, reader, lock, commercial_data)) {
+          if (!IsNextEdgeInternal(directededge, tilebuilder, reader, lock, infer_turn_channels)) {
             directededge.set_turnlanes(false);
           }
         }
@@ -1723,8 +1723,8 @@ void enhance(const boost::property_tree::ptree& pt,
 
         // Test if an internal intersection edge. Must do this after setting
         // opposing edge index
-        if (!commercial_data && IsIntersectionInternal(&tilebuilder, reader, lock, startnode,
-                                                       nodeinfo, directededge, j)) {
+        if (infer_turn_channels && IsIntersectionInternal(&tilebuilder, reader, lock, startnode,
+                                                          nodeinfo, directededge, j)) {
           directededge.set_internal(true);
         }
 

--- a/src/mjolnir/graphenhancer.cc
+++ b/src/mjolnir/graphenhancer.cc
@@ -1399,7 +1399,8 @@ void enhance(const boost::property_tree::ptree& pt,
   sequence<OSMAccess> access_tags(access_file, false);
 
   auto database = pt.get_optional<std::string>("admin");
-  bool infer_internal_intersections = pt.get<bool>("data_processing.infer_internal_intersections", true);
+  bool infer_internal_intersections =
+      pt.get<bool>("data_processing.infer_internal_intersections", true);
   bool apply_country_overrides = pt.get<bool>("data_processing.apply_country_overrides", true);
 
   // Initialize the admin DB (if it exists)
@@ -1713,7 +1714,8 @@ void enhance(const boost::property_tree::ptree& pt,
           // find the edge that has the same wayid as the current DE
           // if it is internal, then add turn lanes for this edge and not the internal one
           // if not internal, then do not add turn lanes for this DE and leave them on the next one.
-          if (!IsNextEdgeInternal(directededge, tilebuilder, reader, lock, infer_internal_intersections)) {
+          if (!IsNextEdgeInternal(directededge, tilebuilder, reader, lock,
+                                  infer_internal_intersections)) {
             directededge.set_turnlanes(false);
           }
         }
@@ -1723,8 +1725,9 @@ void enhance(const boost::property_tree::ptree& pt,
 
         // Test if an internal intersection edge. Must do this after setting
         // opposing edge index
-        if (infer_internal_intersections && IsIntersectionInternal(&tilebuilder, reader, lock, startnode,
-                                                          nodeinfo, directededge, j)) {
+        if (infer_internal_intersections &&
+            IsIntersectionInternal(&tilebuilder, reader, lock, startnode, nodeinfo, directededge,
+                                   j)) {
           directededge.set_internal(true);
         }
 

--- a/src/mjolnir/linkclassification.cc
+++ b/src/mjolnir/linkclassification.cc
@@ -141,7 +141,8 @@ std::pair<uint32_t, uint32_t> Reclassify(LinkTreeNode& root,
                                          sequence<Edge>& edges,
                                          sequence<OSMWay>& ways,
                                          sequence<OSMWayNode>& way_nodes,
-                                         std::queue<LinkTreeNode*>& leaves) {
+                                         std::queue<LinkTreeNode*>& leaves,
+                                         bool infer_turn_channels) {
   // Get the classification at the root node.
   std::pair<uint32_t, uint32_t> counts = std::make_pair(0, 0);
   uint32_t exit_classification = root.classification;
@@ -214,8 +215,8 @@ std::pair<uint32_t, uint32_t> Reclassify(LinkTreeNode& root,
     // nodes along the path can have more than 2 links (fork). The end nodes
     // must have a non-link edge.
     bool turn_channel = false;
-    if (rc > static_cast<uint32_t>(RoadClass::kTrunk) && !has_fork && !has_exit &&
-        ends_have_non_link) {
+    if (infer_turn_channels && (rc > static_cast<uint32_t>(RoadClass::kTrunk) && !has_fork &&
+                                !has_exit && ends_have_non_link)) {
       turn_channel = IsTurnChannel(ways, edges, way_nodes, link_edge_indexes);
     }
 
@@ -255,7 +256,8 @@ std::pair<uint32_t, uint32_t> Reclassify(LinkTreeNode& root,
 void ReclassifyLinks(const std::string& ways_file,
                      const std::string& nodes_file,
                      const std::string& edges_file,
-                     const std::string& way_nodes_file) {
+                     const std::string& way_nodes_file,
+                     bool infer_turn_channels) {
   LOG_INFO("Reclassifying link graph edges...");
 
   // Need to capture these in the expand lambda
@@ -392,7 +394,7 @@ void ReclassifyLinks(const std::string& ways_file,
       }
 
       // Reclassify link edges within the link tree
-      auto counts = Reclassify(exit_node, edges, ways, way_nodes, leaves);
+      auto counts = Reclassify(exit_node, edges, ways, way_nodes, leaves, infer_turn_channels);
       count += counts.first;
       tc_count += counts.second;
     }

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -62,7 +62,9 @@ public:
     }
 
     include_driveways_ = pt.get<bool>("include_driveways", true);
-    commercial_data_ = pt.get<bool>("commercial_data", false);
+    infer_internal_intersections_ =
+        pt.get<bool>("data_processing.infer_internal_intersections", true);
+    infer_turn_channels_ = pt.get<bool>("data_processing.infer_turn_channels", true);
   }
 
   static std::string get_lua(const boost::property_tree::ptree& pt) {
@@ -371,9 +373,10 @@ public:
         ((highway_junction != results.end()) && (highway_junction->second == "motorway_junction"));
 
     for (const auto& tag : results) {
-
-      if (tag.first == "internal_intersection" && commercial_data_) {
+      if (tag.first == "internal_intersection" && !infer_internal_intersections_) {
         w.set_internal(tag.second == "true" ? true : false);
+      } else if (tag.first == "turn_channel" && !infer_turn_channels_) {
+        w.set_turn_channel(tag.second == "true" ? true : false);
       } else if (tag.first == "road_class") {
         RoadClass roadclass = (RoadClass)std::stoi(tag.second);
         switch (roadclass) {
@@ -561,8 +564,6 @@ public:
         w.set_roundabout(tag.second == "true" ? true : false);
       } else if (tag.first == "link") {
         w.set_link(tag.second == "true" ? true : false);
-      } else if (tag.first == "link_type") {
-        w.set_turn_channel(tag.second == "slip" ? true : false);
       } else if (tag.first == "ferry") {
         w.set_ferry(tag.second == "true" ? true : false);
       } else if (tag.first == "rail") {
@@ -1587,8 +1588,13 @@ public:
   // Configuration option to include driveways
   bool include_driveways_;
 
-  // Configuration option for commercial data sets
-  bool commercial_data_;
+  // Configuration option on whether or not to infer internal intersections during the graph enhancer
+  // phase or use the internal_intersection key from the pbf
+  bool infer_internal_intersections_;
+
+  // Configuration option on whether or not to infer turn channels during the graph
+  // enhancer phase or use the turn_channel key from the pbf
+  bool infer_turn_channels_;
 
   // Road class assignment needs to be set to the highway cutoff for ferries and auto trains.
   RoadClass highway_cutoff_rc_;

--- a/valhalla/mjolnir/linkclassification.h
+++ b/valhalla/mjolnir/linkclassification.h
@@ -14,7 +14,8 @@ namespace mjolnir {
 void ReclassifyLinks(const std::string& ways_file,
                      const std::string& nodes_file,
                      const std::string& edges_file,
-                     const std::string& way_nodes_file);
+                     const std::string& way_nodes_file,
+                     bool infer_turn_channels);
 } // namespace mjolnir
 } // namespace valhalla
 #endif // VALHALLA_MJOLNIR_LINK_CLASSIFICATION_H_


### PR DESCRIPTION
# Issue

This PR allows more options for the processing of data.  We can now turn on or off the processing of 
apply_country_overrides, infer_internal_intersections, and infer_turn_channels.  A placeholder has been created for use_admin_db, but the logic has not been added yet.  

Note some config changes:

```
"data_processing": {
      "apply_country_overrides": true,
      "infer_internal_intersections": true,
      "infer_turn_channels": true,
      "use_admin_db": true
    },
```

## Tasklist

 - [x] Add tests
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
