### PR TITLE
Fixes deprecation warning about SQLite package naming

### DIFF
--- a/cmake/FindSQLite3.cmake
+++ b/cmake/FindSQLite3.cmake
@@ -82,7 +82,7 @@ set(SQLITE3_LIBRARIES
 # Handle the QUIETLY and REQUIRED arguments and set SQLITE3_FOUND to TRUE
 # if all listed variables are TRUE
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(SQLITE3
+find_package_handle_standard_args(SQLite3
   DEFAULT_MSG
   SQLITE3_LIBRARIES
   SQLITE3_INCLUDE_DIR)


### PR DESCRIPTION
Specifically:
```
CMake Warning (dev) at /usr/share/cmake-3.17/Modules/FindPackageHandleStandardArgs.cmake:272 (message):
  The package name passed to `find_package_handle_standard_args` (SQLITE3)
  does not match the name of the calling package (SQLite3).  This can lead to
  problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  cmake/FindSQLite3.cmake:85 (find_package_handle_standard_args)
  CMakeLists.txt:219 (find_package)
```

 Link any requirements here. Other pull requests this PR is based on?
