### PR TITLE
Fix break/continue typo in search filtering

### DIFF
--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -523,7 +523,7 @@ struct bin_handler_t {
         for (p_itr = begin; p_itr != end; ++p_itr, ++c_itr) {
           // skip updating this candidate because it was prefiltered
           if (c_itr->prefiltered) {
-            break;
+            continue;
           }
           // how close is the input to this segment
           auto point = p_itr->project(u, v);


### PR DESCRIPTION
# Issue

Introduced a subtle bug in search filter PR #2289 - this caused us to erroneously filter out nearby candidates when the search_filter parameter was set. 

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
