### PR TITLE
Do Lua transform *after* checking for way tags we're not interested in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
    * ADDED: Add support for live traffic. [#2268](https://github.com/valhalla/valhalla/pull/2268)
    * ADDED: Implement per-location search filters for functional road class and forms of way. [#2289](https://github.com/valhalla/valhalla/pull/2289)
    * ADDED: Approach, multi-cue, and length updates [#2313](https://github.com/valhalla/valhalla/pull/2313)
+   * CHANGED: Speed up parsing by skipping Lua callout for building/landuse/etc ways [#2350](https://github.com/valhalla/valhalla/pull/2350)
 
 ## Release Date: 2019-11-21 Valhalla 3.0.9
 * **Bug Fix**

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -251,23 +251,29 @@ public:
       return;
     }
 
-    // Transform tags. If no results that means the way does not have tags
-    // suitable for use in routing.
-    Tags results = lua_.Transform(OSMType::kWay, tags);
-    if (results.size() == 0) {
+    // Don't bother calling out to Lua for ways with no tags at all - they're
+    // not routable without any metadata on them.
+    if (tags.size() == 0) {
       return;
     }
 
     // Throw away closed features with following tags: building, landuse,
     // leisure, natural. See: http://wiki.openstreetmap.org/wiki/Key:area
     if (nodes[0] == nodes[nodes.size() - 1]) {
-      for (const auto& tag : results) {
+      for (const auto& tag : tags) {
         if (tag.first == "building" || tag.first == "landuse" || tag.first == "leisure" ||
             tag.first == "natural") {
           // LOG_INFO("Loop wayid " + std::to_string(osmid) + " Discard?");
           return;
         }
       }
+    }
+
+    // Transform tags. If no results that means the way does not have tags
+    // suitable for use in routing.
+    Tags results = lua_.Transform(OSMType::kWay, tags);
+    if (results.size() == 0) {
+      return;
     }
 
     // Throw away driveways if include_driveways_ is false


### PR DESCRIPTION
# Issue

This PR moves a check for uninteresting way tags (like `building=yes`) to *before* our Lua transform.  If these tags are on the way in the OSM PBF, we know we won't be interested in them for routing, so we don't need to bother wasting time calling out to Lua.

Also adds a check if there are no tags at all, and returns right away (again, avoiding the Lua callout).

Adds a modest 8% speedup - will likely be more on maps that have many buildings mapped (they are by far the most populous `way` tag in OSM).

```sh
# Before
$ /usr/bin/time ./valhalla_build_tiles -c config.json bulgaria-latest.osm.pbf
      143.77 real       207.92 user        12.37 sys
# After
$ /usr/bin/time ./valhalla_build_tiles -c config.json bulgaria-latest.osm.pbf
      125.32 real       199.24 user        11.19 sys
```

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
