### PR TITLE
Guidance views - use changeset for data_id and MatchGuidanceViewJunctions fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
    * FIXED: Fixed an issue for time_allowed logic.  Previously we returned false on the first time allowed restriction and did not check them all. Added conditional restriction gurka test and datetime optional argument to gurka header file. [#2286](https://github.com/valhalla/valhalla/pull/2286)
    * FIXED: Fixed an issue for date ranges.  For example, for the range Jan 04 to Jan 02 we need to test to end of the year and then from the first of the year to the end date.  Also, fixed an emergency tag issue.  We should only set the use to emergency if all other access is off. [2290](https://github.com/valhalla/valhalla/pull/2290)
    * FIXED: Found a few issues with the initial ref and direction logic for ways.  We were overwriting the refs with directionals to the name_offset_map instead of concatenating them together.  Also, we did not allow for blank entries for GetTagTokens. [2298](https://github.com/valhalla/valhalla/pull/2298)
+   * FIXED: Fixed an issue where MatchGuidanceViewJunctions is only looking at the first edge. Set the data_id for guidance views to the changeset id as it is already being populated. Also added test for guidance views. [2303](https://github.com/valhalla/valhalla/pull/2303)
 
 * **Enhancement**
    * ADDED: Return the coordinates of the nodes isochrone input locations snapped to [#2111](https://github.com/valhalla/valhalla/pull/2111)

--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -2740,7 +2740,7 @@ void ManeuversBuilder::MatchGuidanceViewJunctions(Maneuver& maneuver,
        ((node_index < maneuver.end_node_index()) && (edge_count < kOverlayEdgeMax));
        ++node_index, edge_count++) {
     // Loop over guidance view junctions
-    auto curr_edge = trip_path_->GetCurrEdge(maneuver.begin_node_index());
+    auto curr_edge = trip_path_->GetCurrEdge(node_index);
     if (curr_edge && (curr_edge->has_sign())) {
       // Process overlay guidance view junctions
       for (const auto& overlay_guidance_view_junction : curr_edge->sign().guidance_view_junctions()) {
@@ -2748,10 +2748,9 @@ void ManeuversBuilder::MatchGuidanceViewJunctions(Maneuver& maneuver,
         // If overlay(!is_route_number) guidance view junction and a pair...
         if (!overlay_guidance_view_junction.is_route_number() && is_pair(overlay_tokens) &&
             (base_prefix == overlay_tokens.at(0))) {
-          // TODO implement for real in the future
           DirectionsLeg_GuidanceView guidance_view;
-          guidance_view.set_data_id("z");
-          guidance_view.set_type("jct");
+          guidance_view.set_data_id(std::to_string(trip_path_->osm_changeset()));
+          guidance_view.set_type("jct"); // TODO implement for real in the future based on sign type
           guidance_view.set_base_id(base_prefix + base_suffix);
           guidance_view.add_overlay_ids(overlay_tokens.at(0) + overlay_tokens.at(1));
           maneuver.mutable_guidance_views()->emplace_back(guidance_view);

--- a/test/gurka/gurka.h
+++ b/test/gurka/gurka.h
@@ -409,6 +409,7 @@ inline void build_pbf(const nodelayout& node_locations,
     }
     osmium::builder::add_way(buffer, osmium::builder::attr::_id(way_osm_id_map[way.first]),
                              osmium::builder::attr::_version(1),
+                             osmium::builder::attr::_cid(1001),
                              osmium::builder::attr::_timestamp(std::time(nullptr)),
                              osmium::builder::attr::_nodes(nodeids),
                              osmium::builder::attr::_tags(tags));

--- a/test/gurka/gurka.h
+++ b/test/gurka/gurka.h
@@ -408,8 +408,7 @@ inline void build_pbf(const nodelayout& node_locations,
       tags.push_back({keyval.first, keyval.second});
     }
     osmium::builder::add_way(buffer, osmium::builder::attr::_id(way_osm_id_map[way.first]),
-                             osmium::builder::attr::_version(1),
-                             osmium::builder::attr::_cid(1001),
+                             osmium::builder::attr::_version(1), osmium::builder::attr::_cid(1001),
                              osmium::builder::attr::_timestamp(std::time(nullptr)),
                              osmium::builder::attr::_nodes(nodeids),
                              osmium::builder::attr::_tags(tags));

--- a/test/gurka/test_guidance_views.cc
+++ b/test/gurka/test_guidance_views.cc
@@ -1,0 +1,61 @@
+#include "gurka.h"
+#include <gtest/gtest.h>
+
+#if !defined(VALHALLA_SOURCE_DIR)
+#define VALHALLA_SOURCE_DIR
+#endif
+
+using namespace valhalla;
+
+class GuidanceViews : public ::testing::Test {
+protected:
+  static gurka::map map;
+
+  static void SetUpTestSuite() {
+    constexpr double gridsize = 100;
+
+    // A--B-BASE-C--D-OVERLAY-E--F
+    const std::string ascii_map = R"(
+      A----B----C----X
+                 \
+                  D
+                   \
+               E----F----G
+    )";
+    const gurka::ways ways =
+        {{"AB", {{"highway", "motorway"}, {"oneway", "yes"}, {"name", "National Route 1"}}},
+         {"BC",
+          {{"highway", "motorway"},
+           {"oneway", "yes"},
+           {"name", "National Route 1"},
+           {"guidance_view:jct:base", "PA717;1"}}},
+         {"CX", {{"highway", "motorway"}, {"oneway", "yes"}, {"name", "National Route 1"}}},
+         {"CD", {{"highway", "motorway_link"}, {"oneway", "yes"}, {"name", "xyz ramp"}}},
+         {"DF",
+          {{"highway", "motorway_link"},
+           {"oneway", "yes"},
+           {"name", "xyz ramp"},
+           {"guidance_view:jct:overlay", "PA717;E"}}},
+
+         {"EFG", {{"highway", "motorway"}, {"oneway", "yes"}, {"name", "National Route 2"}}}};
+
+    const gurka::nodes nodes = {{"C", {{"highway", "motorway_junction"}, {"ref", "10"}}}};
+    const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100);
+    map = gurka::buildtiles(layout, ways, nodes, {}, "test/data/guidance_views", {});
+  }
+};
+
+gurka::map GuidanceViews::map = {};
+
+/*************************************************************/
+
+TEST_F(GuidanceViews, CheckGuidanceViews) {
+  auto result = gurka::route(map, "A", "G", "auto");
+
+  EXPECT_EQ(result.directions().routes(0).legs(0).maneuver(1).guidance_views_size(), 1);
+  EXPECT_EQ(result.directions().routes(0).legs(0).maneuver(1).guidance_views(0).type(), "jct");
+  EXPECT_EQ(result.directions().routes(0).legs(0).maneuver(1).guidance_views(0).base_id(), "PA7171");
+  EXPECT_EQ(result.directions().routes(0).legs(0).maneuver(1).guidance_views(0).overlay_ids(0),
+            "PA717E");
+  EXPECT_EQ(result.directions().routes(0).legs(0).maneuver(1).guidance_views(0).data_id(), "1001");
+}


### PR DESCRIPTION
# Issue

We needed a way to set the data_id for guidance views.  Decision was made to just use the changeset id that is already being populated.  We should reevaluate the logic in the next version of the tiles.  @dgearhart fixed an issue where MatchGuidanceViewJunctions is only looking at the first edge

## Tasklist

 - [x] Add tests
 - [x] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
