### PR TITLE
More tidy openlr

### DIFF
--- a/test/openlr.cc
+++ b/test/openlr.cc
@@ -202,6 +202,14 @@ TEST(OpenLR, CreateLinearReference) {
   // if positive or negative offset is too large it should throw
   EXPECT_THROW(LineLocation(lrps, lrps[0].distance + 1, 0), std::invalid_argument);
   EXPECT_THROW(LineLocation(lrps, 0, lrps[lrps.size() - 2].distance + 1), std::invalid_argument);
+
+  // make a short line location so that poff and noff must be 0
+  lrps.clear();
+  lrps.emplace_back(0, 0, 90, frc, fow, nullptr, 5, lowest_frc_next_point);
+  lrps.emplace_back(.000005, 0, 270, frc, fow, &lrps.back());
+  LineLocation short_location(lrps, 0, 0);
+  EXPECT_EQ(short_location.poff, 0.f);
+  EXPECT_EQ(short_location.noff, 0.f);
 }
 
 } // namespace

--- a/valhalla/midgard/openlr.h
+++ b/valhalla/midgard/openlr.h
@@ -207,9 +207,14 @@ struct LineLocation {
   }
 
   LineLocation(const std::vector<LocationReferencePoint>& lrps, float poff, float noff)
-      : lrps(lrps), poff(std::round(poff / lrps.at(0).distance * 256) / 256 * lrps.at(0).distance),
-        noff(std::round(noff / lrps.at(lrps.size() - 2).distance * 256) / 256 *
-             lrps.at(lrps.size() - 2).distance) {
+      : lrps(lrps),
+        poff(lrps.at(0).distance > 0
+                 ? std::round(poff / lrps.at(0).distance * 256) / 256 * lrps.at(0).distance
+                 : 0.f),
+        noff(lrps.at(lrps.size() - 2).distance > 0
+                 ? std::round(noff / lrps.at(lrps.size() - 2).distance * 256) / 256 *
+                       lrps.at(lrps.size() - 2).distance
+                 : 0.f) {
     if (poff > lrps.front().distance)
       throw std::invalid_argument("Positive offset out of range");
     if (noff > std::next(lrps.rbegin())->distance)


### PR DESCRIPTION
A pretty insignificant issue but if poff or noff is 0 and the line location is also 0 length then we get `nan` as poff and noff because we cant round them to a bucket. this pr fixes it so that you get 0 for poff and noff when their repsective lrps are 0 length.