### PR TITLE
Removed unnecessary include.

### DIFF
--- a/valhalla/baldr/tilegetter.h
+++ b/valhalla/baldr/tilegetter.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <valhalla/baldr/curler.h>
-
 #include <functional>
 #include <string>
 #include <vector>


### PR DESCRIPTION
This include broke the compilation because we had in tile_getter.h `#include <valhalla/baldr/curler.h>` and in curler.h `#include <valhalla/baldr/tile_getter.h>`