### PR TITLE
Packages third-party headers necessary when linking

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -198,6 +198,14 @@ install(FILES ${valhalla_hdrs}
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/valhalla"
   COMPONENT development)
 
+install(DIRECTORY ${VALHALLA_SOURCE_DIR}/third_party/date/include/date
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/valhalla/third_party"
+  COMPONENT development)
+
+install(DIRECTORY ${VALHALLA_SOURCE_DIR}/third_party/rapidjson/include/rapidjson
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/valhalla/third_party"
+  COMPONENT development)
+
 if(PKG_CONFIG_FOUND)
   ## Configure libvalhalla.pc file with valhalla target linking options via PkgConfig linker
   set(CMAKE_PkgConfig_LINK_EXECUTABLE "<CMAKE_COMMAND> -DINPUT=${VALHALLA_SOURCE_DIR}/libvalhalla.pc.in -DOUTPUT=<TARGET> -DVERSION=${VERSION} -Dprefix=${CMAKE_INSTALL_PREFIX} -Dexec_prefix=${CMAKE_INSTALL_PREFIX} -Dlibdir=${CMAKE_INSTALL_LIBDIR} -Dincludedir=${CMAKE_INSTALL_INCLUDEDIR} -Ddeplibs=\"<FLAGS> <LINK_FLAGS> <LINK_LIBRARIES>\" -P ${CMAKE_SOURCE_DIR}/cmake/PkgConfig.cmake")

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -19,7 +19,7 @@
 #include <valhalla/sif/hierarchylimits.h>
 
 #include <memory>
-#include <third_party/rapidjson/include/rapidjson/document.h>
+#include <rapidjson/document.h>
 #include <unordered_map>
 
 namespace valhalla {

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -19,7 +19,6 @@
 #include <valhalla/sif/hierarchylimits.h>
 
 #include <memory>
-#include <rapidjson/document.h>
 #include <unordered_map>
 
 namespace valhalla {


### PR DESCRIPTION
Since the valhalla headers refer to these headers, it becomes impossible
to build link to libvalhalla without also pointing to these third party
headers

Similar to https://github.com/valhalla/valhalla/issues/2189