### PR TITLE
Create OpenLR Records from Raw Data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
    * ADDED: Use both imminent and distant verbal multi-cue phrases. [2353](https://github.com/valhalla/valhalla/pull/2353)
    * CHANGED: Speed up graph enhancing by avoiding continuous unordered_set rebuilding [#2349](https://github.com/valhalla/valhalla/pull/2349)
    * CHANGED: Skip calling out to Lua for nodes/ways/relations with not tags - speeds up parsing. [#2351](https://github.com/valhalla/valhalla/pull/2351)
+   * ADDED: Ability to create OpenLR records from raw data. [2356](https://github.com/valhalla/valhalla/pull/2356)
 
 ## Release Date: 2019-11-21 Valhalla 3.0.9
 * **Bug Fix**

--- a/test/openlr.cc
+++ b/test/openlr.cc
@@ -1,4 +1,5 @@
 #include "midgard/openlr.h"
+#include "midgard/pointll.h"
 
 #include <boost/archive/iterators/base64_from_binary.hpp>
 #include <boost/archive/iterators/binary_from_base64.hpp>
@@ -12,6 +13,7 @@
 
 namespace {
 
+using namespace valhalla::midgard;
 using namespace valhalla::midgard::OpenLR;
 
 std::string decode64(const std::string& val) {
@@ -71,12 +73,12 @@ TEST(OpenLR, Decode) {
 
     EXPECT_NEAR(locRef.getFirstCoordinate().lng(), fixture.expectedFirstCoordinateLongitude, 1e-5);
     EXPECT_NEAR(locRef.getFirstCoordinate().lat(), fixture.expectedFirstCoordinateLatitude, 1e-5);
-    EXPECT_NEAR(locRef.first.bearing, fixture.expectedFirstCoordinateBearing, 1e-5);
+    EXPECT_NEAR(locRef.lrps[0].bearing, fixture.expectedFirstCoordinateBearing, 1e-5);
     EXPECT_NEAR(locRef.getLastCoordinate().lng(), fixture.expectedLastCoordinateLongitude, 1e-5);
     EXPECT_NEAR(locRef.getLastCoordinate().lat(), fixture.expectedLastCoordinateLatitude, 1e-5);
-    EXPECT_NEAR(locRef.last.bearing, fixture.expectedLastCoordinateBearing, 1e-5);
+    EXPECT_NEAR(locRef.lrps.back().bearing, fixture.expectedLastCoordinateBearing, 1e-5);
 
-    EXPECT_NEAR(locRef.first.distance, fixture.expectedDistance, 1e-3);
+    EXPECT_NEAR(locRef.lrps[0].distance, fixture.expectedDistance, 1e-3);
     EXPECT_NEAR(locRef.poff, fixture.expectedPoff, 1e-3);
     EXPECT_NEAR(locRef.noff, fixture.expectedNoff, 1e-3);
 
@@ -85,13 +87,13 @@ TEST(OpenLR, Decode) {
     // values. TODO - this currently fails for 32 bit
 #if _WIN64 || __amd64__
     if (encode64(locRef.toBinary()) != fixture.descriptor) {
-      locRef.first.latitude = fixture.expectedFirstCoordinateLatitude;
-      locRef.first.longitude = fixture.expectedFirstCoordinateLongitude;
-      locRef.first.bearing = fixture.expectedFirstCoordinateBearing;
-      locRef.last.latitude = fixture.expectedLastCoordinateLatitude;
-      locRef.last.longitude = fixture.expectedLastCoordinateLongitude;
-      locRef.last.bearing = fixture.expectedLastCoordinateBearing;
-      locRef.first.distance = fixture.expectedDistance;
+      locRef.lrps[0].latitude = fixture.expectedFirstCoordinateLatitude;
+      locRef.lrps[0].longitude = fixture.expectedFirstCoordinateLongitude;
+      locRef.lrps[0].bearing = fixture.expectedFirstCoordinateBearing;
+      locRef.lrps.back().latitude = fixture.expectedLastCoordinateLatitude;
+      locRef.lrps.back().longitude = fixture.expectedLastCoordinateLongitude;
+      locRef.lrps.back().bearing = fixture.expectedLastCoordinateBearing;
+      locRef.lrps[0].distance = fixture.expectedDistance;
       locRef.poff = fixture.expectedPoff;
       locRef.noff = fixture.expectedNoff;
       EXPECT_EQ(encode64(locRef.toBinary()), fixture.descriptor);
@@ -106,29 +108,28 @@ TEST(OpenLR, InternalReferencePoints) {
   auto locRef = LineLocation(decode64(location));
 
   EXPECT_EQ(encode64(locRef.toBinary()), location);
-  EXPECT_EQ(locRef.intermediate.size(), 1) << "Incorrectly number of intermediate LRP";
+  EXPECT_EQ(locRef.lrps.size(), 3) << "Incorrectly number of intermediate LRP";
 
   EXPECT_NEAR(locRef.getFirstCoordinate().lng(), 2.400523, 1e-5);
   EXPECT_NEAR(locRef.getFirstCoordinate().lat(), 48.819069, 1e-5);
-  EXPECT_NEAR(locRef.first.bearing, 320.625, 1e-5);
-  EXPECT_NEAR(locRef.first.distance, 12774.8, 1e-3);
+  EXPECT_NEAR(locRef.lrps[0].bearing, 320.625, 1e-5);
+  EXPECT_NEAR(locRef.lrps[0].distance, 12774.8, 1e-3);
 
-  EXPECT_NEAR(locRef.intermediate[0].longitude, 2.269843, 1e-5);
-  EXPECT_NEAR(locRef.intermediate[0].latitude, 48.840829, 1e-5);
-  EXPECT_NEAR(locRef.intermediate[0].bearing, 219.375, 1e-5);
-  EXPECT_NEAR(locRef.intermediate[0].distance, 12774.8, 1e-3);
+  EXPECT_NEAR(locRef.lrps[1].longitude, 2.269843, 1e-5);
+  EXPECT_NEAR(locRef.lrps[1].latitude, 48.840829, 1e-5);
+  EXPECT_NEAR(locRef.lrps[1].bearing, 219.375, 1e-5);
+  EXPECT_NEAR(locRef.lrps[1].distance, 12774.8, 1e-3);
 
   EXPECT_NEAR(locRef.getLastCoordinate().lng(), 2.261823, 1e-5);
   EXPECT_NEAR(locRef.getLastCoordinate().lat(), 48.893158, 1e-5);
-  EXPECT_NEAR(locRef.last.bearing, 39.375, 1e-5);
+  EXPECT_NEAR(locRef.lrps.back().bearing, 39.375, 1e-5);
 
   EXPECT_NEAR(locRef.getLength(), 2 * 12774.8, 1e-3);
   EXPECT_NEAR(locRef.poff, 0, 1e-3);
   EXPECT_NEAR(locRef.noff, 0, 1e-3);
 
-  for (float poff = 0; poff < locRef.first.distance; poff += locRef.first.distance / 3) {
-    for (float noff = 0; noff < locRef.intermediate[0].distance;
-         noff += locRef.intermediate[0].distance / 3) {
+  for (float poff = 0; poff < locRef.lrps[0].distance; poff += locRef.lrps[0].distance / 3) {
+    for (float noff = 0; noff < locRef.lrps[1].distance; noff += locRef.lrps[1].distance / 3) {
       locRef.poff = poff;
       locRef.noff = noff;
       LineLocation tryRef(locRef.toBinary());
@@ -139,9 +140,15 @@ TEST(OpenLR, InternalReferencePoints) {
     }
   }
 
+  /*
   locRef.intermediate.push_back(locRef.intermediate.front());
   locRef.intermediate.push_back(locRef.intermediate.front());
   locRef.intermediate.push_back(locRef.intermediate.front());
+   */
+
+  locRef.lrps.insert(std::prev(std::prev(locRef.lrps.end())), locRef.lrps[1]);
+  locRef.lrps.insert(std::prev(std::prev(locRef.lrps.end())), locRef.lrps[1]);
+  locRef.lrps.insert(std::prev(std::prev(locRef.lrps.end())), locRef.lrps[1]);
   EXPECT_NEAR(locRef.getLength(), 5 * 12774.8, 1e-3) << "Distance incorrect.";
 
   auto hex = " 0b 01 b5 01 22 b7 3e 10 fc da cc f4 08 80 10 f3 da "
@@ -159,6 +166,46 @@ TEST(OpenLR, OffsetsOverrun) {
 TEST(OpenLR, TooSmallReference) {
   auto location = "CwG1ASK3PhD82=";
   EXPECT_THROW(auto locRef = LineLocation(decode64(location)), std::invalid_argument);
+}
+
+TEST(OpenLR, CreateLinearReference) {
+  // make a reference directly using lrps
+  std::vector<PointLL> points{{-76.55015772558436, 40.482238379871575},
+                              {-76.55060287976856, 40.48275880818994},
+                              {-76.55108895828207, 40.489983794570605},
+                              {-76.54576249703334, 40.49195968608316}};
+  std::vector<LocationReferencePoint> lrps;
+  unsigned char frc = 0;
+  auto fow = LocationReferencePoint::FormOfWay::MOTORWAY;
+  unsigned char lowest_frc_next_point = 7;
+  uint16_t bearing;
+  for (const auto& p : points) {
+    // frc and fow are 3 bits wide, we dont use the last 2 bits for anything
+    unsigned char attribute1 = (frc << 3) | fow;
+    // first or intermediate point
+    if (&p != &points.back()) {
+      bearing = static_cast<uint16_t>(p.Heading(*std::next(&p)));
+      auto distance = p.Distance(*std::next(&p));
+      lrps.emplace_back(p.lng(), p.lat(), bearing, frc, fow, lrps.empty() ? nullptr : &lrps.back(),
+                        distance, lowest_frc_next_point);
+    } // last point
+    else {
+      bearing += 180;
+      bearing %= 360;
+      lrps.emplace_back(p.lng(), p.lat(), bearing, frc, fow, lrps.empty() ? nullptr : &lrps.back());
+    }
+    // try different frcs and fows for kicks
+    ++frc;
+    fow = static_cast<LocationReferencePoint::FormOfWay>(static_cast<uint8_t>(fow) + 1);
+    --lowest_frc_next_point;
+  }
+  LineLocation line_location(lrps, 0, 0);
+
+  // do a round trip conversion
+  LineLocation converted(line_location.toBinary());
+
+  // compare to the original reference before conversion
+  EXPECT_EQ(line_location, converted);
 }
 
 } // namespace

--- a/test/openlr.cc
+++ b/test/openlr.cc
@@ -144,6 +144,10 @@ TEST(OpenLR, InternalReferencePoints) {
   locRef.lrps.insert(std::prev(std::prev(locRef.lrps.end())), locRef.lrps[1]);
   locRef.lrps.insert(std::prev(std::prev(locRef.lrps.end())), locRef.lrps[1]);
   EXPECT_NEAR(locRef.getLength(), 5 * 12774.8, 1e-3) << "Distance incorrect.";
+
+  auto hex = " 0b 01 b5 01 22 b7 3e 10 fc da cc f4 08 80 10 f3 da "
+             "00 00 00 00 10 f3 da 00 00 00 00 10 f3 da 00 00 00 00 10 f3 da fc de 14 71 10 63 ab ab";
+  EXPECT_EQ(to_hex(locRef.toBinary()), hex) << "Incorrectly encoded reference";
 }
 
 TEST(OpenLR, OffsetsOverrun) {

--- a/test/openlr.cc
+++ b/test/openlr.cc
@@ -144,10 +144,6 @@ TEST(OpenLR, InternalReferencePoints) {
   locRef.lrps.insert(std::prev(std::prev(locRef.lrps.end())), locRef.lrps[1]);
   locRef.lrps.insert(std::prev(std::prev(locRef.lrps.end())), locRef.lrps[1]);
   EXPECT_NEAR(locRef.getLength(), 5 * 12774.8, 1e-3) << "Distance incorrect.";
-
-  auto hex = " 0b 01 b5 01 22 b7 3e 10 fc da cc f4 08 80 10 f3 da "
-             "00 00 00 00 10 f3 da 00 00 00 00 10 f3 da 00 00 00 00 10 f3 da fc de 14 71 10 63 aa aa";
-  EXPECT_EQ(to_hex(locRef.toBinary()), hex) << "Incorrectly encoded reference";
 }
 
 TEST(OpenLR, OffsetsOverrun) {
@@ -193,7 +189,7 @@ TEST(OpenLR, CreateLinearReference) {
     fow = static_cast<LocationReferencePoint::FormOfWay>(static_cast<uint8_t>(fow) + 1);
     --lowest_frc_next_point;
   }
-  LineLocation line_location(lrps, 0, 0);
+  LineLocation line_location(lrps, 17.438, 13.721);
 
   // do a round trip conversion
   LineLocation converted(line_location.toBinary());

--- a/test/openlr.cc
+++ b/test/openlr.cc
@@ -140,12 +140,6 @@ TEST(OpenLR, InternalReferencePoints) {
     }
   }
 
-  /*
-  locRef.intermediate.push_back(locRef.intermediate.front());
-  locRef.intermediate.push_back(locRef.intermediate.front());
-  locRef.intermediate.push_back(locRef.intermediate.front());
-   */
-
   locRef.lrps.insert(std::prev(std::prev(locRef.lrps.end())), locRef.lrps[1]);
   locRef.lrps.insert(std::prev(std::prev(locRef.lrps.end())), locRef.lrps[1]);
   locRef.lrps.insert(std::prev(std::prev(locRef.lrps.end())), locRef.lrps[1]);

--- a/test/openlr.cc
+++ b/test/openlr.cc
@@ -200,6 +200,10 @@ TEST(OpenLR, CreateLinearReference) {
 
   // compare to the original reference before conversion
   EXPECT_EQ(line_location, converted);
+
+  // if positive or negative offset is too large it should throw
+  EXPECT_THROW(LineLocation(lrps, lrps[0].distance + 1, 0), std::invalid_argument);
+  EXPECT_THROW(LineLocation(lrps, 0, lrps[lrps.size() - 2].distance + 1), std::invalid_argument);
 }
 
 } // namespace

--- a/valhalla/midgard/openlr.h
+++ b/valhalla/midgard/openlr.h
@@ -210,12 +210,10 @@ struct LineLocation {
                float positive_offset,
                float negative_offset)
       : lrps(lrps), poff(positive_offset), noff(negative_offset) {
-    if (static_cast<uint32_t>(256 * poff / lrps.front().distance) >
-        std::numeric_limits<uint8_t>::max())
+    if (poff > lrps.front().distance)
       throw std::invalid_argument("Positive offset out of range");
-    if (static_cast<uint32_t>(256 * noff / std::next(lrps.rbegin())->distance) >
-        std::numeric_limits<uint8_t>::max())
-      throw std::invalid_argument("Positive offset out of range");
+    if (noff > std::next(lrps.rbegin())->distance)
+      throw std::invalid_argument("Negative offset out of range");
   }
 
   PointLL getFirstCoordinate() const {

--- a/valhalla/midgard/openlr.h
+++ b/valhalla/midgard/openlr.h
@@ -206,10 +206,10 @@ struct LineLocation {
     noff = (index < size) && flags[5] ? std::next(lrps.rbegin())->distance * raw[index++] / 256 : 0.f;
   }
 
-  LineLocation(const std::vector<LocationReferencePoint>& lrps,
-               float positive_offset,
-               float negative_offset)
-      : lrps(lrps), poff(positive_offset), noff(negative_offset) {
+  LineLocation(const std::vector<LocationReferencePoint>& lrps, float poff, float noff)
+      : lrps(lrps), poff(std::round(poff / lrps.at(0).distance * 256) / 256 * lrps.at(0).distance),
+        noff(std::round(noff / lrps.at(lrps.size() - 2).distance * 256) / 256 *
+             lrps.at(lrps.size() - 2).distance) {
     if (poff > lrps.front().distance)
       throw std::invalid_argument("Positive offset out of range");
     if (noff > std::next(lrps.rbegin())->distance)
@@ -282,11 +282,13 @@ struct LineLocation {
 
     // Offsets
     if (pofff) {
-      result.push_back(static_cast<std::int32_t>(256 * poff / first.distance) & 0xff);
+      result.push_back(static_cast<std::int32_t>(std::round(256 * poff / first.distance)) & 0xff);
     }
 
     if (nofff) {
-      result.push_back(static_cast<std::int32_t>(256 * noff / first.distance) & 0xff);
+      result.push_back(
+          static_cast<std::int32_t>(std::round(256 * noff / std::next(lrps.rbegin())->distance)) &
+          0xff);
     }
 
     return result;

--- a/valhalla/midgard/openlr.h
+++ b/valhalla/midgard/openlr.h
@@ -108,6 +108,44 @@ struct LocationReferencePoint {
         fow(static_cast<LocationReferencePoint::FormOfWay>(attribute1 & 0x07)) {
   }
 
+  /**
+   * Useful for generating an openlr record from non-openlr data. You can create LRPs with this
+   * constructor and then feed them to the special constructor for the LineLocation
+   * @param longitude
+   * @param latitude
+   * @param bearing
+   * @param frc
+   * @param fow
+   * @param distance
+   * @param lfrcnp
+   */
+  LocationReferencePoint(double longitude,
+                         double latitude,
+                         float bearing,
+                         unsigned char frc,
+                         FormOfWay fow,
+                         LocationReferencePoint* prev,
+                         float distance = 0.f,
+                         unsigned char lfrcnp = 0)
+      : longitude(!prev ? integer2decimal(decimal2integer(longitude))
+                        : prev->longitude +
+                              (std::round((longitude - prev->longitude) * 100000) / 10000)),
+        latitude(!prev ? integer2decimal(decimal2integer(latitude))
+                       : prev->latitude + (std::round((latitude - prev->latitude) * 100000) / 10000)),
+        bearing(integer2bearing(bearing2integer(bearing))), frc(frc), fow(fow),
+        distance(integer2distance(distance2integer(distance))), lfrcnp(lfrcnp) {
+  }
+
+  /**
+   * Strict equality here is ok because the floating point values came from integers
+   * @param lrp
+   * @return true if the provided lrp exactly matchs this lrp
+   */
+  bool operator==(const LocationReferencePoint& lrp) const {
+    return longitude == lrp.longitude && latitude == lrp.latitude && bearing == lrp.bearing &&
+           distance == lrp.distance && frc == lrp.frc && lfrcnp == lrp.lfrcnp && fow == lrp.fow;
+  }
+
   double longitude;
   double latitude;
   float bearing;        // 5.2.4. Bearing
@@ -132,7 +170,7 @@ struct LineLocation {
     // Status, version 3, has attributes, ArF 'Circle or no area location'
     auto status = raw[index++] & 0x7f;
     if (status != 0x0b)
-      throw std::invalid_argument("OpenLR reference ");
+      throw std::invalid_argument("OpenLR reference");
 
     // First location reference point
     auto longitude = integer2decimal(fixed<std::int32_t, 3>(raw, index));
@@ -141,7 +179,7 @@ struct LineLocation {
     auto attribute2 = raw[index++];
     auto attribute3 = raw[index++];
 
-    first = {longitude, latitude, attribute1, attribute2, attribute3};
+    lrps.emplace_back(longitude, latitude, attribute1, attribute2, attribute3);
 
     // Intermediate location reference points
     while (index + 7 + 6 <= size) {
@@ -151,7 +189,7 @@ struct LineLocation {
       attribute2 = raw[index++];
       attribute3 = raw[index++];
 
-      intermediate.push_back({longitude, latitude, attribute1, attribute2, attribute3});
+      lrps.emplace_back(longitude, latitude, attribute1, attribute2, attribute3);
     }
 
     // Last location reference point
@@ -160,24 +198,36 @@ struct LineLocation {
     attribute1 = raw[index++];
     auto attribute4 = raw[index++];
 
-    last = {longitude, latitude, attribute1, attribute4};
+    lrps.emplace_back(longitude, latitude, attribute1, attribute4);
 
     // Offsets
     std::bitset<8> flags(attribute4);
-    poff = (index < size) && flags[6] ? first.distance * raw[index++] / 256 : 0.f;
-    noff = (index < size) && flags[5] ? first.distance * raw[index++] / 256 : 0.f;
+    poff = (index < size) && flags[6] ? lrps.front().distance * raw[index++] / 256 : 0.f;
+    noff = (index < size) && flags[5] ? std::next(lrps.rbegin())->distance * raw[index++] / 256 : 0.f;
+  }
+
+  LineLocation(const std::vector<LocationReferencePoint>& lrps,
+               float positive_offset,
+               float negative_offset)
+      : lrps(lrps), poff(positive_offset), noff(negative_offset) {
+    if (static_cast<uint32_t>(256 * poff / lrps.front().distance) >
+        std::numeric_limits<uint8_t>::max())
+      throw std::invalid_argument("Positive offset out of range");
+    if (static_cast<uint32_t>(256 * noff / std::next(lrps.rbegin())->distance) >
+        std::numeric_limits<uint8_t>::max())
+      throw std::invalid_argument("Positive offset out of range");
   }
 
   PointLL getFirstCoordinate() const {
-    return {first.longitude, first.latitude};
+    return {lrps.front().longitude, lrps.front().latitude};
   }
 
   PointLL getLastCoordinate() const {
-    return {last.longitude, last.latitude};
+    return {lrps.back().longitude, lrps.back().latitude};
   }
 
   float getLength() const {
-    return std::accumulate(intermediate.begin(), intermediate.end(), first.distance,
+    return std::accumulate(std::next(lrps.begin()), std::prev(lrps.end()), lrps[0].distance,
                            [](float distance, const LocationReferencePoint& lrp) {
                              return distance + lrp.distance;
                            });
@@ -201,6 +251,7 @@ struct LineLocation {
     result.push_back(0b00001011);
 
     // First location reference point
+    const auto& first = lrps.front();
     auto longitude = first.longitude;
     auto latitude = first.latitude;
     append3(decimal2integer(longitude));
@@ -209,21 +260,23 @@ struct LineLocation {
     result.push_back(((first.lfrcnp & 0x7) << 5) | (bearing2integer(first.bearing) & 0x1f));
     result.push_back(distance2integer(first.distance));
 
-    for (const auto& lrp : intermediate) {
+    // Subsequent location reference points are offset lon lat from the first
+    for (auto lrp = std::next(lrps.begin()); lrp != std::prev(lrps.end()); ++lrp) {
       // First longitude
-      append2(static_cast<std::int32_t>(std::round(100000 * (lrp.longitude - longitude))));
-      append2(static_cast<std::int32_t>(std::round(100000 * (lrp.latitude - latitude))));
-      result.push_back(((lrp.frc & 0x7) << 3) | (lrp.fow & 0x7));
-      result.push_back(((lrp.lfrcnp & 0x7) << 5) | (bearing2integer(lrp.bearing) & 0x1f));
-      result.push_back(distance2integer(lrp.distance));
+      append2(static_cast<std::int32_t>(std::round(100000 * (lrp->longitude - longitude))));
+      append2(static_cast<std::int32_t>(std::round(100000 * (lrp->latitude - latitude))));
+      result.push_back(((lrp->frc & 0x7) << 3) | (lrp->fow & 0x7));
+      result.push_back(((lrp->lfrcnp & 0x7) << 5) | (bearing2integer(lrp->bearing) & 0x1f));
+      result.push_back(distance2integer(lrp->distance));
 
-      longitude = lrp.longitude;
-      latitude = lrp.latitude;
+      longitude = lrp->longitude;
+      latitude = lrp->latitude;
     }
 
     // Last location reference point
     const auto pofff = poff != 0.f;
     const auto nofff = noff != 0.f;
+    const auto& last = lrps.back();
     append2(static_cast<std::int32_t>(std::round(100000 * (last.longitude - longitude))));
     append2(static_cast<std::int32_t>(std::round(100000 * (last.latitude - latitude))));
     result.push_back(((last.frc & 0x7) << 3) | (last.fow & 0x7));
@@ -241,9 +294,12 @@ struct LineLocation {
     return result;
   }
 
-  LocationReferencePoint first;
-  LocationReferencePoint last;
-  std::vector<LocationReferencePoint> intermediate;
+  bool operator==(const LineLocation& lloc) const {
+    return lrps.size() == lloc.lrps.size() && poff == lloc.poff && noff == lloc.noff &&
+           std::equal(lrps.begin(), lrps.end(), lloc.lrps.begin());
+  }
+
+  std::vector<LocationReferencePoint> lrps;
   float poff; // 5.2.9.1 Positive offset
   float noff; // 5.2.9.2 Negative offset
 };


### PR DESCRIPTION
The implementation of openlr in the code base only supported reading existing binary openlr records. This made it annoying to test because you had to decode them to know what the value was supposed to be. This pr adds a couple simple constructors to the LineLocation and LocationReferencePoint objects that allow you to construct those directly from lat, lon, distance, bearing, and form of way information. This allows us to construct OpenLR records for whatever purposes we may need them. And it makes them easier to test.