### PR TITLE
benchmark: A*-search and bi-directional A*.

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -11,7 +11,7 @@ add_custom_target(run-benchmarks)
 set_target_properties(run-benchmarks PROPERTIES FOLDER "Benchmarks")
 
 # Benchmarks generally require utrecht test tiles to be present, so add this dependency by default.
-#add_dependencies(benchmarks utrecht_tiles)
+add_dependencies(benchmarks utrecht_tiles)
 
 # Macro for defining Google Benchmark microbenchmark targets
 macro (add_valhalla_benchmark target_file)

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -11,13 +11,13 @@ add_custom_target(run-benchmarks)
 set_target_properties(run-benchmarks PROPERTIES FOLDER "Benchmarks")
 
 # Benchmarks generally require utrecht test tiles to be present, so add this dependency by default.
-add_dependencies(benchmarks utrecht_tiles)
+#add_dependencies(benchmarks utrecht_tiles)
 
 # Macro for defining Google Benchmark microbenchmark targets
 macro (add_valhalla_benchmark target_file)
   set(target_name benchmark-${target_file})
-  add_executable(${target_name}
-    ${target_file}.cc)
+  add_executable(${target_name} ${target_file}.cc)
+  target_include_directories(${target_name} PRIVATE .)
   set_target_properties(${target_name} PROPERTIES FOLDER "Benchmarks")
   set_target_properties(${target_name}
     PROPERTIES

--- a/bench/common/utils.h
+++ b/bench/common/utils.h
@@ -35,9 +35,7 @@ cost_ptr_t MakeCosting(const std::string& cost_mode) {
   Costing costing;
   Costing_Enum_Parse(cost_mode, &costing);
   options.set_costing(costing);
-  CostFactory<DynamicCost> factory;
-  factory.RegisterStandardCostingModels();
-  return factory.Create(options);
+  return sif::CostFactory().Create(options);
 }
 } // namespace bench
 } // namespace valhalla

--- a/bench/common/utils.h
+++ b/bench/common/utils.h
@@ -1,0 +1,45 @@
+#ifndef VALHALLA_BENCH_UTILS_H_
+#define VALHALLA_BENCH_UTILS_H_
+
+#include <iostream>
+#include <sstream>
+
+#include "sif/costfactory.h"
+#include "sif/dynamiccost.h"
+#include "valhalla/worker.h"
+
+namespace valhalla {
+
+using sif::cost_ptr_t;
+using sif::CostFactory;
+using sif::DynamicCost;
+
+namespace bench {
+
+std::string LoadFile(const std::string& filename) {
+  std::stringstream ss;
+  std::string line;
+  std::ifstream input_file;
+  input_file.open(filename.c_str());
+  while (std::getline(input_file, line)) {
+    ss << line;
+  }
+  return ss.str();
+}
+
+cost_ptr_t MakeCosting(const std::string& cost_mode) {
+  Options options;
+  for (int i = 0; i < Costing_MAX; ++i) {
+    options.add_costing_options();
+  }
+  Costing costing;
+  Costing_Enum_Parse(cost_mode, &costing);
+  options.set_costing(costing);
+  CostFactory<DynamicCost> factory;
+  factory.RegisterStandardCostingModels();
+  return factory.Create(options);
+}
+} // namespace bench
+} // namespace valhalla
+
+#endif // VALHALLA_BENCH_UTILS_H_

--- a/bench/meili/mapmatch.cc
+++ b/bench/meili/mapmatch.cc
@@ -11,6 +11,10 @@
 #include "sif/costfactory.h"
 #include "tyr/actor.h"
 
+#include "bench/common/utils.h"
+
+using valhalla::bench::LoadFile;
+
 using namespace valhalla::midgard;
 using namespace valhalla::meili;
 using namespace valhalla::sif;
@@ -81,19 +85,6 @@ BENCHMARK_DEFINE_F(OfflineMapmatchFixture, BasicOfflineMatch)(benchmark::State& 
 }
 
 BENCHMARK_REGISTER_F(OfflineMapmatchFixture, BasicOfflineMatch);
-
-// Load fixture files, intended to mirror test cases defined in test/mapmatch.cc.
-
-std::string LoadFile(const std::string& filename) {
-  std::stringstream ss;
-  std::string line;
-  std::ifstream input_file;
-  input_file.open(filename.c_str());
-  while (std::getline(input_file, line)) {
-    ss << line;
-  }
-  return ss.str();
-}
 
 const std::vector<std::string> kBenchmarkCases = {
     // Intersection matching test cases

--- a/bench/thor/CMakeLists.txt
+++ b/bench/thor/CMakeLists.txt
@@ -1,2 +1,4 @@
 add_valhalla_benchmark(costmatrix)
 add_valhalla_benchmark(routes)
+add_valhalla_benchmark(astar)
+add_valhalla_benchmark(routing)

--- a/bench/thor/astar.cc
+++ b/bench/thor/astar.cc
@@ -1,0 +1,126 @@
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <unordered_map>
+#include <utility>
+
+#include <benchmark/benchmark.h>
+#include <boost/property_tree/ptree.hpp>
+
+#include "baldr/graphreader.h"
+#include "baldr/rapidjson_utils.h"
+#include "loki/search.h"
+#include "midgard/logging.h"
+#include "sif/costconstants.h"
+#include "sif/costfactory.h"
+#include "thor/astar.h"
+#include "thor/bidirectional_astar.h"
+#include "thor/pathalgorithm.h"
+
+#include "bench/common/utils.h"
+
+#if !defined(VALHALLA_SOURCE_DIR)
+#define VALHALLA_SOURCE_DIR
+#endif
+
+using namespace valhalla::midgard;
+
+namespace {
+
+using valhalla::baldr::GraphReader;
+using valhalla::baldr::Location;
+using valhalla::baldr::PathLocation;
+using valhalla::midgard::PointLL;
+using valhalla::thor::AStarPathAlgorithm;
+using valhalla::thor::BidirectionalAStar;
+
+using valhalla::bench::MakeCosting;
+
+class RoutingFixture : public benchmark::Fixture {
+public:
+  void SetUp(const benchmark::State& state) {
+    (void)state;
+    InitConfig();
+    InitGraph();
+  }
+
+  // Produce a GraphReader-correlated pair (source, destination) from points.
+  std::pair<valhalla::Location, valhalla::Location> PointToLocation(PointLL src, PointLL dst) const {
+    const auto& stop_type = Location::StopType::BREAK;
+    std::vector<Location> locations = {Location(src, stop_type), Location(dst, stop_type)};
+    const std::unordered_map<Location, PathLocation>& projections =
+        valhalla::loki::Search(locations, *graph_reader_, mode_costing_);
+    valhalla::Location origin;
+    PathLocation::toPBF(projections.at(locations[0]), &origin, *graph_reader_);
+    valhalla::Location dest;
+    PathLocation::toPBF(projections.at(locations[1]), &dest, *graph_reader_);
+    return std::make_pair(origin, dest);
+  }
+
+  valhalla::cost_ptr_t costing() const {
+    return (&mode_costing_)[static_cast<size_t>(travel_mode_)];
+  }
+
+private:
+  void InitConfig() {
+    rapidjson::read_json(VALHALLA_SOURCE_DIR "bench/thor/config.json", config_);
+    mode_costing_ = MakeCosting("auto");
+    travel_mode_ = mode_costing_->travel_mode();
+  }
+
+  void InitGraph() {
+    graph_reader_ = std::make_shared<GraphReader>(config_.get_child("mjolnir"));
+  }
+
+protected:
+  boost::property_tree::ptree config_;
+  valhalla::cost_ptr_t mode_costing_;
+  valhalla::sif::TravelMode travel_mode_;
+  std::shared_ptr<GraphReader> graph_reader_;
+};
+
+// clang-format off
+const std::vector<std::pair<PointLL, PointLL>> kBenchmarkCases = {
+    // ./fixtures/utrecht100m.json
+    {PointLL(5.08531221, 52.0938563), PointLL(5.0865867, 52.0930211)},
+    // ./fixtures/utrecht200m.json
+    {PointLL(5.08531221, 52.0938563), PointLL(5.08769141, 52.0923946)},
+    // ./fixtures/utrecht2km.json
+    {PointLL(5.08531221, 52.0938563), PointLL(5.10351751, 52.09202915)},
+    // ./fixtures/utrecht4km.json
+    {PointLL(5.08531221, 52.0938563), PointLL(5.1117335, 52.0851706)}};
+// clang-format on
+
+BENCHMARK_DEFINE_F(RoutingFixture, BidirectionalAStar)(benchmark::State& state) {
+  logging::Configure({{"type", ""}});
+  std::pair<PointLL, PointLL> bench_case = kBenchmarkCases[state.range(0)];
+  std::pair<valhalla::Location, valhalla::Location> locations =
+      PointToLocation(bench_case.first, bench_case.second);
+  valhalla::cost_ptr_t mode_costing = costing();
+  BidirectionalAStar astar;
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(astar.GetBestPath(locations.first, locations.second, *graph_reader_,
+                                               &mode_costing, travel_mode_));
+  }
+}
+
+BENCHMARK_REGISTER_F(RoutingFixture, BidirectionalAStar)->DenseRange(0, kBenchmarkCases.size() - 1);
+
+BENCHMARK_DEFINE_F(RoutingFixture, AStar)(benchmark::State& state) {
+  logging::Configure({{"type", ""}});
+  std::pair<PointLL, PointLL> bench_case = kBenchmarkCases[state.range(0)];
+  std::pair<valhalla::Location, valhalla::Location> locations =
+      PointToLocation(bench_case.first, bench_case.second);
+  valhalla::cost_ptr_t mode_costing = costing();
+  AStarPathAlgorithm astar;
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(astar.GetBestPath(locations.first, locations.second, *graph_reader_,
+                                               &mode_costing, travel_mode_));
+  }
+}
+
+BENCHMARK_REGISTER_F(RoutingFixture, AStar)->DenseRange(0, kBenchmarkCases.size() - 1);
+
+} // namespace
+
+BENCHMARK_MAIN();

--- a/bench/thor/astar.cc
+++ b/bench/thor/astar.cc
@@ -6,6 +6,7 @@
 
 #include <benchmark/benchmark.h>
 #include <boost/property_tree/ptree.hpp>
+#include <valhalla/proto/options.pb.h>
 
 #include "baldr/graphreader.h"
 #include "baldr/rapidjson_utils.h"
@@ -13,7 +14,7 @@
 #include "midgard/logging.h"
 #include "sif/costconstants.h"
 #include "sif/costfactory.h"
-#include "thor/astar.h"
+#include "thor/astar_bss.h"
 #include "thor/bidirectional_astar.h"
 #include "thor/pathalgorithm.h"
 
@@ -31,10 +32,16 @@ using valhalla::baldr::GraphReader;
 using valhalla::baldr::Location;
 using valhalla::baldr::PathLocation;
 using valhalla::midgard::PointLL;
-using valhalla::thor::AStarPathAlgorithm;
+using valhalla::thor::AStarBSSAlgorithm;
 using valhalla::thor::BidirectionalAStar;
 
 using valhalla::bench::MakeCosting;
+
+void create_costing_options(valhalla::Options& options) {
+  options.set_costing(valhalla::Costing::auto_);
+  rapidjson::Document doc;
+  valhalla::sif::ParseCostingOptions(doc, "/costing_options", options);
+}
 
 class RoutingFixture : public benchmark::Fixture {
 public:
@@ -48,8 +55,9 @@ public:
   std::pair<valhalla::Location, valhalla::Location> PointToLocation(PointLL src, PointLL dst) const {
     const auto& stop_type = Location::StopType::BREAK;
     std::vector<Location> locations = {Location(src, stop_type), Location(dst, stop_type)};
+    const auto& cost = mode_costing_[static_cast<size_t>(travel_mode_)];
     const std::unordered_map<Location, PathLocation>& projections =
-        valhalla::loki::Search(locations, *graph_reader_, mode_costing_);
+        valhalla::loki::Search(locations, *graph_reader_, cost);
     valhalla::Location origin;
     PathLocation::toPBF(projections.at(locations[0]), &origin, *graph_reader_);
     valhalla::Location dest;
@@ -57,15 +65,12 @@ public:
     return std::make_pair(origin, dest);
   }
 
-  valhalla::cost_ptr_t costing() const {
-    return (&mode_costing_)[static_cast<size_t>(travel_mode_)];
-  }
-
 private:
   void InitConfig() {
     rapidjson::read_json(VALHALLA_SOURCE_DIR "bench/thor/config.json", config_);
-    mode_costing_ = MakeCosting("auto");
-    travel_mode_ = mode_costing_->travel_mode();
+    valhalla::Options options;
+    create_costing_options(options);
+    mode_costing_ = valhalla::sif::CostFactory().CreateModeCosting(options, travel_mode_);
   }
 
   void InitGraph() {
@@ -74,9 +79,9 @@ private:
 
 protected:
   boost::property_tree::ptree config_;
-  valhalla::cost_ptr_t mode_costing_;
-  valhalla::sif::TravelMode travel_mode_;
+  valhalla::sif::mode_costing_t mode_costing_;
   std::shared_ptr<GraphReader> graph_reader_;
+  valhalla::sif::TravelMode travel_mode_;
 };
 
 // clang-format off
@@ -96,30 +101,14 @@ BENCHMARK_DEFINE_F(RoutingFixture, BidirectionalAStar)(benchmark::State& state) 
   std::pair<PointLL, PointLL> bench_case = kBenchmarkCases[state.range(0)];
   std::pair<valhalla::Location, valhalla::Location> locations =
       PointToLocation(bench_case.first, bench_case.second);
-  valhalla::cost_ptr_t mode_costing = costing();
   BidirectionalAStar astar;
   for (auto _ : state) {
     benchmark::DoNotOptimize(astar.GetBestPath(locations.first, locations.second, *graph_reader_,
-                                               &mode_costing, travel_mode_));
+                                               mode_costing_, travel_mode_));
   }
 }
 
 BENCHMARK_REGISTER_F(RoutingFixture, BidirectionalAStar)->DenseRange(0, kBenchmarkCases.size() - 1);
-
-BENCHMARK_DEFINE_F(RoutingFixture, AStar)(benchmark::State& state) {
-  logging::Configure({{"type", ""}});
-  std::pair<PointLL, PointLL> bench_case = kBenchmarkCases[state.range(0)];
-  std::pair<valhalla::Location, valhalla::Location> locations =
-      PointToLocation(bench_case.first, bench_case.second);
-  valhalla::cost_ptr_t mode_costing = costing();
-  AStarPathAlgorithm astar;
-  for (auto _ : state) {
-    benchmark::DoNotOptimize(astar.GetBestPath(locations.first, locations.second, *graph_reader_,
-                                               &mode_costing, travel_mode_));
-  }
-}
-
-BENCHMARK_REGISTER_F(RoutingFixture, AStar)->DenseRange(0, kBenchmarkCases.size() - 1);
 
 } // namespace
 

--- a/bench/thor/config.json
+++ b/bench/thor/config.json
@@ -23,7 +23,8 @@
       "search_cutoff": 35000,
       "node_snap_tolerance": 5,
       "street_side_tolerance": 5,
-      "heading_tolerance": 60
+      "heading_tolerance": 60,
+      "street_side_max_distance": 1000
     }
   },
   "thor": {
@@ -104,8 +105,18 @@
       "max_contours": 4,
       "max_distance": 25000.0,
       "max_locations": 1,
-      "max_time": 120
+      "max_time": 120,
+      "max_time_contour": 120,
+      "max_distance_contour": 120
     },
+    "street_side_max_distance": {
+      "max_distance": 5000000.0,
+      "max_locations": 20,
+      "max_matrix_distance": 400000.0,
+      "max_matrix_locations": 50
+    },
+    "street_side_max_distance": 1000,
+    "max_avoid_polygons_length": 10000,
     "max_avoid_locations": 50,
     "max_radius": 200,
     "max_reachability": 100,

--- a/bench/thor/config.json
+++ b/bench/thor/config.json
@@ -1,0 +1,152 @@
+{
+  "mjolnir": {
+    "tile_dir": "test/data/utrecht_tiles",
+    "concurrency": 1
+  },
+  "loki": {
+    "actions": [
+      "locate",
+      "route",
+      "sources_to_targets",
+      "optimized_route",
+      "isochrone",
+      "trace_route",
+      "trace_attributes",
+      "transit_available"
+    ],
+    "logging": {
+      "long_request": 100
+    },
+    "service_defaults": {
+      "minimum_reachability": 50,
+      "radius": 0,
+      "search_cutoff": 35000,
+      "node_snap_tolerance": 5,
+      "street_side_tolerance": 5,
+      "heading_tolerance": 60
+    }
+  },
+  "thor": {
+    "logging": {
+      "long_request": 110
+    }
+  },
+  "skadi": {
+    "actons": [
+      "height"
+    ],
+    "logging": {
+      "long_request": 5
+    }
+  },
+  "meili": {
+    "customizable": [
+      "breakage_distance"
+    ],
+    "mode": "auto",
+    "grid": {
+      "cache_size": 100240,
+      "size": 500
+    },
+    "default": {
+      "beta": 3,
+      "breakage_distance": 2000,
+      "geometry": false,
+      "gps_accuracy": 5.0,
+      "interpolation_distance": 10,
+      "max_route_distance_factor": 3,
+      "max_route_time_factor": 3,
+      "max_search_radius": 100,
+      "route": true,
+      "search_radius": 50,
+      "sigma_z": 4.07,
+      "turn_penalty_factor": 200
+    }
+  },
+  "service_limits": {
+    "auto": {
+      "max_distance": 5000000.0,
+      "max_locations": 20,
+      "max_matrix_distance": 400000.0,
+      "max_matrix_locations": 50
+    },
+    "auto_shorter": {
+      "max_distance": 5000000.0,
+      "max_locations": 20,
+      "max_matrix_distance": 400000.0,
+      "max_matrix_locations": 50
+    },
+    "bicycle": {
+      "max_distance": 500000.0,
+      "max_locations": 50,
+      "max_matrix_distance": 200000.0,
+      "max_matrix_locations": 50
+    },
+    "bus": {
+      "max_distance": 5000000.0,
+      "max_locations": 50,
+      "max_matrix_distance": 400000.0,
+      "max_matrix_locations": 50
+    },
+    "hov": {
+      "max_distance": 5000000.0,
+      "max_locations": 20,
+      "max_matrix_distance": 400000.0,
+      "max_matrix_locations": 50
+    },
+    "taxi": {
+      "max_distance": 5000000.0,
+      "max_locations": 20,
+      "max_matrix_distance": 400000.0,
+      "max_matrix_locations": 50
+    },
+    "isochrone": {
+      "max_contours": 4,
+      "max_distance": 25000.0,
+      "max_locations": 1,
+      "max_time": 120
+    },
+    "max_avoid_locations": 50,
+    "max_radius": 200,
+    "max_reachability": 100,
+    "max_alternates": 2,
+    "multimodal": {
+      "max_distance": 500000.0,
+      "max_locations": 50,
+      "max_matrix_distance": 0.0,
+      "max_matrix_locations": 0
+    },
+    "pedestrian": {
+      "max_distance": 250000.0,
+      "max_locations": 50,
+      "max_matrix_distance": 200000.0,
+      "max_matrix_locations": 50,
+      "max_transit_walking_distance": 10000,
+      "min_transit_walking_distance": 1
+    },
+    "skadi": {
+      "max_shape": 750000,
+      "min_resample": 10.0
+    },
+    "trace": {
+      "max_best_paths": 4,
+      "max_best_paths_shape": 100,
+      "max_distance": 200000.0,
+      "max_gps_accuracy": 100.0,
+      "max_search_radius": 100,
+      "max_shape": 16000
+    },
+    "transit": {
+      "max_distance": 500000.0,
+      "max_locations": 50,
+      "max_matrix_distance": 200000.0,
+      "max_matrix_locations": 50
+    },
+    "truck": {
+      "max_distance": 5000000.0,
+      "max_locations": 20,
+      "max_matrix_distance": 400000.0,
+      "max_matrix_locations": 50
+    }
+  }
+}

--- a/bench/thor/fixtures/utrecht100m.json
+++ b/bench/thor/fixtures/utrecht100m.json
@@ -1,0 +1,15 @@
+{
+  "locations": [
+    {
+      "lon": 5.08531221,
+      "lat": 52.0938563,
+      "type": "break"
+    },
+    {
+      "lon": 5.0865867,
+      "lat": 52.0930211,
+      "type": "break"
+    }
+  ],
+  "costing": "auto"
+}

--- a/bench/thor/fixtures/utrecht200m.json
+++ b/bench/thor/fixtures/utrecht200m.json
@@ -1,0 +1,15 @@
+{
+  "locations": [
+    {
+      "lon": 5.08531221,
+      "lat": 52.0938563,
+      "type": "break"
+    },
+    {
+      "lon": 5.08769141,
+      "lat": 52.0923946,
+      "type": "break"
+    }
+  ],
+  "costing": "auto"
+}

--- a/bench/thor/fixtures/utrecht2km.json
+++ b/bench/thor/fixtures/utrecht2km.json
@@ -1,0 +1,15 @@
+{
+  "locations": [
+    {
+      "lon": 5.08531221,
+      "lat": 52.0938563,
+      "type": "break"
+    },
+    {
+      "lon": 5.10351751,
+      "lat": 52.09202915,
+      "type": "break"
+    }
+  ],
+  "costing": "auto"
+}

--- a/bench/thor/fixtures/utrecht4km.json
+++ b/bench/thor/fixtures/utrecht4km.json
@@ -1,0 +1,15 @@
+{
+  "locations": [
+    {
+      "lon": 5.08531221,
+      "lat": 52.0938563,
+      "type": "break"
+    },
+    {
+      "lon": 5.1117335,
+      "lat": 52.0851706,
+      "type": "break"
+    }
+  ],
+  "costing": "auto"
+}

--- a/bench/thor/routing.cc
+++ b/bench/thor/routing.cc
@@ -1,0 +1,43 @@
+#include <iostream>
+#include <sstream>
+
+#include <benchmark/benchmark.h>
+#include <boost/property_tree/ptree.hpp>
+
+#include "baldr/rapidjson_utils.h"
+#include "midgard/logging.h"
+#include "tyr/actor.h"
+
+#include "bench/common/utils.h"
+
+namespace {
+
+using valhalla::bench::LoadFile;
+
+#if !defined(VALHALLA_SOURCE_DIR)
+#define VALHALLA_SOURCE_DIR
+#endif
+
+const std::vector<std::string> kBenchmarkCases = {
+    VALHALLA_SOURCE_DIR "bench/thor/fixtures/utrecht100m.json",
+    VALHALLA_SOURCE_DIR "bench/thor/fixtures/utrecht200m.json",
+    VALHALLA_SOURCE_DIR "bench/thor/fixtures/utrecht2km.json",
+    VALHALLA_SOURCE_DIR "bench/thor/fixtures/utrecht4km.json",
+};
+
+static void BM_RoutingFixtures(benchmark::State& state) {
+  valhalla::midgard::logging::Configure({{"type", ""}});
+  boost::property_tree::ptree config;
+  rapidjson::read_json(VALHALLA_SOURCE_DIR "bench/thor/config.json", config);
+  valhalla::tyr::actor_t actor(config, true);
+  const std::string test_case(LoadFile(kBenchmarkCases[state.range(0)]));
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(actor.route(test_case));
+  }
+}
+
+BENCHMARK(BM_RoutingFixtures)->DenseRange(0, kBenchmarkCases.size() - 1);
+
+} // namespace
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
- Adds a microbenchmark for different path algorithms, using both
  standalone library functions as well as the Valhalla actor
  framework.
- Organization: Moves some shared benchmark utility functions into a
  separate header.

/cc @kevinkreiser