### PR TITLE
additional data processing options 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
    * ADDED: Implement improved Reachability check using base class Dijkstra. [#2243](https://github.com/valhalla/valhalla/pull/2243)
    * ADDED: Gurka integration test framework with ascii-art maps [#2244](https://github.com/valhalla/valhalla/pull/2244)
    * ADDED: Add to the stop impact when transitioning from higher to lower class road and we are not on a turn channel or ramp. Also, penalize lefts when driving on the right and vice versa. [#2282](https://github.com/valhalla/valhalla/pull/2282)
+   * ADDED: Added reclassify_links, use_direction_on_ways, and allow_alt_name as config options.  If `use_direction_on_ways = true` then use `direction` and `int_direction` on the way to update the directional for the `ref` and `int_ref`. [#2285](https://github.com/valhalla/valhalla/pull/2285)
 
 ## Release Date: 2019-11-21 Valhalla 3.0.9
 * **Bug Fix**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@
    * ADDED: Implement improved Reachability check using base class Dijkstra. [#2243](https://github.com/valhalla/valhalla/pull/2243)
    * ADDED: Gurka integration test framework with ascii-art maps [#2244](https://github.com/valhalla/valhalla/pull/2244)
    * ADDED: Add to the stop impact when transitioning from higher to lower class road and we are not on a turn channel or ramp. Also, penalize lefts when driving on the right and vice versa. [#2282](https://github.com/valhalla/valhalla/pull/2282)
-   * ADDED: Added reclassify_links, use_direction_on_ways, and allow_alt_name as config options.  If `use_direction_on_ways = true` then use `direction` and `int_direction` on the way to update the directional for the `ref` and `int_ref`. [#2285](https://github.com/valhalla/valhalla/pull/2285)
+   * ADDED: Added reclassify_links, use_direction_on_ways, and allow_alt_name as config options.  If `use_direction_on_ways = true` then use `direction` and `int_direction` on the way to update the directional for the `ref` and `int_ref`.  Also, copy int_efs to the refs. [#2285](https://github.com/valhalla/valhalla/pull/2285)
 
 ## Release Date: 2019-11-21 Valhalla 3.0.9
 * **Bug Fix**

--- a/scripts/valhalla_build_config
+++ b/scripts/valhalla_build_config
@@ -33,11 +33,14 @@ config = {
     'import_bike_share_stations': False,
     'global_synchronized_cache': False,
     'max_concurrent_reader_users' : 1,
+    'reclassify_links': True,
     'data_processing': {
       'infer_internal_intersections': True,
       'infer_turn_channels': True,
       'apply_country_overrides': True,
-      'use_admin_db': True
+      'use_admin_db': True,
+      'use_direction_on_ways': False,
+      'allow_alt_name': False
     },
     'logging': {
       'type': 'std_out',
@@ -268,11 +271,14 @@ help_text = {
     'import_bike_share_stations': 'bool indicating whether importing bike share stations(BSS). Set to True when using multimodal - default to False',
     'global_synchronized_cache': 'bool indicating whether global_synchronized_cache is used - default to False',
     'max_concurrent_reader_users' : 'number of threads in the threadpool which can be used to fetch tiles over the network via curl',
+    'reclassify_links' : 'bool indicating whether or not to reclassify links - reclassifies ramps based on the lowest class connecting road',
     'data_processing': {
       'infer_internal_intersections': 'bool indicating whether or not to infer internal intersections during the graph enhancer phase or use the internal_intersection key from the pbf',
       'infer_turn_channels': 'bool indicating whether or not to infer turn channels during the graph enhancer phase or use the turn_channel key from the pbf',
       'apply_country_overrides': 'bool indicating whether or not to apply country overrides during the graph enhancer phase',
-      'use_admin_db': 'bool indicating whether or not to use the administrative database during the graph enhancer phase or use the admin keys from the pbf that are set on the way'
+      'use_admin_db': 'bool indicating whether or not to use the administrative database during the graph enhancer phase or use the admin keys from the pbf that are set on the way',
+      'use_direction_on_ways': 'bool indicating whether or not to process the direction key on the ways or utilize the guidance relation tags during the parsing phase',
+      'allow_alt_name': 'bool indicating whether or not to process the alt_name key on the ways during the parsing phase'
     },
     'logging': {
       'type': 'Type of logger either std_out or file',

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -1037,48 +1037,42 @@ public:
       }
     }
 
-    if (use_direction_on_ways_) {
+    if (use_direction_on_ways_ && !ref.empty()) {
       if (direction.empty()) {
-        if (!ref.empty())
-          w.set_ref_index(osmdata_.name_offset_map.index(ref));
+        w.set_ref_index(osmdata_.name_offset_map.index(ref));
       } else {
-        if (!ref.empty()) {
-          std::vector<std::string> refs = GetTagTokens(ref);
-          std::vector<std::string> directions = GetTagTokens(direction);
+        std::vector<std::string> refs = GetTagTokens(ref);
+        std::vector<std::string> directions = GetTagTokens(direction);
 
-          if (refs.size() == directions.size()) {
-            for (uint32_t i = 0; i < refs.size(); i++) {
-              if (!directions.at(i).empty())
-                w.set_ref_index(osmdata_.name_offset_map.index(refs.at(i) + " " + directions.at(i)));
-              else
-                w.set_ref_index(osmdata_.name_offset_map.index(refs.at(i)));
-            }
-          } else
-            w.set_ref_index(osmdata_.name_offset_map.index(ref));
-        }
+        if (refs.size() == directions.size()) {
+          for (uint32_t i = 0; i < refs.size(); i++) {
+            if (!directions.at(i).empty())
+              w.set_ref_index(osmdata_.name_offset_map.index(refs.at(i) + " " + directions.at(i)));
+            else
+              w.set_ref_index(osmdata_.name_offset_map.index(refs.at(i)));
+          }
+        } else
+          w.set_ref_index(osmdata_.name_offset_map.index(ref));
       }
     }
 
-    if (use_direction_on_ways_) {
+    if (use_direction_on_ways_ && !int_ref.empty()) {
       if (int_direction.empty()) {
-        if (!int_ref.empty())
-          w.set_int_ref_index(osmdata_.name_offset_map.index(int_ref));
+        w.set_int_ref_index(osmdata_.name_offset_map.index(int_ref));
       } else {
-        if (!int_ref.empty()) {
-          std::vector<std::string> int_refs = GetTagTokens(int_ref);
-          std::vector<std::string> int_directions = GetTagTokens(int_direction);
+        std::vector<std::string> int_refs = GetTagTokens(int_ref);
+        std::vector<std::string> int_directions = GetTagTokens(int_direction);
 
-          if (int_refs.size() == int_directions.size()) {
-            for (uint32_t i = 0; i < int_refs.size(); i++) {
-              if (!int_directions.at(i).empty())
-                w.set_int_ref_index(
-                    osmdata_.name_offset_map.index(int_refs.at(i) + " " + int_directions.at(i)));
-              else
-                w.set_int_ref_index(osmdata_.name_offset_map.index(int_refs.at(i)));
-            }
-          } else
-            w.set_int_ref_index(osmdata_.name_offset_map.index(int_ref));
-        }
+        if (int_refs.size() == int_directions.size()) {
+          for (uint32_t i = 0; i < int_refs.size(); i++) {
+            if (!int_directions.at(i).empty())
+              w.set_int_ref_index(
+                  osmdata_.name_offset_map.index(int_refs.at(i) + " " + int_directions.at(i)));
+            else
+              w.set_int_ref_index(osmdata_.name_offset_map.index(int_refs.at(i)));
+          }
+        } else
+          w.set_int_ref_index(osmdata_.name_offset_map.index(int_ref));
       }
     }
 

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -1038,7 +1038,7 @@ public:
     }
 
     if (use_direction_on_ways_) {
-      if (!direction.empty()) {
+      if (direction.empty()) {
         if (!ref.empty())
           w.set_ref_index(osmdata_.name_offset_map.index(ref));
       } else {
@@ -1048,8 +1048,9 @@ public:
 
           if (refs.size() == directions.size()) {
             for (uint32_t i = 0; i < refs.size(); i++) {
-              if (!refs.at(i).empty() && !directions.at(i).empty())
+              if (!directions.at(i).empty())
                 w.set_ref_index(osmdata_.name_offset_map.index(refs.at(i) + " " + directions.at(i)));
+              else w.set_ref_index(osmdata_.name_offset_map.index(refs.at(i)));
             }
           } else w.set_ref_index(osmdata_.name_offset_map.index(ref));
         }
@@ -1057,7 +1058,7 @@ public:
     }
 
     if (use_direction_on_ways_) {
-      if (!int_direction.empty()) {
+      if (int_direction.empty()) {
         if (!int_ref.empty())
           w.set_int_ref_index(osmdata_.name_offset_map.index(int_ref));
       } else {
@@ -1067,8 +1068,9 @@ public:
 
           if (int_refs.size() == int_directions.size()) {
             for (uint32_t i = 0; i < int_refs.size(); i++) {
-              if (!int_refs.at(i).empty() && !int_directions.at(i).empty())
+              if (!int_directions.at(i).empty())
                 w.set_int_ref_index(osmdata_.name_offset_map.index(int_refs.at(i) + " " + int_directions.at(i)));
+              else w.set_int_ref_index(osmdata_.name_offset_map.index(int_refs.at(i)));
             }
           } else w.set_int_ref_index(osmdata_.name_offset_map.index(int_ref));
 

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -1075,6 +1075,35 @@ public:
           w.set_int_ref_index(osmdata_.name_offset_map.index(int_ref));
       }
     }
+    // add int_refs to the end of the refs for now.  makes sure that we don't add dups.
+    if (use_direction_on_ways_ && w.int_ref_index()) {
+      std::string tmp = osmdata_.name_offset_map.name(w.ref_index());
+
+      std::vector<std::string> rs = GetTagTokens(tmp);
+      std::vector<std::string> is = GetTagTokens(osmdata_.name_offset_map.name(w.int_ref_index()));
+      bool bFound = false;
+
+      for (auto& i : is) {
+        for (auto& r : rs) {
+          if (i == r) {
+            bFound = true;
+            break;
+          }
+        }
+        if (!bFound) {
+          if (!tmp.empty()) {
+            tmp += ";";
+          }
+          tmp += i;
+        }
+        bFound = false;
+      }
+      if (!tmp.empty()) {
+        w.set_ref_index(osmdata_.name_offset_map.index(tmp));
+      }
+      // no matter what, clear out the int_ref.
+      w.set_int_ref_index(0);
+    }
 
     // if no surface and tracktype but we have a sac_scale, set surface to path.
     if (!has_surface) {

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -610,11 +610,9 @@ public:
         name = tag.second;
       } else if (tag.first == "name:en" && !tag.second.empty()) {
         w.set_name_en_index(osmdata_.name_offset_map.index(tag.second));
-      }
-      else if (tag.first == "alt_name" && !tag.second.empty() && allow_alt_name_) {
+      } else if (tag.first == "alt_name" && !tag.second.empty() && allow_alt_name_) {
         w.set_alt_name_index(osmdata_.name_offset_map.index(tag.second));
-      }
-      else if (tag.first == "official_name" && !tag.second.empty()) {
+      } else if (tag.first == "official_name" && !tag.second.empty()) {
         w.set_official_name_index(osmdata_.name_offset_map.index(tag.second));
       } else if (tag.first == "max_speed") {
         try {
@@ -804,11 +802,13 @@ public:
       else if (tag.first == "ref" && !tag.second.empty()) {
         if (!use_direction_on_ways_)
           w.set_ref_index(osmdata_.name_offset_map.index(tag.second));
-        else ref = tag.second;
+        else
+          ref = tag.second;
       } else if (tag.first == "int_ref" && !tag.second.empty()) {
         if (!use_direction_on_ways_)
           w.set_int_ref_index(osmdata_.name_offset_map.index(tag.second));
-        else int_ref = tag.second;
+        else
+          int_ref = tag.second;
       } else if (tag.first == "direction" && !tag.second.empty() && use_direction_on_ways_) {
         direction = tag.second;
       } else if (tag.first == "int_direction" && !tag.second.empty() && use_direction_on_ways_) {
@@ -1050,9 +1050,11 @@ public:
             for (uint32_t i = 0; i < refs.size(); i++) {
               if (!directions.at(i).empty())
                 w.set_ref_index(osmdata_.name_offset_map.index(refs.at(i) + " " + directions.at(i)));
-              else w.set_ref_index(osmdata_.name_offset_map.index(refs.at(i)));
+              else
+                w.set_ref_index(osmdata_.name_offset_map.index(refs.at(i)));
             }
-          } else w.set_ref_index(osmdata_.name_offset_map.index(ref));
+          } else
+            w.set_ref_index(osmdata_.name_offset_map.index(ref));
         }
       }
     }
@@ -1069,11 +1071,13 @@ public:
           if (int_refs.size() == int_directions.size()) {
             for (uint32_t i = 0; i < int_refs.size(); i++) {
               if (!int_directions.at(i).empty())
-                w.set_int_ref_index(osmdata_.name_offset_map.index(int_refs.at(i) + " " + int_directions.at(i)));
-              else w.set_int_ref_index(osmdata_.name_offset_map.index(int_refs.at(i)));
+                w.set_int_ref_index(
+                    osmdata_.name_offset_map.index(int_refs.at(i) + " " + int_directions.at(i)));
+              else
+                w.set_int_ref_index(osmdata_.name_offset_map.index(int_refs.at(i)));
             }
-          } else w.set_int_ref_index(osmdata_.name_offset_map.index(int_ref));
-
+          } else
+            w.set_int_ref_index(osmdata_.name_offset_map.index(int_ref));
         }
       }
     }
@@ -1666,16 +1670,16 @@ public:
   // Configuration option to include driveways
   bool include_driveways_;
 
-  // Configuration option indicating whether or not to infer internal intersections during the graph enhancer
-  // phase or use the internal_intersection key from the pbf
+  // Configuration option indicating whether or not to infer internal intersections during the graph
+  // enhancer phase or use the internal_intersection key from the pbf
   bool infer_internal_intersections_;
 
   // Configuration option indicating whether or not to infer turn channels during the graph
   // enhancer phase or use the turn_channel key from the pbf
   bool infer_turn_channels_;
 
-  // Configuration option indicating whether or not to process the direction key on the ways or utilize the
-  // guidance relation tags during the parsing phase
+  // Configuration option indicating whether or not to process the direction key on the ways or
+  // utilize the guidance relation tags during the parsing phase
   bool use_direction_on_ways_;
 
   // Configuration option indicating whether or not to process the alt_name key on the ways during the


### PR DESCRIPTION
# Issue

Added reclassify_links, use_direction_on_ways, and allow_alt_name as config options.  If `use_direction_on_ways = true` then use `direction` and `int_direction` on the way to update the directional for the `ref` and `int_ref`.

## Tasklist

 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
