### PR TITLE
Sort files into groups for IDEs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # This is secondary build configuration provided for convenient development
 # on Windows and using CMake-enabled IDEs.
 #
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 project(valhalla LANGUAGES CXX C)
 
 include(FindPkgConfig)
@@ -32,6 +32,7 @@ option(ENABLE_WERROR "Convert compiler warnings to errors. Requires ENABLE_COMPI
 option(ENABLE_BENCHMARKS "Enable microbenchmarking" ON)
 set(LOGGING_LEVEL "" CACHE STRING "Logging level, default is INFO")
 set_property(CACHE LOGGING_LEVEL PROPERTY STRINGS "NONE;ALL;ERROR;WARN;INFO;DEBUG;TRACE")
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
@@ -75,6 +76,18 @@ else()
   message(STATUS "Unrecognized build type - will use cmake defaults")
 endif()
 
+function(create_source_groups prefix)
+  foreach(file ${ARGN})
+    get_filename_component(file "${file}" ABSOLUTE)
+    string(FIND "${file}" "${PROJECT_BINARY_DIR}/" pos)
+    if(pos EQUAL 0)
+      source_group(TREE "${PROJECT_BINARY_DIR}/" PREFIX "Generated Files" FILES "${file}")
+    else()
+      source_group(TREE "${PROJECT_SOURCE_DIR}/" PREFIX "${prefix}" FILES "${file}")
+    endif()
+  endforeach()
+endfunction()
+
 if(ENABLE_CCACHE AND (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU"))
   find_program(CCACHE_FOUND ccache)
   if(CCACHE_FOUND)
@@ -111,6 +124,7 @@ if(ENABLE_COVERAGE)
     COMMAND ${GENHTML_PATH} --prefix ${CMAKE_CURRENT_BINARY_DIR} --output-directory coverage --title "Test Coverage" --legend --show-details coverage.info
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/coverage.info)
+  set_target_properties(coverage PROPERTIES FOLDER "Tests")
 endif()
 
 ## Dependencies
@@ -152,6 +166,7 @@ if(CMAKE_VERSION VERSION_LESS 3.9)
   if(NOT TARGET protobuf::libprotobuf-lite)
     add_library(protobuf::libprotobuf-lite UNKNOWN IMPORTED)
     set_target_properties(protobuf::libprotobuf-lite PROPERTIES
+      FOLDER "Dependencies"
       INTERFACE_INCLUDE_DIRECTORIES "${PROTOBUF_INCLUDE_DIR}")
 
     if(EXISTS "${PROTOBUF_LIBRARY}")
@@ -265,6 +280,8 @@ if(ENABLE_TOOLS)
   foreach(program ${valhalla_programs})
     get_source_path(path ${program})
     add_executable(${program} ${path})
+    set_target_properties(${program} PROPERTIES FOLDER "Tools")
+    create_source_groups("Source Files" ${path})
     target_link_libraries(${program} Boost::program_options valhalla Threads::Threads Boost::filesystem Boost::system)
     if(WIN32)
       target_link_libraries(${program} ${CURL_LIBRARIES})
@@ -277,6 +294,8 @@ if(ENABLE_DATA_TOOLS)
   foreach(program ${valhalla_data_tools})
     get_source_path(path ${program})
     add_executable(${program} ${path})
+    create_source_groups("Source Files" ${path})
+    set_target_properties(${program} PROPERTIES FOLDER "Data Tools")
     target_link_libraries(${program} valhalla Boost::program_options Threads::Threads Boost::filesystem Boost::system)
     if(WIN32)
       target_link_libraries(${program} ${CURL_LIBRARIES})
@@ -296,6 +315,8 @@ endif()
 if(ENABLE_SERVICES)
   foreach(program ${valhalla_services})
     add_executable(${program} src/${program}.cc)
+    create_source_groups("Source Files" src/${program}.cc)
+    set_target_properties(${program} PROPERTIES FOLDER "Services")
     target_link_libraries(${program} valhalla Boost::program_options Threads::Threads)
     install(TARGETS ${program} DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT runtime)
   endforeach()

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,9 +1,14 @@
+set(BENCHMARK_ENABLE_TESTING OFF)
 add_subdirectory(${VALHALLA_SOURCE_DIR}/third_party/benchmark
   ${CMAKE_BINARY_DIR}/benchmark)
+set_target_properties(benchmark PROPERTIES FOLDER "Dependencies")
+set_target_properties(benchmark_main PROPERTIES FOLDER "Dependencies")
 
 # Custom targets building and running all microbenchmarks in the project
 add_custom_target(benchmarks)
+set_target_properties(benchmarks PROPERTIES FOLDER "Benchmarks")
 add_custom_target(run-benchmarks)
+set_target_properties(run-benchmarks PROPERTIES FOLDER "Benchmarks")
 
 # Benchmarks generally require utrecht test tiles to be present, so add this dependency by default.
 add_dependencies(benchmarks utrecht_tiles)
@@ -12,6 +17,7 @@ add_dependencies(benchmarks utrecht_tiles)
 macro (add_valhalla_benchmark target_file)
   set(target_name benchmark-${target_file})
   add_executable(${target_name} ${target_file}.cc)
+  set_target_properties(${target_name} PROPERTIES FOLDER "Benchmarks")
   set_target_properties(${target_name}
     PROPERTIES
     COMPILE_DEFINITIONS
@@ -24,6 +30,7 @@ macro (add_valhalla_benchmark target_file)
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     COMMENT "Running ${target_name} in ${CMAKE_CURRENT_BINARY_DIR}"
     DEPENDS ${target_name})
+  set_target_properties(run-${target_name} PROPERTIES FOLDER "Benchmarks")
   add_dependencies(run-benchmarks run-${target_name})
 endmacro()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,6 +76,12 @@ function(valhalla_module)
   set(library valhalla-${MODULE_NAME})
   add_library(${library} OBJECT ${MODULE_SOURCES} ${MODULE_HEADERS})
   add_library(valhalla::${MODULE_NAME} ALIAS ${library})
+  set_target_properties(${library} PROPERTIES FOLDER "Modules")
+
+  # Generate source groups so the files are properly sorted in IDEs like Xcode.
+  create_source_groups("Header Files" ${MODULE_HEADERS})
+  create_source_groups("Source Files" ${MODULE_SOURCES})
+
   target_compile_definitions(${library}
     PUBLIC
       $<$<BOOL:${MSVC}>:VC_EXTRALEAN;WIN32_LEAN_AND_MEAN;NOMINMAX;NOGDI>
@@ -161,6 +167,8 @@ if (ENABLE_SERVICES)
 endif()
 
 add_library(valhalla ${valhalla_src})
+set_target_properties(valhalla PROPERTIES FOLDER "Library")
+create_source_groups("Source Files" ${valhalla_src})
 
 target_compile_definitions(valhalla
   PUBLIC
@@ -216,6 +224,7 @@ else()
   if(UNIX)
     add_custom_target(${LIBVALHALLA_SO_LINK} ALL
       COMMAND ${CMAKE_COMMAND} -E create_symlink "${LIBVALHALLA_SO_LINK}.${VALHALLA_VERSION_MAJOR}" ${LIBVALHALLA_SO_LINK})
+    set_target_properties(${LIBVALHALLA_SO_LINK} PROPERTIES FOLDER "Library")
   endif()
 endif()
 
@@ -238,6 +247,7 @@ if(PKG_CONFIG_FOUND)
   add_executable(libvalhalla.pc EXCLUDE_FROM_ALL ../libvalhalla.pc.in)
   target_link_libraries(libvalhalla.pc valhalla)
   set_target_properties(libvalhalla.pc PROPERTIES LINKER_LANGUAGE PkgConfig)
+  set_target_properties(libvalhalla.pc PROPERTIES FOLDER "Library")
   install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} --build . --target libvalhalla.pc OUTPUT_QUIET ERROR_VARIABLE _err RESULT_VARIABLE _res)
   if(NOT \${_res} EQUAL 0)
     message(FATAL_ERROR \"Configuring libvalhalla.pc failed: \${_err}\")

--- a/src/bindings/node/CMakeLists.txt
+++ b/src/bindings/node/CMakeLists.txt
@@ -15,6 +15,7 @@ message(STATUS "Configuring node_valhalla bindings for NodeJs ${NODEJS_VERSION}"
 
 add_nodejs_module(node_valhalla node.cc)
 set_target_properties(node_valhalla PROPERTIES CXX_STANDARD 14)
+set_target_properties(node_valhalla PROPERTIES FOLDER "Node Bindings")
 target_link_libraries(node_valhalla valhalla)
 
 # Include N-API wrappers
@@ -31,3 +32,4 @@ list(APPEND ARTIFACTS "${BINDING_DIR}/node_valhalla.node")
 
 message(STATUS "node_valhalla artifacts will be copied to: ${BINDING_DIR}")
 add_custom_target(copy_node_artifacts ALL DEPENDS ${ARTIFACTS})
+set_target_properties(copy_node_artifacts PROPERTIES FOLDER "Node Bindings")

--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -27,6 +27,7 @@ if(NOT Boost_${PYTHON_LIB}_FOUND)
 else()
   python_add_module(python_valhalla python.cc)
   set_target_properties(python_valhalla PROPERTIES
+    FOLDER "Python Bindings"
     OUTPUT_NAME valhalla
     LINK_LIBRARIES "${PYTHON_LIBRARIES}"
     INCLUDE_DIRECTORIES "${PYTHON_INCLUDE_DIRS}")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,8 @@
 add_subdirectory(${VALHALLA_SOURCE_DIR}/third_party/googletest ${CMAKE_BINARY_DIR}/googletest)
+set_target_properties(gtest PROPERTIES FOLDER "Dependencies")
+set_target_properties(gtest_main PROPERTIES FOLDER "Dependencies")
+set_target_properties(gmock PROPERTIES FOLDER "Dependencies")
+set_target_properties(gmock_main PROPERTIES FOLDER "Dependencies")
 
 ## Lists tests
 set(tests aabb2 access_restriction actor admin attributes_controller complexrestriction countryaccess datetime directededge
@@ -32,7 +36,9 @@ endif()
 foreach(test ${tests})
   add_executable(${test} EXCLUDE_FROM_ALL ${test}.cc )
   set_target_properties(${test} PROPERTIES
+    FOLDER "Tests"
     COMPILE_DEFINITIONS VALHALLA_SOURCE_DIR="${VALHALLA_SOURCE_DIR}/")
+  create_source_groups("Source Files" ${test}.cc)
   target_link_libraries(${test} valhalla gtest gmock pthread)
   target_include_directories(${test} SYSTEM PRIVATE
       ${VALHALLA_SOURCE_DIR}/third_party/protozero/include
@@ -43,7 +49,9 @@ set(cost_tests autocost bicyclecost motorcyclecost motorscootercost pedestrianco
 foreach(test ${cost_tests})
   add_executable(${test} EXCLUDE_FROM_ALL ${VALHALLA_SOURCE_DIR}/src/sif/${test}.cc)
   set_target_properties(${test} PROPERTIES
+    FOLDER "Tests"
     COMPILE_DEFINITIONS INLINE_TEST)
+  create_source_groups("Source Files" ${VALHALLA_SOURCE_DIR}/src/sif/${test}.cc)
   target_link_libraries(${test} valhalla gtest gmock pthread)
 endforeach()
 
@@ -57,6 +65,7 @@ add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/test/data/tz.sqlite
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )
 add_custom_target(build_timezones DEPENDS ${CMAKE_BINARY_DIR}/test/data/tz.sqlite)
+set_target_properties(build_timezones PROPERTIES FOLDER "Tests")
 
 add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/test/data/utrecht_tiles/0/003/196.gph
   COMMAND ${CMAKE_COMMAND} -E make_directory test/data/utrecht_tiles/
@@ -70,6 +79,7 @@ add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/test/data/utrecht_tiles/0/003/196.
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   DEPENDS valhalla_build_tiles valhalla_add_predicted_traffic build_timezones ${VALHALLA_SOURCE_DIR}/test/data/utrecht_netherlands.osm.pbf)
 add_custom_target(utrecht_tiles DEPENDS ${CMAKE_BINARY_DIR}/test/data/utrecht_tiles/0/003/196.gph)
+set_target_properties(utrecht_tiles PROPERTIES FOLDER "Tests")
 
 add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/test/data/whitelion_tiles/2/000/814/309.gph
   COMMAND ${CMAKE_BINARY_DIR}/valhalla_build_tiles
@@ -79,6 +89,7 @@ add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/test/data/whitelion_tiles/2/000/81
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   DEPENDS valhalla_build_tiles ${VALHALLA_SOURCE_DIR}/test/data/whitelion_bristol_uk.osm.pbf)
 add_custom_target(whitelion_tiles DEPENDS ${CMAKE_BINARY_DIR}/test/data/whitelion_tiles/2/000/814/309.gph)
+set_target_properties(whitelion_tiles PROPERTIES FOLDER "Tests")
 
 add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/test/data/whitelion_tiles_reverse/2/000/814/309.gph
   COMMAND ${CMAKE_BINARY_DIR}/valhalla_build_tiles
@@ -88,6 +99,7 @@ add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/test/data/whitelion_tiles_reverse/
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   DEPENDS valhalla_build_tiles ${VALHALLA_SOURCE_DIR}/test/data/whitelion_bristol_uk_reversed_oneway.osm.pbf)
 add_custom_target(reversed_whitelion_tiles DEPENDS ${CMAKE_BINARY_DIR}/test/data/whitelion_tiles_reverse/2/000/814/309.gph)
+set_target_properties(reversed_whitelion_tiles PROPERTIES FOLDER "Tests")
 
 add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/test/data/bayfront_singapore_tiles/1/033/043.gph
   COMMAND ${CMAKE_BINARY_DIR}/valhalla_build_tiles
@@ -97,6 +109,7 @@ add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/test/data/bayfront_singapore_tiles
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   DEPENDS valhalla_build_tiles ${VALHALLA_SOURCE_DIR}/test/data/bayfront_singapore.osm.pbf)
 add_custom_target(bayfront_singapore_tiles DEPENDS ${CMAKE_BINARY_DIR}/test/data/bayfront_singapore_tiles/1/033/043.gph)
+set_target_properties(bayfront_singapore_tiles PROPERTIES FOLDER "Tests")
 
 add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/test/data/roma_tiles/1/047/352.gph
   COMMAND ${CMAKE_COMMAND} -E make_directory test/data/roma_tiles/
@@ -107,6 +120,7 @@ add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/test/data/roma_tiles/1/047/352.gph
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   DEPENDS valhalla_build_tiles valhalla_add_predicted_traffic build_timezones ${VALHALLA_SOURCE_DIR}/test/data/via_montebello_roma_italy.osm.pbf)
 add_custom_target(roma_tiles DEPENDS ${CMAKE_BINARY_DIR}/test/data/roma_tiles/1/047/352.gph)
+set_target_properties(roma_tiles PROPERTIES FOLDER "Tests")
 
 add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/test/data/melborne_tiles/0/001/251.gph
   COMMAND ${CMAKE_COMMAND} -E make_directory test/data/melborne_tiles/
@@ -117,6 +131,7 @@ add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/test/data/melborne_tiles/0/001/251
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   DEPENDS valhalla_build_tiles valhalla_add_predicted_traffic build_timezones ${VALHALLA_SOURCE_DIR}/test/data/melborne.osm.pbf)
 add_custom_target(melborne_tiles DEPENDS ${CMAKE_BINARY_DIR}/test/data/melborne_tiles/0/001/251.gph)
+set_target_properties(melborne_tiles PROPERTIES FOLDER "Tests")
 
 add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/test/data/ny_ar_tiles/2/000/752/104.gph
   COMMAND ${CMAKE_COMMAND} -E make_directory test/data/ny_ar_tiles/
@@ -127,6 +142,7 @@ add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/test/data/ny_ar_tiles/2/000/752/10
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   DEPENDS valhalla_build_tiles build_timezones ${VALHALLA_SOURCE_DIR}/test/data/ny-access-restriction.osm.pbf)
 add_custom_target(ny_ar_tiles DEPENDS ${CMAKE_BINARY_DIR}/test/data/ny_ar_tiles/2/000/752/104.gph)
+set_target_properties(ny_ar_tiles PROPERTIES FOLDER "Tests")
 
 add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/test/data/pa_ar_tiles/2/000/749/212.gph
   COMMAND ${CMAKE_COMMAND} -E make_directory test/data/pa_ar_tiles/
@@ -137,6 +153,7 @@ add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/test/data/pa_ar_tiles/2/000/749/21
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   DEPENDS valhalla_build_tiles build_timezones ${VALHALLA_SOURCE_DIR}/test/data/pa-access-restriction.osm.pbf)
 add_custom_target(pa_ar_tiles DEPENDS ${CMAKE_BINARY_DIR}/test/data/pa_ar_tiles/2/000/749/212.gph)
+set_target_properties(pa_ar_tiles PROPERTIES FOLDER "Tests")
 
 add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/test/data/nh_ar_tiles/2/000/765/074.gph
   COMMAND ${CMAKE_COMMAND} -E make_directory test/data/nh_ar_tiles/
@@ -147,6 +164,7 @@ add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/test/data/nh_ar_tiles/2/000/765/07
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   DEPENDS valhalla_build_tiles build_timezones ${VALHALLA_SOURCE_DIR}/test/data/nh-access-restriction.osm.pbf)
 add_custom_target(nh_ar_tiles DEPENDS ${CMAKE_BINARY_DIR}/test/data/nh_ar_tiles/2/000/765/074.gph)
+set_target_properties(nh_ar_tiles PROPERTIES FOLDER "Tests")
 
 
 file(GLOB locales "${VALHALLA_SOURCE_DIR}/locales/*.json")
@@ -161,6 +179,7 @@ add_custom_command(OUTPUT .locales.timestamp
   COMMENT "Compile locale definition files..."
   VERBATIM)
 add_custom_target(localedef DEPENDS .locales.timestamp)
+set_target_properties(localedef PROPERTIES FOLDER "Tests")
 
 file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/test/data)
 add_custom_command(OUTPUT test/data/sample/N00
@@ -172,6 +191,7 @@ add_custom_command(OUTPUT test/data/sample/N00
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   COMMENT "Creating test directories")
 add_custom_target(test_directories DEPENDS test/data/sample/N00)
+set_target_properties(test_directories PROPERTIES FOLDER "Tests")
 
 
 ## Test run targets
@@ -189,6 +209,7 @@ foreach(test ${tests} ${cost_tests})
     DEPENDS ${test}
     VERBATIM)
   add_custom_target(run-${test} DEPENDS ${test}.log)
+  set_target_properties(run-${test} PROPERTIES FOLDER "Tests")
 endforeach()
 
 ## Run test dependencies
@@ -238,6 +259,7 @@ if(ENABLE_PYTHON_BINDINGS AND ENABLE_DATA_TOOLS)
       python_valhalla
     VERBATIM)
   add_custom_target(run-python_valhalla DEPENDS python_valhalla.log)
+  set_target_properties(run-python_valhalla PROPERTIES FOLDER "Python Bindings")
   set(python_tests python_valhalla)
 endif()
 
@@ -262,6 +284,7 @@ if(ENABLE_NODE_BINDINGS)
       ${VALHALLA_SOURCE_DIR}/test/traffic_matcher_tiles
     VERBATIM)
   add_custom_target(run-node_valhalla DEPENDS node_valhalla.log)
+  set_target_properties(run-node_valhalla PROPERTIES FOLDER "Node Bindings")
 endif()
 
 ## High-level targets
@@ -272,5 +295,7 @@ else()
 endif()
 
 add_custom_target(check DEPENDS ${test_targets})
+set_target_properties(check PROPERTIES FOLDER "Tests")
 add_custom_target(tests DEPENDS ${tests} ${cost_tests})
+set_target_properties(tests PROPERTIES FOLDER "Tests")
 add_subdirectory(gurka)

--- a/test/gurka/CMakeLists.txt
+++ b/test/gurka/CMakeLists.txt
@@ -2,7 +2,10 @@ if(ENABLE_DATA_TOOLS)
   file(GLOB_RECURSE TEST_FILES "${CMAKE_CURRENT_LIST_DIR}/test_*.cc")
 
   add_custom_target(gurka)
+  set_target_properties(gurka PROPERTIES FOLDER "Tests")
   add_custom_target(run-gurka)
+  set_target_properties(run-gurka PROPERTIES FOLDER "Tests")
+
 
   ## Add executable targets
   foreach(FULLFILENAME IN ITEMS ${TEST_FILES})
@@ -10,7 +13,9 @@ if(ENABLE_DATA_TOOLS)
     string(REGEX REPLACE "test_(.*).cc" "gurka_\\1" TESTNAME ${FILENAME})
     add_executable(${TESTNAME} EXCLUDE_FROM_ALL ${FILENAME} ${VALHALLA_SOURCE_DIR}/third_party/microtar/src/microtar.c)
     set_target_properties(${TESTNAME} PROPERTIES
+      FOLDER "Tests"
       COMPILE_DEFINITIONS VALHALLA_SOURCE_DIR="${VALHALLA_SOURCE_DIR}/")
+    create_source_groups("Source Files" ${FILENAME} ${VALHALLA_SOURCE_DIR}/third_party/microtar/src/microtar.c)
     target_link_libraries(${TESTNAME} valhalla gtest_main gmock pthread)
     target_include_directories(${TESTNAME} SYSTEM PRIVATE
       ${VALHALLA_SOURCE_DIR}/third_party/microtar/src
@@ -32,6 +37,7 @@ if(ENABLE_DATA_TOOLS)
       DEPENDS ${TESTNAME}
       VERBATIM)
     add_custom_target(run-${TESTNAME} DEPENDS ${TESTNAME}.log)
+    set_target_properties(run-${TESTNAME} PROPERTIES FOLDER "Tests")
     add_dependencies(gurka ${TESTNAME})
     add_dependencies(run-gurka run-${TESTNAME})
   endforeach()


### PR DESCRIPTION
# Issue

Before:
![image](https://user-images.githubusercontent.com/52399/79870062-aad2a300-83e2-11ea-897f-e8d9233a69dd.png)

After:
![image](https://user-images.githubusercontent.com/52399/79870123-c3db5400-83e2-11ea-95a5-ad4154013ff0.png)

This makes it easier to navigate in UIs like Xcode, because it shows the full file path in the breadcrumb bar as well.

`source_group(TREE ...)` was added in CMake 3.8, hence the minimum requirement bump. Our current CI builders use versions >= 3.15.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
