### PR TITLE
Cleanup unused argument etp in narrativebuilder

### DIFF
--- a/proto/directions.proto
+++ b/proto/directions.proto
@@ -85,7 +85,7 @@ message DirectionsLeg {
       kWest = 6;
       kNorthWest = 7;
     }
-  
+
     // TODO - add others later
     enum Type {
       kNone = 0;
@@ -128,7 +128,7 @@ message DirectionsLeg {
       kMergeRight = 37;
       kMergeLeft = 38;
     }
-  
+
     message SignElement {
       optional string text = 1;               // The actual sign element text, examples: I 95 North or Derry Street
       optional bool is_route_number = 2;      // true if sign element is a reference route number such as: I 81 South or US 322 West
@@ -151,7 +151,7 @@ message DirectionsLeg {
     optional float length = 4;                               // kilometers or miles based on units
     optional double time = 5;                                // seconds
     optional CardinalDirection begin_cardinal_direction = 6; // CardinalDirection
-    optional uint32 begin_heading = 7;                       // 0-360 
+    optional uint32 begin_heading = 7;                       // 0-360
     optional uint32 begin_shape_index = 8;                   // inclusive index
     optional uint32 end_shape_index = 9;                     // inclusive index
     optional bool portions_toll = 10;                        // has portions toll
@@ -181,7 +181,7 @@ message DirectionsLeg {
     optional bool has_time_restrictions = 34;                // Whether edge has any time restrictions or not
     repeated GuidanceView guidance_views = 35;               // List of guidance views
   }
-  
+
   optional uint64 trip_id = 1;
   optional uint32 leg_id = 2;
   optional uint32 leg_count = 3;

--- a/src/odin/directionsbuilder.cc
+++ b/src/odin/directionsbuilder.cc
@@ -95,7 +95,7 @@ void DirectionsBuilder::Build(Api& api) {
         if (options.directions_type() == DirectionsType::instructions) {
           std::unique_ptr<NarrativeBuilder> narrative_builder =
               NarrativeBuilderFactory::Create(options, &etp);
-          narrative_builder->Build(options, &etp, maneuvers);
+          narrative_builder->Build(options, maneuvers);
         }
       }
 

--- a/src/odin/narrativebuilder.cc
+++ b/src/odin/narrativebuilder.cc
@@ -45,9 +45,7 @@ NarrativeBuilder::NarrativeBuilder(const Options& options,
       articulated_preposition_enabled_(false) {
 }
 
-void NarrativeBuilder::Build(const Options& options,
-                             const EnhancedTripLeg* etp,
-                             std::list<Maneuver>& maneuvers) {
+void NarrativeBuilder::Build(const Options& options, std::list<Maneuver>& maneuvers) {
   Maneuver* prev_maneuver = nullptr;
   for (auto& maneuver : maneuvers) {
     switch (maneuver.type()) {

--- a/test/narrativebuilder.cc
+++ b/test/narrativebuilder.cc
@@ -266,7 +266,7 @@ void TryBuild(const Options& options,
               std::list<Maneuver>& expected_maneuvers,
               const EnhancedTripLeg* etp = nullptr) {
   std::unique_ptr<NarrativeBuilder> narrative_builder = NarrativeBuilderFactory::Create(options, etp);
-  narrative_builder->Build(options, etp, maneuvers);
+  narrative_builder->Build(options, maneuvers);
 
   // Check maneuver list sizes
   ASSERT_EQ(maneuvers.size(), expected_maneuvers.size());

--- a/valhalla/odin/narrativebuilder.h
+++ b/valhalla/odin/narrativebuilder.h
@@ -36,7 +36,7 @@ public:
   NarrativeBuilder(const NarrativeBuilder&) = default;
   NarrativeBuilder& operator=(const NarrativeBuilder&) = default;
 
-  void Build(const Options& options, const EnhancedTripLeg* etp, std::list<Maneuver>& maneuvers);
+  void Build(const Options& options, std::list<Maneuver>& maneuvers);
 
 protected:
   /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
# Issue

Minor cleanup of an unused function argument. Likely was missed in a prior refactor.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
