### PR TITLE
fix local date shifting to be without timezone and add test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
    * FIXED: Fixed an issue where MatchGuidanceViewJunctions is only looking at the first edge. Set the data_id for guidance views to the changeset id as it is already being populated. Also added test for guidance views. [2303](https://github.com/valhalla/valhalla/pull/2303)
    * FIXED: Fixed a problem with live speeds where live speeds were being used to determine access, even when a live
    speed (current time) route wasn't what was requested. [#2311](https://github.com/valhalla/valhalla/pull/2311)
+   * FIXED: Don't allow timezone information in the local date time string attached at each location. [2312](https://github.com/valhalla/valhalla/pull/2312)
 
 * **Enhancement**
    * ADDED: Return the coordinates of the nodes isochrone input locations snapped to [#2111](https://github.com/valhalla/valhalla/pull/2111)

--- a/src/thor/route_action.cc
+++ b/src/thor/route_action.cc
@@ -545,7 +545,7 @@ std::string thor_worker_t::offset_date(GraphReader& reader,
   uint64_t in_epoch = DateTime::seconds_since_epoch(in_dt, DateTime::get_tz_db().from_index(in_tz));
   double out_epoch = static_cast<double>(in_epoch) + offset;
   auto out_dt = DateTime::seconds_to_date(static_cast<uint64_t>(out_epoch + .5),
-                                          DateTime::get_tz_db().from_index(out_tz));
+                                          DateTime::get_tz_db().from_index(out_tz), false);
   return out_dt;
 }
 } // namespace thor

--- a/test/multipoint_routes.cc
+++ b/test/multipoint_routes.cc
@@ -107,8 +107,8 @@ void check_dates(bool time_dependent,
 
     if (l.has_date_time()) {
       // should be localtime, ie no timezone
-      EXPECT_TRUE(l.date_time().find("+", l.date_time().find("T")) == std::string::npos &&
-                  l.date_time().find("-", l.date_time().find("T")) == std::string::npos);
+      EXPECT_TRUE(l.date_time().find('+', l.date_time().find('T')) == std::string::npos &&
+                  l.date_time().find('-', l.date_time().find('T')) == std::string::npos);
       // get the timezone
       baldr::GraphId edge_id(l.path_edges().begin()->graph_id());
       const auto* tile = reader.GetGraphTile(edge_id);

--- a/test/multipoint_routes.cc
+++ b/test/multipoint_routes.cc
@@ -106,6 +106,9 @@ void check_dates(bool time_dependent,
     }
 
     if (l.has_date_time()) {
+      // should be localtime, ie no timezone
+      EXPECT_TRUE(l.date_time().find("+", l.date_time().find("T")) == std::string::npos &&
+                  l.date_time().find("-", l.date_time().find("T")) == std::string::npos);
       // get the timezone
       baldr::GraphId edge_id(l.path_edges().begin()->graph_id());
       const auto* tile = reader.GetGraphTile(edge_id);


### PR DESCRIPTION
we have other places in the code where we need to shift the dates that we set at the beginning of the leg to what the date will be at the end of the leg after we know the time the leg will take. in map matching we correctly set local time (ie without timezone). there was an oversight in the regular routing code that made it so that the timezone is added. this is a problem for 2 reasons. one it breaks the api in that the user gets back timezones in their date string. but the worse one is that it means if you have a multipoint leg, when we go to start the next leg we'll have a timezone on there and it will fail to parse nuking the time component of the multi point route.