### PR TITLE
Add methods to get elevation tiles covered by Valhalla tiles

### DIFF
--- a/scripts/valhalla_get_elevation
+++ b/scripts/valhalla_get_elevation
@@ -1,0 +1,83 @@
+#!/bin/bash
+set -e
+
+#This script gets elevation from AWS Public Datasets for the tiles/files listed in
+#the specified file.
+function usage() {
+	echo "Usage: $0 tile_file [target_dir=elevation] [parallelism=$(nproc)] [decompress=true]"
+	exit 1
+}
+
+#make sure land tile file is present
+if [ -z $1 ]; then
+	usage
+else
+	tile_name="$1"
+fi
+
+if [ -z $2 ]; then
+	dest=elevation
+else
+	dest="$2"
+fi
+
+if [ -z $3 ]; then
+	para=$(nproc)
+else
+	para="$3"
+fi
+if [[ -z $4 ]] || [[ $4 != "false" ]]; then
+	decomp=true
+	export decomp
+else
+	unset decomp
+fi
+
+#iterate through the file and make directories based on latitude
+echo "Make directories"
+input=$tile_name
+while IFS= read -r line
+do
+        dir=${line:0:3}
+        echo "${dest}/${dir}"
+done < "$input" | while read d; do mkdir -p $d; done
+
+#get expected count
+expected=$(wc -l < "$tile_name")
+echo "extracting $expected elevation tiles"
+
+#iterate through the file list and get the elevation tiles
+ext=$( [[ ${decomp} ]] && echo "" || echo ".gz" )
+
+input=$tile_name
+while IFS= read -r line
+do
+	file=$line".hgt"
+        dir=$(echo ${file} | sed "s/^\([NS][0-9]\{2\}\).*/\1/g")
+        #if we dont already have it or its the wrong size
+        if [ ! -e ${dest}/${dir}/${file} ] || [ $(stat -c %s ${dest}/${dir}/${file}) -ne $((3601*3601*2)) ]; then
+        	echo "http://s3.amazonaws.com/elevation-tiles-prod/skadi/${dir}/${file}.gz ${dest}/${dir}/${file}${ext}"
+        fi
+done < "$input" | parallel --env decomp --progress -C ' ' -P ${para} 'curl --retry 3 --retry-delay 0 --max-time 100 -s -o - {1} | ( [[ ! ${decomp} ]] && cat || gunzip ) > {2}'
+
+#check they are all there
+echo "checking all files exist"
+total=$(find ${dest} | grep -cF hgt)
+if [ ${total} -ne ${expected} ]; then
+        echo "try again, $((${expected} - ${total})) files are missing"
+        exit 1
+fi
+
+#check their sizes
+echo "checking file sizes"
+if [ ${decomp} ]; then
+        found=$(find ${dest} -type f -size $((3601*3601*2))c | wc -l)
+else
+        found=$(for f in $(find ${dest} -type f); do gzip -l $f | tail -n 1; done | grep -cvF $((3601*3601*2)))
+fi
+if [ ${found} -ne ${expected} ]; then
+        echo "try again, $((${expected} - ${found})) files are corrupt"
+        exit 1
+fi
+
+

--- a/src/valhalla_tiles_for_elevation.cc
+++ b/src/valhalla_tiles_for_elevation.cc
@@ -1,0 +1,133 @@
+#include <fstream>
+#include <iostream>
+#include <vector>
+
+#include "baldr/rapidjson_utils.h"
+#include <boost/filesystem/operations.hpp>
+#include <boost/optional.hpp>
+#include <boost/program_options.hpp>
+#include <boost/property_tree/ptree.hpp>
+
+#include "baldr/graphreader.h"
+#include "baldr/graphtile.h"
+#include "baldr/tilehierarchy.h"
+#include "midgard/aabb2.h"
+#include "midgard/pointll.h"
+#include "midgard/tiles.h"
+
+#include "config.h"
+
+namespace bpo = boost::program_options;
+
+using namespace valhalla::baldr;
+using namespace valhalla::midgard;
+
+// Iterate over all Valhalla tiles within the coverage (specified in the
+// mjolnir properties) and identify the 1 degree tiles that include
+// any Valhalla edge. Returns a list of the base (SW) lat,lng of the tiles
+std::vector<PointLL> get_land_tiles(const boost::property_tree::ptree& pt) {
+  AABB2<PointLL> world(-180.0f, -90.0f, 180.f, 90.f);
+  Tiles<PointLL> one_degree_tiles(world, 1.0f);
+  Tiles<PointLL> local_tiles(world, 0.25f);
+
+  std::set<int> land_tile_ids;
+  boost::property_tree::ptree hierarchy_properties = pt.get_child("mjolnir");
+  auto local_level = TileHierarchy::levels().rbegin()->second.level;
+  GraphReader reader(hierarchy_properties);
+  auto local_tile_ids = reader.GetTileSet(local_level);
+  for (const auto& tile_id : local_tile_ids) {
+    // Convert the local tile to a 1 degree tile ID. Add to the set.
+    PointLL center = local_tiles.Center(tile_id.tileid());
+    land_tile_ids.insert(one_degree_tiles.TileId(center));
+  }
+
+  // Iterate through the set and convert to SW corner lat,lngs
+  std::vector<PointLL> ll;
+  for (auto id : land_tile_ids) {
+    ll.push_back(one_degree_tiles.Base(id));
+  }
+  return ll;
+}
+
+boost::filesystem::path config_file_path;
+
+bool ParseArguments(int argc, char* argv[]) {
+  std::vector<std::string> input_files;
+
+  bpo::options_description options(
+      " Usage: valhalla_land_tiles [options]\n"
+      "valhalla_land_tiles is a program that creates a list of base lat,lng for 1 degree "
+      "tiles that include Valhalla data.\n");
+
+  options.add_options()("help,h", "Print this help message.")("version,v",
+                                                              "Print the version of this software.")(
+      "config,c",
+      boost::program_options::value<boost::filesystem::path>(&config_file_path)->required(),
+      "Path to the json configuration file.")
+      // positional arguments
+      ("input_files",
+       boost::program_options::value<std::vector<std::string>>(&input_files)->multitoken());
+
+  bpo::positional_options_description pos_options;
+  pos_options.add("input_files", 16);
+
+  bpo::variables_map vm;
+  try {
+    bpo::store(bpo::command_line_parser(argc, argv).options(options).positional(pos_options).run(),
+               vm);
+    bpo::notify(vm);
+
+  } catch (std::exception& e) {
+    std::cerr << "Unable to parse command line options because: " << e.what() << "\n"
+              << "This is a bug, please report it at " PACKAGE_BUGREPORT << "\n";
+    return false;
+  }
+  if (vm.count("version")) {
+    std::cout << "ways_to_edges " << VALHALLA_VERSION << "\n";
+    return true;
+  }
+
+  if (vm.count("config")) {
+    if (boost::filesystem::is_regular_file(config_file_path)) {
+      return true;
+    } else {
+      std::cerr << "Configuration file is required\n\n" << options << "\n\n";
+    }
+  }
+  return false;
+}
+
+int main(int argc, char** argv) {
+  // Parse command line arguments
+  if (!ParseArguments(argc, argv)) {
+    return EXIT_FAILURE;
+  }
+
+  // Get the config to see which coverage we are using
+  boost::property_tree::ptree pt;
+  rapidjson::read_json(config_file_path.c_str(), pt);
+
+  // Get the base lat,lng of all 1 degree tiles that include a Valhalla tile
+  auto lls = get_land_tiles(pt);
+
+  // Open output file, iterate through the list of land tiles and output
+  // the elevation filename required for this tile. Uses N,S for latitude
+  // and E,W for longitude and requires 2 digits for latitude and 3 digits
+  // for longitude (padded with 0s).
+  std::ofstream landtiles;
+  landtiles.open("elevation_tiles.txt");
+  for (const auto& ll : lls) {
+    if (ll.lat() >= 0.0f) {
+      landtiles << "N" << std::setfill('0') << std::setw(2) << ll.lat();
+    } else {
+      landtiles << "S" << std::setfill('0') << std::setw(2) << -ll.lat();
+    }
+    if (ll.lng() >= 0.0f) {
+      landtiles << "E" << std::setfill('0') << std::setw(3) << ll.lng();
+    } else {
+      landtiles << "W" << std::setfill('0') << std::setw(3) << -ll.lng();
+    }
+    landtiles << std::endl;
+  }
+  landtiles.close();
+}


### PR DESCRIPTION
Add an application (_valhalla_tiles_for_elevation_) to get a list of elevation tiles that are covered within the set of Valhalla tiles specified in the config file. 

Add a script (_valhalla_get_elevation_) to get elevation data using the list of tiles specified in the input file. This list is the output of _valhalla_tiles_for_elevation_. The list could also be constructed using some other script or could be hand-edited if desired. 

The format of the output file from _valhalla_tiles_for_elevation_ and the input file to _valhalla_get_elevation_  is simply each elevation base filename (without the .hgt suffix). Examples are:

N39W079
S25E133

Note there are 2 digits for latitude and 3 digits for longitude (both 0-padded).
