### PR TITLE
Add missing file

### DIFF
--- a/docs/api/turn-by-turn/add-routing-to-a-map.md
+++ b/docs/api/turn-by-turn/add-routing-to-a-map.md
@@ -2,7 +2,7 @@
 
 The [result of a routing request](api-reference/#outputs-of-a-route) is a special format that needs some processing to show in a JavaScript-based web map application.
 
-For [Leaflet](http://leafletjs.com/) the [Leaflet Routing Machine](https://www.liedman.net/leaflet-routing-machine/) throught plugin [lrm-valhalla](https://github.com/valhalla/lrm-valhalla), as shown in [this outdated, but good tutorial](https://github.com/valhalla/valhalla-docs/blob/master/turn-by-turn/add-routing-to-a-map.md) helps.
-Please note that [mapzen](https://github.com/mapzen/mapzen.js) was shutdown, so you have set ```serviceUrl``` within the ```options``` of ```L.Routing.mapzen``` router to your Valhalla route service!
+For [Leaflet](http://leafletjs.com/), the [Leaflet Routing Machine](https://www.liedman.net/leaflet-routing-machine/) via the [lrm-valhalla](https://github.com/valhalla/lrm-valhalla) plugin (as shown in [this outdated, but good tutorial](https://github.com/valhalla/valhalla-docs/blob/master/turn-by-turn/add-routing-to-a-map.md)) helps.
+Please note that [mapzen](https://github.com/mapzen/mapzen.js) urls are no longer available, so one must set the ```serviceUrl``` within the ```options``` of the ```L.Routing.mapzen``` router to point to a valid Valhalla route service!
 
 You can review the [documentation](api-reference.md) to learn more about routing with Turn-by-Turn.

--- a/docs/api/turn-by-turn/add-routing-to-a-map.md
+++ b/docs/api/turn-by-turn/add-routing-to-a-map.md
@@ -1,0 +1,8 @@
+# Add Turn-by-Turn routing to a map
+
+The [result of a routing request](api-reference/#outputs-of-a-route) is a special format that needs some processing to show in a JavaScript-based web map application.
+
+For [Leaflet](http://leafletjs.com/) the [Leaflet Routing Machine](https://www.liedman.net/leaflet-routing-machine/) throught plugin [lrm-valhalla](https://github.com/valhalla/lrm-valhalla), as shown in [this outdated, but good tutorial](https://github.com/valhalla/valhalla-docs/blob/master/turn-by-turn/add-routing-to-a-map.md) helps.
+Please note that [mapzen](https://github.com/mapzen/mapzen.js) was shutdown, so you have set ```serviceUrl``` within the ```options``` of ```L.Routing.mapzen``` router to your Valhalla route service!
+
+You can review the [documentation](api-reference.md) to learn more about routing with Turn-by-Turn.


### PR DESCRIPTION
fixes #1894 additional to #2347 re-added missing file linked add-routing-to-a-map.md as "display Valhalla routes" in overview.md removed on 08.06.2018 as "outdated docs"

The other option is to remove the whole sentence "You can display Valhalla routes on web and mobile maps." in overview.md