### PR TITLE
Zero Distance Match Leg Causes Nan Duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
    * FIXED: Increased internal precision of time tracking per edge and maneuver so that maneuver times sum to the same time represented in the leg summary [#2195](https://github.com/valhalla/valhalla/pull/2195)
    * FIXED: Tagged speeds were not properly marked. We were not using forward and backward speeds to flag if a speed is tagged or not.  Should not update turn channel speeds if we are not inferring them.  Added additional logic to handle PH in the conditional restrictions. Do not update stop impact for ramps if they are marked as internal. [#2198](https://github.com/valhalla/valhalla/pull/2198)
    * FIXED: Fixed the sharp turn phrase [#2226](https://github.com/valhalla/valhalla/pull/2226)
+   * FIXED: Protect against duplicate points in the input or points that snap to the same location resulting in `nan` times for the legs of the map match (of a 0 distance route) [#2229](https://github.com/valhalla/valhalla/pull/2229)
 
 * **Enhancement**
    * ADDED: Return the coordinates of the nodes isochrone input locations snapped to [#2111](https://github.com/valhalla/valhalla/pull/2111)

--- a/src/thor/trace_route_action.cc
+++ b/src/thor/trace_route_action.cc
@@ -613,8 +613,10 @@ thor_worker_t::map_match(Api& request) {
             // we need to scale the elapsed time of the current edge to undo what FormPath did
             double begin_pct = begin_trimmed ? std::get<2>(edge_group)->distance_along : 0;
             double end_pct = end_trimmed ? std::get<3>(edge_group)->distance_along : 1;
-            double begin_edge_scale = 1.0 / ((trivial_group ? end_pct : 1) - begin_pct);
-            double end_edge_scale = 1.0 / (end_pct - (trivial_group ? begin_pct : 0));
+            double dist_from_begin = (trivial_group ? end_pct : 1) - begin_pct;
+            double dist_to_end = end_pct - (trivial_group ? begin_pct : 0);
+            double begin_edge_scale = dist_from_begin > 0 ? 1 / dist_from_begin : 0;
+            double end_edge_scale = dist_to_end > 0 ? 1 / dist_to_end : 0;
 
             // we get the time up to the last edge before this begin edge if any. we also remove
             // the turn cost at the begging of this edge if there is any

--- a/test/mapmatch.cc
+++ b/test/mapmatch.cc
@@ -1045,6 +1045,28 @@ TEST(Mapmatch, test_intersection_matching) {
   }
 }
 
+TEST(Mapmatch, test_degenerate_match) {
+  std::vector<std::string> test_cases = {
+      R"({"costing":"auto","format":"osrm","shape_match":"map_snap","shape":[
+          {"lat": 52.0981280, "lon": 5.1297250, "type": "break", "time":10},
+          {"lat": 52.0981280, "lon": 5.1297250, "type": "break", "time":169}],
+          "trace_options": {"interpolation_distance": 0}})",
+  };
+  tyr::actor_t actor(conf, true);
+
+  for (size_t i = 0; i < test_cases.size(); ++i) {
+    auto matched = json_to_pt(actor.trace_route(test_cases[i]));
+    const auto& routes = matched.get_child("matchings");
+    for (const auto& route : routes) {
+      const auto& legs = route.second.get_child("legs");
+      for (const auto& leg : legs) {
+        double duration = leg.second.get<double>("duration");
+        ASSERT_TRUE(duration >= 0);
+      }
+    }
+  }
+}
+
 } // namespace
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
So... we allow degenerate routes, where the input is the same location twice and the output is a route with 0 length. The problem is, when we got smart about computing the duration we didnt figure for this. What happens is we get a divide by 0 which sends double to `inf` and then using that later on makes for `nan`. This PR adds a test, which fails with the old code, then it adds code to make sure that the denominator is positive. If the denominator is negative we set everything to 0.