### PR TITLE
prevent calling path_map_match when path_edges are empty.

### DIFF
--- a/src/thor/trace_route_action.cc
+++ b/src/thor/trace_route_action.cc
@@ -183,7 +183,7 @@ thor_worker_t::map_match(Api& request) {
                                            mode, disconnected_edges, options);
 
     // If we want a route but there actually isnt a path, we cant give you one
-    if (path_edges.empty() && options.action() == Options::trace_route) {
+    if (path_edges.empty()) {
       throw std::exception{};
     }
 


### PR DESCRIPTION
# Issue

This is a duck fix to avoid seg fault. When the path edges are empty but there are valid match results, trace route attributes will fail since it try to access the path edges vector. 

There are deeper issue to investigate other than prevent the seg fault happen. Working on the investigation now (why we return valid match results without path edges in the shortest path finding)

