### PR TITLE
Path comparison updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
    * FIXED: Fix shape trimming in leg building for snap candidates that lie within the margin of rounding error [#2326](https://github.com/valhalla/valhalla/pull/2326)
    * FIXED: Fixes route duration underflow with traffic data [#2325](https://github.com/valhalla/valhalla/pull/2325)
    * FIXED: Parse mtb:scale tags and set bicycle access if present [#2117](https://github.com/valhalla/valhalla/pull/2117)
+   * FIXED: Fixed segfault.  Shape was missing from options for valhalla_path_comparison and valhalla_run_route.  Also, costing options was missing in valhalla_path_comparison. [#2343](https://github.com/valhalla/valhalla/pull/2343)
 
 * **Enhancement**
    * ADDED: Add ability to provide custom implementation for candidate collection in CandidateQuery. [#2328](https://github.com/valhalla/valhalla/pull/2328)

--- a/src/valhalla_path_comparison.cc
+++ b/src/valhalla_path_comparison.cc
@@ -270,6 +270,13 @@ int main(int argc, char* argv[]) {
   // Get something we can use to fetch tiles
   valhalla::baldr::GraphReader reader(pt.get_child("mjolnir"));
 
+  if (!map_match) {
+    valhalla::Options options;
+    for (int i = 0; i < valhalla::Costing_MAX; ++i) {
+      request.mutable_options()->add_costing_options();
+    }
+  }
+
   // Construct costing
   CostFactory<DynamicCost> factory;
   factory.RegisterStandardCostingModels();
@@ -279,6 +286,7 @@ int main(int argc, char* argv[]) {
   } else {
     throw std::runtime_error("No costing method found");
   }
+
   cost_ptr_t cost_ptr = factory.Create(request.options());
 
   // If a shape is entered use edge walking

--- a/src/valhalla_path_comparison.cc
+++ b/src/valhalla_path_comparison.cc
@@ -298,7 +298,6 @@ int main(int argc, char* argv[]) {
   } else {
     throw std::runtime_error("No costing method found");
   }
-
   cost_ptr_t cost_ptr = factory.Create(request.options());
 
   // If a shape is entered use edge walking

--- a/src/valhalla_path_comparison.cc
+++ b/src/valhalla_path_comparison.cc
@@ -126,7 +126,7 @@ void walk_edges(const std::string& shape, GraphReader& reader, const cost_ptr_t&
     PathLocation::toPBF(path_location.back(), options.mutable_locations()->Add(), reader);
   }
   std::vector<PathInfo> path;
-    std::vector<PathLocation> correlated;
+  std::vector<PathLocation> correlated;
   bool rtn = RouteMatcher::FormPath(mode_costing, mode, reader, trace, options, path);
   if (!rtn) {
     std::cerr << "ERROR: RouteMatcher returned false - did not match complete shape." << std::endl;

--- a/src/valhalla_path_comparison.cc
+++ b/src/valhalla_path_comparison.cc
@@ -86,36 +86,48 @@ void walk_edges(const std::string& shape, GraphReader& reader, const cost_ptr_t&
   cost_ptr_t mode_costing[10];
   mode_costing[static_cast<uint32_t>(mode)] = cost_ptr;
 
-  // Decode the shape
+  // Get shape
   std::vector<PointLL> shape_pts = decode<std::vector<PointLL>>(shape);
   if (shape_pts.size() <= 1) {
     std::cerr << "Not enough shape points to compute the path...exiting" << std::endl;
   }
+  std::vector<Measurement> trace;
+  trace.reserve(shape_pts.size());
+  std::transform(shape_pts.begin(), shape_pts.end(), std::back_inserter(trace), [](const PointLL& p) {
+    return Measurement{p, 10, 10};
+  });
 
-  std::vector<Measurement> measurements;
-  measurements.reserve(shape_pts.size());
-  for (const auto& ll : shape_pts) {
-    measurements.emplace_back(Measurement{ll, 10, 10});
-  }
+  // Use the shape to form a single edge correlation at the start and end of
+  // the shape (using heading).
+  std::vector<valhalla::baldr::Location> locations{shape_pts.front(), shape_pts.back()};
+  locations.front().heading_ = std::round(PointLL::HeadingAlongPolyline(shape_pts, 30.f));
+  locations.back().heading_ = std::round(PointLL::HeadingAtEndOfPolyline(shape_pts, 30.f));
 
-  // Add a location for the origin (first shape point) and destination (last
-  // shape point)
-  std::vector<baldr::Location> locations;
-  locations.push_back({shape_pts.front()});
-  locations.push_back({shape_pts.back()});
-  const auto projections = Search(locations, reader, cost_ptr);
+  std::shared_ptr<DynamicCost> cost = mode_costing[static_cast<uint32_t>(mode)];
+  const auto projections = Search(locations, reader, cost);
   std::vector<PathLocation> path_location;
   valhalla::Options options;
-  for (const auto& loc : locations) {
-    try {
-      path_location.push_back(projections.at(loc));
-      PathLocation::toPBF(path_location.back(), options.mutable_locations()->Add(), reader);
-    } catch (...) { return; }
+
+  for (const auto& ll : shape_pts) {
+    auto* sll = options.mutable_shape()->Add();
+    sll->mutable_ll()->set_lat(ll.lat());
+    sll->mutable_ll()->set_lng(ll.lng());
+    // set type to via by default
+    sll->set_type(valhalla::Location::kVia);
+  }
+  // first and last always get type break
+  if (options.shape_size()) {
+    options.mutable_shape(0)->set_type(valhalla::Location::kBreak);
+    options.mutable_shape(options.shape_size() - 1)->set_type(valhalla::Location::kBreak);
   }
 
-  std::vector<PathInfo> path_infos;
-  std::vector<PathLocation> correlated;
-  bool rtn = RouteMatcher::FormPath(mode_costing, mode, reader, measurements, options, path_infos);
+  for (const auto& loc : locations) {
+    path_location.push_back(projections.at(loc));
+    PathLocation::toPBF(path_location.back(), options.mutable_locations()->Add(), reader);
+  }
+  std::vector<PathInfo> path;
+    std::vector<PathLocation> correlated;
+  bool rtn = RouteMatcher::FormPath(mode_costing, mode, reader, trace, options, path);
   if (!rtn) {
     std::cerr << "ERROR: RouteMatcher returned false - did not match complete shape." << std::endl;
   }
@@ -124,7 +136,7 @@ void walk_edges(const std::string& shape, GraphReader& reader, const cost_ptr_t&
   uint64_t current_osmid = 0;
   Cost edge_total;
   Cost trans_total;
-  for (const auto& path_info : path_infos) {
+  for (const auto& path_info : path) {
     // std::cout << "lat: " << result.lnglat.lat() << " lon: " << result.lnglat.lng() << std::endl;
     if (path_info.edgeid == current_id || path_info.edgeid == kInvalidGraphId) {
       continue;

--- a/src/valhalla_run_route.cc
+++ b/src/valhalla_run_route.cc
@@ -206,6 +206,20 @@ const valhalla::TripLeg* PathTest(GraphReader& reader,
     const auto projections = Search(locations, reader, cost);
     std::vector<PathLocation> path_location;
     valhalla::Options options;
+
+    for (const auto& ll : shape) {
+      auto* sll = options.mutable_shape()->Add();
+      sll->mutable_ll()->set_lat(ll.lat());
+      sll->mutable_ll()->set_lng(ll.lng());
+      // set type to via by default
+      sll->set_type(valhalla::Location::kVia);
+    }
+    // first and last always get type break
+    if (options.shape_size()) {
+      options.mutable_shape(0)->set_type(valhalla::Location::kBreak);
+      options.mutable_shape(options.shape_size() - 1)->set_type(valhalla::Location::kBreak);
+    }
+
     for (const auto& loc : locations) {
       path_location.push_back(projections.at(loc));
       PathLocation::toPBF(path_location.back(), options.mutable_locations()->Add(), reader);


### PR DESCRIPTION
# Issue

At some point these two binaries got out of date.  Updated.  

Sample command
`./valhalla_path_comparison -s 'crjgkA~lthpCLiMxBofBgm@{AgM?uZxCU?' -t auto --config ../../conf/valhalla.conf`

```
+++++++++++++++++++++++++++++++++++++
wayid: 11929406
name: West Main Street
+++++++++++++++++++++++++++++++++++++

----------Edge----------
Edge GraphId: 0/2905/191349
Edge length: 130
EdgeCost cost: 10.8225 secs: 11.7
------------------------

-------Transition-------
Pred GraphId: 0/2905/191349
TransitionCost cost: 0 secs: 0
------------------------

----------Edge----------
Edge GraphId: 0/2905/192090
Edge length: 141
EdgeCost cost: 11.7383 secs: 12.69
------------------------

+++++++++++++++++++++++++++++++++++++
wayid: 76951972
name: North Decatur Street
+++++++++++++++++++++++++++++++++++++

-------Transition-------
Pred GraphId: 0/2905/192090
TransitionCost cost: 7.5 secs: 7.5
------------------------

----------Edge----------
Edge GraphId: 0/2905/191361
Edge length: 202
EdgeCost cost: 16.8165 secs: 18.18
------------------------

+------------------------------------------------------------------------+
| Total Edge Cost       :    39.3773  Total Edge Secs       :      42.57 |
| Total Transition Cost :        7.5  Total Transition Secs :        7.5 |
| Total Cost            :    46.8773  Total Secs            :      50.07 |
+------------------------------------------------------------------------+

```

## Tasklist

 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
