### PR TITLE
Place invalid lon/lat canary on OSM nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
    * FIXED: Tagged speeds were not properly marked. We were not using forward and backward speeds to flag if a speed is tagged or not.  Should not update turn channel speeds if we are not inferring them.  Added additional logic to handle PH in the conditional restrictions. Do not update stop impact for ramps if they are marked as internal. [#2198](https://github.com/valhalla/valhalla/pull/2198)
    * FIXED: Fixed the sharp turn phrase [#2226](https://github.com/valhalla/valhalla/pull/2226)
    * FIXED: Protect against duplicate points in the input or points that snap to the same location resulting in `nan` times for the legs of the map match (of a 0 distance route) [#2229](https://github.com/valhalla/valhalla/pull/2229)
+   * FIXED: Allow nodes at location 0,0 [#2245](https://github.com/valhalla/valhalla/pull/2245)
 
 * **Enhancement**
    * ADDED: Return the coordinates of the nodes isochrone input locations snapped to [#2111](https://github.com/valhalla/valhalla/pull/2111)

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -146,9 +146,9 @@ void ConstructEdges(const OSMData& osmdata,
     bool valid = true;
     for (auto ni = current_way_node_index; ni <= last_way_node_index; ni++) {
       const auto wn = (*way_nodes[ni]).node;
-      if (wn.lat_ == 0.0 && wn.lng_ == 0.0) {
-        LOG_ERROR("Cannot find node " + std::to_string(wn.osmid_) + " in way " +
-                  std::to_string(way.way_id()));
+      if (wn.lat_ == kInvalidLatitude && wn.lng_ == kInvalidLongitude) {
+        LOG_ERROR("Node " + std::to_string(wn.osmid_) + " in way " + std::to_string(way.way_id()) +
+                  " has not had coordinates initialized");
         valid = false;
       }
     }

--- a/valhalla/baldr/graphconstants.h
+++ b/valhalla/baldr/graphconstants.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <limits>
 
 namespace valhalla {
 namespace baldr {
@@ -15,6 +16,10 @@ constexpr uint32_t kMaxOSMWayId = 4294967295;
 constexpr uint32_t kMaxGraphTileId = 4194303;
 // Maximum id/index within a tile. 21 bits
 constexpr uint32_t kMaxGraphId = 2097151;
+
+// A value to use for invalid latitude/longitudes (i.e. uninitialized)
+constexpr float kInvalidLatitude = std::numeric_limits<float>::max();
+constexpr float kInvalidLongitude = std::numeric_limits<float>::max();
 
 // Access bit field constants. Access in directed edge allows 12 bits.
 constexpr uint16_t kAutoAccess = 1;

--- a/valhalla/baldr/graphconstants.h
+++ b/valhalla/baldr/graphconstants.h
@@ -1,9 +1,9 @@
 #ifndef VALHALLA_BALDR_GRAPHCONSTANTS_H_
 #define VALHALLA_BALDR_GRAPHCONSTANTS_H_
 
+#include <limits>
 #include <string>
 #include <unordered_map>
-#include <limits>
 
 namespace valhalla {
 namespace baldr {

--- a/valhalla/mjolnir/osmnode.h
+++ b/valhalla/mjolnir/osmnode.h
@@ -50,9 +50,12 @@ struct OSMNode {
   /**
    * Constructor with OSM node Id
    */
-  OSMNode(const uint64_t id) {
+  OSMNode(const uint64_t id,
+          const float lat = baldr::kInvalidLongitude,
+          const float lng = baldr::kInvalidLatitude) {
     memset(this, 0, sizeof(OSMNode));
     set_id(id);
+    set_latlng(lat, lng);
   }
 
   /**


### PR DESCRIPTION
#Issue

Way back in https://github.com/valhalla/valhalla/pull/492, @dnesbitt61 added a check for uninitialized node coordinates that were somehow sneaking through.  The test he added checked for lon=0, lat=0, which was the default set by `memset()`-ing the object to all zeros.

However, sometimes lon/lat 0/0 is valid - it's easy to construct test maps around these coordinates, for example.

This PR finishes the work of #492 by initializing lon/lat values in OSMNodes with an invalid canary value `std::numeric_limits<float>::max()`, instead of the default 0.

This allows maps with lon=0,lat=0 to be used, and will still catch cases where lon/lat values go uninitialized for some reason.