### PR TITLE
Adds glog (Google logging) support.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "third_party/benchmark"]
 	path = third_party/benchmark
 	url = https://github.com/google/benchmark
+[submodule "third_party/glog"]
+	path = third_party/glog
+	url = https://github.com/google/glog

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,6 +232,9 @@ elseif(NOT Boost_FOUND)
 endif()
 add_definitions(-DBOOST_NO_CXX11_SCOPED_ENUMS)
 
+## Add external logging
+add_subdirectory(third_party/glog)
+
 ## libvalhalla
 add_subdirectory(src)
 

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -35,3 +35,4 @@ macro (add_valhalla_benchmark target_file)
 endmacro()
 
 add_subdirectory(meili)
+add_subdirectory(midgard)

--- a/bench/midgard/CMakeLists.txt
+++ b/bench/midgard/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_valhalla_benchmark(logging)

--- a/bench/midgard/logging.cc
+++ b/bench/midgard/logging.cc
@@ -1,0 +1,79 @@
+#include <benchmark/benchmark.h>
+#include <glog/logging.h>
+
+#include "midgard/logging.h"
+
+namespace {
+
+static void BM_BasicInfoLoggingMidgard(benchmark::State& state) {
+  // valhalla::midgard::logging::Configure({{"type", ""}});
+  valhalla::midgard::logging::Configure({{"type", "file"}, {"file_name", "/tmp/benchmarking.log"}});
+  for (auto _ : state) {
+    LOG_INFO("HELLO!");
+  }
+}
+
+BENCHMARK(BM_BasicInfoLoggingMidgard);
+BENCHMARK(BM_BasicInfoLoggingMidgard)->Threads(1);
+BENCHMARK(BM_BasicInfoLoggingMidgard)->Threads(2);
+BENCHMARK(BM_BasicInfoLoggingMidgard)->Threads(4);
+BENCHMARK(BM_BasicInfoLoggingMidgard)->Threads(8);
+BENCHMARK(BM_BasicInfoLoggingMidgard)->Threads(16);
+
+static void BM_BasicInfoLoggingMidgard10k(benchmark::State& state) {
+  // valhalla::midgard::logging::Configure({{"type", ""}});
+  valhalla::midgard::logging::Configure({{"type", "file"}, {"file_name", "/tmp/benchmarking.log"}});
+  for (auto _ : state) {
+    size_t n = 10000;
+    while (n--) {
+      LOG_INFO("HELLO!");
+    }
+  }
+}
+
+BENCHMARK(BM_BasicInfoLoggingMidgard10k);
+BENCHMARK(BM_BasicInfoLoggingMidgard10k)->Threads(1);
+BENCHMARK(BM_BasicInfoLoggingMidgard10k)->Threads(2);
+BENCHMARK(BM_BasicInfoLoggingMidgard10k)->Threads(4);
+BENCHMARK(BM_BasicInfoLoggingMidgard10k)->Threads(8);
+BENCHMARK(BM_BasicInfoLoggingMidgard10k)->Threads(16);
+
+static void BM_BasicInfoLogging(benchmark::State& state) {
+  for (auto _ : state) {
+    LOG(INFO) << "Hello!";
+  }
+}
+
+BENCHMARK(BM_BasicInfoLogging);
+BENCHMARK(BM_BasicInfoLogging)->Threads(1);
+BENCHMARK(BM_BasicInfoLogging)->Threads(2);
+BENCHMARK(BM_BasicInfoLogging)->Threads(4);
+BENCHMARK(BM_BasicInfoLogging)->Threads(8);
+BENCHMARK(BM_BasicInfoLogging)->Threads(16);
+
+static void BM_BasicInfoLogging10k(benchmark::State& state) {
+  for (auto _ : state) {
+    size_t n = 10000;
+    while (n--) {
+      LOG(INFO) << "Hello!";
+    }
+  }
+}
+
+BENCHMARK(BM_BasicInfoLogging10k);
+BENCHMARK(BM_BasicInfoLogging10k)->Threads(1);
+BENCHMARK(BM_BasicInfoLogging10k)->Threads(2);
+BENCHMARK(BM_BasicInfoLogging10k)->Threads(4);
+BENCHMARK(BM_BasicInfoLogging10k)->Threads(8);
+BENCHMARK(BM_BasicInfoLogging10k)->Threads(16);
+
+} // namespace
+
+int main(int argc, char** argv) {
+  benchmark::Initialize(&argc, argv);
+  FLAGS_logtostderr = false;
+  google::InitGoogleLogging("logging-test");
+  if (benchmark::ReportUnrecognizedArguments(argc, argv))
+    return 1;
+  benchmark::RunSpecifiedBenchmarks();
+}

--- a/src/meili/CMakeLists.txt
+++ b/src/meili/CMakeLists.txt
@@ -25,4 +25,5 @@ valhalla_module(NAME meili
   DEPENDS
     valhalla::sif
     ${valhalla_protobuf_targets}
-    Boost::boost)
+    Boost::boost
+    glog::glog)

--- a/src/meili/valhalla_run_map_match.cc
+++ b/src/meili/valhalla_run_map_match.cc
@@ -47,7 +47,7 @@ int main(int argc, char* argv[]) {
   rapidjson::read_json(argv[1], config);
   const std::string modename = config.get<std::string>("meili.mode");
   valhalla::Costing costing;
-  CHECK(!valhalla::Costing_Enum_Parse(modename, &costing)) << "No costing method found";
+  CHECK(valhalla::Costing_Enum_Parse(modename, &costing)) << "No costing method found";
 
   MapMatcherFactory matcher_factory(config);
   auto mapmatcher = matcher_factory.Create(costing);

--- a/src/meili/valhalla_run_map_match.cc
+++ b/src/meili/valhalla_run_map_match.cc
@@ -1,6 +1,7 @@
-#include "baldr/rapidjson_utils.h"
 #include <boost/property_tree/ptree.hpp>
+#include <glog/logging.h>
 
+#include "baldr/rapidjson_utils.h"
 #include "meili/map_matcher_factory.h"
 #include "meili/measurement.h"
 
@@ -36,8 +37,9 @@ ReadMeasurements(istream_t& istream, float default_gps_accuracy, float default_s
 }
 
 int main(int argc, char* argv[]) {
+  google::InitGoogleLogging(argv[0]);
   if (argc < 2) {
-    std::cout << "usage: map_matching CONFIG" << std::endl;
+    LOG(ERROR) << "usage: map_matching CONFIG";
     return 1;
   }
 
@@ -45,9 +47,7 @@ int main(int argc, char* argv[]) {
   rapidjson::read_json(argv[1], config);
   const std::string modename = config.get<std::string>("meili.mode");
   valhalla::Costing costing;
-  if (!valhalla::Costing_Enum_Parse(modename, &costing)) {
-    throw std::runtime_error("No costing method found");
-  }
+  CHECK(!valhalla::Costing_Enum_Parse(modename, &costing)) << "No costing method found";
 
   MapMatcherFactory matcher_factory(config);
   auto mapmatcher = matcher_factory.Create(costing);


### PR DESCRIPTION
This is a draft PR demonstrating the use of glog's configurable
logging and assertion macros. A few benefits: log-level
configurability, thread-safety, pretty-good (but synchronous
performance), assertion macros, and signal handlers with clean
backtraces (what logbt provides). There are really great capabilities
outlined in the documentation linked below.

Regarding performance: My understanding is that we don't have a lot of
high-throughput logging use cases out of Valhalla (like logging at
usec resolution), but if we do and we are extremely concerned about
blocking, my understanding is that we can extend
`google::base::Logger` with a minimal amount of hassle. Here's an
example of how to do that:
https://github.com/apache/kudu/blob/master/src/kudu/util/async_logger.h#L36.

Documentation:
- https://github.com/google/glog/blob/master/src/glog/logging.h.in#L155x
- https://github.com/google/glog/blob/master/doc/glog.html
- Rendered: https://hpc.nih.gov/development/glog.html

Follow up to:
- https://github.com/valhalla/valhalla/pull/2216

/cc @kevinkreiser @a-kosak-mbx @mandeepsandhu