### PR TITLE
Easy integration test authoring with ASCII-art maps and helper classes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ jobs:
                 -DENABLE_COMPILER_WARNINGS=On -DENABLE_WERROR=Off -DCMAKE_EXPORT_COMPILE_COMMANDS=On
       - run: make -C build -j4
       - run: scripts/clang-tidy-only-diff.sh 4
-      - run: make -C build -j4 tests
+      - run: make -C build -j2 tests
       - run: make -C build -j2 check
       - run: make -C build install
       - run: make -C build package

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,9 @@
 [submodule "third_party/googletest"]
 	path = third_party/googletest
 	url = https://github.com/google/googletest.git
+[submodule "third_party/libosmium"]
+	path = third_party/libosmium
+	url = https://github.com/osmcode/libosmium.git
+[submodule "third_party/protozero"]
+	path = third_party/protozero
+	url = https://github.com/mapbox/protozero.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
    * ADDED: Added alley factor to autocost.  Factor is defaulted at 1.0f or do not avoid alleys. [#2246](https://github.com/valhalla/valhalla/pull/2246)
    * ADDED: Support unlimited speed limits where maxspeed=none. [#2251](https://github.com/valhalla/valhalla/pull/2251)
    * ADDED: Implement improved Reachability check using base class Dijkstra. [#2243](https://github.com/valhalla/valhalla/pull/2243)
+   * ADDED: Gurka integration test framework with ascii-art maps [#2244](https://github.com/valhalla/valhalla/pull/2244)
 
 ## Release Date: 2019-11-21 Valhalla 3.0.9
 * **Bug Fix**

--- a/src/mjolnir/util.cc
+++ b/src/mjolnir/util.cc
@@ -133,7 +133,8 @@ bool shapes_match(const std::vector<PointLL>& shape1, const std::vector<PointLL>
 bool build_tile_set(const boost::property_tree::ptree& config,
                     const std::vector<std::string>& input_files,
                     const BuildStage start_stage,
-                    const BuildStage end_stage) {
+                    const BuildStage end_stage,
+                    const bool release_osmpbf_memory) {
   auto remove_temp_file = [](const std::string& fname) {
     if (boost::filesystem::exists(fname)) {
       boost::filesystem::remove(fname);
@@ -200,7 +201,9 @@ bool build_tile_set(const boost::property_tree::ptree& config,
                               access_bin, cr_from_bin, cr_to_bin, bss_nodes_bin);
 
     // Free all protobuf memory - cannot use the protobuffer lib after this!
-    OSMPBF::Parser::free();
+    if (release_osmpbf_memory) {
+      OSMPBF::Parser::free();
+    }
 
     // Write the OSMData to files if parsing is the end stage
     if (end_stage <= BuildStage::kEnhance) {

--- a/src/thor/dijkstras.cc
+++ b/src/thor/dijkstras.cc
@@ -92,7 +92,7 @@ Dijkstras::SetTime(google::protobuf::RepeatedPtrField<valhalla::Location>& locat
   // Set the timezone to be the timezone at the end node
   start_tz_index_ = GetTimezone(reader, node_id);
   if (start_tz_index_ == 0)
-    LOG_ERROR("Could not get the timezone at the destination location");
+    LOG_WARN("Could not get the timezone at the destination location");
 
   // Set route start time (seconds from epoch)
   auto start_time = DateTime::seconds_since_epoch(location.date_time(),
@@ -800,7 +800,7 @@ void Dijkstras::ComputeMultiModal(
         mmedgelabels_.size() == 0 ? 0 : GetTimezone(graphreader, mmedgelabels_[0].endnode());
     if (start_tz_index_ == 0) {
       // TODO - should we throw an exception and return an error
-      LOG_ERROR("Could not get the timezone at the origin location");
+      LOG_WARN("Could not get the timezone at the origin location");
     }
     origin_date_time_ = origin_locations.Get(0).date_time();
 

--- a/src/thor/timedep_forward.cc
+++ b/src/thor/timedep_forward.cc
@@ -273,7 +273,7 @@ TimeDepForward::GetBestPath(valhalla::Location& origin,
   origin_tz_index_ = edgelabels_.size() == 0 ? 0 : GetTimezone(graphreader, edgelabels_[0].endnode());
   if (origin_tz_index_ == 0) {
     // TODO - do not throw exception at this time
-    LOG_ERROR("Could not get the timezone at the origin");
+    LOG_WARN("Could not get the timezone at the origin");
   }
 
   // Set route start time (seconds from epoch)

--- a/src/thor/timedep_reverse.cc
+++ b/src/thor/timedep_reverse.cc
@@ -336,7 +336,7 @@ TimeDepReverse::GetBestPath(valhalla::Location& origin,
       edgelabels_rev_.size() == 0 ? 0 : GetTimezone(graphreader, edgelabels_rev_[0].endnode());
   if (dest_tz_index_ == 0) {
     // TODO - do not throw exception at this time
-    LOG_ERROR("Could not get the timezone at the destination");
+    LOG_WARN("Could not get the timezone at the destination");
   }
 
   // Update hierarchy limits

--- a/src/tyr/actor.cc
+++ b/src/tyr/actor.cc
@@ -42,7 +42,8 @@ void actor_t::cleanup() {
   pimpl->cleanup();
 }
 
-std::string actor_t::route(const std::string& request_str, const std::function<void()>& interrupt) {
+valhalla::Api actor_t::unserialized_route(const std::string& request_str,
+                                          const std::function<void()>& interrupt) {
   // set the interrupts
   pimpl->set_interrupts(interrupt);
   // parse the request
@@ -54,12 +55,17 @@ std::string actor_t::route(const std::string& request_str, const std::function<v
   pimpl->thor_worker.route(request);
   // get some directions back from them
   pimpl->odin_worker.narrate(request);
-  // serialize them out to json string
-  auto bytes = tyr::serializeDirections(request);
   // if they want you do to do the cleanup automatically
   if (auto_cleanup) {
     cleanup();
   }
+  return request;
+}
+
+std::string actor_t::route(const std::string& request_str, const std::function<void()>& interrupt) {
+  auto request = unserialized_route(request_str, interrupt);
+  // serialize them out to json string
+  auto bytes = tyr::serializeDirections(request);
   return bytes;
 }
 
@@ -135,8 +141,8 @@ std::string actor_t::isochrone(const std::string& request_str,
   return json;
 }
 
-std::string actor_t::trace_route(const std::string& request_str,
-                                 const std::function<void()>& interrupt) {
+valhalla::Api actor_t::unserialized_trace_route(const std::string& request_str,
+                                                const std::function<void()>& interrupt) {
   // set the interrupts
   pimpl->set_interrupts(interrupt);
   // parse the request
@@ -148,12 +154,18 @@ std::string actor_t::trace_route(const std::string& request_str,
   pimpl->thor_worker.trace_route(request);
   // get some directions back from them
   pimpl->odin_worker.narrate(request);
-  // serialize them out to json string
-  auto bytes = tyr::serializeDirections(request);
   // if they want you do to do the cleanup automatically
   if (auto_cleanup) {
     cleanup();
   }
+  return request;
+}
+
+std::string actor_t::trace_route(const std::string& request_str,
+                                 const std::function<void()>& interrupt) {
+  auto request = unserialized_trace_route(request_str, interrupt);
+  // serialize them out to json string
+  auto bytes = tyr::serializeDirections(request);
   return bytes;
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,6 +34,9 @@ foreach(test ${tests})
   set_target_properties(${test} PROPERTIES
     COMPILE_DEFINITIONS VALHALLA_SOURCE_DIR="${VALHALLA_SOURCE_DIR}/")
   target_link_libraries(${test} valhalla gtest gmock)
+  target_include_directories(${test} SYSTEM PRIVATE
+      ${VALHALLA_SOURCE_DIR}/third_party/protozero/include
+      ${VALHALLA_SOURCE_DIR}/third_party/libosmium/include)
 endforeach()
 
 set(cost_tests autocost bicyclecost motorcyclecost motorscootercost pedestriancost transitcost truckcost)
@@ -269,3 +272,5 @@ endif()
 
 add_custom_target(check DEPENDS ${test_targets})
 add_custom_target(tests DEPENDS ${tests} ${cost_tests})
+
+add_subdirectory(gurka)

--- a/test/astar.cc
+++ b/test/astar.cc
@@ -18,6 +18,7 @@
 #include "mjolnir/graphtilebuilder.h"
 #include "mjolnir/graphvalidator.h"
 #include "mjolnir/pbfgraphparser.h"
+#include "mjolnir/util.h"
 #include "odin/directionsbuilder.h"
 #include "odin/worker.h"
 #include "sif/costconstants.h"
@@ -31,6 +32,8 @@
 #include "thor/triplegbuilder.h"
 #include "thor/worker.h"
 #include "tyr/serializers.h"
+
+#include "gurka/gurka.h"
 
 #include <valhalla/proto/directions.pb.h>
 #include <valhalla/proto/options.pb.h>
@@ -64,244 +67,164 @@ namespace {
 // ph34r the ASCII art diagram:
 //
 // first test is just a square set of roads
-//
-//       0  2
-// a----->--<-----b
-// |              |
-// v 1          3 v
-// |              |
-// ^ 4          7 ^
-// |              |
-// c----->--<-----d
-//       5  6
+const std::string map1 = R"(
+   a1------------2b
+   |              |
+   |              |
+   |              |
+   |              |
+   |              3
+   c--------------d
+)";
+
+const gurka::ways ways1 = {{"ab", {{"highway", "motorway"}}},
+                           {"bd", {{"highway", "motorway"}}},
+                           {"ac", {{"highway", "motorway"}}},
+                           {"dc", {{"highway", "motorway"}}}};
+
 //
 // second test is a triangle set of roads, where the height of the triangle is
 // about a third of its width.
-//
-//      8  10
-//  e--->--<---f
-//  \         /
-// 9 v       v 11
-//    \     /
-//  12 ^   ^ 13
-//      \ /
-//       g
-//
-//
-// Third test has a complex turn restriction preventing N->K->H->I->L  (marked with R)
+
+const std::string map2 = R"(
+    e4--------5f
+    \         /
+     \       /
+      \     /
+       \   /
+        \ /
+         g
+)";
+const gurka::ways ways2 = {{"ef", {{"highway", "residential"}, {"foot", "yes"}}},
+                           {"eg", {{"highway", "residential"}, {"foot", "yes"}}},
+                           {"fg", {{"highway", "residential"}, {"foot", "yes"}}}};
+
+// Third test has a complex turn restriction preventing K->H->I->L  (marked with R)
 // which should force the algorithm to take the detour via the J->M edge
 // if starting at K and heading to L
 //
-//   14  16   17  19
-// h-->--<--i-->--<--j
-// |    R   |        |
-// v 15     v 18     v 20
-// |R     R |        |
-// ^ 21     ^ 23     ^ 25
-// |        |        |
-// k        l-->--<--m
-// |          24  26
-// V 22
-// | R
-// ^ 27
-// |
-// n
+const std::string map3 = R"(
+   h---V----i--------j
+   |        |        |
+   |        |        |
+   6        7        |
+   |        |        |
+   |        |        |
+   k        l8-------m
+   |
+   |
+   |
+   n
+)";
+const gurka::ways ways3 = {{"kh", {{"highway", "motorway"}}}, {"hi", {{"highway", "motorway"}}},
+                           {"ij", {{"highway", "motorway"}}}, {"lm", {{"highway", "motorway"}}},
+                           {"mj", {{"highway", "motorway"}}}, {"il", {{"highway", "motorway"}}},
+                           {"nk", {{"highway", "motorway"}}}};
+
+const gurka::relations relations3 = {{{gurka::relation_member{gurka::way_member, "kh", "from"},
+                                       gurka::relation_member{gurka::way_member, "il", "to"},
+                                       gurka::relation_member{gurka::way_member, "hi", "via"}},
+                                      {{"type", "restriction"}, {"restriction", "no_right_turn"}}}};
+
 //
 const std::string test_dir = "test/data/fake_tiles_astar";
 const vb::GraphId tile_id = vb::TileHierarchy::GetGraphId({.125, .125}, 2);
 
-GraphId make_graph_id(uint32_t id) {
-  return GraphId(tile_id.tileid(), tile_id.level(), id);
+std::unordered_map<std::string, vm::PointLL> node_locations;
+
+const std::string config_file = "test/test_trivial_path";
+
+void write_config(const std::string& filename,
+                  const std::string& tile_dir = "test/data/trivial_tiles") {
+  std::ofstream file;
+  try {
+    file.open(filename, std::ios_base::trunc);
+    file << "{ \
+      \"mjolnir\": { \
+      \"concurrency\": 1, \
+       \"tile_dir\": \"" +
+                tile_dir + "\", \
+        \"admin\": \"" VALHALLA_SOURCE_DIR "test/data/netherlands_admin.sqlite\", \
+         \"timezone\": \"" VALHALLA_SOURCE_DIR "test/data/not_needed.sqlite\" \
+      } \
+    }";
+  } catch (...) {}
+  file.close();
 }
 
-namespace node {
-std::pair<vb::GraphId, vm::PointLL> a({tile_id.tileid(), tile_id.level(), 0}, {0.01, 0.10});
-std::pair<vb::GraphId, vm::PointLL> b({tile_id.tileid(), tile_id.level(), 1}, {0.10, 0.10});
-std::pair<vb::GraphId, vm::PointLL> c({tile_id.tileid(), tile_id.level(), 2}, {0.01, 0.01});
-std::pair<vb::GraphId, vm::PointLL> d({tile_id.tileid(), tile_id.level(), 3}, {0.10, 0.01});
-
-std::pair<vb::GraphId, vm::PointLL> e({tile_id.tileid(), tile_id.level(), 4}, {0.21, 0.14});
-std::pair<vb::GraphId, vm::PointLL> f({tile_id.tileid(), tile_id.level(), 5}, {0.20, 0.14});
-std::pair<vb::GraphId, vm::PointLL> g({tile_id.tileid(), tile_id.level(), 6}, {0.25, 0.11});
-
-std::pair<vb::GraphId, vm::PointLL> h({tile_id.tileid(), tile_id.level(), 7}, {0.00, 0.10});
-std::pair<vb::GraphId, vm::PointLL> i({tile_id.tileid(), tile_id.level(), 8}, {0.10, 0.10});
-std::pair<vb::GraphId, vm::PointLL> j({tile_id.tileid(), tile_id.level(), 9}, {0.20, 0.10});
-std::pair<vb::GraphId, vm::PointLL> k({tile_id.tileid(), tile_id.level(), 10}, {0.00, 0.01});
-std::pair<vb::GraphId, vm::PointLL> l({tile_id.tileid(), tile_id.level(), 11}, {0.10, 0.01});
-std::pair<vb::GraphId, vm::PointLL> m({tile_id.tileid(), tile_id.level(), 12}, {0.20, 0.01});
-std::pair<vb::GraphId, vm::PointLL> n({tile_id.tileid(), tile_id.level(), 13}, {0.00, 0.02});
-} // namespace node
-
 void make_tile() {
-  // Don't recreate tiles if they already exist (leads to silent corruption of tiles)
-  if (filesystem::exists(test_dir)) {
-    return;
+
+  if (boost::filesystem::exists(test_dir))
+    boost::filesystem::remove_all(test_dir);
+
+  boost::filesystem::create_directories(test_dir);
+
+  boost::property_tree::ptree conf;
+  write_config(config_file, test_dir);
+  rapidjson::read_json(config_file, conf);
+
+  // We don't want these in our test tile
+  conf.put("mjolnir.hierarchy", false);
+  conf.put("mjolnir.shortcuts", false);
+
+  const double gridsize = 666;
+
+  {
+    // Build the maps from the ASCII diagrams, and extract the generated lon,lat values
+    auto nodemap = gurka::detail::map_to_coordinates(map1, gridsize, {0, 0.2});
+    const int initial_osm_id = 0;
+    gurka::detail::build_pbf(nodemap, ways1, {}, {}, test_dir + "/map1.pbf", initial_osm_id);
+    for (const auto& n : nodemap)
+      node_locations[n.first] = n.second;
   }
 
-  using namespace valhalla::mjolnir;
+  {
+    auto nodemap = gurka::detail::map_to_coordinates(map2, gridsize, {0.10, 0.2});
+    // Need to use a non-conflicting osm ID range for each map, as they
+    // all get merged during tile building, and we don't want a weirdly connected
+    // graph because IDs are shared
+    const int initial_osm_id = 100;
+    gurka::detail::build_pbf(nodemap, ways2, {}, {}, test_dir + "/map2.pbf", initial_osm_id);
+    for (const auto& n : nodemap)
+      node_locations[n.first] = n.second;
+  }
 
-  GraphTileBuilder tile(test_dir, tile_id, false);
+  {
+    auto nodemap = gurka::detail::map_to_coordinates(map3, gridsize, {0.1, 0.1});
+    const int initial_osm_id = 200;
+    gurka::detail::build_pbf(nodemap, ways3, {}, relations3, test_dir + "/map3.pbf", initial_osm_id);
+    for (const auto& n : nodemap)
+      node_locations[n.first] = n.second;
+  }
 
-  // Set the base lat,lon of the tile
-  uint32_t id = tile_id.tileid();
-  const auto& tl = TileHierarchy::levels().rbegin();
-  PointLL base_ll = tl->second.tiles.Base(id);
-  tile.header_builder().set_base_ll(base_ll);
-
-  uint32_t edge_index = 0;
-
-  auto add_node = [&](const std::pair<vb::GraphId, vm::PointLL>& v, const uint32_t edge_count) {
-    NodeInfo node_builder;
-    node_builder.set_latlng(base_ll, v.second);
-    // node_builder.set_road_class(RoadClass::kSecondary);
-    node_builder.set_access(vb::kAllAccess);
-    node_builder.set_edge_count(edge_count);
-    node_builder.set_edge_index(edge_index);
-    node_builder.set_timezone(1);
-    edge_index += edge_count;
-    tile.nodes().emplace_back(node_builder);
-  };
-
-  auto add_edge = [&](const std::pair<vb::GraphId, vm::PointLL>& u,
-                      const std::pair<vb::GraphId, vm::PointLL>& v, const uint32_t localedgeidx,
-                      const uint32_t opposing_edge_index, const bool forward) {
-    DirectedEdgeBuilder edge_builder({}, v.first, forward, u.second.Distance(v.second) + .5, 1, 1,
-                                     baldr::Use::kRoad, baldr::RoadClass::kMotorway, localedgeidx,
-                                     false, 0, 0, false);
-    edge_builder.set_opp_index(opposing_edge_index);
-    edge_builder.set_opp_local_idx(opposing_edge_index);
-    edge_builder.set_forwardaccess(vb::kAllAccess);
-    edge_builder.set_reverseaccess(vb::kAllAccess);
-    edge_builder.set_free_flow_speed(100);
-    edge_builder.set_constrained_flow_speed(10);
-    std::vector<vm::PointLL> shape = {u.second, u.second.MidPoint(v.second), v.second};
-    if (!forward) {
-      std::reverse(shape.begin(), shape.end());
+  {
+    constexpr bool release_osmpbf_memory = false;
+    mjolnir::build_tile_set(conf,
+                            {test_dir + "/map1.pbf", test_dir + "/map2.pbf", test_dir + "/map3.pbf"},
+                            mjolnir::BuildStage::kInitialize, mjolnir::BuildStage::kValidate,
+                            release_osmpbf_memory);
+    /** Set the freeflow and constrained flow speeds manually on all edges */
+    vj::GraphTileBuilder tile_builder(test_dir, tile_id, false);
+    std::vector<DirectedEdge> directededges;
+    directededges.reserve(tile_builder.header()->directededgecount());
+    for (uint32_t j = 0; j < tile_builder.header()->directededgecount(); ++j) {
+      // skip edges for which we dont have speed data
+      DirectedEdge& directededge = tile_builder.directededge(j);
+      directededge.set_free_flow_speed(100);
+      directededge.set_constrained_flow_speed(10);
+      directededge.set_forwardaccess(vb::kAllAccess);
+      directededge.set_reverseaccess(vb::kAllAccess);
+      directededges.emplace_back(std::move(directededge));
     }
-    bool added;
-    // make more complex edge geom so that there are 3 segments, affine combination doesnt properly
-    // handle arcs but who cares
-    uint32_t edge_info_offset = tile.AddEdgeInfo(localedgeidx, u.first, v.first, 123, // way_id
-                                                 0, 0,
-                                                 120, // speed limit in kph
-                                                 shape, {std::to_string(localedgeidx)}, 0, added);
-    // assert(added);
-    edge_builder.set_edgeinfo_offset(edge_info_offset);
-    tile.directededges().emplace_back(edge_builder);
-  };
-
-  // first set of roads - Square
-  add_edge(node::a, node::b, 0, 0, true);
-  add_edge(node::a, node::c, 1, 0, true);
-  add_node(node::a, 2);
-
-  add_edge(node::b, node::a, 0, 0, false);
-  add_edge(node::b, node::d, 1, 1, true);
-  add_node(node::b, 2);
-
-  add_edge(node::c, node::a, 0, 1, false);
-  add_edge(node::c, node::d, 1, 0, true);
-  add_node(node::c, 2);
-
-  add_edge(node::d, node::c, 0, 1, false);
-  add_edge(node::d, node::b, 1, 1, false);
-  add_node(node::d, 2);
-
-  // second set of roads - Triangle
-  add_edge(node::e, node::f, 0, 0, true);
-  add_edge(node::e, node::g, 1, 0, true);
-  add_node(node::e, 2);
-
-  add_edge(node::f, node::e, 0, 0, false);
-  add_edge(node::f, node::g, 1, 1, true);
-  add_node(node::f, 2);
-
-  add_edge(node::g, node::e, 0, 1, false);
-  add_edge(node::g, node::f, 1, 1, false);
-  add_node(node::g, 2);
-
-  // Third set of roads - Complex restriction with detour
-  add_edge(node::h, node::i, 0, 0, true);
-  {
-    // we only set this to true for vias
-    tile.directededges().back().complex_restriction(true);
+    tile_builder.UpdatePredictedSpeeds(directededges);
   }
-  add_edge(node::h, node::k, 1, 0, true);
-  add_node(node::h, 2);
 
-  add_edge(node::i, node::h, 0, 0, false);
-  {
-    // we only set this to true for vias
-    tile.directededges().back().complex_restriction(true);
-  }
-  add_edge(node::i, node::j, 1, 0, true);
-  add_edge(node::i, node::l, 2, 0, true);
-  {
-    // preventing turn from 27 -> 21 -> 14 -> 18 in the FORWARD direction
-    // Necessary for Forward direction
-    tile.directededges().back().set_end_restriction(kAllAccess);
-    ComplexRestrictionBuilder cr_fwd;
-    cr_fwd.set_type(RestrictionType::kNoEntry);
-    cr_fwd.set_to_id(make_graph_id(18));
-    cr_fwd.set_from_id(make_graph_id(27));
-    std::vector<GraphId> vias;
-    vias.push_back(make_graph_id(14));
-    vias.push_back(make_graph_id(21));
-    cr_fwd.set_via_list(vias);
-    cr_fwd.set_modes(kAllAccess);
-    tile.AddForwardComplexRestriction(cr_fwd);
-  }
-  add_node(node::i, 3);
+  GraphTile tile(test_dir, tile_id);
+  ASSERT_EQ(tile.FileSuffix(tile_id, false), std::string("2/000/519/120.gph"))
+      << "Tile ID didn't match the expected filename";
 
-  add_edge(node::j, node::i, 0, 1, false);
-  add_edge(node::j, node::m, 1, 0, true);
-  add_node(node::j, 2);
-
-  add_edge(node::k, node::h, 0, 1, false);
-  {
-    // we only set this to true for vias
-    tile.directededges().back().complex_restriction(true);
-  }
-  add_edge(node::k, node::n, 1, 0, true);
-  {
-    // Add first part of complex turn restriction in REVERSE direction
-    // preventing turn from 22 -> 15 -> 16 -> 23
-    // Necessary for reverse direction
-    tile.directededges().back().set_start_restriction(kAllAccess);
-    ComplexRestrictionBuilder cr_fwd;
-    cr_fwd.set_type(RestrictionType::kNoEntry);
-    cr_fwd.set_to_id(make_graph_id(23));
-    cr_fwd.set_from_id(make_graph_id(22));
-    std::vector<GraphId> vias;
-    vias.push_back(make_graph_id(15));
-    vias.push_back(make_graph_id(16));
-    cr_fwd.set_via_list(vias);
-    cr_fwd.set_modes(kAllAccess);
-    tile.AddReverseComplexRestriction(cr_fwd);
-  }
-  add_node(node::k, 2);
-
-  add_edge(node::l, node::i, 0, 2, false);
-  add_edge(node::l, node::m, 1, 1, true);
-  add_node(node::l, 2);
-
-  add_edge(node::m, node::j, 0, 1, false);
-  add_edge(node::m, node::l, 1, 1, false);
-  add_node(node::m, 2);
-
-  add_edge(node::n, node::k, 0, 1, true);
-  add_node(node::n, 1);
-
-  tile.StoreTileData();
-
-  GraphTileBuilder::tweeners_t tweeners;
-  GraphTile reloaded(test_dir, tile_id);
-  auto bins = GraphTileBuilder::BinEdges(&reloaded, tweeners);
-  GraphTileBuilder::AddBins(test_dir, &reloaded, bins);
-
-  ASSERT_PRED1(filesystem::exists, test_dir + "/2/000/519/120.gph")
-      << "Still no expected tile, did the actual fname on disk change?";
+  ASSERT_PRED1(filesystem::exists, test_dir + "/" + tile.FileSuffix(tile_id, false))
+      << "Expected tile file didn't show up on disk - are the fixtures in the right location?";
 }
 
 void create_costing_options(Options& options) {
@@ -346,8 +269,8 @@ std::unique_ptr<vb::GraphReader> get_graph_reader(const std::string& tile_dir) {
     throw std::logic_error("test-tiles does not contain expected number of edges");
   }
 
-  const GraphTile* endtile = reader->GetGraphTile(node::b.first);
-  EXPECT_NE(endtile, nullptr) << "bad tile, node::b wasn't found in it";
+  const GraphTile* endtile = reader->GetGraphTile(node_locations["b"]);
+  EXPECT_NE(endtile, nullptr) << "bad tile, node 'b' wasn't found in it";
 
   return reader;
 }
@@ -390,9 +313,6 @@ void assert_is_trivial_path(vt::PathAlgorithm& astar,
     for (const auto& p : path) {
       time += p.elapsed_time;
     }
-    for (const vt::PathInfo& subpath : path) {
-      LOG_INFO("Got path " + std::to_string(subpath.edgeid.id()));
-    }
     EXPECT_EQ(path.size(), expected_num_paths);
     break;
   }
@@ -415,43 +335,36 @@ void assert_is_trivial_path(vt::PathAlgorithm& astar,
   EXPECT_EQ(time, expected_time) << "time in seconds";
 }
 
-// Adds edge to location
-void add(GraphId edge_id, float percent_along, const PointLL& ll, valhalla::Location& location) {
-  location.mutable_path_edges()->Add()->set_graph_id(edge_id);
-  location.mutable_path_edges()->rbegin()->set_percent_along(percent_along);
-  location.mutable_path_edges()->rbegin()->mutable_ll()->set_lng(ll.first);
-  location.mutable_path_edges()->rbegin()->mutable_ll()->set_lat(ll.second);
-  location.mutable_path_edges()->rbegin()->set_distance(0.0f);
-}
-
 // test that a path from A to B succeeds, even if the edges from A to C and B
 // to D appear first in the PathLocation.
 void TestTrivialPath(vt::PathAlgorithm& astar) {
-  using node::a;
-  using node::b;
-  using node::c;
-  using node::d;
 
+  Options options;
+  create_costing_options(options);
+  auto costs = vs::CreateAutoCost(Costing::auto_, options);
+
+  auto reader = get_graph_reader(test_dir);
+
+  std::vector<valhalla::baldr::Location> locations;
+  locations.push_back({node_locations["1"]});
+  locations.push_back({node_locations["2"]});
+
+  const auto projections = loki::Search(locations, *reader, costs);
   valhalla::Location origin;
-  origin.set_date_time("2019-11-21T13:05");
-  origin.mutable_ll()->set_lng(a.second.first);
-  origin.mutable_ll()->set_lat(a.second.second);
-  add(tile_id + uint64_t(1), 0.0f, a.second, origin);
-  add(tile_id + uint64_t(4), 1.0f, a.second, origin);
-  add(tile_id + uint64_t(0), 0.0f, a.second, origin);
-  add(tile_id + uint64_t(2), 1.0f, a.second, origin);
-
+  {
+    const auto& correlated = projections.at(locations[0]);
+    PathLocation::toPBF(correlated, &origin, *reader);
+    origin.set_date_time("2019-11-21T13:05");
+  }
   valhalla::Location dest;
-  dest.set_date_time("2019-11-21T13:05");
-  dest.mutable_ll()->set_lng(b.second.first);
-  dest.mutable_ll()->set_lat(b.second.second);
-  add(tile_id + uint64_t(3), 0.0f, b.second, dest);
-  add(tile_id + uint64_t(7), 1.0f, b.second, dest);
-  add(tile_id + uint64_t(2), 0.0f, b.second, dest);
-  add(tile_id + uint64_t(0), 1.0f, b.second, dest);
+  {
+    const auto& correlated = projections.at(locations[1]);
+    PathLocation::toPBF(correlated, &dest, *reader);
+    dest.set_date_time("2019-11-21T13:05");
+  }
 
   // this should go along the path from A to B
-  assert_is_trivial_path(astar, origin, dest, 1, TrivialPathTest::DurationEqualTo, 3606,
+  assert_is_trivial_path(astar, origin, dest, 1, TrivialPathTest::DurationEqualTo, 3116,
                          vs::TravelMode::kDrive);
 }
 
@@ -468,86 +381,69 @@ TEST(Astar, TestTrivialPathReverse) {
 // test that a path from E to F succeeds, even if the edges from E and F
 // to G appear first in the PathLocation.
 TEST(Astar, TestTrivialPathTriangle) {
-  using node::e;
-  using node::f;
 
+  Options options;
+  create_costing_options(options);
+  auto costs = vs::CreatePedestrianCost(Costing::pedestrian, options);
+
+  auto reader = get_graph_reader(test_dir);
+
+  std::vector<valhalla::baldr::Location> locations;
+  locations.push_back({node_locations["4"]});
+  locations.push_back({node_locations["5"]});
+
+  const auto projections = loki::Search(locations, *reader, costs);
   valhalla::Location origin;
-  origin.mutable_ll()->set_lng(e.second.first);
-  origin.mutable_ll()->set_lat(e.second.second);
-  add(tile_id + uint64_t(9), 0.0f, e.second, origin);
-  add(tile_id + uint64_t(12), 1.0f, e.second, origin);
-  add(tile_id + uint64_t(8), 0.0f, e.second, origin);
-  add(tile_id + uint64_t(10), 1.0f, e.second, origin);
-
+  {
+    const auto& correlated = projections.at(locations[0]);
+    PathLocation::toPBF(correlated, &origin, *reader);
+  }
   valhalla::Location dest;
-  dest.mutable_ll()->set_lng(f.second.first);
-  dest.mutable_ll()->set_lat(f.second.second);
-  add(tile_id + uint64_t(11), 0.0f, f.second, dest);
-  add(tile_id + uint64_t(13), 1.0f, f.second, dest);
-  add(tile_id + uint64_t(10), 0.0f, f.second, dest);
-  add(tile_id + uint64_t(8), 1.0f, f.second, dest);
+  {
+    const auto& correlated = projections.at(locations[1]);
+    PathLocation::toPBF(correlated, &dest, *reader);
+  }
 
   // TODO This fails with graphindex out of bounds for Reverse direction, is this
   // related to why we short-circuit trivial routes to AStarPathAlgorithm in route_action.cc?
   //
   vt::AStarPathAlgorithm astar;
   // this should go along the path from E to F
-  assert_is_trivial_path(astar, origin, dest, 1, TrivialPathTest::MatchesEdge, 8,
+  assert_is_trivial_path(astar, origin, dest, 1, TrivialPathTest::DurationEqualTo, 4231,
                          vs::TravelMode::kPedestrian);
-}
-
-TEST(Astar, TestPartialDurationTrivial) {
-  // Tests a trivial path with partial edge results in partial duration
-  using node::a;
-  using node::b;
-  using node::d;
-
-  valhalla::Location origin;
-  origin.set_date_time("2019-11-21T13:05");
-  origin.mutable_ll()->set_lng(a.second.first);
-  origin.mutable_ll()->set_lat(a.second.second);
-  add(tile_id + uint64_t(0), 0.1f, a.second, origin);
-  add(tile_id + uint64_t(2), 0.9f, a.second, origin);
-
-  float partial_dist = 0.1;
-  valhalla::Location dest;
-  dest.mutable_ll()->set_lng(b.second.first);
-  dest.mutable_ll()->set_lat(b.second.second);
-  add(tile_id + uint64_t(2), 0. + partial_dist, b.second, dest);
-  add(tile_id + uint64_t(0), 1. - partial_dist, b.second, dest);
-  add(tile_id + uint64_t(3), 0.0f, b.second, dest);
-  add(tile_id + uint64_t(7), 1.0f, b.second, dest);
-
-  uint32_t expected_duration = 2885;
-
-  vt::TimeDepForward astar;
-  assert_is_trivial_path(astar, origin, dest, 1, TrivialPathTest::DurationEqualTo, expected_duration,
-                         vs::TravelMode::kDrive);
 }
 
 void TestPartialDuration(vt::PathAlgorithm& astar) {
   // Tests that a partial duration is returned when starting on a partial edge
-  using node::a;
-  using node::b;
-  using node::d;
 
-  float partial_dist = 0.1;
+  Options options;
+  create_costing_options(options);
+  vs::cost_ptr_t costs[int(vs::TravelMode::kMaxTravelMode)];
+  auto mode = vs::TravelMode::kDrive;
+  costs[int(mode)] = vs::CreateAutoCost(Costing::auto_, options);
 
+  auto reader = get_graph_reader(test_dir);
+
+  std::vector<valhalla::baldr::Location> locations;
+  locations.push_back({node_locations["1"]});
+  locations.push_back({node_locations["3"]});
+
+  auto projections = loki::Search(locations, *reader, costs[int(mode)]);
   valhalla::Location origin;
-  origin.set_date_time("2019-11-21T13:05");
-  origin.mutable_ll()->set_lng(a.second.first);
-  origin.mutable_ll()->set_lat(a.second.second);
-  add(tile_id + uint64_t(0), 0. + partial_dist, a.second, origin);
-  add(tile_id + uint64_t(2), 1. - partial_dist, a.second, origin);
+  {
+    auto& correlated = projections.at(locations[0]);
+    PathLocation::toPBF(correlated, &origin, *reader);
+    origin.set_date_time("2019-11-21T13:05");
+  }
 
   valhalla::Location dest;
-  dest.set_date_time("2019-11-21T13:05");
-  dest.mutable_ll()->set_lng(d.second.first);
-  dest.mutable_ll()->set_lat(d.second.second);
-  add(tile_id + uint64_t(7), 0.0f + partial_dist, d.second, dest);
-  add(tile_id + uint64_t(3), 1.0f - partial_dist, d.second, dest);
+  {
+    auto& correlated = projections.at(locations[1]);
+    PathLocation::toPBF(correlated, &dest, *reader);
+    dest.set_date_time("2019-11-21T13:05");
+  }
 
-  uint32_t expected_duration = 9738;
+  uint32_t expected_duration = 7911;
 
   assert_is_trivial_path(astar, origin, dest, 2, TrivialPathTest::DurationEqualTo, expected_duration,
                          vs::TravelMode::kDrive);
@@ -778,10 +674,8 @@ TEST(Astar, test_deadend) {
       if (!name.empty()) {
         name.pop_back();
       }
-      bool is_uturn = false;
       if (m.type() == DirectionsLeg_Maneuver_Type_kUturnRight ||
           m.type() == DirectionsLeg_Maneuver_Type_kUturnLeft) {
-        is_uturn = true;
         uturn_street = name;
       }
       names.push_back(name);
@@ -881,10 +775,8 @@ TEST(Astar, test_deadend_timedep_forward) {
       if (!name.empty()) {
         name.pop_back();
       }
-      bool is_uturn = false;
       if (m.type() == DirectionsLeg_Maneuver_Type_kUturnRight ||
           m.type() == DirectionsLeg_Maneuver_Type_kUturnLeft) {
-        is_uturn = true;
         uturn_street = name;
       }
       names.push_back(name);
@@ -936,10 +828,8 @@ TEST(Astar, test_deadend_timedep_reverse) {
       if (!name.empty()) {
         name.pop_back();
       }
-      bool is_uturn = false;
       if (m.type() == DirectionsLeg_Maneuver_Type_kUturnRight ||
           m.type() == DirectionsLeg_Maneuver_Type_kUturnLeft) {
-        is_uturn = true;
         uturn_street = name;
       }
       names.push_back(name);
@@ -1003,7 +893,7 @@ TEST(Astar, test_time_restricted_road_bidirectional) {
   // Verify JSON payload
   const std::string payload = tyr::serializeDirections(response);
   rapidjson::Document response_json;
-  response_json.Parse(payload);
+  response_json.Parse(payload.c_str());
   std::cout << payload << std::endl;
   {
     const char key[] = "/trip/legs/0/maneuvers/0/has_time_restrictions";
@@ -1250,23 +1140,6 @@ TEST(Astar, TestBacktrackComplexRestrictionForwardDetourAfterRestriction) {
   // This tests if a detour _after_ a partial complex restriction is found.
   // The other tests with Bayfront Singapore tests with a detour _before_
   // the complex restriction
-  auto conf = get_conf(test_dir.c_str());
-  LOG_INFO("");
-
-  valhalla::Location origin;
-  origin.set_date_time("2019-11-21T23:05");
-  origin.mutable_ll()->set_lng(node::n.second.first);
-  origin.mutable_ll()->set_lat(node::n.second.second);
-  add(tile_id + uint64_t(27), 0.0f, node::n.second, origin);
-
-  valhalla::Location dest;
-  dest.set_date_time("2019-11-21T23:05");
-  dest.mutable_ll()->set_lng(node::l.second.first);
-  dest.mutable_ll()->set_lat(node::l.second.second);
-  add(tile_id + uint64_t(23), 0.0f, node::l.second, dest);
-  add(tile_id + uint64_t(18), 1.0f, node::l.second, dest);
-  add(tile_id + uint64_t(24), 0.0f, node::l.second, dest);
-  add(tile_id + uint64_t(26), 1.0f, node::l.second, dest);
 
   Options options;
   create_costing_options(options);
@@ -1275,32 +1148,62 @@ TEST(Astar, TestBacktrackComplexRestrictionForwardDetourAfterRestriction) {
   costs[int(mode)] = vs::CreateAutoCost(Costing::auto_, options);
   ASSERT_TRUE(bool(costs[int(mode)]));
 
-  auto verify_paths = [](const std::vector<vt::PathInfo>& paths) {
-    std::vector<uint32_t> walked_path;
+  auto reader = get_graph_reader(test_dir);
+
+  auto tile = reader->GetGraphTile(tile_id);
+
+  auto verify_paths = [&](const std::vector<vt::PathInfo>& paths) {
+    std::vector<std::string> walked_path;
     for (auto path_info : paths) {
       LOG_INFO("Got pathinfo " + std::to_string(path_info.edgeid.id()));
-      walked_path.push_back(path_info.edgeid.id());
+      auto directededge = tile->directededge(path_info.edgeid);
+      auto edgeinfo = tile->edgeinfo(directededge->edgeinfo_offset());
+      auto names = edgeinfo.GetNames();
+      walked_path.push_back(names.front());
     }
-    std::vector<uint32_t> expected_path;
-    expected_path.push_back(27);
-    expected_path.push_back(21);
-    expected_path.push_back(14);
-    expected_path.push_back(17);
-    expected_path.push_back(20);
-    expected_path.push_back(26);
+    std::vector<std::string> expected_path;
+    expected_path.push_back("kh");
+    expected_path.push_back("hi");
+    expected_path.push_back("ij");
+    expected_path.push_back("mj");
+    expected_path.push_back("lm");
+    expected_path.push_back("il");
     ASSERT_EQ(walked_path, expected_path) << "Wrong path";
   };
-  auto reader = get_graph_reader(test_dir);
+
+  std::vector<valhalla::baldr::Location> locations;
+  locations.push_back({node_locations["6"]});
+  locations.push_back({node_locations["7"]});
+
+  const auto projections = loki::Search(locations, *reader, costs[int(mode)]);
+
+  std::vector<PathLocation> path_location;
+  for (const auto& loc : locations) {
+    ASSERT_NO_THROW(
+        path_location.push_back(projections.at(loc));
+        PathLocation::toPBF(path_location.back(), options.mutable_locations()->Add(), *reader);)
+        << "fail_invalid_origin";
+  }
+
+  // Set departure date for timedep forward
+  options.mutable_locations(0)->set_date_time("2019-11-21T13:05");
+
   {
-    LOGLN_INFO("Forward direction");
     vt::TimeDepForward astar;
-    auto paths = astar.GetBestPath(origin, dest, *reader, costs, mode).front();
+    auto paths = astar
+                     .GetBestPath(*options.mutable_locations(0), *options.mutable_locations(1),
+                                  *reader, costs, mode)
+                     .front();
+
     verify_paths(paths);
   }
   {
-    LOGLN_INFO("Reverse direction");
     vt::TimeDepReverse astar;
-    auto paths = astar.GetBestPath(origin, dest, *reader, costs, mode).front();
+    auto paths = astar
+                     .GetBestPath(*options.mutable_locations(0), *options.mutable_locations(1),
+                                  *reader, costs, mode)
+                     .front();
+
     verify_paths(paths);
   }
 }
@@ -1331,6 +1234,7 @@ Api timed_access_restriction_ny(const std::string& mode, const std::string& date
 TEST(Astar, test_timed_no_access_restriction_1) {
   auto response = timed_access_restriction_ny("bicycle", "2018-05-13T19:14");
   const auto& legs = response.trip().routes(0).legs();
+  EXPECT_EQ(legs.size(), 1) << "Should have 1 leg";
   const auto& directions = response.directions().routes(0).legs(0);
   const auto& maneuvers_size = directions.maneuver_size();
   EXPECT_EQ(maneuvers_size, 3) << "This route should remain on Orchard St.";
@@ -1339,6 +1243,7 @@ TEST(Astar, test_timed_no_access_restriction_1) {
 TEST(Astar, test_timed_no_access_restriction_2) {
   auto response = timed_access_restriction_ny("bicycle", "2018-05-14T17:14");
   const auto& legs = response.trip().routes(0).legs();
+  EXPECT_EQ(legs.size(), 1) << "Should have 1 leg";
   const auto& directions = response.directions().routes(0).legs(0);
   const auto& maneuvers_size = directions.maneuver_size();
   EXPECT_EQ(maneuvers_size, 3) << "This route should remain on Orchard St.";
@@ -1347,6 +1252,7 @@ TEST(Astar, test_timed_no_access_restriction_2) {
 TEST(Astar, test_timed_no_access_restriction_3) {
   auto response = timed_access_restriction_ny("pedestrian", "2018-05-13T17:14");
   const auto& legs = response.trip().routes(0).legs();
+  EXPECT_EQ(legs.size(), 1) << "Should have 1 leg";
   const auto& directions = response.directions().routes(0).legs(0);
   const auto& maneuvers_size = directions.maneuver_size();
   EXPECT_EQ(maneuvers_size, 3) << "This route should remain on Orchard St.";
@@ -1357,6 +1263,7 @@ TEST(Astar, test_timed_no_access_restriction_3) {
 TEST(Astar, test_timed_access_restriction_1) {
   auto response = timed_access_restriction_ny("bicycle", "2018-05-13T17:14");
   const auto& legs = response.trip().routes(0).legs();
+  EXPECT_EQ(legs.size(), 1) << "Should have 1 leg";
   const auto& directions = response.directions().routes(0).legs(0);
   const auto& maneuvers_size = directions.maneuver_size();
   EXPECT_NE(maneuvers_size, 3)
@@ -1366,6 +1273,7 @@ TEST(Astar, test_timed_access_restriction_1) {
 TEST(Astar, test_timed_access_restriction_2) {
   auto response = timed_access_restriction_ny("auto", "2018-05-13T17:14");
   const auto& legs = response.trip().routes(0).legs();
+  EXPECT_EQ(legs.size(), 1) << "Should have 1 leg";
   const auto& directions = response.directions().routes(0).legs(0);
   const auto& maneuvers_size = directions.maneuver_size();
   EXPECT_NE(maneuvers_size, 3)
@@ -1418,6 +1326,7 @@ Api timed_conditional_restriction_nh(const std::string& mode, const std::string&
 TEST(Astar, test_timed_no_conditional_restriction_1) {
   auto response = timed_conditional_restriction_pa("auto", "2018-11-01T06:30");
   const auto& legs = response.trip().routes(0).legs();
+  EXPECT_EQ(legs.size(), 1) << "Should have 1 leg";
   const auto& directions = response.directions().routes(0).legs(0);
   const auto& maneuvers_size = directions.maneuver_size();
   EXPECT_EQ(maneuvers_size, 3) << "This route should turn R onto Dickinson Ave.";
@@ -1426,6 +1335,7 @@ TEST(Astar, test_timed_no_conditional_restriction_1) {
 TEST(Astar, test_timed_no_conditional_restriction_2) {
   auto response = timed_conditional_restriction_pa("auto", "2018-11-01T10:00");
   const auto& legs = response.trip().routes(0).legs();
+  EXPECT_EQ(legs.size(), 1) << "Should have 1 leg";
   const auto& directions = response.directions().routes(0).legs(0);
   const auto& maneuvers_size = directions.maneuver_size();
   EXPECT_EQ(maneuvers_size, 3) << "This route should turn R onto Dickinson Ave.";
@@ -1434,6 +1344,7 @@ TEST(Astar, test_timed_no_conditional_restriction_2) {
 TEST(Astar, test_timed_no_conditional_restriction_3) {
   auto response = timed_conditional_restriction_nh("truck", "2018-05-02T18:00");
   const auto& legs = response.trip().routes(0).legs();
+  EXPECT_EQ(legs.size(), 1) << "Should have 1 leg";
   const auto& directions = response.directions().routes(0).legs(0);
   const auto& maneuvers_size = directions.maneuver_size();
   EXPECT_LE(maneuvers_size, 3) << "This route should turn R onto Old Derry Rd.";
@@ -1444,6 +1355,7 @@ TEST(Astar, test_timed_no_conditional_restriction_3) {
 TEST(Astar, test_timed_conditional_restriction_1) {
   auto response = timed_conditional_restriction_pa("auto", "2018-11-01T07:00");
   const auto& legs = response.trip().routes(0).legs();
+  EXPECT_EQ(legs.size(), 1) << "Should have 1 leg";
   const auto& directions = response.directions().routes(0).legs(0);
   const auto& maneuvers_size = directions.maneuver_size();
   EXPECT_NE(maneuvers_size, 3) << "This route should turn L onto Dickinson Ave.";
@@ -1452,6 +1364,7 @@ TEST(Astar, test_timed_conditional_restriction_1) {
 TEST(Astar, test_timed_conditional_restriction_2) {
   auto response = timed_conditional_restriction_pa("auto", "2018-11-01T09:00");
   const auto& legs = response.trip().routes(0).legs();
+  EXPECT_EQ(legs.size(), 1) << "Should have 1 leg";
   const auto& directions = response.directions().routes(0).legs(0);
   const auto& maneuvers_size = directions.maneuver_size();
   EXPECT_NE(maneuvers_size, 3) << "This route should turn L onto Dickinson Ave.";
@@ -1484,27 +1397,27 @@ TEST(Astar, test_complex_restriction_short_path_fake) {
   costs[int(mode)] = vs::CreateAutoCost(Costing::auto_, options);
   ASSERT_TRUE(bool(costs[int(mode)]));
 
+  std::vector<valhalla::baldr::Location> locations;
+  locations.push_back({node_locations["n"]});
+  locations.push_back({node_locations["i"]});
+
+  const auto projections = loki::Search(locations, *reader, costs[int(mode)]);
+  valhalla::Location origin;
+  {
+    const auto& correlated = projections.at(locations[0]);
+    PathLocation::toPBF(correlated, &origin, *reader);
+  }
+  valhalla::Location dest;
+  {
+    const auto& correlated = projections.at(locations[1]);
+    PathLocation::toPBF(correlated, &dest, *reader);
+  }
+
   // Test Bidirectional both for forward and reverse expansion
   vt::BidirectionalAStar astar;
 
   // Two tests where start and end lives on a partial complex restriction
   //      Under this circumstance the restriction should _not_ trigger
-
-  // Put the origin on N which is start of restriction
-  using node::n;
-  valhalla::Location origin;
-  origin.mutable_ll()->set_lng(n.second.first);
-  origin.mutable_ll()->set_lat(n.second.second);
-  add(tile_id + uint64_t(27), 0.0f, n.second, origin);
-  add(tile_id + uint64_t(22), 1.0f, n.second, origin);
-
-  // Put the destination at I which in the middle of restriction
-  using node::i;
-  valhalla::Location dest;
-  dest.mutable_ll()->set_lng(i.second.first);
-  dest.mutable_ll()->set_lat(i.second.second);
-  add(tile_id + uint64_t(16), 0.0f, i.second, dest);
-  add(tile_id + uint64_t(14), 1.0f, i.second, dest);
 
   auto paths = astar.GetBestPath(origin, dest, *reader, costs, mode);
 
@@ -1514,11 +1427,17 @@ TEST(Astar, test_complex_restriction_short_path_fake) {
       visited.push_back(path_info.edgeid.id());
     }
   }
-  std::vector<uint32_t> expected;
-  expected.push_back(27);
-  expected.push_back(21);
-  expected.push_back(14);
-  ASSERT_EQ(visited, expected) << "Unexpected edges in case 1 of bidirectional a*";
+  {
+    std::vector<uint32_t> expected;
+    auto reader = get_graph_reader(test_dir);
+    auto e1 = gurka::findEdge(reader, node_locations, tile_id, "nk", "k");
+    auto e2 = gurka::findEdge(reader, node_locations, tile_id, "kh", "h");
+    auto e3 = gurka::findEdge(reader, node_locations, tile_id, "hi", "i");
+    expected.push_back(std::get<0>(e1).id());
+    expected.push_back(std::get<0>(e2).id());
+    expected.push_back(std::get<0>(e3).id());
+    ASSERT_EQ(visited, expected) << "Unexpected edges in case 1 of bidirectional a*";
+  }
 
   // For the second test, just switch origin/destination and reverse expected,
   // result should be the same
@@ -1531,11 +1450,18 @@ TEST(Astar, test_complex_restriction_short_path_fake) {
       visited.push_back(path_info.edgeid.id());
     }
   }
-  expected.clear();
-  expected.push_back(16);
-  expected.push_back(15);
-  expected.push_back(22);
-  ASSERT_EQ(visited, expected) << "Unexpected edges in case 2 of bidirectional a*";
+
+  {
+    std::vector<uint32_t> expected;
+    auto reader = get_graph_reader(test_dir);
+    auto e1 = gurka::findEdge(reader, node_locations, tile_id, "hi", "h");
+    auto e2 = gurka::findEdge(reader, node_locations, tile_id, "kh", "k");
+    auto e3 = gurka::findEdge(reader, node_locations, tile_id, "nk", "n");
+    expected.push_back(std::get<0>(e1).id());
+    expected.push_back(std::get<0>(e2).id());
+    expected.push_back(std::get<0>(e3).id());
+    ASSERT_EQ(visited, expected) << "Unexpected edges in case 1 of bidirectional a*";
+  }
 
   {
     // TestBacktrackComplexRestrictionBidirectional tests the behaviour with a
@@ -1582,38 +1508,51 @@ TEST(Astar, test_IsBridgingEdgeRestricted) {
   // Lets construct the inputs fed to IsBridgingEdgeRestricted for a situation
   // where it tries to connect edge 14 to edge_labels_fwd from 21 and opposing edges
   // from 18
-  DirectedEdge edge_27;
-  edge_27.complex_restriction(true);
+  DirectedEdge edge_nk;
   {
-    edge_labels_fwd.emplace_back(kInvalidLabel, make_graph_id(27), make_graph_id(22), &edge_27,
+    auto result = gurka::findEdge(reader, node_locations, tile_id, "nk", "k");
+    ASSERT_NE(nullptr, std::get<1>(result));
+    edge_nk = *std::get<1>(result);
+    edge_nk.complex_restriction(true);
+    edge_labels_fwd.emplace_back(kInvalidLabel, std::get<0>(result), std::get<2>(result), &edge_nk,
                                  vs::Cost{}, vs::TravelMode::kDrive, vs::Cost{}, 0, false, false);
   }
-  DirectedEdge edge_21;
-  edge_21.complex_restriction(true);
+  DirectedEdge edge_kh;
   {
-    edge_labels_fwd.emplace_back(edge_labels_fwd.size() - 1, make_graph_id(21), make_graph_id(15),
-                                 &edge_21, vs::Cost{}, vs::TravelMode::kDrive, vs::Cost{}, 0, false,
+    auto result = gurka::findEdge(reader, node_locations, tile_id, "kh", "h");
+    ASSERT_NE(nullptr, std::get<1>(result));
+    edge_kh = *std::get<1>(result);
+    edge_kh.complex_restriction(true);
+    edge_labels_fwd.emplace_back(edge_labels_fwd.size() - 1, std::get<0>(result), std::get<2>(result),
+                                 &edge_kh, vs::Cost{}, vs::TravelMode::kDrive, vs::Cost{}, 0, false,
                                  false);
   }
   // Create our fwd_pred for the bridging check
-  DirectedEdge edge_14;
-  edge_14.complex_restriction(true);
+  DirectedEdge edge_hi;
+  auto edge_hi_result = gurka::findEdge(reader, node_locations, tile_id, "hi", "i");
+  ASSERT_NE(nullptr, std::get<1>(edge_hi_result));
+  edge_hi = *std::get<1>(edge_hi_result);
+  edge_hi.complex_restriction(true);
   vs::BDEdgeLabel fwd_pred(edge_labels_fwd.size() - 1, // Index to predecessor in edge_labels_fwd
-                           make_graph_id(14), make_graph_id(16), &edge_14, vs::Cost{}, 0.0, 0.0,
-                           vs::TravelMode::kDrive, vs::Cost{}, false, false);
+                           std::get<0>(edge_hi_result), std::get<2>(edge_hi_result), &edge_hi,
+                           vs::Cost{}, 0.0, 0.0, vs::TravelMode::kDrive, vs::Cost{}, false, false);
 
-  DirectedEdge edge_23;
-  edge_23.complex_restriction(true);
+  DirectedEdge edge_il;
   {
-    edge_labels_rev.emplace_back(kInvalidLabel, make_graph_id(23), make_graph_id(18), &edge_23,
+    auto result = gurka::findEdge(reader, node_locations, tile_id, "il", "i");
+    ASSERT_NE(nullptr, std::get<1>(result));
+    edge_il = *std::get<1>(result);
+    edge_il.complex_restriction(true);
+    edge_labels_rev.emplace_back(kInvalidLabel, std::get<0>(result), std::get<2>(result), &edge_il,
                                  vs::Cost{}, vs::TravelMode::kDrive, vs::Cost{}, 0, false, false);
   }
   // Create the rev_pred for the bridging check
-  DirectedEdge edge_16;
-  edge_16.complex_restriction(true);
+  DirectedEdge edge_ih;
+  edge_ih = *std::get<3>(edge_hi_result); // use result from earlier, which already got opposing edge
+  edge_ih.complex_restriction(true);
   vs::BDEdgeLabel rev_pred(edge_labels_rev.size() - 1, // Index to predecessor in edge_labels_rev
-                           make_graph_id(16), make_graph_id(14), &edge_16, vs::Cost{}, 0.0, 0.0,
-                           vs::TravelMode::kDrive, vs::Cost{}, false, false);
+                           std::get<2>(edge_hi_result), std::get<0>(edge_hi_result), &edge_ih,
+                           vs::Cost{}, 0.0, 0.0, vs::TravelMode::kDrive, vs::Cost{}, false, false);
 
   {
     // Test for forward search
@@ -1629,20 +1568,55 @@ TEST(ComplexRestriction, WalkVias) {
   // TODO Future improvement would be to make it simpler to quickly generate
   // tiles programmatically
   auto reader = get_graph_reader(test_dir);
-  std::vector<GraphId> expected_vias;
-  expected_vias.push_back(make_graph_id(14));
-  expected_vias.push_back(make_graph_id(21));
-
   Options options;
   create_costing_options(options);
   auto costing = vs::CreateAutoCost(Costing::auto_, options);
 
   bool is_forward = true;
   auto* tile = reader->GetGraphTile(tile_id);
-  auto restrictions = tile->GetRestrictions(is_forward, make_graph_id(18), costing->access_mode());
-  ASSERT_EQ(restrictions.size(), 1);
 
-  const auto cr = restrictions[0];
+  std::vector<valhalla::baldr::Location> locations;
+  locations.push_back({node_locations["7"]});
+  const auto projections = loki::Search(locations, *reader, costing);
+  const auto& correlated = projections.at(locations[0]);
+
+  ASSERT_EQ(correlated.edges.size(), 2) << "Expected only 2 edges in snapping response";
+
+  // Need to figure out if it's the forward or backward edge that we need to
+  // use for walking
+  const auto cr = [&]() -> ComplexRestriction* {
+    const auto first_id = correlated.edges.front().id;
+    auto restrictions = tile->GetRestrictions(is_forward, first_id, costing->access_mode());
+    if (!restrictions.empty())
+      return restrictions.front();
+    const auto second_id = correlated.edges.back().id;
+    restrictions = tile->GetRestrictions(is_forward, second_id, costing->access_mode());
+    if (!restrictions.empty())
+      return restrictions.front();
+    return nullptr;
+  }();
+
+  ASSERT_NE(cr, nullptr) << "Failed to find the target edge of the test restriction";
+
+  std::vector<GraphId> expected_vias;
+  {
+    std::vector<valhalla::baldr::Location> via_locations;
+    via_locations.push_back({node_locations["V"]});
+    const auto via_projections = loki::Search(via_locations, *reader, costing);
+    const auto& via_correlated = via_projections.at(via_locations[0]);
+    ASSERT_EQ(via_correlated.edges.size(), 2) << "Should've found 2 edges for the via point";
+
+    auto* de1 = tile->directededge(via_correlated.edges.front().id);
+    auto* de2 = tile->directededge(via_correlated.edges.back().id);
+    if (de1->part_of_complex_restriction()) {
+      expected_vias.push_back(via_correlated.edges.front().id);
+    }
+    if (de2->part_of_complex_restriction()) {
+      expected_vias.push_back(via_correlated.edges.back().id);
+    }
+    ASSERT_LE(expected_vias.size(), 2) << "Found too many edges - max should be 2 (2 DirectedEdges)";
+    ASSERT_NE(expected_vias.size(), 0) << "Failed to find the via edge";
+  }
 
   {
     // Walk all vias
@@ -1651,7 +1625,10 @@ TEST(ComplexRestriction, WalkVias) {
       walked_vias.push_back(*via);
       return WalkingVia::KeepWalking;
     });
-    EXPECT_EQ(walked_vias, expected_vias) << "Did not walk expected vias";
+    EXPECT_EQ(walked_vias.size(), 1);
+    EXPECT_NE(std::find(expected_vias.begin(), expected_vias.end(), walked_vias.front()),
+              expected_vias.end())
+        << "Did not walk expected vias";
   }
 }
 

--- a/test/gurka/CMakeLists.txt
+++ b/test/gurka/CMakeLists.txt
@@ -1,0 +1,38 @@
+if(ENABLE_DATA_TOOLS)
+  file(GLOB_RECURSE TEST_FILES "${CMAKE_CURRENT_LIST_DIR}/test_*.cc")
+
+  add_custom_target(gurka)
+  add_custom_target(run-gurka)
+
+  foreach(FULLFILENAME IN ITEMS ${TEST_FILES})
+    file(RELATIVE_PATH FILENAME "${CMAKE_CURRENT_LIST_DIR}" ${FULLFILENAME})
+    string(REGEX REPLACE "test_(.*).cc" "gurka_\\1" TESTNAME ${FILENAME})
+    add_executable(${TESTNAME} EXCLUDE_FROM_ALL ${FILENAME})
+    set_target_properties(${TESTNAME} PROPERTIES
+      COMPILE_DEFINITIONS VALHALLA_SOURCE_DIR="${VALHALLA_SOURCE_DIR}/")
+    target_link_libraries(${TESTNAME} valhalla gtest_main gmock)
+    target_include_directories(${TESTNAME} SYSTEM PRIVATE
+      ${VALHALLA_SOURCE_DIR}/third_party/protozero/include
+      ${VALHALLA_SOURCE_DIR}/third_party/libosmium/include)
+
+    add_custom_command(OUTPUT ${TESTNAME}.log
+      COMMAND
+        LOCPATH=${VALHALLA_SOURCE_DIR}/locales
+        /bin/bash -c "${CMAKE_CURRENT_BINARY_DIR}/${TESTNAME} >& ${CMAKE_CURRENT_BINARY_DIR}/${TESTNAME}.log \
+        && echo [PASS] ${TESTNAME} \
+        || ( exit=$? ; \
+             echo [FAIL] ${TESTNAME} ; \
+             cat ${CMAKE_CURRENT_BINARY_DIR}/${TESTNAME}.log ; \
+             exit $exit )"
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+      DEPENDS ${TESTNAME}
+      VERBATIM)
+    add_custom_target(run-${TESTNAME} DEPENDS ${TESTNAME}.log)
+    add_dependencies(gurka ${TESTNAME})
+    add_dependencies(run-gurka run-${TESTNAME})
+  endforeach()
+
+  add_dependencies(tests gurka)
+  add_dependencies(check run-gurka)
+
+endif()

--- a/test/gurka/README.md
+++ b/test/gurka/README.md
@@ -1,0 +1,208 @@
+# Valhalla Gurka Tests
+
+Tesst in this directory are "integration" level tests.  They check the full pipeline from
+map parsing through to route/match/etc result generation.
+
+# Test structure
+
+Inside the gurka/ directory, every file called `test_*.cc` is built as a distinct executable.
+A file called `test_turns.cc` will end up as `build/test/gurka/gurka_turns`
+
+# Using Gurka
+
+The `gurka.h` header provides helper functions for generating small test maps from ASCII art,
+building tiles from them, executing Valhalla API requests against those tiles, and helpers
+for checking parts of the API response for expected results.
+
+A minimal example test looks like this:
+
+  1. Create a file called `test/gurka/test_example.cc`
+  2. Populate a test case
+
+```cpp
+#include <gtest/gtest.h>
+#include "gurka.h"
+
+TEST(TestSuite, TestName) {
+
+    const std::string &ascii_map = R"(
+        A----B----C
+    )";
+    const gurka::ways ways = {{"ABC", {{"highway", "primary"}}}};
+
+    auto map = gurka::buildtiles(ascii_map, 100, ways, {}, {}, "test/data/example");
+
+    auto result = gurka::route(map, "A", "C", "auto");
+
+    EXPECT_EQ(result.directions().routes_size(), 1);
+    EXPECT_EQ(result.directions().routes(0).legs_size(), 1);
+
+}
+```
+
+To build it, you can do `make gurka_example`, and `make run-gurka_example`.
+
+You can build and execute gurka tests with `make run-gurka`
+
+# How to construct a map
+
+You need 4 things to build a test map.  It's helpful to understand the [OSM Data Model](https://labs.mapbox.com/mapping/osm-data-model/) before beginning.
+
+  1. Define the positions of nodes on the map by drawing an ASCII representation.
+     The map is interpreted as a 2d grid (see `gridsize` below). The letters A-Za-z0-9
+     represent OSM nodes.  Only node positions are interpreted from the ASCII grid,
+     but you can use any other character to help give context (i.e. use ---- to indicate
+     that two nodes will be connected by a way).
+     Using C++ Raw String Literals (6) https://en.cppreference.com/w/cpp/language/string_literal
+     is an easy way to to draw multiline string maps.
+     Example:
+
+```cpp
+const std::string ascii_map = R"(
+    A---B---C     j
+        |        /
+    D---E---f---h
+)";
+```
+
+     **Remember**: only the position of the A-Za-z0-9 characters matter - other characters
+     are ignored and are just helpful for describing your intent.
+
+  2. Define how the nodes are connected together (as OSM ways).  You need to build a
+     `gurka::ways` object.  This object has a `std::string` key which defines a sequence
+     of nodes that are connected, then a `std::vector` of key/value pairs that describe
+     the tags to go on a way.  C++ inializer-list syntax allows for a fairly compact
+     expression of a list of ways and their tags.
+     Example:
+
+```cpp
+const gurka::ways ways = {
+    { "ABC",   // String referencing nodes to be connected in order
+      { {"highway","motorway"},  // key/value tags to be put on the way
+        {"access","none"},
+        {"name","Test Road"} }
+    },
+    { "BE",  
+      { {"highway","motorway"},
+        {"access","none"},
+        {"name","Test Connector"} }
+    },
+    ...
+}
+```
+
+  3. Define properties on the nodes, if any.  Here, you need a `gurka::nodes` object.  Construction
+     is identical to the `gurka::ways` object, except that the primary key should just be
+     a single character (not a `char`, but a 1-character `std::string`).
+
+```cpp
+const gurka::nodes nodes = {
+    { "A",   // String referencing nodes to be connected in order
+      { {"barrier","true"} } // key/value tags to put on the node
+    },
+    ...
+}
+```
+
+  4. A list of relations.  A common example is a [restriction relation](https://wiki.openstreetmap.org/wiki/Relation:restriction), which restricts possible maneuvers.
+     You need to build a `gurka::relation` object.  Construction here is a little more
+     complex, but C++ initializer list syntax still works (get used to lots of {}).
+
+
+```cpp
+const gurka::relations relations = {
+    {
+        { // List of the members on the relation
+            gurka::relation_member{gurka::way_member, "kh", "from"},
+            gurka::relation_member{gurka::way_member, "il", "to"},
+            gurka::relation_member{gurka::way_member, "hi", "via"}
+        },
+        { // List of the key/value tags on the relation
+            {"type", "restriction"},
+            {"restriction", "no_right_turn"}
+        }
+    },
+    ...
+};
+```
+
+Once you have all these elements, you can now use them to build an OSM PBF file, and generate
+tiles for it, using:
+
+```cpp
+    auto map = gurka::buildtiles(ascii_map, 100, ways, nodes, relations, "test/data/example");
+```
+
+The `map.pbf` and tiles will be written to `test/data/example`.  The value `100` is the size of the grid to be used.  It's in metres, and decides the distance between the nodes in the ascii map.
+
+The returned `map` object has two properties:
+
+  - `config` - the boost::property_tree that was used to generate the tiles
+  - `nodes` - an `std::unordered_map` that with keys for the nodes, and the values are the PointLL that was assigned (this is useful for getting the coordinate of a node in a generated map)
+
+
+# Using a generated map
+
+Once you have map tiles, you can then do tests on them.  Gurka provides some helpers to make
+it easy to perform some normal interactions.
+
+```cpp
+valhalla::Api
+route(const gurka::map& map, const std::vector<std::string>& waypoints, const std::string& costing) {
+```
+
+This performs a valhalla route request on the map.  You can use named waypoints that you've drawn
+on the map as positions to route between.
+
+```cpp
+valhalla::Api
+match(const gurka::map& map, const std::vector<std::string>& waypoints, const bool break_at_waypoints, const std::string& costing) {
+```
+
+This performs a Valhalla trace request with the waypoints provided.  You can toggle the `type: break`
+parameter by setting `break_at_waypoints`.
+
+# Assertions
+
+Gurka provides some helper functions to make it easy to test various aspects of an API response.
+
+By default, the `gurka::route` and `gurka::match` functions return a `valhalla::Api` object, which is the
+raw protobuf that Valhalla passes around.  You can check some things directly on this with the helpers
+in the `gurka::assert::raw` namespace:
+
+## `gurka::assert::raw`
+
+```cpp
+void expect_maneuvers(const valhalla::Api& result,
+                      const std::vector<valhalla::DirectionsLeg_Maneuver_Type>& expected_maneuvers);
+
+void expect_path_length(const valhalla::Api& result,
+                        const float expected_length_km,
+                        const float error_margin = 0);
+```
+
+## `gurka::assert::osrm`
+
+Valhalla can also return responses in OSRM-compatible format.  To test that results contain things you
+expect when serialized to OSRM form, you can use the helpers in the `gurka::assert::osrm` namespace.
+These functions will first serialize the raw `valhalla::Api` object into a JSON document
+(using `tyr::serializeDirections`), then perform assertions within the JSON document only.
+
+```cpp
+void expect_route(valhalla::Api& raw_result,
+                  const std::vector<std::string>& expected_names,
+                  bool dedupe = true);
+
+void expect_match(valhalla::Api& raw_result,
+                  const std::vector<std::string>& expected_names,
+                  bool dedupe = true);
+```
+
+# Utility functions
+
+The main purpose of Gurka is to write high-level, end-to-end tests on minimaps.  There are some
+low-level helper functions available in case you want to do something a little more custom:
+
+  - `gurka::detail::build_config(workdir);` - builds a `boost::property_tree` for tile generation in `workdir`
+  - `gurka::detail::map_to_coordinates(ascii_map, gridsize);` - calculates coordinates for all the A-Za-z0-9 nodes in the `ascii_map` given the `gridsize`
+  - `gurka::detail::build_pbf(node_locations, ways, nodes, relations, pbf_filename);` - generates an OSM PBF for the nodes, ways, and relations you've defined.  The `nodemap` is the result of `gurka::detail::map_to_coordinates`

--- a/test/gurka/gurka.h
+++ b/test/gurka/gurka.h
@@ -1,0 +1,782 @@
+#ifndef VALHALLA_TEST_GURKA_H
+#define VALHALLA_TEST_GURKA_H
+/******************************************************************************
+ * End-to-end tests
+ *
+ * These include:
+ *   1. Parsing an OSM map
+ *   2. Generating tiles
+ *   3. Calculating routes on tiles
+ *   4. Verify the expected route
+ ******************************************************************************/
+#include "baldr/directededge.h"
+#include "baldr/graphid.h"
+#include "baldr/graphreader.h"
+#include "loki/worker.h"
+#include "mjolnir/util.h"
+#include "odin/worker.h"
+#include "thor/worker.h"
+#include "tyr/actor.h"
+#include "tyr/serializers.h"
+
+#include <boost/filesystem.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+
+#include "rapidjson/document.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/writer.h"
+
+#include "midgard/constants.h"
+#include "midgard/logging.h"
+#include "midgard/pointll.h"
+
+#include <osmium/builder/attr.hpp>
+#include <osmium/builder/osm_object_builder.hpp>
+#include <osmium/io/pbf_output.hpp>
+
+#include <regex>
+#include <string>
+#include <tuple>
+
+#include <gtest/gtest.h>
+
+namespace valhalla {
+namespace gurka {
+
+struct map {
+  boost::property_tree::ptree config;
+  std::unordered_map<std::string, midgard::PointLL> nodes;
+};
+
+using ways = std::unordered_map<std::string, std::unordered_map<std::string, std::string>>;
+using nodes = std::unordered_map<std::string, std::unordered_map<std::string, std::string>>;
+
+enum relation_member_type { node_member, way_member };
+struct relation_member {
+  relation_member_type type;
+  std::string ref;
+  std::string role;
+};
+struct relation {
+  std::vector<relation_member> members;
+  std::unordered_map<std::string, std::string> tags;
+};
+
+using relations = std::vector<relation>;
+
+using nodelayout = std::unordered_map<std::string, midgard::PointLL>;
+
+namespace detail {
+
+boost::property_tree::ptree build_config(const std::string& tiledir) {
+
+  const std::string default_config = R"(
+    {"mjolnir":{"tile_dir":"", "concurrency": 1},
+     "thor":{
+       "logging" : {"long_request" : 100}
+     },
+     "meili":{
+       "logging" : {"long_request" : 100},
+       "grid" : {"cache_size" : 100, "size": 100 },
+       "default": {
+         "beta": 3,
+         "breakage_distance": 2000,
+         "geometry": false,
+         "gps_accuracy": 5.0,
+         "interpolation_distance": 10,
+         "max_route_distance_factor": 5,
+         "max_route_time_factor": 5,
+         "max_search_radius": 100,
+         "route": true,
+         "search_radius": 50,
+         "sigma_z": 4.07,
+         "turn_penalty_factor": 0
+       },
+       "customizable": [
+         "mode",
+         "search_radius",
+         "turn_penalty_factor",
+         "gps_accuracy",
+         "interpolation_distance",
+         "sigma_z",
+         "beta",
+         "max_route_distance_factor",
+         "max_route_time_factor"
+       ]
+     },
+     "loki":{
+       "actions": [
+         "locate",
+         "route",
+         "height",
+         "sources_to_targets",
+         "optimized_route",
+         "isochrone",
+         "trace_route",
+         "trace_attributes",
+         "transit_available"
+       ],
+       "logging" : {"long_request" : 100}, 
+       "service_defaults" : {
+         "minimum_reachability" : 50,
+         "radius" : 0,
+         "search_cutoff" : 35000,
+         "node_snap_tolerance" : 5,
+         "street_side_tolerance" : 5,
+         "heading_tolerance" : 60
+        }
+     },
+     "service_limits": {
+      "auto": {"max_distance": 5000000.0, "max_locations": 20,"max_matrix_distance": 400000.0,"max_matrix_locations": 50},
+      "auto_shorter": {"max_distance": 5000000.0,"max_locations": 20,"max_matrix_distance": 400000.0,"max_matrix_locations": 50},
+      "bicycle": {"max_distance": 500000.0,"max_locations": 50,"max_matrix_distance": 200000.0,"max_matrix_locations": 50},
+      "bus": {"max_distance": 5000000.0,"max_locations": 50,"max_matrix_distance": 400000.0,"max_matrix_locations": 50},
+      "hov": {"max_distance": 5000000.0,"max_locations": 20,"max_matrix_distance": 400000.0,"max_matrix_locations": 50},
+      "taxi": {"max_distance": 5000000.0,"max_locations": 20,"max_matrix_distance": 400000.0,"max_matrix_locations": 50},
+      "isochrone": {"max_contours": 4,"max_distance": 25000.0,"max_locations": 1,"max_time": 120},
+      "max_avoid_locations": 50,"max_radius": 200,"max_reachability": 100,"max_alternates":2,
+      "multimodal": {"max_distance": 500000.0,"max_locations": 50,"max_matrix_distance": 0.0,"max_matrix_locations": 0},
+      "pedestrian": {"max_distance": 250000.0,"max_locations": 50,"max_matrix_distance": 200000.0,"max_matrix_locations": 50,"max_transit_walking_distance": 10000,"min_transit_walking_distance": 1},
+      "skadi": {"max_shape": 750000,"min_resample": 10.0},
+      "trace": {"max_distance": 200000.0,"max_gps_accuracy": 100.0,"max_search_radius": 100,"max_shape": 16000,"max_best_paths":4,"max_best_paths_shape":100},
+      "transit": {"max_distance": 500000.0,"max_locations": 50,"max_matrix_distance": 200000.0,"max_matrix_locations": 50},
+      "truck": {"max_distance": 5000000.0,"max_locations": 20,"max_matrix_distance": 400000.0,"max_matrix_locations": 50}
+    }
+  })";
+
+  std::stringstream stream(default_config);
+  boost::property_tree::ptree ptree;
+  boost::property_tree::json_parser::read_json(stream, ptree);
+  ptree.put("mjolnir.tile_dir", tiledir);
+  return ptree;
+}
+
+std::string build_valhalla_route_request(const map& map,
+                                         const std::vector<std::string>& waypoints,
+                                         const std::string& costing = "auto") {
+
+  rapidjson::Document doc;
+  doc.SetObject();
+  auto& allocator = doc.GetAllocator();
+
+  rapidjson::Value locations(rapidjson::kArrayType);
+  for (const auto& waypoint : waypoints) {
+    rapidjson::Value p(rapidjson::kObjectType);
+    p.AddMember("lon", map.nodes.at(waypoint).lng(), allocator);
+    p.AddMember("lat", map.nodes.at(waypoint).lat(), allocator);
+    locations.PushBack(p, allocator);
+  }
+  doc.AddMember("locations", locations, allocator);
+  doc.AddMember("costing", costing, allocator);
+
+  rapidjson::StringBuffer sb;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(sb);
+  doc.Accept(writer);
+  return sb.GetString();
+}
+
+std::string build_valhalla_match_request(const map& map,
+                                         const std::vector<std::string>& waypoints,
+                                         const bool break_at_points = false,
+                                         const std::string& costing = "auto") {
+
+  rapidjson::Document doc;
+  doc.SetObject();
+  auto& allocator = doc.GetAllocator();
+
+  rapidjson::Value locations(rapidjson::kArrayType);
+  for (const auto& waypoint : waypoints) {
+    rapidjson::Value p(rapidjson::kObjectType);
+    p.AddMember("lon", map.nodes.at(waypoint).lng(), allocator);
+    p.AddMember("lat", map.nodes.at(waypoint).lat(), allocator);
+    if (break_at_points) {
+      p.AddMember("type", "break", allocator);
+    }
+    locations.PushBack(p, allocator);
+  }
+  doc.AddMember("shape", locations, allocator);
+  doc.AddMember("costing", costing, allocator);
+  doc.AddMember("shape_match", "map_snap", allocator);
+
+  rapidjson::StringBuffer sb;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(sb);
+  doc.Accept(writer);
+  return sb.GetString();
+}
+
+std::vector<std::string> splitter(const std::string in_pattern, const std::string& content) {
+  std::vector<std::string> split_content;
+  std::regex pattern(in_pattern);
+  std::copy(std::sregex_token_iterator(content.begin(), content.end(), pattern, -1),
+            std::sregex_token_iterator(), std::back_inserter(split_content));
+  return split_content;
+}
+
+void ltrim(std::string& s) {
+  s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int ch) { return !std::isspace(ch); }));
+}
+void rtrim(std::string& s) {
+  s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) { return !std::isspace(ch); }).base(),
+          s.end());
+}
+
+std::string trim(std::string s) {
+  ltrim(s);
+  rtrim(s);
+  return s;
+}
+
+/**
+ * Given a string that's an "ASCII map", will decide on coordinates
+ * for the nodes drawn on the grid.
+ *
+ * @returns a dictionary of node IDs to lon/lat values
+ */
+nodelayout map_to_coordinates(const std::string& map,
+                              const double gridsize_metres,
+                              const midgard::PointLL& topleft = {0, 0}) {
+
+  // Gridsize is in meters per character
+
+  /// Mercator projection
+  auto y2lat_m = [](double y) {
+    return (2 * atan(exp(y / midgard::kRadEarthMeters)) - midgard::kPiD / 2) * midgard::kDegPerRadD;
+  };
+  auto x2lon_m = [](double x) { return (x / midgard::kRadEarthMeters) * midgard::kDegPerRadD; };
+
+  // Split string into lines
+  // Strip whitespace lines, if they exist
+  // Strip common leading whitespace
+  // Decide locations for nodes based on remaining grid
+
+  // Split string into lines
+  auto lines = splitter("\n", map);
+  if (lines.empty())
+    return {};
+
+  // Remove the leading whitespace lines, if they exist
+  while (trim(lines.front()).empty()) {
+    lines.erase(lines.begin());
+  }
+
+  // Find out the min whitespace on each line, then remove that from each line
+  long min_whitespace = std::numeric_limits<long>::max();
+  for (const auto& line : lines) {
+    // Skip blank lines, as they might have no space at all, but shouldn't
+    // be allowed to affect positioning
+    if (trim(line).empty())
+      continue;
+    auto pos =
+        std::find_if(line.begin(), line.end(), [](const auto& ch) { return !std::isspace(ch); });
+    min_whitespace = std::min(min_whitespace, static_cast<long>(std::distance(line.begin(), pos)));
+    if (min_whitespace == 0) // No need to continue if something is up against the left
+      break;
+  }
+
+  // In-place remove leading whitespace from each line
+  for (auto& line : lines) {
+    // This must be a blank line or something
+    if (line.size() < min_whitespace)
+      continue;
+    line.erase(line.begin(), line.begin() + min_whitespace);
+  }
+
+  // TODO: the way this projects coordinates onto the sphere could do with some work.
+  //       it's not always going to be sensible to lay a grid down onto a sphere
+  nodelayout result;
+  for (std::size_t y = 0; y < lines.size(); y++) {
+    for (std::size_t x = 0; x < lines[y].size(); x++) {
+      auto ch = lines[y][x];
+      // Only do A-Za-z0-9 for nodes - all other things are ignored
+      if (std::isalnum(ch)) {
+        // Always project west, then south, for consistency
+        double lon = topleft.lng() + x2lon_m(x * gridsize_metres);
+        double lat = topleft.lat() - y2lat_m(y * gridsize_metres);
+        result.insert({std::string(1, ch), {lon, lat}});
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Given a map of node locations, ways, node properties and relations, will
+ * generate an OSM compatible PBF file, suitable for loading into Valhalla
+ */
+inline void build_pbf(const nodelayout& node_locations,
+                      const ways& ways,
+                      const nodes& nodes,
+                      const relations& relations,
+                      const std::string& filename,
+                      const int initial_osm_id = 0) {
+
+  const size_t initial_buffer_size = 10000;
+  osmium::memory::Buffer buffer{initial_buffer_size, osmium::memory::Buffer::auto_grow::yes};
+
+  std::unordered_set<std::string> used_nodes;
+  for (const auto& way : ways) {
+    for (const auto& ch : way.first) {
+      used_nodes.insert(std::string(1, ch));
+    }
+  }
+  for (const auto& node : nodes) {
+    for (const auto& ch : node.first) {
+      used_nodes.insert(std::string(1, ch));
+    }
+  }
+  for (const auto& relation : relations) {
+    for (const auto& member : relation.members) {
+      if (member.type == node_member) {
+        used_nodes.insert(member.ref);
+      }
+    }
+  }
+
+  for (auto& used_node : used_nodes) {
+    if (node_locations.count(used_node) == 0) {
+      throw std::runtime_error("Node " + used_node + " was referred to but was not in the ASCII map");
+    }
+  }
+
+  std::unordered_map<std::string, int> node_id_map;
+  std::unordered_map<std::string, int> node_osm_id_map;
+  int id = 0;
+  for (auto& loc : node_locations) {
+    node_id_map[loc.first] = id++;
+  }
+  int osm_id = initial_osm_id;
+  for (auto& loc : node_locations) {
+    if (used_nodes.count(loc.first) > 0) {
+      node_osm_id_map[loc.first] = osm_id++;
+
+      std::vector<std::pair<std::string, std::string>> tags;
+
+      if (nodes.count(loc.first) == 0) {
+        tags.push_back({"name", loc.first});
+      } else {
+        auto otags = nodes.at(loc.first);
+        if (otags.count("name") == 0) {
+          tags.push_back({"name", loc.first});
+        }
+        for (const auto& keyval : otags) {
+          tags.push_back({keyval.first, keyval.second});
+        }
+      }
+
+      osmium::builder::add_node(buffer, osmium::builder::attr::_id(node_osm_id_map[loc.first]),
+                                osmium::builder::attr::_version(1),
+                                osmium::builder::attr::_timestamp(std::time(nullptr)),
+                                osmium::builder::attr::_location(
+                                    osmium::Location{loc.second.lng(), loc.second.lat()}),
+                                osmium::builder::attr::_tags(tags));
+    }
+  }
+
+  std::unordered_map<std::string, int> way_osm_id_map;
+  for (const auto& way : ways) {
+    way_osm_id_map[way.first] = osm_id++;
+    std::vector<int> nodeids;
+    for (const auto& ch : way.first) {
+      nodeids.push_back(node_osm_id_map[std::string(1, ch)]);
+    }
+    std::vector<std::pair<std::string, std::string>> tags;
+    if (way.second.count("name") == 0) {
+      tags.push_back({"name", way.first});
+    }
+    for (const auto& keyval : way.second) {
+      tags.push_back({keyval.first, keyval.second});
+    }
+    osmium::builder::add_way(buffer, osmium::builder::attr::_id(way_osm_id_map[way.first]),
+                             osmium::builder::attr::_version(1),
+                             osmium::builder::attr::_timestamp(std::time(nullptr)),
+                             osmium::builder::attr::_nodes(nodeids),
+                             osmium::builder::attr::_tags(tags));
+  }
+
+  for (const auto& relation : relations) {
+
+    std::vector<osmium::builder::attr::member_type> members;
+
+    for (const auto& member : relation.members) {
+      if (member.type == node_member) {
+        members.push_back(
+            {osmium::item_type::node, node_osm_id_map[member.ref], member.role.c_str()});
+      } else {
+        if (way_osm_id_map.count(member.ref) == 0) {
+          throw std::runtime_error("Relation member refers to an undefined way " + member.ref);
+        }
+        members.push_back({osmium::item_type::way, way_osm_id_map[member.ref], member.role.c_str()});
+      }
+    }
+
+    std::vector<std::pair<std::string, std::string>> tags;
+    for (const auto& tag : relation.tags) {
+      tags.push_back({tag.first, tag.second});
+    }
+
+    osmium::builder::add_relation(buffer, osmium::builder::attr::_id(osm_id++),
+                                  osmium::builder::attr::_version(1),
+                                  osmium::builder::attr::_timestamp(std::time(nullptr)),
+                                  osmium::builder::attr::_members(members),
+                                  osmium::builder::attr::_tags(tags));
+  }
+
+  // Create header and set generator.
+  osmium::io::Header header;
+  header.set("generator", "valhalla-test-creator");
+
+  osmium::io::File output_file{filename, "pbf"};
+
+  // Initialize Writer using the header from above and tell it that it
+  // is allowed to overwrite a possibly existing file.
+  osmium::io::Writer writer{output_file, header, osmium::io::overwrite::allow};
+
+  // Write out the contents of the output buffer.
+  writer(std::move(buffer));
+
+  // Explicitly close the writer. Will throw an exception if there is
+  // a problem. If you wait for the destructor to close the writer, you
+  // will not notice the problem, because destructors must not throw.
+  writer.close();
+}
+
+} // namespace detail
+
+/**
+ * Given a node layout, set of ways, node properties and relations, generates an OSM PBF file,
+ * and builds a set of Valhalla tiles for it.
+ *
+ * @param layout the locations of all the nodes
+ * @param ways the way definitions (which nodes are connected, and their properties
+ * @param nodes properties on any of the defined nodes
+ * @param relations OSM relations that related nodes and ways together
+ * @param workdir where to build the PBF and the tiles
+ * @return a map object that contains the Valhalla config (to pass to GraphReader) and node layout
+ *         (for converting node names to coordinates)
+ */
+map buildtiles(const nodelayout layout,
+               const ways& ways,
+               const nodes& nodes,
+               const relations& relations,
+               const std::string& workdir) {
+
+  map result;
+  result.config = detail::build_config(workdir);
+  result.nodes = layout;
+
+  // Sanity check so that we don't blow away / by mistake
+  if (workdir == "/") {
+    throw std::runtime_error("Can't use / for tests, as we need to clean it out first");
+  }
+
+  if (boost::filesystem::exists(workdir))
+    boost::filesystem::remove_all(workdir);
+  boost::filesystem::create_directories(workdir);
+
+  auto pbf_filename = workdir + "/map.pbf";
+  std::cerr << "[          ] generating map PBF at " << pbf_filename << std::endl;
+  detail::build_pbf(result.nodes, ways, nodes, relations, pbf_filename);
+  std::cerr << "[          ] building tiles in " << result.config.get<std::string>("mjolnir.tile_dir")
+            << std::endl;
+  midgard::logging::Configure({{"type", ""}});
+
+  mjolnir::build_tile_set(result.config, {pbf_filename}, mjolnir::BuildStage::kInitialize,
+                          mjolnir::BuildStage::kValidate, false);
+
+  return result;
+}
+
+/**
+ * Finds a directed edge in the generated map.  Helpful because the IDs assigned
+ * to edges depends on the shape of the map.
+ *
+ * @param reader a reader configured to read graph tiles
+ * @param nodes a lookup table from node names to coordinates
+ * @param tile_id the tile to search
+ * @param way_name the way name you want a directed edge for
+ * @param end_node the node that should be the target of the directed edge you want
+ * @return the directed edge that matches, or nullptr if there was no match
+ */
+std::tuple<const baldr::GraphId,
+           const baldr::DirectedEdge*,
+           const baldr::GraphId,
+           const baldr::DirectedEdge*>
+findEdge(const std::unique_ptr<valhalla::baldr::GraphReader>& reader,
+         const std::unordered_map<std::string, midgard::PointLL>& nodes,
+         const baldr::GraphId& tile_id,
+         const std::string& way_name,
+         const std::string& end_node) {
+  auto* tile = reader->GetGraphTile(tile_id);
+
+  auto end_node_coordinates = nodes.at(end_node);
+
+  // Iterate over all directed edges to find one with the name we want
+  for (uint32_t i = 0; i < tile->header()->directededgecount(); i++) {
+    const auto* forward_directed_edge = tile->directededge(i);
+    // Now, see if the endnode for this edge is our end_node
+    auto de_endnode = forward_directed_edge->endnode();
+    auto de_endnode_coordinates = tile->get_node_ll(de_endnode);
+    const auto threshold = 0.00001; // Degrees.  About 1m at the equator
+    if (std::abs(de_endnode_coordinates.lng() - end_node_coordinates.lng()) < threshold &&
+        std::abs(de_endnode_coordinates.lat() - end_node_coordinates.lat()) < threshold) {
+      auto names = tile->GetNames(forward_directed_edge->edgeinfo_offset());
+      for (const auto& name : names) {
+        if (name == way_name) {
+          auto forward_edge_id = tile_id;
+          forward_edge_id.set_id(i);
+          auto reverse_edge_id = tile->GetOpposingEdgeId(forward_directed_edge);
+          auto* reverse_directed_edge = tile->directededge(i);
+          return std::make_tuple(forward_edge_id, forward_directed_edge, reverse_edge_id,
+                                 reverse_directed_edge);
+        }
+      }
+    }
+  }
+
+  return std::make_tuple(baldr::GraphId{}, nullptr, baldr::GraphId{}, nullptr);
+}
+
+std::tuple<const baldr::GraphId,
+           const baldr::DirectedEdge*,
+           const baldr::GraphId,
+           const baldr::DirectedEdge*>
+findEdge(const map& map,
+         const baldr::GraphId& tile_id,
+         const std::string& way_name,
+         const std::string& end_node) {
+  std::unique_ptr<baldr::GraphReader> reader(new baldr::GraphReader(map.config));
+  return findEdge(reader, map.nodes, tile_id, way_name, end_node);
+}
+
+/**
+ * Calculates a route along a set of waypoints with a given costing model, and returns the
+ * valhalla::Api result.
+ *
+ * @param map a map returned by buildtiles
+ * @param waypoints an array of node names to use as waypoints
+ * @param costing the name of the costing model to use
+ */
+valhalla::Api
+route(const map& map, const std::vector<std::string>& waypoints, const std::string& costing) {
+  std::cerr << "[          ] Routing with mjolnir.tile_dir = "
+            << map.config.get<std::string>("mjolnir.tile_dir") << " with waypoints ";
+  bool first = true;
+  for (const auto& waypoint : waypoints) {
+    if (!first)
+      std::cerr << " -> ";
+    std::cerr << waypoint;
+    first = false;
+  };
+  std::cerr << " with costing " << costing << std::endl;
+  auto request_json = detail::build_valhalla_route_request(map, waypoints, costing);
+  std::cerr << "[          ] Valhalla request is: " << request_json << std::endl;
+
+  valhalla::tyr::actor_t actor(map.config, true);
+  return actor.unserialized_route(request_json);
+}
+
+valhalla::Api
+route(const map& map, const std::string& from, const std::string& to, const std::string& costing) {
+  return route(map, {from, to}, costing);
+}
+
+valhalla::Api match(const map& map,
+                    const std::vector<std::string>& waypoints,
+                    const bool break_at_points,
+                    const std::string& costing) {
+  std::cerr << "[          ] Matching with mjolnir.tile_dir = "
+            << map.config.get<std::string>("mjolnir.tile_dir") << " with waypoints ";
+  bool first = true;
+  for (const auto& waypoint : waypoints) {
+    if (!first)
+      std::cerr << " -> ";
+    std::cerr << waypoint;
+    first = false;
+  };
+  std::cerr << " with costing " << costing << std::endl;
+  auto request_json = detail::build_valhalla_match_request(map, waypoints, break_at_points, costing);
+  std::cerr << "[          ] Valhalla request is: " << request_json << std::endl;
+
+  valhalla::tyr::actor_t actor(map.config, true);
+  return actor.unserialized_trace_route(request_json);
+}
+
+namespace assert {
+namespace osrm {
+
+/**
+ * Tests if a found path traverses the expected roads in the expected order
+ *
+ * @param result the result of a /route or /match request
+ * @param expected_names the names of the roads the path should traverse in order
+ * @param dedupe whether subsequent same-name roads should appear multiple times or not (default not)
+ */
+void expect_route(valhalla::Api& raw_result,
+                  const std::vector<std::string>& expected_names,
+                  bool dedupe = true) {
+
+  raw_result.mutable_options()->set_format(valhalla::Options_Format_osrm);
+  auto json = tyr::serializeDirections(raw_result);
+
+  rapidjson::Document result;
+  result.Parse(json.c_str());
+  if (result.HasParseError()) {
+    FAIL();
+  }
+
+  EXPECT_TRUE(result.HasMember("routes"));
+  EXPECT_TRUE(result["routes"].IsArray());
+  EXPECT_EQ(result["routes"].Size(), 1);
+
+  EXPECT_TRUE(result["routes"][0].IsObject());
+  EXPECT_TRUE(result["routes"][0].HasMember("legs"));
+  EXPECT_TRUE(result["routes"][0]["legs"].IsArray());
+
+  std::vector<std::string> actual_names;
+  for (auto leg_iter = result["routes"][0]["legs"].Begin();
+       leg_iter != result["routes"][0]["legs"].End(); ++leg_iter) {
+    EXPECT_TRUE(leg_iter->IsObject());
+    EXPECT_TRUE(leg_iter->HasMember("steps"));
+    EXPECT_TRUE(leg_iter->FindMember("steps")->value.IsArray());
+    for (auto step_iter = leg_iter->FindMember("steps")->value.Begin();
+         step_iter != leg_iter->FindMember("steps")->value.End(); ++step_iter) {
+
+      // If we're on the last leg, append the last step, otherwise skip it, because it'll
+      // exist on the first step of the next leg
+      if (leg_iter == result["routes"][0]["legs"].End() ||
+          step_iter != leg_iter->FindMember("steps")->value.End()) {
+        EXPECT_TRUE(step_iter->IsObject());
+        auto name = step_iter->FindMember("name");
+        EXPECT_NE(name, step_iter->MemberEnd());
+        EXPECT_TRUE(name->value.IsString());
+        actual_names.push_back(name->value.GetString());
+      }
+    }
+  }
+
+  if (dedupe) {
+    auto last = std::unique(actual_names.begin(), actual_names.end());
+    actual_names.erase(last, actual_names.end());
+  }
+
+  EXPECT_EQ(actual_names, expected_names) << "Actual path didn't match expected path";
+}
+/**
+ * Tests if a found path traverses the expected roads in the expected order
+ *
+ * @param result the result of a /route or /match request
+ * @param expected_names the names of the roads the path should traverse in order
+ * @param dedupe whether subsequent same-name roads should appear multiple times or not (default not)
+ */
+void expect_match(valhalla::Api& raw_result,
+                  const std::vector<std::string>& expected_names,
+                  bool dedupe = true) {
+
+  raw_result.mutable_options()->set_format(valhalla::Options_Format_osrm);
+  auto json = tyr::serializeDirections(raw_result);
+
+  rapidjson::Document result;
+  result.Parse(json.c_str());
+  if (result.HasParseError()) {
+    FAIL();
+  }
+
+  EXPECT_TRUE(result.HasMember("matchings"));
+  EXPECT_TRUE(result["matchings"].IsArray());
+  EXPECT_EQ(result["matchings"].Size(), 1);
+
+  EXPECT_TRUE(result["matchings"][0].IsObject());
+  EXPECT_TRUE(result["matchings"][0].HasMember("legs"));
+  EXPECT_TRUE(result["matchings"][0]["legs"].IsArray());
+
+  std::vector<std::string> actual_names;
+  for (auto leg_iter = result["matchings"][0]["legs"].Begin();
+       leg_iter != result["matchings"][0]["legs"].End(); ++leg_iter) {
+    EXPECT_TRUE(leg_iter->IsObject());
+    EXPECT_TRUE(leg_iter->HasMember("steps"));
+    EXPECT_TRUE(leg_iter->FindMember("steps")->value.IsArray());
+    for (auto step_iter = leg_iter->FindMember("steps")->value.Begin();
+         step_iter != leg_iter->FindMember("steps")->value.End(); ++step_iter) {
+
+      // If we're on the last leg, append the last step, otherwise skip it, because it'll
+      // exist on the first step of the next leg
+      if (leg_iter == result["matchings"][0]["legs"].End() ||
+          step_iter != leg_iter->FindMember("steps")->value.End()) {
+        EXPECT_TRUE(step_iter->IsObject());
+        auto name = step_iter->FindMember("name");
+        EXPECT_NE(name, step_iter->MemberEnd());
+        EXPECT_TRUE(name->value.IsString());
+        actual_names.push_back(name->value.GetString());
+      }
+    }
+  }
+
+  if (dedupe) {
+    auto last = std::unique(actual_names.begin(), actual_names.end());
+    actual_names.erase(last, actual_names.end());
+  }
+
+  EXPECT_EQ(actual_names, expected_names) << "Actual path didn't match expected path";
+}
+} // namespace osrm
+
+namespace raw {
+/**
+ * Tests whether the expected sequence of maneuvers is emitted for the route.
+ * Looks at the output of Odin in the result.
+ *
+ * @param result the result of a /route or /match request
+ * @param expected_maneuvers all the maneuvers expected in the DirectionsLeg for the route
+ */
+void expect_maneuvers(const valhalla::Api& result,
+                      const std::vector<valhalla::DirectionsLeg_Maneuver_Type>& expected_maneuvers) {
+
+  EXPECT_EQ(result.directions().routes_size(), 1);
+  EXPECT_EQ(result.directions().routes(0).legs_size(), 1);
+
+  const auto& leg = result.directions().routes(0).legs(0);
+
+  std::vector<valhalla::DirectionsLeg_Maneuver_Type> actual_maneuvers;
+  for (int i = 0; i < leg.maneuver_size(); i++) {
+    actual_maneuvers.push_back(leg.maneuver(i).type());
+  }
+
+  EXPECT_EQ(actual_maneuvers, expected_maneuvers)
+      << "Actual maneuvers didn't match expected maneuvers";
+}
+
+void expect_path_length(const valhalla::Api& result,
+                        const float expected_length_km,
+                        const float error_margin = 0) {
+  EXPECT_EQ(result.trip().routes_size(), 1);
+  EXPECT_EQ(result.trip().routes(0).legs_size(), 1);
+
+  const auto& route = result.trip().routes(0);
+
+  float length_km = 0;
+  for (int legnum = 0; legnum < route.legs_size(); legnum++) {
+    const auto& leg = route.legs(legnum);
+    for (int nodenum = 0; nodenum < leg.node_size(); nodenum++) {
+      const auto& node = leg.node(nodenum);
+      if (node.has_edge()) {
+        length_km += node.edge().length();
+      }
+    }
+  }
+
+  if (error_margin == 0) {
+    EXPECT_FLOAT_EQ(length_km, expected_length_km);
+  } else {
+    EXPECT_NEAR(length_km, expected_length_km, error_margin);
+  }
+}
+
+} // namespace raw
+} // namespace assert
+
+} // namespace gurka
+} // namespace valhalla
+
+#endif // VALHALLA_TEST_GURKA_H

--- a/test/gurka/test_accessibility.cc
+++ b/test/gurka/test_accessibility.cc
@@ -1,0 +1,70 @@
+#include "gurka.h"
+#include <gtest/gtest.h>
+
+using namespace valhalla;
+
+class Accessibility : public ::testing::Test {
+protected:
+  static gurka::map map;
+
+  static void SetUpTestSuite() {
+    constexpr double gridsize = 100;
+
+    const std::string ascii_map = R"(
+    A----B----C
+    |    .
+    D----E----F
+    |    . \
+    G----H----I)";
+
+    // BE and EH are highway=path, so no cars
+    // EI is a shortcut that's not accessible to bikes
+    const gurka::ways ways = {{"AB", {{"highway", "primary"}}},
+                              {"BC", {{"highway", "primary"}}},
+                              {"DEF", {{"highway", "primary"}}},
+                              {"GHI", {{"highway", "primary"}}},
+                              {"ADG", {{"highway", "motorway"}}},
+                              {"BE", {{"highway", "path"}}},
+                              {"EI", {{"highway", "path"}, {"bicycle", "no"}}},
+                              {"EH", {{"highway", "path"}}}};
+    const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100);
+
+    map = gurka::buildtiles(layout, ways, {}, {}, "test/data/accessibility");
+  }
+};
+
+gurka::map Accessibility::map = {};
+
+/*************************************************************/
+TEST_F(Accessibility, Auto1) {
+  auto result = gurka::route(map, "C", "F", "auto");
+  gurka::assert::osrm::expect_route(result, {"BC", "AB", "ADG", "DEF"});
+}
+TEST_F(Accessibility, Auto2) {
+  auto result = gurka::route(map, "C", "I", "auto");
+  gurka::assert::osrm::expect_route(result, {"BC", "AB", "ADG", "GHI"});
+}
+TEST_F(Accessibility, WalkUsesShortcut1) {
+  auto result = gurka::route(map, "C", "F", "pedestrian");
+  gurka::assert::osrm::expect_route(result, {"BC", "BE", "DEF"});
+}
+TEST_F(Accessibility, WalkUsesBothShortcuts) {
+  auto result = gurka::route(map, "C", "I", "pedestrian");
+  gurka::assert::osrm::expect_route(result, {"BC", "BE", "EI"});
+}
+TEST_F(Accessibility, BikeUsesShortcut) {
+  auto result = gurka::route(map, "C", "F", "bicycle");
+  gurka::assert::osrm::expect_route(result, {"BC", "BE", "DEF"});
+}
+TEST_F(Accessibility, BikeAvoidsSecondShortcut) {
+  auto result = gurka::route(map, "C", "I", "bicycle");
+  gurka::assert::osrm::expect_route(result, {"BC", "BE", "EH", "GHI"});
+}
+TEST_F(Accessibility, WalkAvoidsMotorway) {
+  auto result = gurka::route(map, "A", "G", "pedestrian");
+  gurka::assert::osrm::expect_route(result, {"AB", "BE", "EH", "GHI"});
+}
+TEST_F(Accessibility, AutoUsesMotorway) {
+  auto result = gurka::route(map, "A", "G", "auto");
+  gurka::assert::osrm::expect_route(result, {"ADG"});
+}

--- a/test/gurka/test_match.cc
+++ b/test/gurka/test_match.cc
@@ -1,0 +1,34 @@
+#include "gurka.h"
+#include <gtest/gtest.h>
+
+using namespace valhalla;
+
+/*************************************************************/
+TEST(Standalone, BasicMatch) {
+
+  const std::string ascii_map = R"(
+      1
+    A---2B-3-4C
+              |
+              |5
+              D
+         )";
+
+  const gurka::ways ways = {{"AB", {{"highway", "primary"}}},
+                            {"BC", {{"highway", "primary"}}},
+                            {"CD", {{"highway", "primary"}}}};
+
+  const double gridsize = 10;
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, gridsize);
+  auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/basic_match");
+
+  auto result = gurka::match(map, {"1", "2", "3", "4", "5"}, false, "auto");
+
+  gurka::assert::osrm::expect_match(result, {"AB", "BC", "CD"});
+  gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
+                                                DirectionsLeg_Maneuver_Type_kContinue,
+                                                DirectionsLeg_Maneuver_Type_kRight,
+                                                DirectionsLeg_Maneuver_Type_kDestination});
+
+  gurka::assert::raw::expect_path_length(result, 0.100, 0.001);
+}

--- a/test/gurka/test_simple_restrictions.cc
+++ b/test/gurka/test_simple_restrictions.cc
@@ -1,0 +1,49 @@
+#include "gurka.h"
+#include <gtest/gtest.h>
+
+using namespace valhalla;
+
+class SimpleRestrictions : public ::testing::Test {
+protected:
+  static gurka::map map;
+
+  static void SetUpTestSuite() {
+    constexpr double gridsize = 100;
+
+    const std::string ascii_map = R"(
+    A---1B----C
+    |    |
+    D----E----F
+    |    |
+    G----H----I)";
+
+    const gurka::ways ways = {{"AB", {{"highway", "primary"}}},  {"BC", {{"highway", "primary"}}},
+                              {"DEF", {{"highway", "primary"}}}, {"GHI", {{"highway", "primary"}}},
+                              {"ADG", {{"highway", "primary"}}}, {"BE", {{"highway", "primary"}}},
+                              {"EH", {{"highway", "primary"}}}};
+
+    const gurka::relations relations = {{{{gurka::way_member, "BC", "from"},
+                                          {gurka::way_member, "BE", "to"},
+                                          {gurka::node_member, "B", "via"}},
+                                         {{"type", "restriction"}, {"restriction", "no_left_turn"}}}};
+
+    const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100);
+    map = gurka::buildtiles(layout, ways, {}, relations, "test/data/simple_restrictions");
+  }
+};
+
+gurka::map SimpleRestrictions::map = {};
+
+/*************************************************************/
+TEST_F(SimpleRestrictions, ForceDetour) {
+  auto result = gurka::route(map, "C", "F", "auto");
+  gurka::assert::osrm::expect_route(result, {"BC", "AB", "ADG", "DEF"});
+}
+TEST_F(SimpleRestrictions, NoDetourWhenReversed) {
+  auto result = gurka::route(map, "F", "C", "auto");
+  gurka::assert::osrm::expect_route(result, {"DEF", "BE", "BC"});
+}
+TEST_F(SimpleRestrictions, NoDetourFromDifferentStart) {
+  auto result = gurka::route(map, "1", "F", "auto");
+  gurka::assert::osrm::expect_route(result, {"AB", "BE", "DEF"});
+}

--- a/test/gurka/test_turns.cc
+++ b/test/gurka/test_turns.cc
@@ -1,0 +1,82 @@
+#include "gurka.h"
+#include <gtest/gtest.h>
+
+using namespace valhalla;
+
+/*************************************************************/
+TEST(Standalone, TurnStraight) {
+
+  const std::string ascii_map = R"(
+    A----B----C
+         |
+         D)";
+
+  const gurka::ways ways = {{"ABC", {{"highway", "primary"}}}, {"BD", {{"highway", "primary"}}}};
+
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100);
+  auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_turns_3");
+
+  auto result = gurka::route(map, "A", "C", "auto");
+
+  gurka::assert::osrm::expect_route(result, {"ABC"});
+  gurka::assert::raw::expect_path_length(result, 1.0);
+}
+/*************************************************************/
+
+const std::string ascii_map_1 = R"(
+    A----B----C
+         |
+         D)";
+
+const gurka::ways map_1_ways = {{"ABC", {{"highway", "primary"}}}, {"BD", {{"highway", "primary"}}}};
+
+const std::string ascii_map_2 = R"(
+    E----B----C
+    |    |
+    F----D)";
+
+const gurka::ways map_2_ways = {{"FEBC", {{"highway", "primary"}}},
+                                {"FDB", {{"highway", "primary"}}}};
+
+class Turns : public ::testing::Test {
+protected:
+  static gurka::map map_1;
+  static gurka::map map_2;
+
+  static void SetUpTestSuite() {
+    constexpr double gridsize = 100;
+
+    const auto layout1 = gurka::detail::map_to_coordinates(ascii_map_1, gridsize);
+    const auto layout2 = gurka::detail::map_to_coordinates(ascii_map_2, gridsize);
+    map_1 = gurka::buildtiles(layout1, map_1_ways, {}, {}, "test/data/gurka_turns_1");
+    map_2 = gurka::buildtiles(layout2, map_2_ways, {}, {}, "test/data/gurka_turns_2");
+  }
+};
+
+gurka::map Turns::map_1 = {};
+gurka::map Turns::map_2 = {};
+
+/************************************************************************************/
+TEST_F(Turns, TurnRight) {
+
+  auto result = gurka::route(map_1, "A", "D", "auto");
+
+  gurka::assert::osrm::expect_route(result, {"ABC", "BD"});
+
+  gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
+                                                DirectionsLeg_Maneuver_Type_kRight,
+                                                DirectionsLeg_Maneuver_Type_kDestination});
+  gurka::assert::raw::expect_path_length(result, 0.7, 0.001);
+}
+/************************************************************************************/
+TEST_F(Turns, TurnLeft) {
+
+  auto result = gurka::route(map_2, "C", "D", "auto");
+
+  gurka::assert::osrm::expect_route(result, {"FEBC", "FDB"});
+
+  gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
+                                                DirectionsLeg_Maneuver_Type_kLeft,
+                                                DirectionsLeg_Maneuver_Type_kDestination});
+  gurka::assert::raw::expect_path_length(result, 0.7, 0.001);
+}

--- a/valhalla/mjolnir/util.h
+++ b/valhalla/mjolnir/util.h
@@ -113,12 +113,15 @@ uint32_t compute_curvature(const std::list<midgard::PointLL>& shape);
  * @param input_files   Tells what osm pbf files to build the tiles from
  * @param start_stage   Starting stage of the pipeline to run
  * @param end_stage     End stage of the pipeline to run
+ * @param release_osmpbf_memory Free PBF parsing libs after use.  Saves RAM, but makes libprotobuf
+ * unusable afterwards.  Set to false if you need to perform protobuf operations after building tiles.
  * @return Returns true if no errors occur, false if an error occurs.
  */
 bool build_tile_set(const boost::property_tree::ptree& config,
                     const std::vector<std::string>& input_files,
                     const BuildStage start_stage = BuildStage::kInitialize,
-                    const BuildStage end_stage = BuildStage::kValidate);
+                    const BuildStage end_stage = BuildStage::kValidate,
+                    const bool release_osmpbf_memory = true);
 
 } // namespace mjolnir
 } // namespace valhalla

--- a/valhalla/tyr/actor.h
+++ b/valhalla/tyr/actor.h
@@ -5,6 +5,8 @@
 #include <memory>
 #include <unordered_map>
 
+#include <valhalla/proto/api.pb.h>
+
 namespace valhalla {
 namespace tyr {
 
@@ -32,6 +34,11 @@ public:
                                 const std::function<void()>& interrupt = []() -> void {});
   std::string expansion(const std::string& request_str,
                         const std::function<void()>& interrupt = []() -> void {});
+
+  valhalla::Api unserialized_route(const std::string& request_str,
+                                   const std::function<void()>& interrupt = []() -> void {});
+  valhalla::Api unserialized_trace_route(const std::string& request_str,
+                                         const std::function<void()>& interrupt = []() -> void {});
 
 protected:
   struct pimpl_t;


### PR DESCRIPTION
# Issue

Creating test scenarios is a PITA.  Getting all the little details right takes time, especially when the tooling doesn't help you do it.

This PR adds a new set of tests I'm going to call `gurka` (Swedish for 🥒 ) as they're somewhat modelled after OSRM's Cucumber test suite.

The tests add some helpers that make it easy to draw small maps using ASCII art (and a couple of helper structs to define ways and relations).  It then adds some helpers that can convert these maps into Valhalla tiles, and then perform API operations on them.

The included README describes in detail how to use the framework.  Some sample simple tests are included.

I also converted the `test/astar.cc` to use ASCII-art map instead of hand-crafted edges (which were tiresome to maintain).

cc @PureW 

## Tasklist

 - [x] Add tests
 - [x] Add #fixes with the issue number that this PR addresses
 - [x] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)