### PR TITLE
[WIP] Remove singleton .tar container from GraphReader

### DIFF
--- a/src/baldr/connectivity_map.cc
+++ b/src/baldr/connectivity_map.cc
@@ -112,7 +112,7 @@ std::string to_feature_collection(const std::unordered_map<size_t, polygon_t>& b
 
 namespace valhalla {
 namespace baldr {
-connectivity_map_t::connectivity_map_t(const baldr::GraphReader &reader) {
+connectivity_map_t::connectivity_map_t(const baldr::GraphReader& reader) {
   // See what kind of tiles we are dealing with here by getting a graphreader
   auto tiles = reader.GetTileSet();
   transit_level = TileHierarchy::levels().rbegin()->second.level + 1;

--- a/src/baldr/connectivity_map.cc
+++ b/src/baldr/connectivity_map.cc
@@ -112,9 +112,8 @@ std::string to_feature_collection(const std::unordered_map<size_t, polygon_t>& b
 
 namespace valhalla {
 namespace baldr {
-connectivity_map_t::connectivity_map_t(const boost::property_tree::ptree& pt) {
+connectivity_map_t::connectivity_map_t(const baldr::GraphReader &reader) {
   // See what kind of tiles we are dealing with here by getting a graphreader
-  GraphReader reader(pt);
   auto tiles = reader.GetTileSet();
   transit_level = TileHierarchy::levels().rbegin()->second.level + 1;
 

--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -23,7 +23,6 @@ namespace valhalla {
 namespace baldr {
 
 GraphReader::tile_extract_t::tile_extract_t(const boost::property_tree::ptree& pt) {
-  std::cout << "Initizliaing a tile extract" << std::endl;
   // if you really meant to load it
   if (pt.get_optional<std::string>("tile_extract")) {
     try {

--- a/src/bindings/node/node.cc
+++ b/src/bindings/node/node.cc
@@ -30,7 +30,7 @@ boost::property_tree::ptree make_conf(const char* config) {
 class ActorWorker : public Napi::AsyncWorker {
 public:
   ActorWorker(Napi::Function& callback,
-              const std::string request,
+              const std::string& request,
               valhalla::tyr::actor_t& actor,
               const std::function<std::string(valhalla::tyr::actor_t& actor,
                                               const std::string& request)>& func)

--- a/src/bindings/node/node.cc
+++ b/src/bindings/node/node.cc
@@ -124,7 +124,8 @@ public:
   };
 
   Actor(const Napi::CallbackInfo& info)
-      : actor(get_conf_from_info(info), true), Napi::ObjectWrap<Actor>(info) {
+      : reader(get_conf_from_info(info).get_child("mjolnir")),
+        actor(get_conf_from_info(info), reader, true), Napi::ObjectWrap<Actor>(info) {
     Napi::Env env = info.Env();
     Napi::HandleScope scope(env);
 
@@ -222,6 +223,7 @@ private:
                               -> std::string { return actor.expansion(request); });
   }
 
+  valhalla::baldr::GraphReader reader;
   valhalla::tyr::actor_t actor;
 };
 

--- a/src/bindings/python/python.cc
+++ b/src/bindings/python/python.cc
@@ -53,14 +53,56 @@ void py_configure(const std::string& config_file) {
   configure(config_file);
 }
 
-struct TyrActorWrapper : public valhalla::tyr::actor_t {
+struct TyrActorWrapper {
 
   TyrActorWrapper(boost::property_tree::ptree config)
-      : reader(config.get_child("mjolnir")), actor_t(config, reader, true) {
+      : reader(config.get_child("mjolnir")), actor(config, reader, true) {
+  }
+
+  std::string route(const std::string& request_str,
+                    const std::function<void()>& interrupt = []() -> void {}) {
+    return actor.route(request_str, interrupt);
+  }
+  std::string locate(const std::string& request_str,
+                     const std::function<void()>& interrupt = []() -> void {}) {
+    return actor.locate(request_str, interrupt);
+  }
+  std::string matrix(const std::string& request_str,
+                     const std::function<void()>& interrupt = []() -> void {}) {
+    return actor.matrix(request_str, interrupt);
+  }
+  std::string optimized_route(const std::string& request_str,
+                              const std::function<void()>& interrupt = []() -> void {}) {
+    return actor.optimized_route(request_str, interrupt);
+  }
+  std::string isochrone(const std::string& request_str,
+                        const std::function<void()>& interrupt = []() -> void {}) {
+    return actor.isochrone(request_str, interrupt);
+  }
+  std::string trace_route(const std::string& request_str,
+                          const std::function<void()>& interrupt = []() -> void {}) {
+    return actor.trace_route(request_str, interrupt);
+  }
+  std::string trace_attributes(const std::string& request_str,
+                               const std::function<void()>& interrupt = []() -> void {}) {
+    return actor.trace_attributes(request_str, interrupt);
+  }
+  std::string height(const std::string& request_str,
+                     const std::function<void()>& interrupt = []() -> void {}) {
+    return actor.height(request_str, interrupt);
+  }
+  std::string transit_available(const std::string& request_str,
+                                const std::function<void()>& interrupt = []() -> void {}) {
+    return actor.transit_available(request_str, interrupt);
+  }
+  std::string expansion(const std::string& request_str,
+                        const std::function<void()>& interrupt = []() -> void {}) {
+    return actor.expansion(request_str, interrupt);
   }
 
 protected:
   valhalla::baldr::GraphReader reader;
+  valhalla::tyr::actor_t actor;
 };
 
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(route_overloads, route, 1, 1);
@@ -80,11 +122,7 @@ BOOST_PYTHON_MODULE(valhalla) {
   // python interface for configuring the system, always call this first in your python program
   boost::python::def("Configure", py_configure);
 
-  boost::python::class_<valhalla::tyr::actor_t, boost::noncopyable>("ActorBase",
-                                                                    boost::python::no_init);
-
-  boost::python::class_<TyrActorWrapper, boost::python::bases<valhalla::tyr::actor_t>,
-                        boost::noncopyable,
+  boost::python::class_<TyrActorWrapper, boost::noncopyable,
                         boost::shared_ptr<TyrActorWrapper>>("Actor", boost::python::no_init)
       .def("__init__", boost::python::make_constructor(
                            +[]() { return boost::make_shared<TyrActorWrapper>(configure()); }))

--- a/src/bindings/python/python.cc
+++ b/src/bindings/python/python.cc
@@ -73,7 +73,9 @@ BOOST_PYTHON_MODULE(valhalla) {
   boost::python::class_<valhalla::tyr::actor_t, boost::noncopyable,
                         boost::shared_ptr<valhalla::tyr::actor_t>>("Actor", boost::python::no_init)
       .def("__init__", boost::python::make_constructor(+[]() {
-             return boost::make_shared<valhalla::tyr::actor_t>(configure(), true);
+             auto config = configure();
+             valhalla::baldr::GraphReader reader(config.get_child("mjolnir"));
+             return boost::make_shared<valhalla::tyr::actor_t>(config, reader, true);
            }))
       .def("Route", &valhalla::tyr::actor_t::route, route_overloads())
       .def("Locate", &valhalla::tyr::actor_t::route, locate_overloads())

--- a/src/bindings/python/python.cc
+++ b/src/bindings/python/python.cc
@@ -56,7 +56,7 @@ void py_configure(const std::string& config_file) {
 struct TyrActorWrapper : public valhalla::tyr::actor_t {
 
   TyrActorWrapper(boost::property_tree::ptree config)
-      : reader(config), actor_t(config, reader, true) {
+      : reader(config.get_child("mjolnir")), actor_t(config, reader, true) {
   }
 
 protected:

--- a/src/loki/isochrone_action.cc
+++ b/src/loki/isochrone_action.cc
@@ -84,10 +84,10 @@ void loki_worker_t::isochrones(Api& request) {
   try {
     // correlate the various locations to the underlying graph
     auto locations = PathLocation::fromPBF(options.locations());
-    const auto projections = loki::Search(locations, *reader, costing);
+    const auto projections = loki::Search(locations, reader, costing);
     for (size_t i = 0; i < locations.size(); ++i) {
       const auto& projection = projections.at(locations[i]);
-      PathLocation::toPBF(projection, options.mutable_locations(i), *reader);
+      PathLocation::toPBF(projection, options.mutable_locations(i), reader);
     }
   } catch (const std::exception&) { throw valhalla_exception_t{171}; }
 }

--- a/src/loki/locate_action.cc
+++ b/src/loki/locate_action.cc
@@ -20,8 +20,8 @@ std::string loki_worker_t::locate(Api& request) {
   // correlate the various locations to the underlying graph
   init_locate(request);
   auto locations = PathLocation::fromPBF(request.options().locations());
-  auto projections = loki::Search(locations, *reader, costing);
-  return tyr::serializeLocate(request, locations, projections, *reader);
+  auto projections = loki::Search(locations, reader, costing);
+  return tyr::serializeLocate(request, locations, projections, reader);
 }
 
 } // namespace loki

--- a/src/loki/matrix_action.cc
+++ b/src/loki/matrix_action.cc
@@ -115,7 +115,7 @@ void loki_worker_t::matrix(Api& request) {
   // correlate the various locations to the underlying graph
   std::unordered_map<size_t, size_t> color_counts;
   try {
-    const auto searched = loki::Search(sources_targets, *reader, costing);
+    const auto searched = loki::Search(sources_targets, reader, costing);
     for (size_t i = 0; i < sources_targets.size(); ++i) {
       const auto& l = sources_targets[i];
       const auto& projection = searched.at(l);
@@ -123,7 +123,7 @@ void loki_worker_t::matrix(Api& request) {
                           i < options.sources_size()
                               ? options.mutable_sources(i)
                               : options.mutable_targets(i - options.sources_size()),
-                          *reader);
+                          reader);
       // TODO: get transit level for transit costing
       // TODO: if transit send a non zero radius
       if (!connectivity_map) {

--- a/src/loki/route_action.cc
+++ b/src/loki/route_action.cc
@@ -89,10 +89,10 @@ void loki_worker_t::route(Api& request) {
   std::unordered_map<size_t, size_t> color_counts;
   try {
     auto locations = PathLocation::fromPBF(options.locations(), true);
-    const auto projections = loki::Search(locations, *reader, costing);
+    const auto projections = loki::Search(locations, reader, costing);
     for (size_t i = 0; i < locations.size(); ++i) {
       const auto& correlated = projections.at(locations[i]);
-      PathLocation::toPBF(correlated, options.mutable_locations(i), *reader);
+      PathLocation::toPBF(correlated, options.mutable_locations(i), reader);
       // TODO: get transit level for transit costing
       // TODO: if transit send a non zero radius
       if (!connectivity_map) {

--- a/src/loki/trace_route_action.cc
+++ b/src/loki/trace_route_action.cc
@@ -184,12 +184,12 @@ void loki_worker_t::locations_from_shape(Api& request) {
 
     // Project first and last shape point onto nearest edge(s). Clear current locations list
     // and set the path locations
-    auto projections = loki::Search(locations, *reader, costing);
+    auto projections = loki::Search(locations, reader, costing);
     options.clear_locations();
     PathLocation::toPBF(projections.at(locations.front()), options.mutable_locations()->Add(),
-                        *reader);
+                        reader);
     PathLocation::toPBF(projections.at(locations.back()), options.mutable_locations()->Add(),
-                        *reader);
+                        reader);
 
     // If locations were provided, backfill the origin and dest lat,lon and update
     // side of street on associated edges. TODO - create a constant for side of street
@@ -201,7 +201,7 @@ void loki_worker_t::locations_from_shape(Api& request) {
       orig->mutable_ll()->set_lat(orig_ll.lat());
       for (auto& e : *orig->mutable_path_edges()) {
         GraphId edgeid(e.graph_id());
-        const GraphTile* tile = reader->GetGraphTile(edgeid);
+        const GraphTile* tile = reader.GetGraphTile(edgeid);
         const DirectedEdge* de = tile->directededge(edgeid);
         auto& shape = tile->edgeinfo(de->edgeinfo_offset()).shape();
         auto closest = orig_ll.ClosestPoint(shape);
@@ -228,7 +228,7 @@ void loki_worker_t::locations_from_shape(Api& request) {
       dest->mutable_ll()->set_lat(dest_ll.lat());
       for (auto& e : *dest->mutable_path_edges()) {
         GraphId edgeid(e.graph_id());
-        const GraphTile* tile = reader->GetGraphTile(edgeid);
+        const GraphTile* tile = reader.GetGraphTile(edgeid);
         const DirectedEdge* de = tile->directededge(edgeid);
         auto& shape = tile->edgeinfo(de->edgeinfo_offset()).shape();
         auto closest = dest_ll.ClosestPoint(shape);

--- a/src/loki/trace_route_action.cc
+++ b/src/loki/trace_route_action.cc
@@ -188,8 +188,7 @@ void loki_worker_t::locations_from_shape(Api& request) {
     options.clear_locations();
     PathLocation::toPBF(projections.at(locations.front()), options.mutable_locations()->Add(),
                         reader);
-    PathLocation::toPBF(projections.at(locations.back()), options.mutable_locations()->Add(),
-                        reader);
+    PathLocation::toPBF(projections.at(locations.back()), options.mutable_locations()->Add(), reader);
 
     // If locations were provided, backfill the origin and dest lat,lon and update
     // side of street on associated edges. TODO - create a constant for side of street

--- a/src/loki/worker.cc
+++ b/src/loki/worker.cc
@@ -139,7 +139,7 @@ loki_worker_t::loki_worker_t(const boost::property_tree::ptree& config,
                              baldr::GraphReader& graph_reader)
     : config(config), reader(graph_reader),
       connectivity_map(config.get<bool>("loki.use_connectivity", true)
-                           ? new connectivity_map_t(config.get_child("mjolnir"))
+                           ? new connectivity_map_t(graph_reader)
                            : nullptr),
       long_request(config.get<float>("loki.logging.long_request")),
       max_contours(config.get<size_t>("service_limits.isochrone.max_contours")),

--- a/src/loki/worker.cc
+++ b/src/loki/worker.cc
@@ -319,7 +319,7 @@ loki_worker_t::work(const std::list<zmq::message_t>& job,
   }
 }
 
-void run_service(const boost::property_tree::ptree& config, baldr::GraphReader &reader) {
+void run_service(const boost::property_tree::ptree& config, baldr::GraphReader& reader) {
   // gets requests from the http server
   auto upstream_endpoint = config.get<std::string>("loki.service.proxy") + "_out";
   // sends them on to thor

--- a/src/meili/valhalla_run_map_match.cc
+++ b/src/meili/valhalla_run_map_match.cc
@@ -49,7 +49,8 @@ int main(int argc, char* argv[]) {
     throw std::runtime_error("No costing method found");
   }
 
-  MapMatcherFactory matcher_factory(config);
+  valhalla::baldr::GraphReader reader(config.get_child("mjolnir"));
+  MapMatcherFactory matcher_factory(config, reader);
   auto mapmatcher = matcher_factory.Create(costing);
 
   const float default_gps_accuracy = mapmatcher->config().get<float>("gps_accuracy"),

--- a/src/mjolnir/elevationbuilder.cc
+++ b/src/mjolnir/elevationbuilder.cc
@@ -35,13 +35,11 @@ constexpr double kMinimumInterval = 10.0f;
 /**
  * Adds elevation to a set of tiles. Each thread pulls a tile of the queue
  */
-void add_elevation(const boost::property_tree::ptree& pt,
+void add_elevation(GraphReader& graphreader,
                    std::deque<GraphId>& tilequeue,
                    std::mutex& lock,
                    const std::unique_ptr<const valhalla::skadi::sample>& sample,
                    std::promise<uint32_t>& result) {
-  // Local Graphreader
-  GraphReader graphreader(pt.get_child("mjolnir"));
 
   // We usually end up accessing the same shape twice (once for each direction along an edge).
   // Use a cache to record elevation attributes based on the EdgeInfo offset. This includes
@@ -207,7 +205,7 @@ void ElevationBuilder::Build(const boost::property_tree::ptree& pt) {
   // Spawn the threads
   for (auto& thread : threads) {
     results.emplace_back();
-    thread.reset(new std::thread(add_elevation, std::cref(pt), std::ref(tilequeue), std::ref(lock),
+    thread.reset(new std::thread(add_elevation, std::ref(reader), std::ref(tilequeue), std::ref(lock),
                                  std::cref(sample), std::ref(results.back())));
   }
 

--- a/src/mjolnir/valhalla_build_connectivity.cc
+++ b/src/mjolnir/valhalla_build_connectivity.cc
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "baldr/connectivity_map.h"
+#include "baldr/graphreader.h"
 #include "baldr/tilehierarchy.h"
 #include "config.h"
 
@@ -115,7 +116,8 @@ int main(int argc, char** argv) {
   rapidjson::read_json(config_file_path.c_str(), pt);
 
   // Get something we can use to fetch tiles
-  valhalla::baldr::connectivity_map_t connectivity_map(pt.get_child("mjolnir"));
+  valhalla::baldr::GraphReader reader(pt.get_child("mjolnir"));
+  valhalla::baldr::connectivity_map_t connectivity_map(reader);
 
   uint32_t transit_level = TileHierarchy::levels().rbegin()->second.level + 1;
   for (uint32_t level = 0; level <= transit_level; level++) {

--- a/src/thor/isochrone_action.cc
+++ b/src/thor/isochrone_action.cc
@@ -33,8 +33,8 @@ std::string thor_worker_t::isochrones(Api& request) {
   // where there has been a higher cost that might still be marked in the isochrone
   auto grid = (costing == "multimodal" || costing == "transit")
                   ? isochrone_gen.ComputeMultiModal(*options.mutable_locations(),
-                                                    contours.back() + 10, *reader, mode_costing, mode)
-                  : isochrone_gen.Compute(*options.mutable_locations(), contours.back() + 10, *reader,
+                                                    contours.back() + 10, reader, mode_costing, mode)
+                  : isochrone_gen.Compute(*options.mutable_locations(), contours.back() + 10, reader,
                                           mode_costing, mode);
 
   // turn it into geojson

--- a/src/thor/matrix_action.cc
+++ b/src/thor/matrix_action.cc
@@ -44,12 +44,12 @@ std::string thor_worker_t::matrix(Api& request) {
   std::vector<TimeDistance> time_distances;
   auto costmatrix = [&]() {
     thor::CostMatrix matrix;
-    return matrix.SourceToTarget(options.sources(), options.targets(), *reader, mode_costing, mode,
+    return matrix.SourceToTarget(options.sources(), options.targets(), reader, mode_costing, mode,
                                  max_matrix_distance.find(costing)->second);
   };
   auto timedistancematrix = [&]() {
     thor::TimeDistanceMatrix matrix;
-    return matrix.SourceToTarget(options.sources(), options.targets(), *reader, mode_costing, mode,
+    return matrix.SourceToTarget(options.sources(), options.targets(), reader, mode_costing, mode,
                                  max_matrix_distance.find(costing)->second);
   };
   switch (source_to_target_algorithm) {

--- a/src/thor/optimized_route_action.cc
+++ b/src/thor/optimized_route_action.cc
@@ -30,7 +30,7 @@ void thor_worker_t::optimized_route(Api& request) {
   // Use CostMatrix to find costs from each location to every other location
   CostMatrix costmatrix;
   std::vector<thor::TimeDistance> td =
-      costmatrix.SourceToTarget(options.sources(), options.targets(), *reader, mode_costing, mode,
+      costmatrix.SourceToTarget(options.sources(), options.targets(), reader, mode_costing, mode,
                                 max_matrix_distance.find(costing)->second);
 
   // Return an error if any locations are totally unreachable

--- a/src/tyr/actor.cc
+++ b/src/tyr/actor.cc
@@ -14,9 +14,9 @@ namespace valhalla {
 namespace tyr {
 
 struct actor_t::pimpl_t {
-  pimpl_t(const boost::property_tree::ptree& config)
-      : reader(new baldr::GraphReader(config.get_child("mjolnir"))), loki_worker(config, reader),
-        thor_worker(config, reader), odin_worker(config) {
+  pimpl_t(const boost::property_tree::ptree& config, baldr::GraphReader& reader_)
+      : reader{reader_}, loki_worker(config, reader), thor_worker(config, reader),
+        odin_worker(config) {
   }
   void set_interrupts(const std::function<void()>& interrupt_function) {
     loki_worker.set_interrupt(interrupt_function);
@@ -28,14 +28,16 @@ struct actor_t::pimpl_t {
     thor_worker.cleanup();
     odin_worker.cleanup();
   }
-  std::shared_ptr<baldr::GraphReader> reader;
+  baldr::GraphReader& reader;
   loki::loki_worker_t loki_worker;
   thor::thor_worker_t thor_worker;
   odin_worker_t odin_worker;
 };
 
-actor_t::actor_t(const boost::property_tree::ptree& config, bool auto_cleanup)
-    : pimpl(new pimpl_t(config)), auto_cleanup(auto_cleanup) {
+actor_t::actor_t(const boost::property_tree::ptree& config,
+                 baldr::GraphReader& reader,
+                 bool auto_cleanup)
+    : pimpl(new pimpl_t(config, reader)), auto_cleanup(auto_cleanup) {
 }
 
 void actor_t::cleanup() {

--- a/src/valhalla_loki_worker.cc
+++ b/src/valhalla_loki_worker.cc
@@ -1,8 +1,8 @@
 #include <iostream>
 
+#include "baldr/graphreader.h"
 #include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
-#include "baldr/graphreader.h"
 
 #include "loki/worker.h"
 

--- a/src/valhalla_loki_worker.cc
+++ b/src/valhalla_loki_worker.cc
@@ -2,6 +2,7 @@
 
 #include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
+#include "baldr/graphreader.h"
 
 #include "loki/worker.h"
 
@@ -17,8 +18,10 @@ int main(int argc, char** argv) {
   boost::property_tree::ptree config;
   rapidjson::read_json(config_file, config);
 
+  valhalla::baldr::GraphReader reader(config.get_child("mjolnir"));
+
   // run the service worker
-  valhalla::loki::run_service(config);
+  valhalla::loki::run_service(config, reader);
 
   return 0;
 }

--- a/src/valhalla_path_comparison.cc
+++ b/src/valhalla_path_comparison.cc
@@ -288,7 +288,7 @@ int main(int argc, char* argv[]) {
   }
 
   // If JSON is entered we do map matching
-  MapMatcherFactory map_matcher_factory(pt);
+  MapMatcherFactory map_matcher_factory(pt, reader);
   std::shared_ptr<valhalla::meili::MapMatcher> matcher(
       map_matcher_factory.Create(costing, request.options()));
 

--- a/src/valhalla_run_matrix.cc
+++ b/src/valhalla_run_matrix.cc
@@ -186,7 +186,7 @@ int main(int argc, char* argv[]) {
 
   // Find path locations (loki) for sources and targets
   auto t0 = std::chrono::high_resolution_clock::now();
-  loki_worker_t lw(pt);
+  loki_worker_t lw(pt, reader);
   lw.matrix(request);
   auto t1 = std::chrono::high_resolution_clock::now();
   uint32_t ms = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();

--- a/src/valhalla_run_route.cc
+++ b/src/valhalla_run_route.cc
@@ -611,7 +611,7 @@ int main(int argc, char* argv[]) {
 
   // Find path locations (loki) for sources and targets
   auto tw0 = std::chrono::high_resolution_clock::now();
-  loki_worker_t lw(pt);
+  loki_worker_t lw(pt, reader);
   auto tw1 = std::chrono::high_resolution_clock::now();
   auto msw = std::chrono::duration_cast<std::chrono::milliseconds>(tw1 - tw0).count();
   LOG_INFO("Location Worker construction took " + std::to_string(msw) + " ms");

--- a/src/valhalla_thor_worker.cc
+++ b/src/valhalla_thor_worker.cc
@@ -1,5 +1,6 @@
 #include <iostream>
 
+#include "baldr/graphreader.h"
 #include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 
@@ -18,7 +19,8 @@ int main(int argc, char** argv) {
   rapidjson::read_json(config_file, config);
 
   // run the service worker
-  valhalla::thor::run_service(config);
+  valhalla::baldr::GraphReader reader(config.get_child("mjolnir"));
+  valhalla::thor::run_service(config, reader);
 
   return 0;
 }

--- a/test/graphreader.cc
+++ b/test/graphreader.cc
@@ -114,7 +114,8 @@ TEST(ConnectivityMap, Basic) {
   touch_tile(d1, tile_dir);
 
   // check that it looks right
-  connectivity_map_t conn(pt);
+  GraphReader reader(pt);
+  connectivity_map_t conn(reader);
 
   EXPECT_EQ(conn.get_color({a0, 2, 0}), conn.get_color({a1, 2, 0})) << "a's should be connected";
   EXPECT_EQ(conn.get_color({a0, 2, 0}), conn.get_color({a2, 2, 0})) << "a's should be connected";

--- a/test/gurka/gurka.h
+++ b/test/gurka/gurka.h
@@ -503,12 +503,12 @@ std::tuple<const baldr::GraphId,
            const baldr::DirectedEdge*,
            const baldr::GraphId,
            const baldr::DirectedEdge*>
-findEdge(const std::unique_ptr<valhalla::baldr::GraphReader>& reader,
+findEdge(valhalla::baldr::GraphReader& reader,
          const std::unordered_map<std::string, midgard::PointLL>& nodes,
          const baldr::GraphId& tile_id,
          const std::string& way_name,
          const std::string& end_node) {
-  auto* tile = reader->GetGraphTile(tile_id);
+  auto* tile = reader.GetGraphTile(tile_id);
 
   auto end_node_coordinates = nodes.at(end_node);
 
@@ -546,7 +546,7 @@ findEdge(const map& map,
          const baldr::GraphId& tile_id,
          const std::string& way_name,
          const std::string& end_node) {
-  std::unique_ptr<baldr::GraphReader> reader(new baldr::GraphReader(map.config));
+  baldr::GraphReader reader(map.config.get_child("mjolnir"));
   return findEdge(reader, map.nodes, tile_id, way_name, end_node);
 }
 
@@ -573,7 +573,8 @@ route(const map& map, const std::vector<std::string>& waypoints, const std::stri
   auto request_json = detail::build_valhalla_route_request(map, waypoints, costing);
   std::cerr << "[          ] Valhalla request is: " << request_json << std::endl;
 
-  valhalla::tyr::actor_t actor(map.config, true);
+  baldr::GraphReader reader(map.config.get_child("mjolnir"));
+  valhalla::tyr::actor_t actor(map.config, reader, true);
   return actor.unserialized_route(request_json);
 }
 
@@ -599,7 +600,8 @@ valhalla::Api match(const map& map,
   auto request_json = detail::build_valhalla_match_request(map, waypoints, break_at_points, costing);
   std::cerr << "[          ] Valhalla request is: " << request_json << std::endl;
 
-  valhalla::tyr::actor_t actor(map.config, true);
+  baldr::GraphReader reader(map.config.get_child("mjolnir"));
+  valhalla::tyr::actor_t actor(map.config, reader, true);
   return actor.unserialized_trace_route(request_json);
 }
 

--- a/test/http_tiles.cc
+++ b/test/http_tiles.cc
@@ -87,7 +87,8 @@ make_conf(const std::string& tile_dir, bool tile_url_gz, size_t curler_count) {
 
 void test_route(const std::string& tile_dir, bool tile_url_gz) {
   auto conf = make_conf(tile_dir, tile_url_gz, 1);
-  tyr::actor_t actor(conf);
+  baldr::GraphReader reader(conf.get_child("mjolnir"));
+  tyr::actor_t actor(conf, reader);
 
   auto route_json = actor.route(R"({"locations":[{"lat":52.09620,"lon": 5.11909,"type":"break"},
           {"lat":52.09585,"lon":5.11934,"type":"break"}],"costing":"auto"})");

--- a/test/isochrone.cc
+++ b/test/isochrone.cc
@@ -87,9 +87,9 @@ void try_isochrone(GraphReader& reader,
 
 TEST(Isochronies, Basic) {
   // Test setup
-  loki_worker_t loki_worker(config);
-  thor_worker_t thor_worker(config);
   GraphReader reader(config.get_child("mjolnir"));
+  loki_worker_t loki_worker(config, reader);
+  thor_worker_t thor_worker(config, reader);
 
 // Test auto isochrone with one contour
 // 32bit builds fail in release mode we'll look at this separately
@@ -125,9 +125,9 @@ TEST(Isochronies, Basic) {
 int main(int argc, char* argv[]) {
   // user wants to try it
   if (argc > 1) {
-    loki_worker_t loki_worker(config);
-    thor_worker_t thor_worker(config);
     GraphReader reader(config.get_child("mjolnir"));
+    loki_worker_t loki_worker(config, reader);
+    thor_worker_t thor_worker(config, reader);
     Api request;
     ParseApi(argv[1], Options::isochrone, request);
     loki_worker.isochrones(request);

--- a/test/loki_service.cc
+++ b/test/loki_service.cc
@@ -1,8 +1,8 @@
 #include "test.h"
 #include <cstdint>
 
-#include "baldr/rapidjson_utils.h"
 #include "baldr/graphreader.h"
+#include "baldr/rapidjson_utils.h"
 #include "midgard/logging.h"
 #include <boost/property_tree/ptree.hpp>
 #include <prime_server/http_protocol.hpp>
@@ -384,36 +384,36 @@ void run_requests(const std::vector<http_request_t>& requests,
   auto request = requests.cbegin();
   std::string request_str;
   int success_count = 0;
-  http_client_t client(
-      context, "ipc:///tmp/test_loki_server",
-      [&requests, &request, &request_str]() {
-        // we dont have any more requests so bail
-        if (request == requests.cend()) {
-          return std::make_pair<const void*, size_t>(nullptr, 0);
-        }
-        // get the string of bytes to send formatted for http protocol
-        request_str = request->to_string();
-        // LOG_INFO("Loki Test Request :: " + request_str + '\n');
-        ++request;
-        return std::make_pair<const void*, size_t>(request_str.c_str(), request_str.size());
-      },
-      [&requests, &request, &responses, &success_count](const void* data, size_t size) {
-        auto response = http_response_t::from_string(static_cast<const char*>(data), size);
-        EXPECT_EQ(response.code, responses[request - requests.cbegin() - 1].first);
+  http_client_t
+      client(context, "ipc:///tmp/test_loki_server",
+             [&requests, &request, &request_str]() {
+               // we dont have any more requests so bail
+               if (request == requests.cend()) {
+                 return std::make_pair<const void*, size_t>(nullptr, 0);
+               }
+               // get the string of bytes to send formatted for http protocol
+               request_str = request->to_string();
+               // LOG_INFO("Loki Test Request :: " + request_str + '\n');
+               ++request;
+               return std::make_pair<const void*, size_t>(request_str.c_str(), request_str.size());
+             },
+             [&requests, &request, &responses, &success_count](const void* data, size_t size) {
+               auto response = http_response_t::from_string(static_cast<const char*>(data), size);
+               EXPECT_EQ(response.code, responses[request - requests.cbegin() - 1].first);
 
-        // Parse as rapidjson::Document which correctly doesn't care about order-dependence
-        // of the json-data compared to the boost::property_tree::ptree
-        rapidjson::Document response_json, expected_json;
-        response_json.Parse(response.body);
-        expected_json.Parse(responses[request - requests.cbegin() - 1].second);
-        EXPECT_EQ(response_json, expected_json)
-            << "\nExpected Response: " + responses[request - requests.cbegin() - 1].second +
-                   "\n, Actual Response: " + response.body;
+               // Parse as rapidjson::Document which correctly doesn't care about order-dependence
+               // of the json-data compared to the boost::property_tree::ptree
+               rapidjson::Document response_json, expected_json;
+               response_json.Parse(response.body);
+               expected_json.Parse(responses[request - requests.cbegin() - 1].second);
+               EXPECT_EQ(response_json, expected_json)
+                   << "\nExpected Response: " + responses[request - requests.cbegin() - 1].second +
+                          "\n, Actual Response: " + response.body;
 
-        ++success_count;
-        return request != requests.cend();
-      },
-      1);
+               ++success_count;
+               return request != requests.cend();
+             },
+             1);
   // request and receive
   client.batch();
 

--- a/test/loki_service.cc
+++ b/test/loki_service.cc
@@ -2,6 +2,7 @@
 #include <cstdint>
 
 #include "baldr/rapidjson_utils.h"
+#include "baldr/graphreader.h"
 #include "midgard/logging.h"
 #include <boost/property_tree/ptree.hpp>
 #include <prime_server/http_protocol.hpp>
@@ -371,7 +372,8 @@ void start_service() {
   rapidjson::read_json(json, config);
 
   // service worker
-  std::thread worker(valhalla::loki::run_service, config);
+  valhalla::baldr::GraphReader reader(config.get_child("mjolnir"));
+  std::thread worker(valhalla::loki::run_service, config, std::ref(reader));
   worker.detach();
 }
 
@@ -382,36 +384,36 @@ void run_requests(const std::vector<http_request_t>& requests,
   auto request = requests.cbegin();
   std::string request_str;
   int success_count = 0;
-  http_client_t
-      client(context, "ipc:///tmp/test_loki_server",
-             [&requests, &request, &request_str]() {
-               // we dont have any more requests so bail
-               if (request == requests.cend()) {
-                 return std::make_pair<const void*, size_t>(nullptr, 0);
-               }
-               // get the string of bytes to send formatted for http protocol
-               request_str = request->to_string();
-               // LOG_INFO("Loki Test Request :: " + request_str + '\n');
-               ++request;
-               return std::make_pair<const void*, size_t>(request_str.c_str(), request_str.size());
-             },
-             [&requests, &request, &responses, &success_count](const void* data, size_t size) {
-               auto response = http_response_t::from_string(static_cast<const char*>(data), size);
-               EXPECT_EQ(response.code, responses[request - requests.cbegin() - 1].first);
+  http_client_t client(
+      context, "ipc:///tmp/test_loki_server",
+      [&requests, &request, &request_str]() {
+        // we dont have any more requests so bail
+        if (request == requests.cend()) {
+          return std::make_pair<const void*, size_t>(nullptr, 0);
+        }
+        // get the string of bytes to send formatted for http protocol
+        request_str = request->to_string();
+        // LOG_INFO("Loki Test Request :: " + request_str + '\n');
+        ++request;
+        return std::make_pair<const void*, size_t>(request_str.c_str(), request_str.size());
+      },
+      [&requests, &request, &responses, &success_count](const void* data, size_t size) {
+        auto response = http_response_t::from_string(static_cast<const char*>(data), size);
+        EXPECT_EQ(response.code, responses[request - requests.cbegin() - 1].first);
 
-               // Parse as rapidjson::Document which correctly doesn't care about order-dependence
-               // of the json-data compared to the boost::property_tree::ptree
-               rapidjson::Document response_json, expected_json;
-               response_json.Parse(response.body);
-               expected_json.Parse(responses[request - requests.cbegin() - 1].second);
-               EXPECT_EQ(response_json, expected_json)
-                   << "\nExpected Response: " + responses[request - requests.cbegin() - 1].second +
-                          "\n, Actual Response: " + response.body;
+        // Parse as rapidjson::Document which correctly doesn't care about order-dependence
+        // of the json-data compared to the boost::property_tree::ptree
+        rapidjson::Document response_json, expected_json;
+        response_json.Parse(response.body);
+        expected_json.Parse(responses[request - requests.cbegin() - 1].second);
+        EXPECT_EQ(response_json, expected_json)
+            << "\nExpected Response: " + responses[request - requests.cbegin() - 1].second +
+                   "\n, Actual Response: " + response.body;
 
-               ++success_count;
-               return request != requests.cend();
-             },
-             1);
+        ++success_count;
+        return request != requests.cend();
+      },
+      1);
   // request and receive
   client.batch();
 

--- a/test/loki_service.cc
+++ b/test/loki_service.cc
@@ -388,36 +388,36 @@ void run_requests(const std::vector<http_request_t>& requests,
   auto request = requests.cbegin();
   std::string request_str;
   int success_count = 0;
-  http_client_t client(
-      context, "ipc:///tmp/test_loki_server",
-      [&requests, &request, &request_str]() {
-        // we dont have any more requests so bail
-        if (request == requests.cend()) {
-          return std::make_pair<const void*, size_t>(nullptr, 0);
-        }
-        // get the string of bytes to send formatted for http protocol
-        request_str = request->to_string();
-        // LOG_INFO("Loki Test Request :: " + request_str + '\n');
-        ++request;
-        return std::make_pair<const void*, size_t>(request_str.c_str(), request_str.size());
-      },
-      [&requests, &request, &responses, &success_count](const void* data, size_t size) {
-        auto response = http_response_t::from_string(static_cast<const char*>(data), size);
-        EXPECT_EQ(response.code, responses[request - requests.cbegin() - 1].first);
+  http_client_t
+      client(context, "ipc:///tmp/test_loki_server",
+             [&requests, &request, &request_str]() {
+               // we dont have any more requests so bail
+               if (request == requests.cend()) {
+                 return std::make_pair<const void*, size_t>(nullptr, 0);
+               }
+               // get the string of bytes to send formatted for http protocol
+               request_str = request->to_string();
+               // LOG_INFO("Loki Test Request :: " + request_str + '\n');
+               ++request;
+               return std::make_pair<const void*, size_t>(request_str.c_str(), request_str.size());
+             },
+             [&requests, &request, &responses, &success_count](const void* data, size_t size) {
+               auto response = http_response_t::from_string(static_cast<const char*>(data), size);
+               EXPECT_EQ(response.code, responses[request - requests.cbegin() - 1].first);
 
-        // Parse as rapidjson::Document which correctly doesn't care about order-dependence
-        // of the json-data compared to the boost::property_tree::ptree
-        rapidjson::Document response_json, expected_json;
-        response_json.Parse(response.body);
-        expected_json.Parse(responses[request - requests.cbegin() - 1].second);
-        EXPECT_EQ(response_json, expected_json)
-            << "\nExpected Response: " + responses[request - requests.cbegin() - 1].second +
-                   "\n, Actual Response: " + response.body;
+               // Parse as rapidjson::Document which correctly doesn't care about order-dependence
+               // of the json-data compared to the boost::property_tree::ptree
+               rapidjson::Document response_json, expected_json;
+               response_json.Parse(response.body);
+               expected_json.Parse(responses[request - requests.cbegin() - 1].second);
+               EXPECT_EQ(response_json, expected_json)
+                   << "\nExpected Response: " + responses[request - requests.cbegin() - 1].second +
+                          "\n, Actual Response: " + response.body;
 
-        ++success_count;
-        return request != requests.cend();
-      },
-      1);
+               ++success_count;
+               return request != requests.cend();
+             },
+             1);
   // request and receive
   client.batch();
 

--- a/test/map_matcher_factory.cc
+++ b/test/map_matcher_factory.cc
@@ -1,6 +1,7 @@
 // -*- mode: c++ -*-
 #include <string>
 
+#include "baldr/graphreader.h"
 #include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
 
@@ -65,7 +66,8 @@ TEST(MapMatcherFactory, TestMapMatcherFactory) {
       auto config = root;
       config.put<std::string>("meili.auto.hello", "world");
       config.put<std::string>("meili.default.hello", "default world");
-      meili::MapMatcherFactory factory(config);
+      baldr::GraphReader reader(root.get_child("mjolnir"));
+      meili::MapMatcherFactory factory(config, reader);
       auto matcher = factory.Create(Costing::auto_, options);
       EXPECT_EQ(matcher->travelmode(), sif::TravelMode::kDrive);
 
@@ -81,7 +83,8 @@ TEST(MapMatcherFactory, TestMapMatcherFactory) {
       create_costing_options(options);
       auto config = root;
       config.put<std::string>("meili.default.hello", "default world");
-      meili::MapMatcherFactory factory(config);
+      baldr::GraphReader reader(root.get_child("mjolnir"));
+      meili::MapMatcherFactory factory(config, reader);
       auto matcher = factory.Create(Costing::bicycle, options);
       EXPECT_EQ(matcher->travelmode(), sif::TravelMode::kBicycle);
 
@@ -96,7 +99,8 @@ TEST(MapMatcherFactory, TestMapMatcherFactory) {
       Options options;
       create_costing_options(options);
       auto config = root;
-      meili::MapMatcherFactory factory(config);
+      baldr::GraphReader reader(root.get_child("mjolnir"));
+      meili::MapMatcherFactory factory(config, reader);
       float preferred_search_radius = 3;
       float incorrect_search_radius = 2;
       float default_search_radius = 1;
@@ -115,7 +119,8 @@ TEST(MapMatcherFactory, TestMapMatcherFactory) {
     {
       Options options;
       create_costing_options(options);
-      meili::MapMatcherFactory factory(root);
+      baldr::GraphReader reader(root.get_child("mjolnir"));
+      meili::MapMatcherFactory factory(root, reader);
       float preferred_search_radius = 3;
       options.set_search_radius(preferred_search_radius);
       auto matcher = factory.Create(Costing::pedestrian, options);
@@ -129,7 +134,8 @@ TEST(MapMatcherFactory, TestMapMatcherFactory) {
     {
       Options options;
       create_costing_options(options);
-      meili::MapMatcherFactory factory(root);
+      baldr::GraphReader reader(root.get_child("mjolnir"));
+      meili::MapMatcherFactory factory(root, reader);
       auto matcher = factory.Create(options);
       EXPECT_EQ(matcher->travelmode(), sif::TravelMode::kDrive)
           << "should read default mode in the meili.mode correctly";
@@ -141,7 +147,8 @@ TEST(MapMatcherFactory, TestMapMatcherFactory) {
     {
       Options options;
       create_costing_options(options);
-      meili::MapMatcherFactory factory(root);
+      baldr::GraphReader reader(root.get_child("mjolnir"));
+      meili::MapMatcherFactory factory(root, reader);
       options.set_costing(Costing::pedestrian);
       auto matcher = factory.Create(options);
       EXPECT_EQ(matcher->travelmode(), sif::TravelMode::kPedestrian)
@@ -161,7 +168,8 @@ TEST(MapMatcherFactory, TestMapMatcherFactory) {
     {
       Options options;
       create_costing_options(options);
-      meili::MapMatcherFactory factory(root);
+      baldr::GraphReader reader(root.get_child("mjolnir"));
+      meili::MapMatcherFactory factory(root, reader);
       options.set_costing(Costing::pedestrian);
       auto matcher = factory.Create(options);
       EXPECT_NE(matcher->costing()->travel_type(), (int)sif::PedestrianType::kSegway)
@@ -186,8 +194,9 @@ TEST(MapMatcherFactory, TestMapMatcher) {
   rapidjson::read_json(VALHALLA_SOURCE_DIR "test/valhalla.json", root);
 
   // Nothing special to test for the moment
+  baldr::GraphReader reader(root.get_child("mjolnir"));
 
-  meili::MapMatcherFactory factory(root);
+  meili::MapMatcherFactory factory(root, reader);
   Options options;
   create_costing_options(options);
   auto auto_matcher = factory.Create(Costing::auto_, options);

--- a/test/matrix.cc
+++ b/test/matrix.cc
@@ -270,7 +270,6 @@ TEST(Matrix, test_matrix) {
   loki_worker.matrix(request);
   adjust_scores(*request.mutable_options());
 
-
   cost_ptr_t costing = CreateSimpleCost(request.options());
 
   CostMatrix cost_matrix;

--- a/test/matrix.cc
+++ b/test/matrix.cc
@@ -262,14 +262,14 @@ bool within_tolerance(const uint32_t v1, const uint32_t v2) {
 }
 
 TEST(Matrix, test_matrix) {
-  loki_worker_t loki_worker(config);
+  GraphReader reader(config.get_child("mjolnir"));
+  loki_worker_t loki_worker(config, reader);
 
   Api request;
   ParseApi(test_request, Options::sources_to_targets, request);
   loki_worker.matrix(request);
   adjust_scores(*request.mutable_options());
 
-  GraphReader reader(config.get_child("mjolnir"));
 
   cost_ptr_t costing = CreateSimpleCost(request.options());
 
@@ -303,15 +303,14 @@ TEST(Matrix, test_matrix) {
 
 // TODO: it was commented before. Why?
 TEST(Matrix, DISABLED_test_matrix_osrm) {
-  loki_worker_t loki_worker(config);
+  GraphReader reader(config.get_child("mjolnir"));
+  loki_worker_t loki_worker(config, reader);
 
   Api request;
   ParseApi(test_request_osrm, Options::sources_to_targets, request);
 
   loki_worker.matrix(request);
   adjust_scores(*request.mutable_options());
-
-  GraphReader reader(config.get_child("mjolnir"));
 
   cost_ptr_t costing = CreateSimpleCost(request.options());
 

--- a/test/multipoint_routes.cc
+++ b/test/multipoint_routes.cc
@@ -69,8 +69,8 @@ boost::property_tree::ptree get_conf() {
 
 struct route_tester {
   route_tester()
-      : conf(get_conf()), reader(new GraphReader(conf.get_child("mjolnir"))),
-        loki_worker(conf, reader), thor_worker(conf, reader), odin_worker(conf) {
+      : conf(get_conf()), reader(conf.get_child("mjolnir")), loki_worker(conf, reader),
+        thor_worker(conf, reader), odin_worker(conf) {
   }
   Api test(const std::string& request_json) {
     Api request;
@@ -84,7 +84,7 @@ struct route_tester {
     return request;
   }
   boost::property_tree::ptree conf;
-  std::shared_ptr<GraphReader> reader;
+  GraphReader reader;
   loki_worker_t loki_worker;
   thor_worker_t thor_worker;
   odin_worker_t odin_worker;
@@ -160,7 +160,7 @@ void test_mid_break(const std::string& date_time) {
       << "Should be a destination at the midpoint and reverse the route for the second leg";
 
   check_dates(date_time.find(R"("type":)") != std::string::npos, response.options().locations(),
-              *tester.reader);
+              tester.reader);
 
   mid_break_distance =
       directions.begin()->summary().length() + directions.rbegin()->summary().length();
@@ -202,7 +202,7 @@ void test_mid_through(const std::string& date_time) {
       << "Should continue through the midpoint and around the block";
 
   check_dates(date_time.find(R"("type":)") != std::string::npos, response.options().locations(),
-              *tester.reader);
+              tester.reader);
 
   mid_through_distance = directions.begin()->summary().length();
 }
@@ -248,7 +248,7 @@ void test_mid_via(const std::string& date_time) {
       << "Should be a uturn at the mid point";
 
   check_dates(date_time.find(R"("type":)") != std::string::npos, response.options().locations(),
-              *tester.reader);
+              tester.reader);
 }
 
 void test_mid_break_through(const std::string& date_time) {
@@ -294,7 +294,7 @@ void test_mid_break_through(const std::string& date_time) {
       << "Should be a destination at the midpoint and continue around the block";
 
   check_dates(date_time.find(R"("type":)") != std::string::npos, response.options().locations(),
-              *tester.reader);
+              tester.reader);
 }
 
 TEST(MultiPointRoutesBreak, test_mid_break_no_time) {

--- a/test/shape_attributes.cc
+++ b/test/shape_attributes.cc
@@ -61,8 +61,10 @@ const auto conf = json_to_pt(R"({
     }
   })");
 
+valhalla::baldr::GraphReader reader(conf.get_child("mjolnir"));
+
 TEST(ShapeAttributes, test_shape_attributes_included) {
-  tyr::actor_t actor(conf);
+  tyr::actor_t actor(conf, reader);
 
   auto result_json = actor.trace_attributes(
       R"({"shape":[
@@ -121,7 +123,7 @@ TEST(ShapeAttributes, test_shape_attributes_included) {
 }
 
 TEST(ShapeAttributes, test_shape_attributes_no_turncosts) {
-  tyr::actor_t actor(conf);
+  tyr::actor_t actor(conf, reader);
   auto result_json = actor.trace_attributes(
       R"({"shape":[
          {"lat":52.09110,"lon":5.09806},

--- a/test/skadi_service.cc
+++ b/test/skadi_service.cc
@@ -231,23 +231,24 @@ TEST(SkadiService, test_requests) {
   // client makes requests and gets back responses in a batch fashion
   auto request = requests.cbegin();
   std::string request_str;
-  http_client_t client(
-      context, "ipc:///tmp/test_skadi_server",
-      [&request, &request_str]() {
-        // we dont have any more requests so bail
-        if (request == requests.cend())
-          return std::make_pair<const void*, size_t>(nullptr, 0);
-        // get the string of bytes to send formatted for http protocol
-        request_str = request->to_string();
-        ++request;
-        return std::make_pair<const void*, size_t>(request_str.c_str(), request_str.size());
-      },
-      [&request](const void* data, size_t size) {
-        auto response = http_response_t::from_string(static_cast<const char*>(data), size);
-        EXPECT_EQ(response.body, responses[request - requests.cbegin() - 1]);
-        return request != requests.cend();
-      },
-      1);
+  http_client_t client(context, "ipc:///tmp/test_skadi_server",
+                       [&request, &request_str]() {
+                         // we dont have any more requests so bail
+                         if (request == requests.cend())
+                           return std::make_pair<const void*, size_t>(nullptr, 0);
+                         // get the string of bytes to send formatted for http protocol
+                         request_str = request->to_string();
+                         ++request;
+                         return std::make_pair<const void*, size_t>(request_str.c_str(),
+                                                                    request_str.size());
+                       },
+                       [&request](const void* data, size_t size) {
+                         auto response =
+                             http_response_t::from_string(static_cast<const char*>(data), size);
+                         EXPECT_EQ(response.body, responses[request - requests.cbegin() - 1]);
+                         return request != requests.cend();
+                       },
+                       1);
   // request and receive
   client.batch();
 }

--- a/test/skadi_service.cc
+++ b/test/skadi_service.cc
@@ -206,7 +206,9 @@ boost::property_tree::ptree make_config() {
   return config;
 }
 
-void start_service(zmq::context_t& context, boost::property_tree::ptree &config, valhalla::baldr::GraphReader &reader) {
+void start_service(zmq::context_t& context,
+                   boost::property_tree::ptree& config,
+                   valhalla::baldr::GraphReader& reader) {
   // server
   std::thread server(
       std::bind(&http_server_t::serve,
@@ -235,23 +237,24 @@ TEST(SkadiService, test_requests) {
   // client makes requests and gets back responses in a batch fashion
   auto request = requests.cbegin();
   std::string request_str;
-  http_client_t client(
-      context, "ipc:///tmp/test_skadi_server",
-      [&request, &request_str]() {
-        // we dont have any more requests so bail
-        if (request == requests.cend())
-          return std::make_pair<const void*, size_t>(nullptr, 0);
-        // get the string of bytes to send formatted for http protocol
-        request_str = request->to_string();
-        ++request;
-        return std::make_pair<const void*, size_t>(request_str.c_str(), request_str.size());
-      },
-      [&request](const void* data, size_t size) {
-        auto response = http_response_t::from_string(static_cast<const char*>(data), size);
-        EXPECT_EQ(response.body, responses[request - requests.cbegin() - 1]);
-        return request != requests.cend();
-      },
-      1);
+  http_client_t client(context, "ipc:///tmp/test_skadi_server",
+                       [&request, &request_str]() {
+                         // we dont have any more requests so bail
+                         if (request == requests.cend())
+                           return std::make_pair<const void*, size_t>(nullptr, 0);
+                         // get the string of bytes to send formatted for http protocol
+                         request_str = request->to_string();
+                         ++request;
+                         return std::make_pair<const void*, size_t>(request_str.c_str(),
+                                                                    request_str.size());
+                       },
+                       [&request](const void* data, size_t size) {
+                         auto response =
+                             http_response_t::from_string(static_cast<const char*>(data), size);
+                         EXPECT_EQ(response.body, responses[request - requests.cbegin() - 1]);
+                         return request != requests.cend();
+                       },
+                       1);
   // request and receive
   client.batch();
 }

--- a/test/summary.cc
+++ b/test/summary.cc
@@ -61,7 +61,7 @@ boost::property_tree::ptree get_conf() {
 
 struct route_tester {
   route_tester()
-      : conf(get_conf()), reader(new GraphReader(conf.get_child("mjolnir"))),
+      : conf(get_conf()), reader(conf.get_child("mjolnir")),
         loki_worker(conf, reader), thor_worker(conf, reader), odin_worker(conf) {
   }
   Api test(const std::string& request_json) {
@@ -76,7 +76,7 @@ struct route_tester {
     return request;
   }
   boost::property_tree::ptree conf;
-  std::shared_ptr<GraphReader> reader;
+  GraphReader reader;
   loki_worker_t loki_worker;
   thor_worker_t thor_worker;
   odin_worker_t odin_worker;

--- a/test/summary.cc
+++ b/test/summary.cc
@@ -61,8 +61,8 @@ boost::property_tree::ptree get_conf() {
 
 struct route_tester {
   route_tester()
-      : conf(get_conf()), reader(conf.get_child("mjolnir")),
-        loki_worker(conf, reader), thor_worker(conf, reader), odin_worker(conf) {
+      : conf(get_conf()), reader(conf.get_child("mjolnir")), loki_worker(conf, reader),
+        thor_worker(conf, reader), odin_worker(conf) {
   }
   Api test(const std::string& request_json) {
     Api request;

--- a/test/thor_service.cc
+++ b/test/thor_service.cc
@@ -2,6 +2,7 @@
 
 #include "midgard/logging.h"
 #include "thor/worker.h"
+#include "baldr/graphreader.h"
 #include <unistd.h>
 
 #include <thread>
@@ -89,7 +90,8 @@ TEST(ThorService, test_failure_requests) {
   customizable.push_back(std::make_pair("", mode));
   customizable.push_back(std::make_pair("", search_radius));
   config.add_child("meili.customizable", customizable);
-  thor_worker_t worker(config);
+  baldr::GraphReader reader(config.get_child("mjolnir"));
+  thor_worker_t worker(config, reader);
   for (auto& req_resp : failure_request_responses) {
     std::list<zmq::message_t> messages;
     http_request_info_t request_info;

--- a/test/thor_service.cc
+++ b/test/thor_service.cc
@@ -1,8 +1,8 @@
 #include "test.h"
 
+#include "baldr/graphreader.h"
 #include "midgard/logging.h"
 #include "thor/worker.h"
-#include "baldr/graphreader.h"
 #include <unistd.h>
 
 #include <thread>

--- a/test/thor_worker.cc
+++ b/test/thor_worker.cc
@@ -56,8 +56,10 @@ const auto conf = json_to_pt(R"({
     }
   })");
 
+valhalla::baldr::GraphReader reader(conf.get_child("mjolnir"));
+
 TEST(ThorWorker, test_parse_filter_attributes_defaults) {
-  tyr::actor_t actor(conf, true);
+  tyr::actor_t actor(conf, reader, true);
 
   auto result = json_to_pt(actor.trace_attributes(
       R"({"costing":"auto","shape_match":"map_snap","shape":[
@@ -72,7 +74,7 @@ TEST(ThorWorker, test_parse_filter_attributes_defaults) {
 }
 
 TEST(ThorWorker, test_parse_filter_attributes_excludes) {
-  tyr::actor_t actor(conf, true);
+  tyr::actor_t actor(conf, reader, true);
 
   std::vector<std::string> test_cases = {
       actor.trace_attributes(
@@ -105,7 +107,7 @@ TEST(ThorWorker, test_parse_filter_attributes_excludes) {
 }
 
 TEST(ThorWorker, test_parse_filter_attributes_includes) {
-  tyr::actor_t actor(conf, true);
+  tyr::actor_t actor(conf, reader, true);
 
   std::vector<std::string> test_cases = {
       actor.trace_attributes(

--- a/test/timedep_paths.cc
+++ b/test/timedep_paths.cc
@@ -147,8 +147,8 @@ void try_path(GraphReader& reader,
 
 TEST(TimeDepPaths, test_depart_at_paths) {
   // Test setup
-  loki_worker_t loki_worker(config);
   GraphReader reader(config.get_child("mjolnir"));
+  loki_worker_t loki_worker(config, reader);
 
   // Simple path along oneway edge in the driveable direction - should return a single edge
   const auto test_request1 = R"({"locations":[{"lat":52.079079,"lon":5.115197},
@@ -164,8 +164,8 @@ TEST(TimeDepPaths, test_depart_at_paths) {
 
 TEST(TimeDepPaths, test_arrive_by_paths) {
   // Test setup
-  loki_worker_t loki_worker(config);
   GraphReader reader(config.get_child("mjolnir"));
+  loki_worker_t loki_worker(config, reader);
 
   // Simple path along oneway edge in the driveable direction - should return a single edge
   const auto test_request1 = R"({"locations":[{"lat":52.079079,"lon":5.115197},

--- a/test/trivial_paths.cc
+++ b/test/trivial_paths.cc
@@ -139,8 +139,8 @@ void try_path(GraphReader& reader,
 
 TEST(TrivialPaths, test_trivial_paths) {
   // Test setup
-  loki_worker_t loki_worker(config);
   GraphReader reader(config.get_child("mjolnir"));
+  loki_worker_t loki_worker(config, reader);
 
   // Simple path along oneway edge in the driveable direction - should return a single edge
   const auto test_request1 = R"({"locations":[{"lat":52.079079,"lon":5.115197},

--- a/valhalla/baldr/connectivity_map.h
+++ b/valhalla/baldr/connectivity_map.h
@@ -17,7 +17,7 @@ public:
    * Constructs the connectivity map
    * @param pt   the ptree sub child labeled mjolnir in the valhalla json config
    */
-  connectivity_map_t(const boost::property_tree::ptree& pt);
+  connectivity_map_t(const GraphReader& reader);
 
   /**
    * Returns the color for the given graphid

--- a/valhalla/baldr/graphreader.h
+++ b/valhalla/baldr/graphreader.h
@@ -13,6 +13,7 @@
 #include <valhalla/baldr/tilehierarchy.h>
 #include <valhalla/midgard/aabb2.h>
 #include <valhalla/midgard/pointll.h>
+#include <valhalla/midgard/sequence.h>
 
 namespace valhalla {
 namespace baldr {
@@ -738,10 +739,12 @@ public:
 
 protected:
   // (Tar) extract of tiles - the contents are empty if not being used
-  struct tile_extract_t;
-  std::shared_ptr<const tile_extract_t> tile_extract_;
-  static std::shared_ptr<const GraphReader::tile_extract_t>
-  get_extract_instance(const boost::property_tree::ptree& pt);
+  struct tile_extract_t {
+    tile_extract_t(const boost::property_tree::ptree& pt);
+    std::unordered_map<uint64_t, std::pair<char*, size_t>> tiles;
+    std::shared_ptr<midgard::tar> archive;
+  };
+  const tile_extract_t tile_extract_;
 
   // Information about where the tiles are kept
   const std::string tile_dir_;

--- a/valhalla/loki/worker.h
+++ b/valhalla/loki/worker.h
@@ -22,13 +22,12 @@ namespace valhalla {
 namespace loki {
 
 #ifdef HAVE_HTTP
-void run_service(const boost::property_tree::ptree& config);
+void run_service(const boost::property_tree::ptree& config, baldr::GraphReader &graph_reader);
 #endif
 
 class loki_worker_t : public service_worker_t {
 public:
-  loki_worker_t(const boost::property_tree::ptree& config,
-                const std::shared_ptr<baldr::GraphReader>& graph_reader = {});
+  loki_worker_t(const boost::property_tree::ptree& config, baldr::GraphReader& graph_reader);
 #ifdef HAVE_HTTP
   virtual prime_server::worker_t::result_t work(const std::list<zmq::message_t>& job,
                                                 void* request_info,
@@ -63,7 +62,7 @@ protected:
   boost::property_tree::ptree config;
   sif::CostFactory<sif::DynamicCost> factory;
   sif::cost_ptr_t costing;
-  std::shared_ptr<baldr::GraphReader> reader;
+  baldr::GraphReader& reader;
   std::shared_ptr<baldr::connectivity_map_t> connectivity_map;
   std::string action_str;
   std::unordered_map<std::string, size_t> max_locations;

--- a/valhalla/loki/worker.h
+++ b/valhalla/loki/worker.h
@@ -22,7 +22,7 @@ namespace valhalla {
 namespace loki {
 
 #ifdef HAVE_HTTP
-void run_service(const boost::property_tree::ptree& config, baldr::GraphReader &graph_reader);
+void run_service(const boost::property_tree::ptree& config, baldr::GraphReader& graph_reader);
 #endif
 
 class loki_worker_t : public service_worker_t {

--- a/valhalla/meili/map_matcher_factory.h
+++ b/valhalla/meili/map_matcher_factory.h
@@ -20,12 +20,11 @@ namespace meili {
 
 class MapMatcherFactory final {
 public:
-  MapMatcherFactory(const boost::property_tree::ptree& root,
-                    const std::shared_ptr<baldr::GraphReader>& graph_reader = {});
+  MapMatcherFactory(const boost::property_tree::ptree& root, baldr::GraphReader& graph_reader);
 
   ~MapMatcherFactory();
 
-  std::shared_ptr<baldr::GraphReader>& graphreader() {
+  baldr::GraphReader& graphreader() {
     return graphreader_;
   }
 
@@ -54,7 +53,7 @@ private:
 
   boost::property_tree::ptree config_;
 
-  std::shared_ptr<baldr::GraphReader> graphreader_;
+  baldr::GraphReader &graphreader_;
 
   valhalla::sif::cost_ptr_t mode_costing_[kModeCostingCount];
 

--- a/valhalla/meili/map_matcher_factory.h
+++ b/valhalla/meili/map_matcher_factory.h
@@ -53,7 +53,7 @@ private:
 
   boost::property_tree::ptree config_;
 
-  baldr::GraphReader &graphreader_;
+  baldr::GraphReader& graphreader_;
 
   valhalla::sif::cost_ptr_t mode_costing_[kModeCostingCount];
 

--- a/valhalla/thor/worker.h
+++ b/valhalla/thor/worker.h
@@ -32,14 +32,13 @@ namespace valhalla {
 namespace thor {
 
 #ifdef HAVE_HTTP
-void run_service(const boost::property_tree::ptree& config);
+void run_service(const boost::property_tree::ptree& config, baldr::GraphReader& graph_reader);
 #endif
 
 class thor_worker_t : public service_worker_t {
 public:
   enum SOURCE_TO_TARGET_ALGORITHM { SELECT_OPTIMAL = 0, COST_MATRIX = 1, TIME_DISTANCE_MATRIX = 2 };
-  thor_worker_t(const boost::property_tree::ptree& config,
-                const std::shared_ptr<baldr::GraphReader>& graph_reader = {});
+  thor_worker_t(const boost::property_tree::ptree& config, baldr::GraphReader& graph_reader);
   virtual ~thor_worker_t();
 #ifdef HAVE_HTTP
   virtual prime_server::worker_t::result_t work(const std::list<zmq::message_t>& job,
@@ -102,7 +101,7 @@ protected:
   std::unordered_map<std::string, float> max_matrix_distance;
   SOURCE_TO_TARGET_ALGORITHM source_to_target_algorithm;
   meili::MapMatcherFactory matcher_factory;
-  std::shared_ptr<baldr::GraphReader> reader;
+  baldr::GraphReader& reader;
   AttributesController controller;
 };
 

--- a/valhalla/tyr/actor.h
+++ b/valhalla/tyr/actor.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <unordered_map>
 
+#include <valhalla/baldr/graphreader.h>
 #include <valhalla/proto/api.pb.h>
 
 namespace valhalla {
@@ -12,7 +13,9 @@ namespace tyr {
 
 class actor_t {
 public:
-  actor_t(const boost::property_tree::ptree& config, bool auto_cleanup = false);
+  actor_t(const boost::property_tree::ptree& config,
+          baldr::GraphReader& reader,
+          bool auto_cleanup = false);
   void cleanup();
   std::string route(const std::string& request_str,
                     const std::function<void()>& interrupt = []() -> void {});


### PR DESCRIPTION
# Issue

**NOTE:** `GraphReader` is not thread-safe, and this PR cannot be merged until it is made so.  The `cache_` member variable needs to become thread-safe, perhaps via some `thread_local` magic.
---

The `GraphReader` class has a singleton for the `tar_extract_` object - this is primarily to avoid accidentally parsing/loading a large `.tar` file more than once from multiple locations in the code.

Unfortunately, singletons are notoriously hard to test - if you wanted two different `GraphReader` objects that pointed to different `tile_extract` tar files you couldn't do it.  Once initialized, the `tile_extract` member variable of the `GraphReader` was fixed.  There was also no way to pass a subclassed `GraphReader` in to many of the places it was needed.

This PR changes all that.  It makes a few changes:
  - All `std::shared_ptr<GraphReader>` are changed to `GraphReader &`
  - The singleton `GraphReader::get_extract_instance` function is removed
  - locations inside workers/etc where `new GraphReader` was called previously are replaced with function parameters

This is essentially a conversion from the [Singleton Pattern](https://en.wikipedia.org/wiki/Singleton_pattern) to the [Dependency Injection Pattern](https://en.wikipedia.org/wiki/Dependency_injection).  The primary advantage is that test cases now have control over the `GraphReader` being used.  A minor beneficial side-effect *minor* advantage that there is a little bit less pointer de-referencing being done, and the `GraphReader` is now stack allocated in many cases.

## Tasklist

 - [x] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
