### PR TITLE
[WIP] Improve road class output in osrm serializer

### DIFF
--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -500,8 +500,8 @@ json::ArrayPtr intersections(const valhalla::DirectionsLeg::Maneuver& maneuver,
       if (maneuver.portions_toll() || curr_edge->toll()) {
         classes.push_back("toll");
       }
-      // TODO We might want to have more specific logic for ramp
-      if ((curr_edge->road_class() == TripLeg_RoadClass_kMotorway) || curr_edge->IsRampUse()) {
+      // TODO We might want to label motorway for motorway_link
+      if (curr_edge->road_class() == TripLeg_RoadClass_kMotorway) {
         classes.push_back("motorway");
       }
       if (curr_edge->use() == TripLeg::Use::TripLeg_Use_kFerryUse) {

--- a/src/tyr/serializers.cc
+++ b/src/tyr/serializers.cc
@@ -126,9 +126,7 @@ json::ArrayPtr waypoints(const valhalla::Trip& trip) {
         continue;
       }
       const auto& edge =
-          is_first_location
-              ? &leg.node(0).edge()
-              : &leg.node(leg.node_size() - 2).edge();
+          is_first_location ? &leg.node(0).edge() : &leg.node(leg.node_size() - 2).edge();
       waypoints->emplace_back(waypoint(location, *edge, false, false));
     }
   }

--- a/test/gurka/test_waypoints_osrm.cc
+++ b/test/gurka/test_waypoints_osrm.cc
@@ -1,0 +1,79 @@
+#include "gurka.h"
+#include <gtest/gtest.h>
+
+using namespace valhalla;
+
+TEST(Standalone, WaypointsOsrmSingleEdge) {
+  const std::string ascii_map = R"(
+    A--B
+  )";
+
+  const gurka::ways ways = {
+      {"AB", {{"highway", "motorway"}}},
+  };
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, 10);
+  auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_waypoints_osrm");
+  auto result = gurka::route(map, "A", "B", "auto");
+
+  result.mutable_options()->set_format(valhalla::Options_Format_osrm);
+  auto json = tyr::serializeDirections(result);
+
+  rapidjson::Document result_json;
+  result_json.Parse(json.c_str());
+  if (result_json.HasParseError()) {
+    FAIL();
+  }
+
+  std::cout << json.c_str() << std::endl;
+  EXPECT_TRUE(result_json.HasMember("waypoints"));
+  EXPECT_TRUE(result_json["waypoints"].IsArray());
+  EXPECT_EQ(result_json["waypoints"].Size(), 2);
+  EXPECT_TRUE(result_json["waypoints"][0].IsObject());
+  EXPECT_EQ(result_json["waypoints"][0]["name"], "AB");
+  EXPECT_EQ(result_json["waypoints"][0]["road_class"], "motorway");
+
+  EXPECT_TRUE(result_json["waypoints"][1].IsObject());
+  EXPECT_EQ(result_json["waypoints"][1]["name"], "AB");
+  EXPECT_EQ(result_json["waypoints"][1]["road_class"], "motorway");
+}
+
+TEST(Standalone, WaypointsOsrmMultiLeg) {
+  const std::string ascii_map = R"(
+    A--B
+       |
+       C
+  )";
+
+  const gurka::ways ways = {
+      {"AB", {{"highway", "motorway"}}},
+      {"BC", {{"highway", "service"}}},
+  };
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, 10);
+  auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_waypoints_osrm");
+  auto result = gurka::route(map, {"A", "B", "C"}, "auto");
+
+  result.mutable_options()->set_format(valhalla::Options_Format_osrm);
+  auto json = tyr::serializeDirections(result);
+
+  rapidjson::Document result_json;
+  result_json.Parse(json.c_str());
+  if (result_json.HasParseError()) {
+    FAIL();
+  }
+
+  std::cout << json.c_str() << std::endl;
+  EXPECT_TRUE(result_json.HasMember("waypoints"));
+  EXPECT_TRUE(result_json["waypoints"].IsArray());
+  EXPECT_EQ(result_json["waypoints"].Size(), 3);
+  EXPECT_TRUE(result_json["waypoints"][0].IsObject());
+  EXPECT_EQ(result_json["waypoints"][0]["name"], "AB");
+  EXPECT_EQ(result_json["waypoints"][0]["road_class"], "motorway");
+
+  EXPECT_TRUE(result_json["waypoints"][1].IsObject());
+  EXPECT_EQ(result_json["waypoints"][1]["name"], "AB");
+  EXPECT_EQ(result_json["waypoints"][1]["road_class"], "motorway");
+
+  EXPECT_TRUE(result_json["waypoints"][2].IsObject());
+  EXPECT_EQ(result_json["waypoints"][2]["name"], "BC");
+  EXPECT_EQ(result_json["waypoints"][2]["road_class"], "service_other");
+}

--- a/test/gurka/test_waypoints_osrm.cc
+++ b/test/gurka/test_waypoints_osrm.cc
@@ -5,14 +5,16 @@ using namespace valhalla;
 
 TEST(Standalone, WaypointsOsrmSingleEdge) {
   const std::string ascii_map = R"(
-    A--B
-  )";
+    A----B
+         |
+         C)";
 
   const gurka::ways ways = {
       {"AB", {{"highway", "motorway"}}},
+      {"BC", {{"highway", "service"}}},
   };
   const auto layout = gurka::detail::map_to_coordinates(ascii_map, 10);
-  auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_waypoints_osrm");
+  auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_waypoints_osrm_1");
   auto result = gurka::route(map, "A", "B", "auto");
 
   result.mutable_options()->set_format(valhalla::Options_Format_osrm);
@@ -39,17 +41,16 @@ TEST(Standalone, WaypointsOsrmSingleEdge) {
 
 TEST(Standalone, WaypointsOsrmMultiLeg) {
   const std::string ascii_map = R"(
-    A--B
-       |
-       C
-  )";
+    A----B
+         |
+         C)";
 
   const gurka::ways ways = {
       {"AB", {{"highway", "motorway"}}},
       {"BC", {{"highway", "service"}}},
   };
-  const auto layout = gurka::detail::map_to_coordinates(ascii_map, 10);
-  auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_waypoints_osrm");
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100);
+  auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_waypoints_osrm_2");
   auto result = gurka::route(map, {"A", "B", "C"}, "auto");
 
   result.mutable_options()->set_format(valhalla::Options_Format_osrm);

--- a/test/gurka/test_waypoints_osrm.cc
+++ b/test/gurka/test_waypoints_osrm.cc
@@ -6,14 +6,12 @@ using namespace valhalla;
 TEST(Standalone, WaypointsOsrmSingleEdge) {
   const std::string ascii_map = R"(
     A----B
-         |
-         C)";
+  )";
 
   const gurka::ways ways = {
       {"AB", {{"highway", "motorway"}}},
-      {"BC", {{"highway", "service"}}},
   };
-  const auto layout = gurka::detail::map_to_coordinates(ascii_map, 10);
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100);
   auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_waypoints_osrm_1");
   auto result = gurka::route(map, "A", "B", "auto");
 

--- a/test/gurka/test_waypoints_osrm.cc
+++ b/test/gurka/test_waypoints_osrm.cc
@@ -6,10 +6,13 @@ using namespace valhalla;
 TEST(Standalone, WaypointsOsrmSingleEdge) {
   const std::string ascii_map = R"(
     A----B
+         |
+         C
   )";
 
   const gurka::ways ways = {
       {"AB", {{"highway", "motorway"}}},
+      {"BC", {{"highway", "motorway"}}},
   };
   const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100);
   auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_waypoints_osrm_1");

--- a/valhalla/tyr/serializers.h
+++ b/valhalla/tyr/serializers.h
@@ -109,6 +109,10 @@ namespace osrm {
  */
 valhalla::baldr::json::MapPtr
 waypoint(const valhalla::Location& location, bool is_tracepoint = false, bool is_optimized = false);
+valhalla::baldr::json::MapPtr waypoint(const valhalla::Location& location,
+                                       const valhalla::TripLeg_Edge& edge,
+                                       bool is_tracepoint = false,
+                                       bool is_optimized = false);
 
 /*
  * Serialize locations into osrm waypoints
@@ -116,7 +120,7 @@ waypoint(const valhalla::Location& location, bool is_tracepoint = false, bool is
 valhalla::baldr::json::ArrayPtr
 waypoints(const google::protobuf::RepeatedPtrField<valhalla::Location>& locations,
           bool tracepoints = false);
-valhalla::baldr::json::ArrayPtr waypoints(const valhalla::Trip& locations);
+valhalla::baldr::json::ArrayPtr waypoints(const valhalla::Trip& trip);
 
 } // namespace osrm
 


### PR DESCRIPTION
# Issue
**Work in progress**

Fixes an issue with intersections.classes array including `"motorway"` when the outgoing edge is any type of ramp, even non motorway links.

Adds an optional `road_class` property to the `waypoints` part of the output. 


## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
