### PR TITLE
Fix RapidJSON warnings and naming conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
    * FIXED: Fixed the sharp turn phrase [#2226](https://github.com/valhalla/valhalla/pull/2226)
    * FIXED: Protect against duplicate points in the input or points that snap to the same location resulting in `nan` times for the legs of the map match (of a 0 distance route) [#2229](https://github.com/valhalla/valhalla/pull/2229)
    * FIXED: Allow nodes at location 0,0 [#2245](https://github.com/valhalla/valhalla/pull/2245)
+   * FIXED: Fix RapidJSON compiler warnings and naming conflict [#2249](https://github.com/valhalla/valhalla/pull/2249)
 
 * **Enhancement**
    * ADDED: Return the coordinates of the nodes isochrone input locations snapped to [#2111](https://github.com/valhalla/valhalla/pull/2111)

--- a/valhalla/baldr/rapidjson_utils.h
+++ b/valhalla/baldr/rapidjson_utils.h
@@ -18,6 +18,8 @@
 #define RAPIDJSON_ASSERT(x)                                                                          \
   if (!(x))                                                                                          \
   throw std::logic_error(RAPIDJSON_STRINGIFY(x))
+// Because we now throw exceptions, we need to turn of RAPIDJSON_NOEXCEPT
+#define RAPIDJSON_HAS_CXX11_NOEXCEPT 0
 
 #include <rapidjson/document.h>
 #include <rapidjson/error/en.h>

--- a/valhalla/baldr/rapidjson_utils.h
+++ b/valhalla/baldr/rapidjson_utils.h
@@ -225,7 +225,7 @@ void read_json(const std::string& filename, Ptree& pt, const std::locale& loc = 
   if (!stream)
     throw std::runtime_error("Cannot open file " + filename);
   stream.imbue(loc);
-  read_json(stream, pt);
+  rapidjson::read_json(stream, pt);
 }
 
 } // namespace rapidjson


### PR DESCRIPTION
Fixes a compiler warning - we override RAPIDJSON_ASSERT to throw exceptions, but by default, RapidJSON uses `noexcept` when available.  Our exception throwing logic means that `noexcept` shouldn't be used.

Also fixes a naming ambiguity with `read_json` - if you import, say, `boost::property_tree::json_parser`, you can get an ambiguity resolving which `read_json` is intended.  This PR makes the call explicit.