### PR TITLE
Added default tile getter interface

### DIFF
--- a/test/http_tiles.cc
+++ b/test/http_tiles.cc
@@ -2,6 +2,7 @@
 
 #include "baldr/graphtile.h"
 #include "baldr/rapidjson_utils.h"
+#include "baldr/tilegetter.h"
 #include "tyr/actor.h"
 #include "valhalla/filesystem.h"
 #include "valhalla/tile_server.h"
@@ -159,7 +160,8 @@ void test_tile_download(size_t tile_count, size_t curler_count, size_t thread_co
 
   const auto non_existent_tile_id = params.get_nonexistent_tile_id();
 
-  curler_pool_t curlers_(curler_count, "");
+  curl_tile_getter_t tile_getter(curler_count, "", params.is_gzipped_tile);
+  EXPECT_EQ(tile_getter.gzipped(), params.is_gzipped_tile);
 
   std::vector<std::thread> threads;
   threads.reserve(thread_count);
@@ -178,19 +180,13 @@ void test_tile_download(size_t tile_count, size_t curler_count, size_t thread_co
         auto tile_uri = params.tile_url_base;
         tile_uri += tile_name;
         tile_uri += params.request_params;
-
         {
-          scoped_curler_t curler(curlers_);
-          long http_code;
+          auto result = tile_getter.get(tile_uri);
 
-          auto tile_data = curler.get()(tile_uri, http_code, params.is_gzipped_tile);
-
-          if (http_code != 404) {
-            EXPECT_EQ(http_code, 200);
-            auto tile = GraphTile(GraphId(), tile_data.data(), tile_data.size());
+          if (result.status_ == tile_getter_t::status_code_t::SUCCESS) {
+            auto tile = GraphTile(GraphId(), result.bytes_.data(), result.bytes_.size());
             EXPECT_EQ(tile.id(), expected_tile_id);
           } else {
-            // The test is expecting to get 404 since the tile does not exist
             EXPECT_EQ(expected_tile_id, non_existent_tile_id);
           }
         }
@@ -210,7 +206,8 @@ void test_graphreader_tile_download(size_t tile_count, size_t curler_count, size
 
   const auto non_existent_tile_id = params.get_nonexistent_tile_id();
 
-  curler_pool_t curlers_(curler_count, "");
+  curl_tile_getter_t tile_getter(curler_count, "", params.is_gzipped_tile);
+  EXPECT_EQ(tile_getter.gzipped(), params.is_gzipped_tile);
 
   std::vector<std::thread> threads;
   threads.reserve(thread_count);
@@ -224,18 +221,13 @@ void test_graphreader_tile_download(size_t tile_count, size_t curler_count, size
 
         auto test_tile_index = tile_i % params.test_tile_names.size();
         auto expected_tile_id = params.test_tile_ids[test_tile_index];
+        auto tile =
+            GraphTile::CacheTileURL(params.full_tile_url_pattern, expected_tile_id, &tile_getter, "");
 
-        {
-          scoped_curler_t curler(curlers_);
-
-          auto tile = GraphTile::CacheTileURL(params.full_tile_url_pattern, expected_tile_id,
-                                              curler.get(), params.is_gzipped_tile, "");
-
-          if (expected_tile_id != non_existent_tile_id) {
-            EXPECT_EQ(tile.id(), expected_tile_id);
-          } else {
-            EXPECT_EQ(tile.header(), nullptr) << "Expected empty header";
-          }
+        if (expected_tile_id != non_existent_tile_id) {
+          EXPECT_EQ(tile.id(), expected_tile_id);
+        } else {
+          EXPECT_EQ(tile.header(), nullptr) << "Expected empty header";
         }
       }
     });

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -2,6 +2,7 @@
 #define VALHALLA_BALDR_GRAPHTILE_H_
 
 #include "filesystem.h"
+
 #include <valhalla/baldr/accessrestriction.h>
 #include <valhalla/baldr/admininfo.h>
 #include <valhalla/baldr/complexrestriction.h>
@@ -24,6 +25,7 @@
 #include <valhalla/baldr/transitstop.h>
 #include <valhalla/baldr/transittransfer.h>
 #include <valhalla/baldr/turnlanes.h>
+
 #include <valhalla/midgard/aabb2.h>
 #include <valhalla/midgard/logging.h>
 #include <valhalla/midgard/util.h>
@@ -37,6 +39,7 @@
 namespace valhalla {
 namespace baldr {
 
+class tile_getter_t;
 /**
  * Graph information for a tile within the Tiled Hierarchical Graph.
  */
@@ -70,14 +73,13 @@ public:
    * Construct a tile given a url for the tile using curl
    * @param  tile_url URL of tile
    * @param  graphid Tile Id
-   * @param  curler curler that will handle tile downloading
-   * @param  gzipped whether the file url will need the .gz extension
+   * @param  tile_getter object that will handle tile downloading
    * @return whether or not the tile could be cached to disk
    */
+
   static GraphTile CacheTileURL(const std::string& tile_url,
                                 const GraphId& graphid,
-                                curler_t& curler,
-                                bool gzipped,
+                                tile_getter_t* tile_getter,
                                 const std::string& cache_location);
 
   /**

--- a/valhalla/baldr/tilegetter.h
+++ b/valhalla/baldr/tilegetter.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <valhalla/baldr/curler.h>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace valhalla {
+namespace baldr {
+
+/**
+ * Synchronous interface for getting tiles.
+ */
+class tile_getter_t {
+public:
+  // TODO: Consider other error codes.
+  /**
+   * Operation status code.
+   */
+  enum class status_code_t { SUCCESS, FAILURE };
+
+  /**
+   * Raw bytes we get as a response.
+   */
+  using bytes_t = std::vector<char>;
+
+  /**
+   * The result of synchronous operation. Contains raw data and operations result code.
+   */
+  struct response_t {
+    bytes_t bytes_;
+    status_code_t status_ = status_code_t::FAILURE;
+  };
+
+  /**
+   * Makes a synchronous request to the corresponding url and returns response_t object.
+   * */
+  virtual response_t get(const std::string& url) = 0;
+
+  /**
+   * Whether tiles are with .gz extension.
+   */
+  virtual bool gzipped() const {
+    return false;
+  }
+
+  virtual ~tile_getter_t() = default;
+};
+
+/**
+ * Default implementation which uses libcurl and curler_pool_t.
+ */
+class curl_tile_getter_t : public tile_getter_t {
+public:
+  /**
+   * @param pool_size  the number of curler instances in the pool
+   * @param user_agent  user agent to use by curlers for HTTP requests
+   * @param gzipped  whether to request for gzip compressed data
+   */
+  curl_tile_getter_t(const size_t pool_size, const std::string& user_agent, bool gzipped)
+      : curlers_(pool_size, user_agent), gzipped_(gzipped) {
+  }
+
+  using response_t = tile_getter_t::response_t;
+
+  response_t get(const std::string& url) override {
+    scoped_curler_t curler(curlers_);
+    long http_code = 0;
+    auto tile_data = curler.get()(url, http_code, gzipped_);
+    response_t result;
+    // TODO: Check other codes.
+    if (http_code == 200) {
+      result.bytes_ = std::move(tile_data);
+      result.status_ = tile_getter_t::status_code_t::SUCCESS;
+    }
+
+    return result;
+  }
+
+  bool gzipped() const override {
+    return gzipped_;
+  }
+
+private:
+  curler_pool_t curlers_;
+  const bool gzipped_;
+};
+
+} // namespace baldr
+} // namespace valhalla


### PR DESCRIPTION
For `GraphrReader` to work not only with libcurl but with any other http (or even something else) clients we are introducing `tile_getter_t` interface which users may want to implement. We allow users to configure `GraphReader` with their own `tile_getter_t` implementation which could be another http library, some data base, etc. 
It still will be libcurl under the hood if a user provides nullptr instead of tile_getter_t so no breaking changes for the API. 

Possible iOS implementation:
```objc
class ios_tile_getter_t : public tile_getter_t {
public:
  using result_t = tile_getter_t::result_t;

  result_t get(const std::string& url) const override {
      NSURL* requestURL = [[NSURL alloc] initWithString:@(url.c_str())];
      NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:requestURL];
      [request setHTTPMethod:@"GET"];
      dispatch_semaphore_t sem = dispatch_semaphore_create(0);
      result_t result;
      NSURLSessionTask* task = 
         [NSURLSession.sharedSession dataTaskWithRequest:request
         completionHandler:[&result](NSData* data, NSURLResponse* response, NSError* error) {
           NSHTTPURLResponse* urlResponse = (NSHTTPURLResponse *)response;
           if (data && !error) {
             char* bytes = [data bytes]
             size_t length = [data length];
             result.data_ = tile_getter_t::response_t(bytes, bytes + length);
             result.status_ = static_cast<tile_getter_t::status_t>([urlResponse statusCode]);
           }
         }];
      [task resume];
      dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
      return result;
  }
};
```