### PR TITLE
Range updates for datetime and emergency updates. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
    * FIXED: Update intersection classes in osrm response to not label all ramps as motorway [#2279](https://github.com/valhalla/valhalla/pull/2279)
    * FIXED: Fixed bug in mapmatcher when interpolation point goes before the first valid match or after the last valid match. Such behavior usually leads to discontinuity in matching. [#2275](https://github.com/valhalla/valhalla/pull/2275)
    * FIXED: Fixed an issue for time_allowed logic.  Previously we returned false on the first time allowed restriction and did not check them all. Added conditional restriction gurka test and datetime optional argument to gurka header file. [#2286](https://github.com/valhalla/valhalla/pull/2286)
+   * FIXED: Fixed an issue for date ranges.  For example, for the range Jan 04 to Jan 02 we need to test to end of the year and then from the first of the year to the end date.  Also, fixed an emergency tag issue.  We should only set the use to emergency if all other access is off. [2290](https://github.com/valhalla/valhalla/pull/2290)
 
 * **Enhancement**
    * ADDED: Return the coordinates of the nodes isochrone input locations snapped to [#2111](https://github.com/valhalla/valhalla/pull/2111)

--- a/lua/graph.lua
+++ b/lua/graph.lua
@@ -1340,7 +1340,13 @@ function filter_tags_generic(kv)
     use = 0 --general road, no special use
   end
 
-  if kv["access"] == "emergency" or kv["emergency"] == "yes" then
+  if (kv["access"] == "emergency" or kv["emergency"] == "yes") and
+      kv["auto_forward"] == "false" and kv["auto_backward"] == "false" and
+      kv["truck_forward"] == "false" and kv["truck_backward"] == "false" and
+      kv["bus_forward"] == "false" and kv["bus_backward"] == "false" and
+      kv["bike_forward"] == "false" and kv["bike_backward"] == "false" and
+      kv["moped_forward"] == "false" and kv["moped_backward"] == "false" and
+      kv["motorcycle_forward"] == "false" and kv["motorcycle_backward"] == "false" then
     use = 7
   end
 

--- a/src/baldr/datetime.cc
+++ b/src/baldr/datetime.cc
@@ -115,9 +115,9 @@ int timezone_diff(const uint64_t seconds,
   auto duration = std::chrono::duration_cast<std::chrono::seconds>(origin.get_local_time() -
                                                                    dest.get_local_time());
   if (origin.get_info().offset < dest.get_info().offset) {
-    return abs(duration.count());
+    return std::abs(duration.count());
   } else {
-    return -1 * abs(duration.count());
+    return -1 * std::abs(duration.count());
   }
 }
 

--- a/src/baldr/datetime.cc
+++ b/src/baldr/datetime.cc
@@ -246,6 +246,7 @@ bool is_conditional_active(const bool type,
   std::chrono::seconds dur(current_time);
   std::chrono::time_point<std::chrono::system_clock> tp(dur);
 
+  uint32_t e_year = 0, b_year = 0;
   const auto in_local_time = date::make_zoned(time_zone, tp);
   auto date = date::floor<date::days>(in_local_time.get_local_time());
   auto d = date::year_month_day(date);
@@ -317,6 +318,7 @@ bool is_conditional_active(const bool type,
       e_day_dow = unsigned((date::year_month(e_d.year(), e_d.month()) / date::last).day());
     }
 
+    bool edge_case = false; // Jan 04 to Jan 01
     // month only
     if (type == kYMD && (b_month && e_month) && (!b_day_dow && !e_day_dow && !b_week && !b_week) &&
         b_month == e_month) {
@@ -332,10 +334,10 @@ bool is_conditional_active(const bool type,
       return (dow_in_range && dt_in_range);
     } else if (type == kYMD && b_month && b_day_dow) {
 
-      uint32_t e_year = int(d.year()), b_year = int(d.year());
+      e_year = int(d.year()), b_year = int(d.year());
       if (b_month == e_month) {
         if (b_day_dow > e_day_dow) { // Mar 15 - Mar 1
-          e_year = int(d.year()) + 1;
+          edge_case = true;
         }
       } else if (b_month > e_month) { // Oct 10 - Mar 3
         if (b_month > unsigned(d.month())) {
@@ -353,10 +355,10 @@ bool is_conditional_active(const bool type,
                e_day_dow) { // kNthDow types can have a mix of ymd and nthdow. (e.g. Dec Su[-1]-Mar
                             // 3 Sat 15:00-17:00)
 
-      uint32_t e_year = int(d.year()), b_year = int(d.year());
+      e_year = int(d.year()), b_year = int(d.year());
       if (b_month == e_month) {
         if (b_day_dow > e_day_dow) { // Mar 15 - Mar 1
-          e_year = int(d.year()) + 1;
+          edge_case = true;
         }
       } else if (b_month > e_month) { // Oct 10 - Mar 3
         if (b_month > unsigned(d.month())) {
@@ -426,8 +428,30 @@ bool is_conditional_active(const bool type,
     auto local_dt = date::make_zoned(time_zone, date::local_days(d));
     auto e_in_local_time = date::make_zoned(time_zone, date::local_days(end_date));
 
-    dt_in_range = (b_in_local_time.get_local_time() <= local_dt.get_local_time() &&
-                   local_dt.get_local_time() <= e_in_local_time.get_local_time());
+    if (edge_case) {
+
+      // Jan 04 to Jan 02.  We need to test to end of the year and then from the first of the
+      // year to the end date.
+
+      // begin date = Jan 04, 2021
+      // end date = Jan 02, 2021
+      date::year_month_day new_ed =
+          date::year_month_day(date::year(b_year), date::month(12), date::day(31));
+      auto new_e_in_local_time = date::make_zoned(time_zone, date::local_days(new_ed));
+
+      date::year_month_day new_bd =
+          date::year_month_day(date::year(b_year), date::month(1), date::day(1));
+      auto new_b_in_local_time = date::make_zoned(time_zone, date::local_days(new_bd));
+
+      // we need to check Jan 04, 2021 to Dec 31, 2021 and Jan 01, 2021 to Jan 02, 2021
+      dt_in_range = (((b_in_local_time.get_local_time() <= local_dt.get_local_time() &&
+                       local_dt.get_local_time() <= new_e_in_local_time.get_local_time())) ||
+                     ((new_b_in_local_time.get_local_time() <= local_dt.get_local_time() &&
+                       local_dt.get_local_time() <= e_in_local_time.get_local_time())));
+    } else {
+      dt_in_range = (b_in_local_time.get_local_time() <= local_dt.get_local_time() &&
+                     local_dt.get_local_time() <= e_in_local_time.get_local_time());
+    }
 
     bool time_in_range = false;
 

--- a/test/datetime.cc
+++ b/test/datetime.cc
@@ -459,6 +459,29 @@ TEST(DateTime, TestIsRestricted) {
   TryIsRestricted(td, "2019-01-06T08:30", false);
   TryIsRestricted(td, "2019-03-02T08:30", true);
   TryIsRestricted(td, "2019-03-03T08:30", false);
+
+  // (Jan 04-Jan 01 Mo-Sa 22:00-24:00)
+  td = TimeDomain(74766824773372);
+  TryIsRestricted(td, "2020-01-03T22:21", false);
+  TryIsRestricted(td, "2020-01-03T21:21", false);
+
+  TryIsRestricted(td, "2020-01-05T22:21", false);
+  TryIsRestricted(td, "2020-01-05T21:21", false);
+
+  TryIsRestricted(td, "2020-01-06T22:21", true);
+  TryIsRestricted(td, "2020-01-06T21:21", false);
+
+  TryIsRestricted(td, "2020-01-01T22:21", true);
+  TryIsRestricted(td, "2020-01-01T21:21", false);
+
+  TryIsRestricted(td, "2020-01-04T22:21", true);
+  TryIsRestricted(td, "2020-01-04T21:21", false);
+
+  TryIsRestricted(td, "2020-03-01T22:21", false);
+  TryIsRestricted(td, "2020-03-01T21:21", false);
+
+  TryIsRestricted(td, "2020-03-02T22:21", true);
+  TryIsRestricted(td, "2020-03-02T21:21", false);
 }
 
 TEST(DateTime, TestTimezoneDiff) {

--- a/test/datetime.cc
+++ b/test/datetime.cc
@@ -55,7 +55,6 @@ std::string test_iso_date_time(const uint8_t dow_mask,
 
   auto now = date::make_zoned(time_zone, std::chrono::system_clock::now());
   auto date = date::floor<date::days>(now.get_local_time());
-  auto d = date::year_month_day(date);
   auto t = date::make_time(now.get_local_time() - date);      // Yields time_of_day type
   std::chrono::minutes current_tod = t.hours() + t.minutes(); // Yields time_of_day type
   std::chrono::minutes desired_tod;


### PR DESCRIPTION
# Issue

Fixed an issue for date ranges.  For example, for the range Jan 04 to Jan 02 we need to test to end of the year and then from the first of the year to the end date.  Also, fixed an emergency tag issue.  We should only set the use to emergency if all other access is off.

## Tasklist

 - [x] Add tests
 - [x] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
