### PR TITLE
Use flow mask when considering access for live traffic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@
    * FIXED: Fixed an issue for date ranges.  For example, for the range Jan 04 to Jan 02 we need to test to end of the year and then from the first of the year to the end date.  Also, fixed an emergency tag issue.  We should only set the use to emergency if all other access is off. [2290](https://github.com/valhalla/valhalla/pull/2290)
    * FIXED: Found a few issues with the initial ref and direction logic for ways.  We were overwriting the refs with directionals to the name_offset_map instead of concatenating them together.  Also, we did not allow for blank entries for GetTagTokens. [2298](https://github.com/valhalla/valhalla/pull/2298)
    * FIXED: Fixed an issue where MatchGuidanceViewJunctions is only looking at the first edge. Set the data_id for guidance views to the changeset id as it is already being populated. Also added test for guidance views. [2303](https://github.com/valhalla/valhalla/pull/2303)
+   * FIXED: Fixed a problem with live speeds where live speeds were being used to determine access, even when a live
+   speed (current time) route wasn't what was requested. [#2311](https://github.com/valhalla/valhalla/pull/2311)
 
 * **Enhancement**
    * ADDED: Return the coordinates of the nodes isochrone input locations snapped to [#2111](https://github.com/valhalla/valhalla/pull/2111)

--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -391,8 +391,11 @@ bool AutoCost::Allowed(const baldr::DirectedEdge* edge,
                        const uint64_t current_time,
                        const uint32_t tz_index,
                        bool& has_time_restrictions) const {
-  if (tile->IsClosedDueToTraffic(edgeid))
-    return false;
+
+  if (flow_mask_ & kCurrentFlowMask) {
+    if (tile->IsClosedDueToTraffic(edgeid))
+      return false;
+  }
   // Check access, U-turn, and simple turn restriction.
   // Allow U-turns at dead-end nodes in case the origin is inside
   // a not thru region and a heading selected an edge entering the
@@ -419,8 +422,10 @@ bool AutoCost::AllowedReverse(const baldr::DirectedEdge* edge,
                               const uint64_t current_time,
                               const uint32_t tz_index,
                               bool& has_time_restrictions) const {
-  if (tile->IsClosedDueToTraffic(opp_edgeid))
-    return false;
+  if (flow_mask_ & kCurrentFlowMask) {
+    if (tile->IsClosedDueToTraffic(opp_edgeid))
+      return false;
+  }
   // Check access, U-turn, and simple turn restriction.
   // Allow U-turns at dead-end nodes.
   if (!(opp_edge->forwardaccess() & kAutoAccess) ||
@@ -841,6 +846,10 @@ bool BusCost::Allowed(const baldr::DirectedEdge* edge,
                       const uint64_t current_time,
                       const uint32_t tz_index,
                       bool& has_time_restrictions) const {
+  if (flow_mask_ & kCurrentFlowMask) {
+    if (tile->IsClosedDueToTraffic(edgeid))
+      return false;
+  }
   // TODO - obtain and check the access restrictions.
 
   // Check access, U-turn, and simple turn restriction.
@@ -867,6 +876,10 @@ bool BusCost::AllowedReverse(const baldr::DirectedEdge* edge,
                              const uint64_t current_time,
                              const uint32_t tz_index,
                              bool& has_time_restrictions) const {
+  if (flow_mask_ & kCurrentFlowMask) {
+    if (tile->IsClosedDueToTraffic(opp_edgeid))
+      return false;
+  }
   // Check access, U-turn, and simple turn restriction.
   // Allow U-turns at dead-end nodes.
   if (!(opp_edge->forwardaccess() & kBusAccess) ||
@@ -1033,6 +1046,10 @@ bool HOVCost::Allowed(const baldr::DirectedEdge* edge,
                       const uint64_t current_time,
                       const uint32_t tz_index,
                       bool& has_time_restrictions) const {
+  if (flow_mask_ & kCurrentFlowMask) {
+    if (tile->IsClosedDueToTraffic(edgeid))
+      return false;
+  }
   // TODO - obtain and check the access restrictions.
 
   // Check access, U-turn, and simple turn restriction.
@@ -1061,6 +1078,10 @@ bool HOVCost::AllowedReverse(const baldr::DirectedEdge* edge,
                              const uint64_t current_time,
                              const uint32_t tz_index,
                              bool& has_time_restrictions) const {
+  if (flow_mask_ & kCurrentFlowMask) {
+    if (tile->IsClosedDueToTraffic(opp_edgeid))
+      return false;
+  }
   // TODO - obtain and check the access restrictions.
 
   // Check access, U-turn, and simple turn restriction.
@@ -1229,6 +1250,10 @@ bool TaxiCost::Allowed(const baldr::DirectedEdge* edge,
                        const uint64_t current_time,
                        const uint32_t tz_index,
                        bool& has_time_restrictions) const {
+  if (flow_mask_ & kCurrentFlowMask) {
+    if (tile->IsClosedDueToTraffic(edgeid))
+      return false;
+  }
   // TODO - obtain and check the access restrictions.
 
   // Check access, U-turn, and simple turn restriction.
@@ -1257,6 +1282,10 @@ bool TaxiCost::AllowedReverse(const baldr::DirectedEdge* edge,
                               const uint64_t current_time,
                               const uint32_t tz_index,
                               bool& has_time_restrictions) const {
+  if (flow_mask_ & kCurrentFlowMask) {
+    if (tile->IsClosedDueToTraffic(opp_edgeid))
+      return false;
+  }
   // TODO - obtain and check the access restrictions.
 
   // Check access, U-turn, and simple turn restriction.
@@ -1322,6 +1351,9 @@ public:
                        const uint64_t current_time,
                        const uint32_t tz_index,
                        bool& has_time_restrictions) const {
+
+    // Note: this profile ignores closures in live traffic, so that check is not
+    //       present, unlike other Allowed() implementations
     // Check access and return false (not allowed if no auto access is allowed in either
     // direction. Also disallow simple U-turns except at dead-end nodes.
     if (!((edge->forwardaccess() & kAutoAccess) || (edge->reverseaccess() & kAutoAccess)) ||

--- a/src/sif/motorcyclecost.cc
+++ b/src/sif/motorcyclecost.cc
@@ -403,8 +403,10 @@ bool MotorcycleCost::Allowed(const baldr::DirectedEdge* edge,
                              const uint64_t current_time,
                              const uint32_t tz_index,
                              bool& has_time_restrictions) const {
-  if (tile->IsClosedDueToTraffic(edgeid))
-    return false;
+  if (flow_mask_ & kCurrentFlowMask) {
+    if (tile->IsClosedDueToTraffic(edgeid))
+      return false;
+  }
 
   // Check access, U-turn, and simple turn restriction.
   // Allow U-turns at dead-end nodes.
@@ -431,8 +433,11 @@ bool MotorcycleCost::AllowedReverse(const baldr::DirectedEdge* edge,
                                     const uint64_t current_time,
                                     const uint32_t tz_index,
                                     bool& has_time_restrictions) const {
-  if (tile->IsClosedDueToTraffic(opp_edgeid))
-    return false;
+  if (flow_mask_ & kCurrentFlowMask) {
+    if (tile->IsClosedDueToTraffic(opp_edgeid))
+      return false;
+  }
+
   // Check access, U-turn, and simple turn restriction.
   // Allow U-turns at dead-end nodes.
   if (!(opp_edge->forwardaccess() & kMotorcycleAccess) ||

--- a/src/sif/motorscootercost.cc
+++ b/src/sif/motorscootercost.cc
@@ -412,8 +412,10 @@ bool MotorScooterCost::Allowed(const baldr::DirectedEdge* edge,
                                const uint64_t current_time,
                                const uint32_t tz_index,
                                bool& has_time_restrictions) const {
-  if (tile->IsClosedDueToTraffic(edgeid))
-    return false;
+  if (flow_mask_ & kCurrentFlowMask) {
+    if (tile->IsClosedDueToTraffic(edgeid))
+      return false;
+  }
   // Check access, U-turn, and simple turn restriction.
   // Allow U-turns at dead-end nodes.
   if (!(edge->forwardaccess() & kMopedAccess) ||
@@ -439,8 +441,10 @@ bool MotorScooterCost::AllowedReverse(const baldr::DirectedEdge* edge,
                                       const uint64_t current_time,
                                       const uint32_t tz_index,
                                       bool& has_time_restrictions) const {
-  if (tile->IsClosedDueToTraffic(opp_edgeid))
-    return false;
+  if (flow_mask_ & kCurrentFlowMask) {
+    if (tile->IsClosedDueToTraffic(opp_edgeid))
+      return false;
+  }
   // Check access, U-turn, and simple turn restriction.
   // Allow U-turns at dead-end nodes.
   if (!(opp_edge->forwardaccess() & kMopedAccess) ||

--- a/src/sif/transitcost.cc
+++ b/src/sif/transitcost.cc
@@ -538,8 +538,10 @@ bool TransitCost::Allowed(const baldr::DirectedEdge* edge,
                           const uint64_t current_time,
                           const uint32_t tz_index,
                           bool& has_time_restrictions) const {
-  if (tile->IsClosedDueToTraffic(edgeid))
-    return false;
+  if (flow_mask_ & kCurrentFlowMask) {
+    if (tile->IsClosedDueToTraffic(edgeid))
+      return false;
+  }
   // TODO - obtain and check the access restrictions.
 
   if (exclude_stops_.size()) {

--- a/src/sif/truckcost.cc
+++ b/src/sif/truckcost.cc
@@ -453,7 +453,7 @@ bool TruckCost::AllowedReverse(const baldr::DirectedEdge* edge,
                                const uint32_t tz_index,
                                bool& has_time_restrictions) const {
   if (flow_mask_ & kCurrentFlowMask) {
-    if (tile->IsClosedDueToTraffic(edgeid))
+    if (tile->IsClosedDueToTraffic(opp_edgeid))
       return false;
   }
   // Check access, U-turn, and simple turn restriction.

--- a/src/sif/truckcost.cc
+++ b/src/sif/truckcost.cc
@@ -425,8 +425,10 @@ inline bool TruckCost::Allowed(const baldr::DirectedEdge* edge,
                                const uint64_t current_time,
                                const uint32_t tz_index,
                                bool& has_time_restrictions) const {
-  if (tile->IsClosedDueToTraffic(edgeid))
-    return false;
+  if (flow_mask_ & kCurrentFlowMask) {
+    if (tile->IsClosedDueToTraffic(edgeid))
+      return false;
+  }
   // Check access, U-turn, and simple turn restriction.
   // TODO - perhaps allow U-turns at dead-end nodes?
   if (!(edge->forwardaccess() & kTruckAccess) || (pred.opp_local_idx() == edge->localedgeidx()) ||
@@ -450,8 +452,10 @@ bool TruckCost::AllowedReverse(const baldr::DirectedEdge* edge,
                                const uint64_t current_time,
                                const uint32_t tz_index,
                                bool& has_time_restrictions) const {
-  if (tile->IsClosedDueToTraffic(opp_edgeid))
-    return false;
+  if (flow_mask_ & kCurrentFlowMask) {
+    if (tile->IsClosedDueToTraffic(edgeid))
+      return false;
+  }
   // Check access, U-turn, and simple turn restriction.
   // TODO - perhaps allow U-turns at dead-end nodes?
   if (!(opp_edge->forwardaccess() & kTruckAccess) || (pred.opp_local_idx() == edge->localedgeidx()) ||

--- a/test/gurka/gurka.h
+++ b/test/gurka/gurka.h
@@ -175,9 +175,14 @@ std::string build_valhalla_route_request(const map& map,
   }
 
   rapidjson::Value dt(rapidjson::kObjectType);
+  rapidjson::Value speed_types(rapidjson::kArrayType);
+  speed_types.PushBack("freeflow", allocator);
+  speed_types.PushBack("constrained", allocator);
+  speed_types.PushBack("predicted", allocator);
   if (datetime == "current") {
     dt.AddMember("type", 0, allocator);
     dt.AddMember("value", "current", allocator);
+    speed_types.PushBack("current", allocator);
   } else if (datetime != "") {
     dt.AddMember("type", 1, allocator);
     dt.AddMember("value", datetime, allocator);
@@ -185,8 +190,14 @@ std::string build_valhalla_route_request(const map& map,
 
   doc.AddMember("locations", locations, allocator);
   doc.AddMember("costing", costing, allocator);
-  if (datetime != "")
+  if (datetime != "") {
     doc.AddMember("date_time", dt, allocator);
+  }
+  rapidjson::Value costing_options(rapidjson::kObjectType);
+  rapidjson::Value co(rapidjson::kObjectType);
+  co.AddMember("speed_types", speed_types, allocator);
+  costing_options.AddMember(rapidjson::Value(costing, allocator), co, allocator);
+  doc.AddMember("costing_options", costing_options, allocator);
 
   rapidjson::StringBuffer sb;
   rapidjson::Writer<rapidjson::StringBuffer> writer(sb);

--- a/test/gurka/test_traffic.cc
+++ b/test/gurka/test_traffic.cc
@@ -172,8 +172,8 @@ TEST(Traffic, BasicUpdates) {
       gurka::assert::osrm::expect_route(result, {"BD"});
       gurka::assert::raw::expect_eta(result, 28.8, 0.01);
     }
-    // Now do another route with the same (not restarted) actor to see if
-    // it's noticed the changes in the live traffic file
+    // Repeat the B->D route, but this time with no timestamp - this should
+    // disable using live traffc and the road should be open again.
     {
       auto result = gurka::route(map, "B", "D", "auto", "", clean_reader);
       gurka::assert::osrm::expect_route(result, {"BD"});


### PR DESCRIPTION
# Issue

When using live traffic data, roads can sometimes be flagged as closed.  Route calculation
should only consider this closure when the user has requested a route that considers live
traffic.  Routing at a time other than "now" should not use current closures.

This PR fixes the checks in the various `Allowed()` functions to ensure that live closures
are only used when `kCurrentFlowMask` is set.

It also updates the gurka tests to properly set the flow mask depending on what departure
time is passed to the routing function.

## Tasklist

 - [x] Add tests
 - [x] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
