### PR TITLE
map matching: throw error (443) when no candidate edges are available.

### DIFF
--- a/src/meili/map_matcher.cc
+++ b/src/meili/map_matcher.cc
@@ -711,9 +711,8 @@ std::vector<MatchResults> MapMatcher::OfflineMatch(const std::vector<Measurement
 
   // Separate the measurements we are using for matching from the ones we'll just interpolate
   auto interpolated = AppendMeasurements(measurements);
-  // Should no matching edge candidates be found for the minimum required number of points, throw a
-  // 443 - NoSegment error code.
-  if (interpolated.size() < 2) {
+  // Without minimum number of edge candidates, throw a 443 - NoSegment error code.
+  if (!container_.HasMinimumCandidates()) {
     throw valhalla_exception_t{443};
   }
 

--- a/src/meili/map_matcher.cc
+++ b/src/meili/map_matcher.cc
@@ -6,6 +6,8 @@
 #include "meili/routing.h"
 #include "meili/transition_cost_model.h"
 #include "midgard/distanceapproximator.h"
+#include "worker.h"
+
 #include <array>
 
 namespace {
@@ -709,6 +711,11 @@ std::vector<MatchResults> MapMatcher::OfflineMatch(const std::vector<Measurement
 
   // Separate the measurements we are using for matching from the ones we'll just interpolate
   auto interpolated = AppendMeasurements(measurements);
+  // Should no matching edge candidates be found for the minimum required number of points, throw a
+  // 443 - NoSegment error code.
+  if (interpolated.size() < 2) {
+    throw valhalla_exception_t{443};
+  }
 
   // For k paths
   std::vector<StateId> state_ids;

--- a/src/thor/trace_route_action.cc
+++ b/src/thor/trace_route_action.cc
@@ -93,7 +93,11 @@ void thor_worker_t::trace_route(Api& request) {
     case ShapeMatch::map_snap:
       try {
         map_match(request);
-      } catch (...) { throw valhalla_exception_t{442}; }
+      } catch (const valhalla_exception_t& e) {
+        throw e;
+      } catch (...) {
+        throw valhalla_exception_t{442};
+      }
       break;
     // If we think that we have the exact shape but there ends up being no Valhalla route match,
     // then we want to fallback to try and use meili map matching to match to local route

--- a/src/thor/trace_route_action.cc
+++ b/src/thor/trace_route_action.cc
@@ -91,6 +91,7 @@ void thor_worker_t::trace_route(Api& request) {
     // If non-exact shape points are used, then we need to correct this shape by sending them
     // through the map-matching algorithm to snap the points to the correct shape
     case ShapeMatch::map_snap:
+      // clang-format off
       try {
         map_match(request);
       } catch (const valhalla_exception_t& e) {
@@ -98,6 +99,7 @@ void thor_worker_t::trace_route(Api& request) {
       } catch (...) {
         throw valhalla_exception_t{442};
       }
+      // clang-format on
       break;
     // If we think that we have the exact shape but there ends up being no Valhalla route match,
     // then we want to fallback to try and use meili map matching to match to local route

--- a/src/thor/trace_route_action.cc
+++ b/src/thor/trace_route_action.cc
@@ -105,6 +105,7 @@ void thor_worker_t::trace_route(Api& request) {
     // then we want to fallback to try and use meili map matching to match to local route
     // network. No shortcuts are used and detailed information at every intersection becomes
     // available.
+    // clang-format off
     case ShapeMatch::walk_or_snap:
       try {
         route_match(request);
@@ -113,8 +114,13 @@ void thor_worker_t::trace_route(Api& request) {
                  " algorithm failed to find exact route match; Falling back to map_match...");
         try {
           map_match(request);
-        } catch (...) { throw valhalla_exception_t{442}; }
+        } catch (const valhalla_exception_t& e) {
+          throw e;
+        } catch (...) {
+          throw valhalla_exception_t{442};
+        }
       }
+      // clang-format on
       break;
   }
 

--- a/test/mapmatch.cc
+++ b/test/mapmatch.cc
@@ -1376,6 +1376,36 @@ TEST(Mapmatch, duplicated_end_points) {
     ASSERT_EQ(req_rep.options().shape_size() - 1, req_rep.trip().routes(0).legs_size());
   }
 }
+
+TEST(Mapmatch, no_edge_candidates) {
+  // clang-format off
+  std::vector<std::pair<size_t, std::string>> test_cases = {
+    {443, R"({"shape":[
+             {"lat":"52.0954408","lon":"5.1135341","type":"break","radius":15},
+             {"lat":"52.0954819","lon":"5.1135190","type":"break","radius":15}],
+              "costing":"auto","shape_match":"map_snap","format":"osrm",
+              "trace_options":{"interpolation_distance":0}})"},
+    {443, R"({"shape":[
+             {"lat":"52.0954408","lon":"5.1135341","type":"break","radius":15},
+             {"lat":"52.0954819","lon":"5.1135190","type":"break","radius":15},
+             {"lat":"52.0954010","lon":"5.1135599","type":"break","radius":15}],
+             "costing":"auto","shape_match":"map_snap","format":"osrm",
+             "trace_options":{"interpolation_distance":0}})"},
+    {442, R"({"shape":[
+             {"lat":"52.0954342","lon":"5.1140063","type":"break","radius":15},
+             {"lat":"52.0954819","lon":"5.1135190","type":"break","radius":15}],
+             "costing":"auto","shape_match":"map_snap","format":"osrm",
+             "trace_options":{"interpolation_distance":0}})"}
+  };
+  // clang-format on
+  tyr::actor_t actor(conf, true);
+  for (size_t i = 0; i < test_cases.size(); ++i) {
+    Api req_rep;
+    try {
+      actor.trace_route(test_cases[i].second, nullptr, &req_rep);
+    } catch (const valhalla::valhalla_exception_t& e) { ASSERT_EQ(e.code, test_cases[i].first); }
+  }
+}
 } // namespace
 
 int main(int argc, char* argv[]) {

--- a/test/mapmatch.cc
+++ b/test/mapmatch.cc
@@ -1380,6 +1380,7 @@ TEST(Mapmatch, duplicated_end_points) {
 TEST(Mapmatch, no_edge_candidates) {
   // clang-format off
   std::vector<std::pair<size_t, std::string>> test_cases = {
+    // First two cases are too far from the road to have candidates, so throw 443 NoSegment.
     {443, R"({"shape":[
              {"lat":"52.0954408","lon":"5.1135341","type":"break","radius":15},
              {"lat":"52.0954819","lon":"5.1135190","type":"break","radius":15}],
@@ -1391,6 +1392,7 @@ TEST(Mapmatch, no_edge_candidates) {
              {"lat":"52.0954010","lon":"5.1135599","type":"break","radius":15}],
              "costing":"auto","shape_match":"map_snap","format":"osrm",
              "trace_options":{"interpolation_distance":0}})"},
+    // Only a single point is too far, so we should throw 442 NoRoute.
     {442, R"({"shape":[
              {"lat":"52.0954342","lon":"5.1140063","type":"break","radius":15},
              {"lat":"52.0954819","lon":"5.1135190","type":"break","radius":15}],

--- a/valhalla/meili/state.h
+++ b/valhalla/meili/state.h
@@ -127,9 +127,11 @@ public:
   // Check to see if we have the minimum number of measurements and edge candidates to perform a map
   // match. We need at least two measurements with a non-zero number of edge candidates.
   bool HasMinimumCandidates() {
-    size_t num_nonempty =
-        std::count_if(columns_.begin(), columns_.end(), [](Column& col) { return !col.empty(); });
-    return size() > 1 && num_nonempty > 1;
+    if (size() < 2) {
+      return false;
+    }
+    return std::find_if(columns_.begin(), columns_.end(),
+                        [](Column& col) { return col.size() > 0; }) != columns_.end();
   }
 
   std::string geojson(const StateId& s) const {

--- a/valhalla/meili/state.h
+++ b/valhalla/meili/state.h
@@ -2,6 +2,7 @@
 #ifndef MMP_STATE_H_
 #define MMP_STATE_H_
 
+#include <algorithm>
 #include <unordered_map>
 #include <vector>
 

--- a/valhalla/meili/state.h
+++ b/valhalla/meili/state.h
@@ -123,6 +123,14 @@ public:
     return static_cast<StateId::Time>(columns_.size());
   }
 
+  // Check to see if we have the minimum number of measurements and edge candidates to perform a map
+  // match. We need at least two measurements with a non-zero number of edge candidates.
+  bool HasMinimumCandidates() {
+    size_t num_nonempty =
+        std::count_if(columns_.begin(), columns_.end(), [](Column& col) { return !col.empty(); });
+    return size() > 1 && num_nonempty > 1;
+  }
+
   std::string geojson(const StateId& s) const {
     if (s.IsValid()) {
       return geojson(state(s));

--- a/valhalla/meili/state.h
+++ b/valhalla/meili/state.h
@@ -125,7 +125,7 @@ public:
   }
 
   // Check to see if we have the minimum number of measurements and edge candidates to perform a map
-  // match. We need at least two measurements with a non-zero number of edge candidates.
+  // match. We need at least one measurements with a non-zero number of edge candidates.
   bool HasMinimumCandidates() {
     if (size() < 2) {
       return false;


### PR DESCRIPTION
- When making map matching requests far from the road network, we
  currently return 442 'NoRoute' error, when a 443 'NoSegment' would
  be more appropriate. This checks for the number of (interpolated)
  measurements and uses Valhalla's exception handling to return the
  correct error code to the client.

/cc @kevinkreiser @yuzheyan