### PR TITLE
Pluggable graphreader

### DIFF
--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -383,24 +383,6 @@ bool GraphReader::DoesTileExist(const GraphId& graphid) const {
          stat((file_location + ".gz").c_str(), &buffer) == 0;
 }
 
-bool GraphReader::DoesTileExist(const boost::property_tree::ptree& pt, const GraphId& graphid) {
-  if (!graphid.Is_Valid() || graphid.level() > TileHierarchy::get_max_level()) {
-    return false;
-  }
-  // if you are using an extract only check that
-  auto extract = get_extract_instance(pt);
-  if (!extract->tiles.empty()) {
-    return extract->tiles.find(graphid) != extract->tiles.cend();
-  }
-  // otherwise check the disk
-  std::string file_location = pt.get<std::string>("tile_dir") +
-                              filesystem::path::preferred_separator +
-                              GraphTile::FileSuffix(graphid.Tile_Base());
-  struct stat buffer;
-  return stat(file_location.c_str(), &buffer) == 0 ||
-         stat((file_location + ".gz").c_str(), &buffer) == 0;
-}
-
 // Get a pointer to a graph tile object given a GraphId. Return nullptr
 // if the tile is not found/empty
 const GraphTile* GraphReader::GetGraphTile(const GraphId& graphid) {

--- a/src/mjolnir/transitbuilder.cc
+++ b/src/mjolnir/transitbuilder.cc
@@ -685,7 +685,7 @@ void TransitBuilder::Build(const boost::property_tree::ptree& pt) {
               (transit_file_itr->path().string().size() - 4)) {
         auto graph_id = GraphTile::GetTileId(transit_file_itr->path().string());
         GraphId local_graph_id(graph_id.tileid(), graph_id.level() - 1, graph_id.id());
-        if (GraphReader::DoesTileExist(hierarchy_properties, local_graph_id)) {
+        if (reader.DoesTileExist(local_graph_id)) {
           const GraphTile* tile = reader.GetGraphTile(local_graph_id);
           tiles.emplace(local_graph_id);
           const std::string destination_path = pt.get<std::string>("mjolnir.tile_dir") +

--- a/src/mjolnir/valhalla_benchmark_admins.cc
+++ b/src/mjolnir/valhalla_benchmark_admins.cc
@@ -192,7 +192,7 @@ void Benchmark(const boost::property_tree::ptree& pt) {
   for (uint32_t id = 0; id < tiles.TileCount(); id++) {
     // Get the admin polys if there is data for tiles that exist
     GraphId tile_id(id, local_level, 0);
-    if (GraphReader::DoesTileExist(hierarchy_properties, tile_id)) {
+    if (reader.DoesTileExist(tile_id)) {
       polys = GetAdminInfo(db_handle, drive_on_right, tiles.TileBounds(id));
       LOG_INFO("polys: " + std::to_string(polys.size()));
       if (polys.size() < 128) {

--- a/src/mjolnir/valhalla_build_statistics.cc
+++ b/src/mjolnir/valhalla_build_statistics.cc
@@ -509,6 +509,8 @@ void BuildStatistics(const boost::property_tree::ptree& pt) {
   // Graph tile properties
   auto tile_properties = pt.get_child("mjolnir");
 
+  GraphReader reader(tile_properties);
+
   // Create a randomized queue of tiles to work from
   std::deque<GraphId> tilequeue;
   for (const auto& tier : TileHierarchy::levels()) {
@@ -517,7 +519,7 @@ void BuildStatistics(const boost::property_tree::ptree& pt) {
     for (uint32_t id = 0; id < tiles.TileCount(); id++) {
       // If tile exists add it to the queue
       GraphId tile_id(id, level, 0);
-      if (GraphReader::DoesTileExist(tile_properties, tile_id)) {
+      if (reader.DoesTileExist(tile_id)) {
         tilequeue.emplace_back(std::move(tile_id));
       }
     }
@@ -528,7 +530,7 @@ void BuildStatistics(const boost::property_tree::ptree& pt) {
       for (uint32_t id = 0; id < tiles.TileCount(); id++) {
         // If tile exists add it to the queue
         GraphId tile_id(id, level, 0);
-        if (GraphReader::DoesTileExist(tile_properties, tile_id)) {
+        if (reader.DoesTileExist(tile_id)) {
           tilequeue.emplace_back(std::move(tile_id));
         }
       }

--- a/src/mjolnir/valhalla_ways_to_edges.cc
+++ b/src/mjolnir/valhalla_ways_to_edges.cc
@@ -118,7 +118,7 @@ int main(int argc, char** argv) {
   for (uint32_t id = 0; id < tiles.TileCount(); id++) {
     // If tile exists add it to the queue
     GraphId edge_id(id, local_level, 0);
-    if (!reader.DoesTileExist(tile_properties, edge_id)) {
+    if (!reader.DoesTileExist(edge_id)) {
       continue;
     }
 

--- a/valhalla/baldr/graphreader.h
+++ b/valhalla/baldr/graphreader.h
@@ -354,7 +354,6 @@ public:
    * @param  graphid  GraphId of the tile to test (tile id and level).
    */
   bool DoesTileExist(const GraphId& graphid) const;
-  static bool DoesTileExist(const boost::property_tree::ptree& pt, const GraphId& graphid);
 
   /**
    * Get a pointer to a graph tile object given a GraphId.

--- a/valhalla/baldr/graphreader.h
+++ b/valhalla/baldr/graphreader.h
@@ -343,7 +343,9 @@ public:
   explicit GraphReader(const boost::property_tree::ptree& pt,
                        std::unique_ptr<tile_getter_t>&& tile_getter = nullptr);
 
-  void SetInterrupt(const tile_getter_t::interrupt_t* interrupt) {
+  virtual ~GraphReader() = default;
+
+  virtual void SetInterrupt(const tile_getter_t::interrupt_t* interrupt) {
     if (tile_getter_) {
       tile_getter_->set_interrupt(interrupt);
     }
@@ -353,14 +355,14 @@ public:
    * Test if tile exists
    * @param  graphid  GraphId of the tile to test (tile id and level).
    */
-  bool DoesTileExist(const GraphId& graphid) const;
+  virtual bool DoesTileExist(const GraphId& graphid) const;
 
   /**
    * Get a pointer to a graph tile object given a GraphId.
    * @param graphid  the graphid of the tile
    * @return GraphTile* a pointer to the graph tile
    */
-  const GraphTile* GetGraphTile(const GraphId& graphid);
+  virtual const GraphTile* GetGraphTile(const GraphId& graphid);
 
   /**
    * Get a pointer to a graph tile object given a GraphId. This method also
@@ -401,7 +403,7 @@ public:
   /**
    * Clears the cache
    */
-  void Clear() {
+  virtual void Clear() {
     cache_->Clear();
   }
 
@@ -409,7 +411,7 @@ public:
    * Tries to ensure the cache footprint below allowed maximum
    * In some cases may even remove the entire cache.
    */
-  void Trim() {
+  virtual void Trim() {
     cache_->Trim();
   }
 
@@ -425,7 +427,7 @@ public:
    * Lets you know if the cache is too large
    * @return true if the cache is over committed with respect to the limit
    */
-  bool OverCommitted() const {
+  virtual bool OverCommitted() const {
     return cache_->OverCommitted();
   }
 


### PR DESCRIPTION
A more lightweight alternative to https://github.com/valhalla/valhalla/pull/2333.

The idea here is that implementations will have an easier time overriding the `GetGraphTile` method for accessing tiles in alternative storage locations.

A further refactor could be to move the members of `GraphReader` to a `GraphReaderImpl`, pimpl-style, and build a factory in the `GraphReader` constructor that chooses the impl.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)

