### PR TITLE
Properly set not_thru_pruning flag on destination edges

### DIFF
--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -884,7 +884,7 @@ void BidirectionalAStar::SetDestination(GraphReader& graphreader, const valhalla
     edgestatus_reverse_.Set(opp_edge_id, EdgeSet::kTemporary, idx,
                             graphreader.GetGraphTile(opp_edge_id));
     edgelabels_reverse_.emplace_back(kInvalidLabel, opp_edge_id, edgeid, opp_dir_edge, cost, sortcost,
-                                     dist, mode_, c, false, false);
+                                     dist, mode_, c, !opp_dir_edge->not_thru(), false);
     adjacencylist_reverse_->add(idx);
 
     // setting this edge as settled, sending the opposing because this is the reverse tree


### PR DESCRIPTION
Properly set the not_thru_pruning flag on the destination edge (just as it is done for the origin edge). This is needed to prevent Uturns at cul-de-sacs and other not_thru regions that connect to the destination edge.

Sorry I missed this one when I did the PR for Uturns at the origin.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
