### PR TITLE
nomenclature update for intersection geom index

### DIFF
--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -430,7 +430,7 @@ json::ArrayPtr intersections(const valhalla::DirectionsLeg::Maneuver& maneuver,
     loc->emplace_back(json::fp_t{ll.lng(), 6});
     loc->emplace_back(json::fp_t{ll.lat(), 6});
     intersection->emplace("location", loc);
-    intersection->emplace("shape_index", static_cast<uint64_t>(shape_index));
+    intersection->emplace("geometry_index", static_cast<uint64_t>(shape_index));
     if (node->has_transition_time())
       intersection->emplace("duration", json::fp_t{node->transition_time(), 3});
 


### PR DESCRIPTION
i realized that in osrm parlance the shape is refered to as "geometry" so i changed the new parameter to be called `geometry_index` instead