### PR TITLE
Added cancelation to tile getter interface.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 
 * **Enhancement**
    * ADDED: Add ability to provide custom implementation for candidate collection in CandidateQuery. [#2328](https://github.com/valhalla/valhalla/pull/2328)
+   * ADDED: Cancellation of tile downloading. [#2319](https://github.com/valhalla/valhalla/pull/2319)
    * ADDED: Return the coordinates of the nodes isochrone input locations snapped to [#2111](https://github.com/valhalla/valhalla/pull/2111)
    * ADDED: Allows more complicated routes in timedependent a-star before timing out [#2068](https://github.com/valhalla/valhalla/pull/2068)
    * ADDED: Guide signs and junction names [#2096](https://github.com/valhalla/valhalla/pull/2096)

--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -9,6 +9,7 @@
 #include "midgard/logging.h"
 
 #include "baldr/connectivity_map.h"
+#include "baldr/curl_tilegetter.h"
 #include "filesystem.h"
 
 using namespace valhalla::midgard;

--- a/src/loki/worker.cc
+++ b/src/loki/worker.cc
@@ -236,6 +236,11 @@ void loki_worker_t::cleanup() {
   }
 }
 
+void loki_worker_t::set_interrupt(const std::function<void()>* interrupt_function) {
+  interrupt = interrupt_function;
+  reader->SetInterrupt(interrupt);
+}
+
 #ifdef HAVE_HTTP
 
 prime_server::worker_t::result_t
@@ -261,7 +266,7 @@ loki_worker_t::work(const std::list<zmq::message_t>& job,
     }
 
     // Set the interrupt function
-    service_worker_t::set_interrupt(interrupt_function);
+    service_worker_t::set_interrupt(&interrupt_function);
 
     prime_server::worker_t::result_t result{true};
     // do request specific processing

--- a/src/odin/worker.cc
+++ b/src/odin/worker.cc
@@ -52,7 +52,7 @@ odin_worker_t::work(const std::list<zmq::message_t>& job,
   Api request;
   try {
     // Set the interrupt function
-    service_worker_t::set_interrupt(interrupt_function);
+    service_worker_t::set_interrupt(&interrupt_function);
 
     // crack open the in progress request
     request.ParseFromArray(job.front().data(), job.front().size());

--- a/src/thor/worker.cc
+++ b/src/thor/worker.cc
@@ -112,7 +112,7 @@ thor_worker_t::work(const std::list<zmq::message_t>& job,
     const auto& options = request.options();
 
     // Set the interrupt function
-    service_worker_t::set_interrupt(interrupt_function);
+    service_worker_t::set_interrupt(&interrupt_function);
 
     prime_server::worker_t::result_t result{true};
     double denominator = 0;
@@ -361,5 +361,9 @@ void thor_worker_t::cleanup() {
   }
 }
 
+void thor_worker_t::set_interrupt(const std::function<void()>* interrupt_function) {
+  interrupt = interrupt_function;
+  reader->SetInterrupt(interrupt);
+}
 } // namespace thor
 } // namespace valhalla

--- a/src/tyr/actor.cc
+++ b/src/tyr/actor.cc
@@ -22,7 +22,7 @@ struct actor_t::pimpl_t {
       : reader(&graph_reader, [](baldr::GraphReader*) {}), loki_worker(config, reader),
         thor_worker(config, reader), odin_worker(config) {
   }
-  void set_interrupts(const std::function<void()>& interrupt_function) {
+  void set_interrupts(const std::function<void()>* interrupt_function) {
     loki_worker.set_interrupt(interrupt_function);
     thor_worker.set_interrupt(interrupt_function);
     odin_worker.set_interrupt(interrupt_function);
@@ -52,7 +52,7 @@ void actor_t::cleanup() {
 }
 
 std::string
-actor_t::route(const std::string& request_str, const std::function<void()>& interrupt, Api* api) {
+actor_t::route(const std::string& request_str, const std::function<void()>* interrupt, Api* api) {
   // set the interrupts
   pimpl->set_interrupts(interrupt);
   // parse the request
@@ -78,7 +78,7 @@ actor_t::route(const std::string& request_str, const std::function<void()>& inte
 }
 
 std::string
-actor_t::locate(const std::string& request_str, const std::function<void()>& interrupt, Api* api) {
+actor_t::locate(const std::string& request_str, const std::function<void()>* interrupt, Api* api) {
   // set the interrupts
   pimpl->set_interrupts(interrupt);
   // parse the request
@@ -98,7 +98,7 @@ actor_t::locate(const std::string& request_str, const std::function<void()>& int
 }
 
 std::string
-actor_t::matrix(const std::string& request_str, const std::function<void()>& interrupt, Api* api) {
+actor_t::matrix(const std::string& request_str, const std::function<void()>* interrupt, Api* api) {
   // set the interrupts
   pimpl->set_interrupts(interrupt);
   // parse the request
@@ -120,7 +120,7 @@ actor_t::matrix(const std::string& request_str, const std::function<void()>& int
 }
 
 std::string actor_t::optimized_route(const std::string& request_str,
-                                     const std::function<void()>& interrupt,
+                                     const std::function<void()>* interrupt,
                                      Api* api) {
   // set the interrupts
   pimpl->set_interrupts(interrupt);
@@ -147,7 +147,7 @@ std::string actor_t::optimized_route(const std::string& request_str,
 }
 
 std::string
-actor_t::isochrone(const std::string& request_str, const std::function<void()>& interrupt, Api* api) {
+actor_t::isochrone(const std::string& request_str, const std::function<void()>* interrupt, Api* api) {
   // set the interrupts
   pimpl->set_interrupts(interrupt);
   // parse the request
@@ -169,7 +169,7 @@ actor_t::isochrone(const std::string& request_str, const std::function<void()>& 
 }
 
 std::string actor_t::trace_route(const std::string& request_str,
-                                 const std::function<void()>& interrupt,
+                                 const std::function<void()>* interrupt,
                                  Api* api) {
   // set the interrupts
   pimpl->set_interrupts(interrupt);
@@ -196,7 +196,7 @@ std::string actor_t::trace_route(const std::string& request_str,
 }
 
 std::string actor_t::trace_attributes(const std::string& request_str,
-                                      const std::function<void()>& interrupt,
+                                      const std::function<void()>* interrupt,
                                       Api* api) {
   // set the interrupts
   pimpl->set_interrupts(interrupt);
@@ -219,7 +219,7 @@ std::string actor_t::trace_attributes(const std::string& request_str,
 }
 
 std::string
-actor_t::height(const std::string& request_str, const std::function<void()>& interrupt, Api* api) {
+actor_t::height(const std::string& request_str, const std::function<void()>* interrupt, Api* api) {
   // set the interrupts
   pimpl->set_interrupts(interrupt);
   // parse the request
@@ -239,7 +239,7 @@ actor_t::height(const std::string& request_str, const std::function<void()>& int
 }
 
 std::string actor_t::transit_available(const std::string& request_str,
-                                       const std::function<void()>& interrupt,
+                                       const std::function<void()>* interrupt,
                                        Api* api) {
   // set the interrupts
   pimpl->set_interrupts(interrupt);
@@ -260,7 +260,7 @@ std::string actor_t::transit_available(const std::string& request_str,
 }
 
 std::string
-actor_t::expansion(const std::string& request_str, const std::function<void()>& interrupt, Api* api) {
+actor_t::expansion(const std::string& request_str, const std::function<void()>* interrupt, Api* api) {
   // set the interrupts
   pimpl->set_interrupts(interrupt);
   // parse the request

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -1356,8 +1356,8 @@ service_worker_t::service_worker_t() : interrupt(nullptr) {
 }
 service_worker_t::~service_worker_t() {
 }
-void service_worker_t::set_interrupt(const std::function<void()>& interrupt_function) {
-  interrupt = &interrupt_function;
+void service_worker_t::set_interrupt(const std::function<void()>* interrupt_function) {
+  interrupt = interrupt_function;
 }
 
 } // namespace valhalla

--- a/test/actor.cc
+++ b/test/actor.cc
@@ -1,4 +1,7 @@
+#include <functional>
+#include <sstream>
 #include <stdexcept>
+#include <string>
 
 #include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
@@ -111,15 +114,16 @@ TEST_F(ActorInterrupt, Route) {
   tyr::actor_t actor(conf);
   std::string request = R"({"locations":[{"lat":40.546115,"lon":-76.385076,"type":"break"},
         {"lat":40.544232,"lon":-76.385752,"type":"break"}],"costing":"auto"})";
-  EXPECT_THROW(actor.route(request, []() -> void { throw test_exception_t{}; }), test_exception_t);
+  std::function<void()> interrupt = [] { throw test_exception_t{}; };
+  EXPECT_THROW(actor.route(request, &interrupt), test_exception_t);
 }
 
 TEST_F(ActorInterrupt, TraceAttributes) {
   tyr::actor_t actor(conf);
   std::string request = R"({"shape":[{"lat":40.546115,"lon":-76.385076},
         {"lat":40.544232,"lon":-76.385752}],"costing":"auto","shape_match":"map_snap"})";
-  EXPECT_THROW(actor.trace_attributes(request, []() -> void { throw test_exception_t{}; }),
-               test_exception_t);
+  std::function<void()> interrupt = [] { throw test_exception_t{}; };
+  EXPECT_THROW(actor.trace_attributes(request, &interrupt), test_exception_t);
 }
 
 // TODO: test the rest of them

--- a/test/gurka/gurka.h
+++ b/test/gurka/gurka.h
@@ -631,7 +631,7 @@ valhalla::Api route(const map& map,
 
   valhalla::tyr::actor_t actor(map.config, *reader, true);
   valhalla::Api api;
-  actor.route(request_json, []() {}, &api);
+  actor.route(request_json, nullptr, &api);
   return api;
 }
 
@@ -647,7 +647,7 @@ valhalla::Api route(const map& map,
 valhalla::Api route(const map& map, const std::string& request_json) {
   valhalla::tyr::actor_t actor(map.config, true);
   valhalla::Api api;
-  actor.route(request_json, []() {}, &api);
+  actor.route(request_json, nullptr, &api);
   return api;
 }
 
@@ -670,7 +670,7 @@ valhalla::Api match(const map& map,
 
   valhalla::tyr::actor_t actor(map.config, true);
   valhalla::Api api;
-  actor.trace_route(request_json, []() {}, &api);
+  actor.trace_route(request_json, nullptr, &api);
   return api;
 }
 

--- a/valhalla/baldr/curl_tilegetter.h
+++ b/valhalla/baldr/curl_tilegetter.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <valhalla/baldr/curler.h>
+#include <valhalla/baldr/tilegetter.h>
+
+#include <string>
+#include <utility>
+
+namespace valhalla {
+namespace baldr {
+
+/**
+ * Default implementation which uses libcurl and curler_pool_t.
+ */
+class curl_tile_getter_t : public tile_getter_t {
+public:
+  /**
+   * @param pool_size  the number of curler instances in the pool
+   * @param user_agent  user agent to use by curlers for HTTP requests
+   * @param gzipped  whether to request for gzip compressed data
+   */
+  curl_tile_getter_t(const size_t pool_size, const std::string& user_agent, bool gzipped)
+      : curlers_(pool_size, user_agent), gzipped_(gzipped) {
+  }
+
+  using response_t = tile_getter_t::response_t;
+
+  response_t get(const std::string& url) override {
+    scoped_curler_t curler(curlers_);
+    long http_code = 0;
+    auto tile_data = curler.get()(url, http_code, gzipped_, interrupt_);
+    response_t result;
+    // TODO: Check other codes.
+    if (http_code == 200) {
+      result.bytes_ = std::move(tile_data);
+      result.status_ = tile_getter_t::status_code_t::SUCCESS;
+    }
+
+    return result;
+  }
+
+  bool gzipped() const override {
+    return gzipped_;
+  }
+
+  using interrupt_t = tile_getter_t::interrupt_t;
+
+  void set_interrupt(const interrupt_t* interrupt) override {
+    interrupt_ = interrupt;
+  }
+
+private:
+  curler_pool_t curlers_;
+  const bool gzipped_;
+  const interrupt_t* interrupt_ = nullptr;
+};
+
+} // namespace baldr
+} // namespace valhalla

--- a/valhalla/baldr/curler.h
+++ b/valhalla/baldr/curler.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <valhalla/baldr/tilegetter.h>
+
 #include <array>
 #include <condition_variable>
 #include <memory>
@@ -18,15 +20,20 @@ struct curler_t {
    */
   explicit curler_t(const std::string& user_agent);
 
+  using interrupt_t = tile_getter_t::interrupt_t;
   /**
    * Fetch a url and return the bytes that we got
    *
    * @param  url                the url to fetch
    * @param  http_code          the code we got back when fetching
    * @param  gzipped            whether to request for gzip compressed data
+   * @param  interrupt          throws if request should be interrupted
    * @return the bytes we fetched
    */
-  std::vector<char> operator()(const std::string& url, long& http_code, bool gzipped);
+  std::vector<char> operator()(const std::string& url,
+                               long& http_code,
+                               bool gzipped,
+                               const interrupt_t* interrupt) const;
 
   /**
    * Allow only moves and forbid copies. We don't want

--- a/valhalla/baldr/graphreader.h
+++ b/valhalla/baldr/graphreader.h
@@ -343,6 +343,12 @@ public:
   explicit GraphReader(const boost::property_tree::ptree& pt,
                        std::unique_ptr<tile_getter_t>&& tile_getter = nullptr);
 
+  void SetInterrupt(const tile_getter_t::interrupt_t* interrupt) {
+    if (tile_getter_) {
+      tile_getter_->set_interrupt(interrupt);
+    }
+  }
+
   /**
    * Test if tile exists
    * @param  graphid  GraphId of the tile to test (tile id and level).

--- a/valhalla/baldr/tilegetter.h
+++ b/valhalla/baldr/tilegetter.h
@@ -2,8 +2,8 @@
 
 #include <valhalla/baldr/curler.h>
 
+#include <functional>
 #include <string>
-#include <utility>
 #include <vector>
 
 namespace valhalla {
@@ -45,46 +45,18 @@ public:
     return false;
   }
 
-  virtual ~tile_getter_t() = default;
-};
-
-/**
- * Default implementation which uses libcurl and curler_pool_t.
- */
-class curl_tile_getter_t : public tile_getter_t {
-public:
   /**
-   * @param pool_size  the number of curler instances in the pool
-   * @param user_agent  user agent to use by curlers for HTTP requests
-   * @param gzipped  whether to request for gzip compressed data
+   * A callback which is called to check if the request should be interrupted.
    */
-  curl_tile_getter_t(const size_t pool_size, const std::string& user_agent, bool gzipped)
-      : curlers_(pool_size, user_agent), gzipped_(gzipped) {
-  }
+  using interrupt_t = std::function<void()>;
 
-  using response_t = tile_getter_t::response_t;
+  /**
+   * Allows users to interrupt downloading requests.
+   * Returns true if the request should be interrupted.
+   */
+  virtual void set_interrupt(const interrupt_t* interrupt){};
 
-  response_t get(const std::string& url) override {
-    scoped_curler_t curler(curlers_);
-    long http_code = 0;
-    auto tile_data = curler.get()(url, http_code, gzipped_);
-    response_t result;
-    // TODO: Check other codes.
-    if (http_code == 200) {
-      result.bytes_ = std::move(tile_data);
-      result.status_ = tile_getter_t::status_code_t::SUCCESS;
-    }
-
-    return result;
-  }
-
-  bool gzipped() const override {
-    return gzipped_;
-  }
-
-private:
-  curler_pool_t curlers_;
-  const bool gzipped_;
+  virtual ~tile_getter_t() = default;
 };
 
 } // namespace baldr

--- a/valhalla/loki/worker.h
+++ b/valhalla/loki/worker.h
@@ -44,6 +44,8 @@ public:
   std::string height(Api& request);
   std::string transit_available(Api& request);
 
+  void set_interrupt(const std::function<void()>* interrupt) override;
+
 protected:
   void parse_locations(
       google::protobuf::RepeatedPtrField<valhalla::Location>* locations,

--- a/valhalla/meili/map_matcher.h
+++ b/valhalla/meili/map_matcher.h
@@ -76,6 +76,7 @@ public:
    */
   void set_interrupt(const std::function<void()>* interrupt_callback) {
     interrupt_ = interrupt_callback;
+    graphreader_.SetInterrupt(interrupt_);
   }
 
 private:

--- a/valhalla/thor/worker.h
+++ b/valhalla/thor/worker.h
@@ -56,6 +56,8 @@ public:
   std::string trace_attributes(Api& request);
   std::string expansion(Api& request);
 
+  void set_interrupt(const std::function<void()>* interrupt) override;
+
 protected:
   std::vector<std::vector<thor::PathInfo>> get_path(PathAlgorithm* path_algorithm,
                                                     Location& origin,

--- a/valhalla/tyr/actor.h
+++ b/valhalla/tyr/actor.h
@@ -19,34 +19,34 @@ public:
           bool auto_cleanup = false);
   void cleanup();
   std::string route(const std::string& request_str,
-                    const std::function<void()>& interrupt = []() -> void {},
+                    const std::function<void()>* interrupt = nullptr,
                     Api* api = nullptr);
   std::string locate(const std::string& request_str,
-                     const std::function<void()>& interrupt = []() -> void {},
+                     const std::function<void()>* interrupt = nullptr,
                      Api* api = nullptr);
   std::string matrix(const std::string& request_str,
-                     const std::function<void()>& interrupt = []() -> void {},
+                     const std::function<void()>* interrupt = nullptr,
                      Api* api = nullptr);
   std::string optimized_route(const std::string& request_str,
-                              const std::function<void()>& interrupt = []() -> void {},
+                              const std::function<void()>* interrupt = nullptr,
                               Api* api = nullptr);
   std::string isochrone(const std::string& request_str,
-                        const std::function<void()>& interrupt = []() -> void {},
+                        const std::function<void()>* interrupt = nullptr,
                         Api* api = nullptr);
   std::string trace_route(const std::string& request_str,
-                          const std::function<void()>& interrupt = []() -> void {},
+                          const std::function<void()>* interrupt = nullptr,
                           Api* api = nullptr);
   std::string trace_attributes(const std::string& request_str,
-                               const std::function<void()>& interrupt = []() -> void {},
+                               const std::function<void()>* interrupt = nullptr,
                                Api* api = nullptr);
   std::string height(const std::string& request_str,
-                     const std::function<void()>& interrupt = []() -> void {},
+                     const std::function<void()>* interrupt = nullptr,
                      Api* api = nullptr);
   std::string transit_available(const std::string& request_str,
-                                const std::function<void()>& interrupt = []() -> void {},
+                                const std::function<void()>* interrupt = nullptr,
                                 Api* api = nullptr);
   std::string expansion(const std::string& request_str,
-                        const std::function<void()>& interrupt = []() -> void {},
+                        const std::function<void()>* interrupt = nullptr,
                         Api* api = nullptr);
 
 protected:

--- a/valhalla/worker.h
+++ b/valhalla/worker.h
@@ -228,7 +228,7 @@ public:
    * supposed to be halted
    * @param  interrupt    the function to be called which should throw
    */
-  virtual void set_interrupt(const std::function<void()>& interrupt) final;
+  virtual void set_interrupt(const std::function<void()>* interrupt);
 
 protected:
   const std::function<void()>* interrupt;


### PR DESCRIPTION
It's sometimes helpful for users to have an option to interrupt network requests. This pr introduces the simple solution for it: passing a function which will be called (if set) to check if `tile_getter_t` should interrupt the particular url fetching. For the default implementation (curl based) we have a callback which is called (if set) each time the progress function is called.
So a possible solution for users who want to use default curl-based tile getter and who also want to interrupt request would be having an `atomic<bool>` which returns from a custom interrupt function the user provided, or, if the user wants to interrupt the particular url, adding the url in a thread safe collection of urls and check that the collection contains url inside the function. 