### PR TITLE
ref and directional fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
    * FIXED: Fixed bug in mapmatcher when interpolation point goes before the first valid match or after the last valid match. Such behavior usually leads to discontinuity in matching. [#2275](https://github.com/valhalla/valhalla/pull/2275)
    * FIXED: Fixed an issue for time_allowed logic.  Previously we returned false on the first time allowed restriction and did not check them all. Added conditional restriction gurka test and datetime optional argument to gurka header file. [#2286](https://github.com/valhalla/valhalla/pull/2286)
    * FIXED: Fixed an issue for date ranges.  For example, for the range Jan 04 to Jan 02 we need to test to end of the year and then from the first of the year to the end date.  Also, fixed an emergency tag issue.  We should only set the use to emergency if all other access is off. [2290](https://github.com/valhalla/valhalla/pull/2290)
+   * FIXED: Found a few issues with the initial ref and direction logic for ways.  We were overwriting the refs with directionals to the name_offset_map instead of concatenating them together.  Also, we did not allow for blank entries for GetTagTokens. [2298](https://github.com/valhalla/valhalla/pull/2298)
 
 * **Enhancement**
    * ADDED: Return the coordinates of the nodes isochrone input locations snapped to [#2111](https://github.com/valhalla/valhalla/pull/2111)

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -1044,13 +1044,18 @@ public:
         std::vector<std::string> refs = GetTagTokens(ref);
         std::vector<std::string> directions = GetTagTokens(direction);
 
+        std::string tmp_ref;
         if (refs.size() == directions.size()) {
           for (uint32_t i = 0; i < refs.size(); i++) {
+            if (!tmp_ref.empty()) {
+              tmp_ref += ";";
+            }
             if (!directions.at(i).empty())
-              w.set_ref_index(osmdata_.name_offset_map.index(refs.at(i) + " " + directions.at(i)));
+              tmp_ref += refs.at(i) + " " + directions.at(i);
             else
-              w.set_ref_index(osmdata_.name_offset_map.index(refs.at(i)));
+              tmp_ref += refs.at(i);
           }
+          w.set_ref_index(osmdata_.name_offset_map.index(tmp_ref));
         } else
           w.set_ref_index(osmdata_.name_offset_map.index(ref));
       }
@@ -1063,18 +1068,23 @@ public:
         std::vector<std::string> int_refs = GetTagTokens(int_ref);
         std::vector<std::string> int_directions = GetTagTokens(int_direction);
 
+        std::string tmp_ref;
         if (int_refs.size() == int_directions.size()) {
           for (uint32_t i = 0; i < int_refs.size(); i++) {
+            if (!tmp_ref.empty()) {
+              tmp_ref += ";";
+            }
             if (!int_directions.at(i).empty())
-              w.set_int_ref_index(
-                  osmdata_.name_offset_map.index(int_refs.at(i) + " " + int_directions.at(i)));
+              tmp_ref += int_refs.at(i) + " " + int_directions.at(i);
             else
-              w.set_int_ref_index(osmdata_.name_offset_map.index(int_refs.at(i)));
+              tmp_ref += int_refs.at(i);
           }
+          w.set_int_ref_index(osmdata_.name_offset_map.index(tmp_ref));
         } else
           w.set_int_ref_index(osmdata_.name_offset_map.index(int_ref));
       }
     }
+
     // add int_refs to the end of the refs for now.  makes sure that we don't add dups.
     if (use_direction_on_ways_ && w.int_ref_index()) {
       std::string tmp = osmdata_.name_offset_map.name(w.ref_index());

--- a/src/mjolnir/util.cc
+++ b/src/mjolnir/util.cc
@@ -51,7 +51,7 @@ namespace mjolnir {
 std::vector<std::string> GetTagTokens(const std::string& tag_value, char delim) {
   std::vector<std::string> tokens;
   boost::algorithm::split(tokens, tag_value, std::bind1st(std::equal_to<char>(), delim),
-                          boost::algorithm::token_compress_on);
+                          boost::algorithm::token_compress_off);
   return tokens;
 }
 

--- a/test/gurka/test_use_direction_on_ways.cc
+++ b/test/gurka/test_use_direction_on_ways.cc
@@ -15,7 +15,7 @@ protected:
     constexpr double gridsize = 100;
 
     const std::string ascii_map = R"(
-         A----B----C----D----E
+         A--B--C--D--E
     )";
 
     const gurka::ways ways = {

--- a/test/gurka/test_use_direction_on_ways.cc
+++ b/test/gurka/test_use_direction_on_ways.cc
@@ -15,7 +15,11 @@ protected:
     constexpr double gridsize = 100;
 
     const std::string ascii_map = R"(
-         A--B--C--D--E
+         A--B
+            |
+         D--C
+         |
+         E
     )";
 
     const gurka::ways ways = {

--- a/test/gurka/test_use_direction_on_ways.cc
+++ b/test/gurka/test_use_direction_on_ways.cc
@@ -30,7 +30,7 @@ protected:
     const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100);
     map =
         gurka::buildtiles(layout, ways, {}, {}, "test/data/use_direction_on_ways",
-                          {{"mjolnir.data_processing.use_direction_on_ways", true}});
+                          {{"mjolnir.timezone", {VALHALLA_SOURCE_DIR "build/test/data/tz.sqlite"}}});
   }
 };
 

--- a/test/gurka/test_use_direction_on_ways.cc
+++ b/test/gurka/test_use_direction_on_ways.cc
@@ -15,18 +15,23 @@ protected:
     constexpr double gridsize = 100;
 
     const std::string ascii_map = R"(
-         A----B----C   
+         A----B----C----D
     )";
 
     const gurka::ways ways = {
         {"AB", {{"highway", "primary"}, {"ref", "US 30;US 222"}, {"direction", "East;North"}}},
-        {"BC", {{"highway", "primary"}}},
+        {"BC", {{"highway", "primary"}, {"int_ref", "I-95;US 40"}, {"int_direction", "North;East"}}},
+        {"CD",
+         {{"highway", "primary"},
+          {"ref", "US 15"},
+          {"direction", "South"},
+          {"int_ref", "I-80;US 15"},
+          {"int_direction", "West;South"}}},
     };
 
     const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100);
-    map =
-        gurka::buildtiles(layout, ways, {}, {}, "test/data/use_direction_on_ways",
-                          {{"mjolnir.timezone", {VALHALLA_SOURCE_DIR "build/test/data/tz.sqlite"}}});
+    map = gurka::buildtiles(layout, ways, {}, {}, "test/data/use_direction_on_ways",
+                            {{"mjolnir.data_processing.use_direction_on_ways", "true"}});
   }
 };
 
@@ -34,7 +39,25 @@ gurka::map UseDirectionOnWays::map = {};
 
 /*************************************************************/
 
-TEST_F(UseDirectionOnWays, Route) {
-  auto result = gurka::route(map, "A", "C", "auto");
-  gurka::assert::osrm::expect_route(result, {"WE", "BC"});
+TEST_F(UseDirectionOnWays, CheckNamesAndRefs) {
+  auto result = gurka::route(map, "A", "D", "auto");
+  gurka::assert::osrm::expect_route(result, {"AB", "BC", "CD"});
+
+  // test direction is used correctly
+  EXPECT_EQ(result.directions().routes(0).legs(0).maneuver(0).street_name_size(), 3);
+  EXPECT_EQ(result.directions().routes(0).legs(0).maneuver(0).street_name(0).value(), "AB");
+  EXPECT_EQ(result.directions().routes(0).legs(0).maneuver(0).street_name(1).value(), "US 30 East");
+  EXPECT_EQ(result.directions().routes(0).legs(0).maneuver(0).street_name(2).value(), "US 222 North");
+
+  // int_refs are copied to refs
+  EXPECT_EQ(result.directions().routes(0).legs(0).maneuver(1).street_name_size(), 3);
+  EXPECT_EQ(result.directions().routes(0).legs(0).maneuver(1).street_name(0).value(), "BC");
+  EXPECT_EQ(result.directions().routes(0).legs(0).maneuver(1).street_name(1).value(), "I-95 North");
+  EXPECT_EQ(result.directions().routes(0).legs(0).maneuver(1).street_name(2).value(), "US 40 East");
+
+  // ensure dups are removed
+  EXPECT_EQ(result.directions().routes(0).legs(0).maneuver(2).street_name_size(), 3);
+  EXPECT_EQ(result.directions().routes(0).legs(0).maneuver(2).street_name(0).value(), "CD");
+  EXPECT_EQ(result.directions().routes(0).legs(0).maneuver(2).street_name(1).value(), "US 15 South");
+  EXPECT_EQ(result.directions().routes(0).legs(0).maneuver(2).street_name(2).value(), "I-80 West");
 }

--- a/test/gurka/test_use_direction_on_ways.cc
+++ b/test/gurka/test_use_direction_on_ways.cc
@@ -15,7 +15,7 @@ protected:
     constexpr double gridsize = 100;
 
     const std::string ascii_map = R"(
-         A----B----C----D
+         A----B----C----D----E
     )";
 
     const gurka::ways ways = {
@@ -27,6 +27,12 @@ protected:
           {"direction", "South"},
           {"int_ref", "I-80;US 15"},
           {"int_direction", "West;South"}}},
+        {"DE",
+         {{"highway", "primary"},
+          {"ref", "US 119"},
+          {"direction", "South"},
+          {"int_ref", "I-99;US XX;US 119"},
+          {"int_direction", "North;;South"}}},
     };
 
     const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100);
@@ -40,8 +46,8 @@ gurka::map UseDirectionOnWays::map = {};
 /*************************************************************/
 
 TEST_F(UseDirectionOnWays, CheckNamesAndRefs) {
-  auto result = gurka::route(map, "A", "D", "auto");
-  gurka::assert::osrm::expect_route(result, {"AB", "BC", "CD"});
+  auto result = gurka::route(map, "A", "E", "auto");
+  gurka::assert::osrm::expect_route(result, {"AB", "BC", "CD", "DE"});
 
   // test direction is used correctly
   EXPECT_EQ(result.directions().routes(0).legs(0).maneuver(0).street_name_size(), 3);
@@ -60,4 +66,11 @@ TEST_F(UseDirectionOnWays, CheckNamesAndRefs) {
   EXPECT_EQ(result.directions().routes(0).legs(0).maneuver(2).street_name(0).value(), "CD");
   EXPECT_EQ(result.directions().routes(0).legs(0).maneuver(2).street_name(1).value(), "US 15 South");
   EXPECT_EQ(result.directions().routes(0).legs(0).maneuver(2).street_name(2).value(), "I-80 West");
+
+  // test empty directionals
+  EXPECT_EQ(result.directions().routes(0).legs(0).maneuver(3).street_name_size(), 4);
+  EXPECT_EQ(result.directions().routes(0).legs(0).maneuver(3).street_name(0).value(), "DE");
+  EXPECT_EQ(result.directions().routes(0).legs(0).maneuver(3).street_name(1).value(), "US 119 South");
+  EXPECT_EQ(result.directions().routes(0).legs(0).maneuver(3).street_name(2).value(), "I-99 North");
+  EXPECT_EQ(result.directions().routes(0).legs(0).maneuver(3).street_name(3).value(), "US XX");
 }

--- a/test/gurka/test_use_direction_on_ways.cc
+++ b/test/gurka/test_use_direction_on_ways.cc
@@ -19,12 +19,8 @@ protected:
     )";
 
     const gurka::ways ways = {
-        {"AB",
-         {{"highway", "primary"},
-          {"ref", "US 30;US 222"},
-          {"direction", "East;North"}}},
-        {"BC",
-         {{"highway", "primary"}}},
+        {"AB", {{"highway", "primary"}, {"ref", "US 30;US 222"}, {"direction", "East;North"}}},
+        {"BC", {{"highway", "primary"}}},
     };
 
     const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100);
@@ -42,4 +38,3 @@ TEST_F(UseDirectionOnWays, Route) {
   auto result = gurka::route(map, "A", "C", "auto");
   gurka::assert::osrm::expect_route(result, {"WE", "BC"});
 }
-

--- a/test/gurka/test_use_direction_on_ways.cc
+++ b/test/gurka/test_use_direction_on_ways.cc
@@ -1,0 +1,45 @@
+#include "gurka.h"
+#include <gtest/gtest.h>
+
+#if !defined(VALHALLA_SOURCE_DIR)
+#define VALHALLA_SOURCE_DIR
+#endif
+
+using namespace valhalla;
+
+class UseDirectionOnWays : public ::testing::Test {
+protected:
+  static gurka::map map;
+
+  static void SetUpTestSuite() {
+    constexpr double gridsize = 100;
+
+    const std::string ascii_map = R"(
+         A----B----C   
+    )";
+
+    const gurka::ways ways = {
+        {"AB",
+         {{"highway", "primary"},
+          {"ref", "US 30;US 222"},
+          {"direction", "East;North"}}},
+        {"BC",
+         {{"highway", "primary"}}},
+    };
+
+    const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100);
+    map =
+        gurka::buildtiles(layout, ways, {}, {}, "test/data/use_direction_on_ways",
+                          {{"mjolnir.data_processing.use_direction_on_ways", true}});
+  }
+};
+
+gurka::map UseDirectionOnWays::map = {};
+
+/*************************************************************/
+
+TEST_F(UseDirectionOnWays, Route) {
+  auto result = gurka::route(map, "A", "C", "auto");
+  gurka::assert::osrm::expect_route(result, {"WE", "BC"});
+}
+


### PR DESCRIPTION
# Issue

Found a few issues with the initial ref and direction logic for ways.  We were overwriting the refs with directionals to the name_offset_map instead of concatenating them together.  Also, we did not allow for blank entries for GetTagTokens.

## Tasklist

 - [x] Add tests
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
