### PR TITLE
Add rapidjson schema to the baldr rapidjson wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
    * ADDED: Implement per-location search filters for functional road class and forms of way. [#2289](https://github.com/valhalla/valhalla/pull/2289)
    * ADDED: Approach, multi-cue, and length updates [#2313](https://github.com/valhalla/valhalla/pull/2313)
    * ADDED: Speed up timezone differencing calculation if cache is provided. [#2316](https://github.com/valhalla/valhalla/pull/2316)
+   * ADDED: Added rapidjson/schema.h to baldr/rapidjson_util.h to make it available for use within valhalla. [#2330](https://github.com/valhalla/valhalla/issues/2330)
 
 ## Release Date: 2019-11-21 Valhalla 3.0.9
 * **Bug Fix**

--- a/valhalla/baldr/rapidjson_utils.h
+++ b/valhalla/baldr/rapidjson_utils.h
@@ -27,6 +27,7 @@
 #include <rapidjson/pointer.h>
 #include <rapidjson/prettywriter.h>
 #include <rapidjson/rapidjson.h>
+#include <rapidjson/schema.h>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 


### PR DESCRIPTION
Added rapidjson/schema.h to baldr/rapidjson_util.h. This makes json
schema validation functionality available within valhalla.

Fixes #2330
