### PR TITLE
Properly utilize CircleCI caches per build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,8 +216,8 @@ jobs:
       - run: git submodule sync && git submodule update --init
       - restore_cache:
           keys:
-            - ccache-macos-{{ .Branch }}
-            - ccache-macos
+            - ccache-release-macos-{{ .Branch }}
+            - ccache-release-macos
       - run: wget https://raw.githubusercontent.com/valhalla/homebrew-valhalla/master/Formula/prime_server.rb
       - run: brew install --build-from-source ./prime_server.rb
       - run: npm install --ignore-scripts
@@ -227,7 +227,7 @@ jobs:
       - run: make -C build -j4 tests
       - run: make -C build -j2 check
       - save_cache:
-          key: ccache-macos-{{ .Branch }}-{{ epoch }}
+          key: ccache-release-macos-{{ .Branch }}-{{ epoch }}
           paths:
             - ~/.ccache
 
@@ -240,8 +240,8 @@ jobs:
       - run: git submodule sync && git submodule update --init
       - restore_cache:
           keys:
-            - ccache-macos-{{ .Branch }}
-            - ccache-macos
+            - ccache-release-macos-{{ .Branch }}
+            - ccache-release-macos
       - run: npm install --ignore-scripts
       - run: mkdir -p build
       - run: cd build && cmake .. -DBUILD_SHARED_LIBS=Off -DENABLE_PYTHON_BINDINGS=Off -DENABLE_DATA_TOOLS=OFF -DENABLE_SERVICES=OFF -DBoost_USE_STATIC_LIBS=ON -DProtobuf_USE_STATIC_LIBS=ON -DLZ4_USE_STATIC_LIBS=ON
@@ -254,7 +254,7 @@ jobs:
             export BUILD_TYPE=Release
             ./scripts/publish.sh
       - save_cache:
-          key: ccache-macos-{{ .Branch }}-{{ epoch }}
+          key: ccache-release-macos-{{ .Branch }}-{{ epoch }}
           paths:
             - ~/.ccache
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,9 +29,6 @@ jobs:
     steps:
       - setup_remote_docker
       - checkout
-      - restore_cache:
-          keys:
-            - ccache
       - run:
           name: Build Valhalla base Dockerfile
           command: |
@@ -40,10 +37,6 @@ jobs:
           name: Build Valhalla base Dockerfile x86
           command: |
             docker build -f ./docker/Dockerfile-build-x86 --tag valhalla/valhalla:build-x86-latest ./docker
-      - save_cache:
-          key: ccache
-          paths:
-            - ~/.ccache
       - run:
           name: Push Valhalla base image
           command: |
@@ -70,7 +63,8 @@ jobs:
       - run: git submodule sync && git submodule update --init
       - restore_cache:
           keys:
-            - ccache
+            - ccache-release-linux-x86_64-{{ .Branch }}
+            - ccache-release-linux-x86_64
       - run: npm install --ignore-scripts
       - run: mkdir build
       - run: |
@@ -89,7 +83,7 @@ jobs:
             export BUILD_TYPE=Release
             ./scripts/publish.sh
       - save_cache:
-          key: ccache
+          key: ccache-release-linux-x86_64-{{ .Branch }}-{{ epoch }}
           paths:
             - ~/.ccache
 
@@ -111,7 +105,8 @@ jobs:
       - run: git submodule sync && git submodule update --init
       - restore_cache:
           keys:
-            - ccache
+            - ccache-debug-linux-x86_64-{{ .Branch }}
+            - ccache-debug-linux-x86_64
       - run: npm install --ignore-scripts
       - run: mkdir build
       - run: |
@@ -128,7 +123,7 @@ jobs:
             export BUILD_TYPE=Debug
             ./scripts/publish.sh
       - save_cache:
-          key: ccache
+          key: ccache-debug-linux-x86_64-{{ .Branch }}-{{ epoch }}
           paths:
             - ~/.ccache
 
@@ -141,7 +136,8 @@ jobs:
       - run: git submodule sync && git submodule update --init
       - restore_cache:
           keys:
-            - ccache
+            - ccache-debug-linux-x86_64-{{ .Branch }}
+            - ccache-debug-linux-x86_64
       - run: npm install --ignore-scripts
       - run: mkdir build
       - run: |
@@ -158,7 +154,7 @@ jobs:
       - run: make -C build coverage
       - run: /bin/bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
       - save_cache:
-          key: ccache
+          key: ccache-debug-linux-x86_64-{{ .Branch }}-{{ epoch }}
           paths:
             - ~/.ccache
 
@@ -171,7 +167,8 @@ jobs:
       - run: git submodule sync && git submodule update --init
       - restore_cache:
           keys:
-            - ccache
+            - ccache-release-linux-x86_64-{{ .Branch }}
+            - ccache-release-linux-x86_64
       - run: npm install --ignore-scripts
       - run: mkdir build
       - run: |
@@ -183,7 +180,7 @@ jobs:
       - run: make -C build install
       - run: make -C build package
       - save_cache:
-          key: ccache
+          key: ccache-release-linux-x86_64-{{ .Branch }}-{{ epoch }}
           paths:
             - ~/.ccache
 
@@ -196,7 +193,8 @@ jobs:
       - run: git submodule sync && git submodule update --init
       - restore_cache:
           keys:
-            - ccache
+            - ccache-release-linux-x86_32-{{ .Branch }}
+            - ccache-release-linux-x86_32
       - run: npm install --ignore-scripts
       - run: mkdir build
       - run: |
@@ -205,7 +203,7 @@ jobs:
       - run: make -C build -j4 tests
       - run: make -C build -j2 check
       - save_cache:
-          key: ccache
+          key: ccache-release-linux-x86_32-{{ .Branch }}-{{ epoch }}
           paths:
             - ~/.ccache
 
@@ -216,9 +214,10 @@ jobs:
       - checkout
       - run: ./scripts/format.sh && ./scripts/error_on_dirty.sh
       - run: git submodule sync && git submodule update --init
-      # - restore_cache:
-      #     keys:
-      #       - ccache
+      - restore_cache:
+          keys:
+            - ccache-macos-{{ .Branch }}
+            - ccache-macos
       - run: wget https://raw.githubusercontent.com/valhalla/homebrew-valhalla/master/Formula/prime_server.rb
       - run: brew install --build-from-source ./prime_server.rb
       - run: npm install --ignore-scripts
@@ -228,7 +227,7 @@ jobs:
       - run: make -C build -j4 tests
       - run: make -C build -j2 check
       - save_cache:
-          key: ccache
+          key: ccache-macos-{{ .Branch }}-{{ epoch }}
           paths:
             - ~/.ccache
 
@@ -239,6 +238,10 @@ jobs:
       - checkout
       - run: ./scripts/format.sh && ./scripts/error_on_dirty.sh
       - run: git submodule sync && git submodule update --init
+      - restore_cache:
+          keys:
+            - ccache-macos-{{ .Branch }}
+            - ccache-macos
       - run: npm install --ignore-scripts
       - run: mkdir -p build
       - run: cd build && cmake .. -DBUILD_SHARED_LIBS=Off -DENABLE_PYTHON_BINDINGS=Off -DENABLE_DATA_TOOLS=OFF -DENABLE_SERVICES=OFF -DBoost_USE_STATIC_LIBS=ON -DProtobuf_USE_STATIC_LIBS=ON -DLZ4_USE_STATIC_LIBS=ON
@@ -250,6 +253,10 @@ jobs:
             export COMMIT_MESSAGE=$(git log --oneline --format=%B -n 1 ${CIRCLE_SHA1} | head -n 1)
             export BUILD_TYPE=Release
             ./scripts/publish.sh
+      - save_cache:
+          key: ccache-macos-{{ .Branch }}-{{ epoch }}
+          paths:
+            - ~/.ccache
 
   build-debug-binary-osx:
     executor: macos
@@ -258,6 +265,10 @@ jobs:
       - checkout
       - run: ./scripts/format.sh && ./scripts/error_on_dirty.sh
       - run: git submodule sync && git submodule update --init
+      - restore_cache:
+          keys:
+            - ccache-debug-macos-{{ .Branch }}
+            - ccache-debug-macos
       - run: npm install --ignore-scripts
       - run: mkdir -p build
       - run: cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_PYTHON_BINDINGS=Off -DBUILD_SHARED_LIBS=Off -DENABLE_DATA_TOOLS=OFF -DENABLE_SERVICES=OFF -DBoost_USE_STATIC_LIBS=ON -DProtobuf_USE_STATIC_LIBS=ON -DLZ4_USE_STATIC_LIBS=ON
@@ -269,6 +280,10 @@ jobs:
             export COMMIT_MESSAGE=$(git log --oneline --format=%B -n 1 ${CIRCLE_SHA1} | head -n 1)
             export BUILD_TYPE=Debug
             ./scripts/publish.sh
+      - save_cache:
+          key: ccache-debug-macos-{{ .Branch }}-{{ epoch }}
+          paths:
+            - ~/.ccache
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,10 @@ jobs:
           cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=Off -DENABLE_PYTHON_BINDINGS=On \
           -DCPACK_GENERATOR=DEB -DCPACK_PACKAGE_VERSION_SUFFIX="-0ubuntu1-$(lsb_release -sc)" -DENABLE_SERVICES=OFF
       - run: make -C build -j4
+      - save_cache:
+          key: ccache-release-linux-x86_64-{{ .Branch }}-{{ epoch }}
+          paths:
+            - ~/.ccache
       - run: make -C build install
       - run: make -C build package
       - run:
@@ -82,10 +86,6 @@ jobs:
             export COMMIT_MESSAGE=$(git log --oneline --format=%B -n 1 ${CIRCLE_SHA1} | head -n 1)
             export BUILD_TYPE=Release
             ./scripts/publish.sh
-      - save_cache:
-          key: ccache-release-linux-x86_64-{{ .Branch }}-{{ epoch }}
-          paths:
-            - ~/.ccache
 
   build-debug-binary-linux:
     docker:
@@ -113,6 +113,10 @@ jobs:
           cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=Off -DENABLE_PYTHON_BINDINGS=On \
           -DCPACK_GENERATOR=DEB -DCPACK_PACKAGE_VERSION_SUFFIX="-0ubuntu1-$(lsb_release -sc)" -DENABLE_SERVICES=OFF
       - run: make -C build -j4
+      - save_cache:
+          key: ccache-debug-linux-x86_64-{{ .Branch }}-{{ epoch }}
+          paths:
+            - ~/.ccache
       - run: make -C build install
       - run: make -C build package
       - run:
@@ -122,10 +126,6 @@ jobs:
             export COMMIT_MESSAGE=$(git log --oneline --format=%B -n 1 ${CIRCLE_SHA1} | head -n 1)
             export BUILD_TYPE=Debug
             ./scripts/publish.sh
-      - save_cache:
-          key: ccache-debug-linux-x86_64-{{ .Branch }}-{{ epoch }}
-          paths:
-            - ~/.ccache
 
   lint-build-debug:
     docker:
@@ -146,17 +146,19 @@ jobs:
             && cmake .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=On -DCPACK_GENERATOR=DEB \
                 -DENABLE_COMPILER_WARNINGS=On -DENABLE_WERROR=Off -DCMAKE_EXPORT_COMPILE_COMMANDS=On
       - run: make -C build -j4
-      - run: scripts/clang-tidy-only-diff.sh 4
       - run: make -C build -j2 tests
       - run: make -C build -j2 check
-      - run: make -C build install
-      - run: make -C build package
-      - run: make -C build coverage
-      - run: /bin/bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
+      # Note: we save the cache here before doing linting so that if linting fails, we can rebuild quickly
+      # for follow-up fixes
       - save_cache:
           key: ccache-debug-linux-x86_64-{{ .Branch }}-{{ epoch }}
           paths:
             - ~/.ccache
+      - run: scripts/clang-tidy-only-diff.sh 4
+      - run: make -C build install
+      - run: make -C build package
+      - run: make -C build coverage
+      - run: /bin/bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
 
   build-release:
     docker:
@@ -177,12 +179,12 @@ jobs:
       - run: make -C build -j4
       - run: make -C build -j4 tests
       - run: make -C build -j2 check
-      - run: make -C build install
-      - run: make -C build package
       - save_cache:
           key: ccache-release-linux-x86_64-{{ .Branch }}-{{ epoch }}
           paths:
             - ~/.ccache
+      - run: make -C build install
+      - run: make -C build package
 
   build-release-x86:
     docker:
@@ -246,6 +248,10 @@ jobs:
       - run: mkdir -p build
       - run: cd build && cmake .. -DBUILD_SHARED_LIBS=Off -DENABLE_PYTHON_BINDINGS=Off -DENABLE_DATA_TOOLS=OFF -DENABLE_SERVICES=OFF -DBoost_USE_STATIC_LIBS=ON -DProtobuf_USE_STATIC_LIBS=ON -DLZ4_USE_STATIC_LIBS=ON
       - run: make -C build -j4
+      - save_cache:
+          key: ccache-release-macos-{{ .Branch }}-{{ epoch }}
+          paths:
+            - ~/.ccache
       - run:
           command: |
             export PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")
@@ -253,10 +259,6 @@ jobs:
             export COMMIT_MESSAGE=$(git log --oneline --format=%B -n 1 ${CIRCLE_SHA1} | head -n 1)
             export BUILD_TYPE=Release
             ./scripts/publish.sh
-      - save_cache:
-          key: ccache-release-macos-{{ .Branch }}-{{ epoch }}
-          paths:
-            - ~/.ccache
 
   build-debug-binary-osx:
     executor: macos
@@ -273,6 +275,10 @@ jobs:
       - run: mkdir -p build
       - run: cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_PYTHON_BINDINGS=Off -DBUILD_SHARED_LIBS=Off -DENABLE_DATA_TOOLS=OFF -DENABLE_SERVICES=OFF -DBoost_USE_STATIC_LIBS=ON -DProtobuf_USE_STATIC_LIBS=ON -DLZ4_USE_STATIC_LIBS=ON
       - run: make -C build -j4
+      - save_cache:
+          key: ccache-debug-macos-{{ .Branch }}-{{ epoch }}
+          paths:
+            - ~/.ccache
       - run:
           command: |
             export PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")
@@ -280,10 +286,6 @@ jobs:
             export COMMIT_MESSAGE=$(git log --oneline --format=%B -n 1 ${CIRCLE_SHA1} | head -n 1)
             export BUILD_TYPE=Debug
             ./scripts/publish.sh
-      - save_cache:
-          key: ccache-debug-macos-{{ .Branch }}-{{ epoch }}
-          paths:
-            - ~/.ccache
 
 workflows:
   version: 2


### PR DESCRIPTION
# Issue

CircleCI cache keys are immutable.  Once you've written to a cache key, it can't be changed until it expires (30 days).

We are currently trying to "save the cache" to a key called `ccache` for all builds.  This doesn't really work, as most builds fail to write to the cache, and the restored cache that most builds get doesn't contain any data that leads to `ccache` hits.

The fix is to use [partial cache restore](https://circleci.com/docs/2.0/caching/#restoring-cache).  The basic strategy is:

  1. When a build completes, write out to a very specific cache key.  In our case, the build name, plus the branch, and the current timestamp.
  2. When a build tries to restore the cache, try a series of fallbacks:
    1. Use the build name+branch+timestamp, or
    2. Use the most recent build name+branch-* key
    3. Use the most recent build name-* key

This should have the effect of actually getting some cache hits - it'll pick up the most recent completed build on a branch if available, otherwise it'll pick up the most recent build of that type (e.g. `ccache-release-linux-x86_64`).  This can mean that the `.ccache` that gets restored isn't super valid, but it should be better than nothing for most builds.  For branches that only get one commit, the hit rate may be low, but we should see improved hit rates for longer-lived branches where many commits are made and the `.ccache` from a previous build contains useful cache results.

Overall, the hope is that this should bring down the build times on CI for many common cases.

One of the focuses here is to improve the build times for tag builds - often when those occur, we want them to be done as quickly as possible (as a previous "testing" build has already completed, so it's mostly just a matter of re-building with the tag).

`build-release` goes from about 10+ minutes with no cache hits down to about 4m30s for a no-op build (full cache hits).
`lint-linux-debug` (the slowest job) goes from 29 minutes down to about 21 minutes.

This change only speeds up compilation steps using `ccache`.  Further work could be done to detect when binaries are unchanged and tests do not need to be re-run (for example).

## Tasklist

 - [ ] Update the [changelog](CHANGELOG.md)