### PR TITLE
Don't allow more than one dot when parsing numbers in Lua.

### DIFF
--- a/lua/graph.lua
+++ b/lua/graph.lua
@@ -636,12 +636,16 @@ function numeric_prefix(num_str, allow_decimals)
 
   --find where the numbers stop
   local index = 0
+  -- flag to say if we've seen a decimal dot already. we shouldn't allow two,
+  -- otherwise the call to tonumber() might fail.
+  local seen_dot = false
   for c in num_str:gmatch"." do
     if tonumber(c) == nil then
       if c == "." then
-        if allow_decimals == false then
+        if allow_decimals == false or seen_dot then
            break
         end
+        seen_dot = true
       else
         break
       end

--- a/lua/graph.lua
+++ b/lua/graph.lua
@@ -718,71 +718,62 @@ end
 function normalize_measurement(measurement)
 
   if measurement then
+    -- turn commas into dots to handle European-style decimal separators
+    measurement = measurement:gsub(",", ".")
 
-    local m = measurement:gsub("%s+", "")
-    --7'6" or 7ft6in
-    --7m
-    --7
-    --grab the number prefix
-    local num = numeric_prefix(m, true)
+    -- handle the simple case: it's just a plain number
+    local num = tonumber(measurement)
     if num then
-      if m:sub(-1) == "m" or m:sub(-5) == "meter" or m:sub(-6) == "meters" then
-        if (num .. "m" == m) or (num .. "meter" == m) or (num .. "meters" == m) then
-          return round(tonumber(num),2)
-        end
+      return round(num, 2)
+    end
+
+    -- more complicated case, try some Lua patterns. they're almost like regular
+    -- expressions, so there'll probably be some unintended consequences!
+    --
+    -- because we want to parse compount expressions such as 3ft6in, then we use
+    -- an accumulator to sum up each term in meters. this has the unintended
+    -- side-effect that 10m6ft would also be valid... but whatever.
+    local sum = 0
+    local count = 0
+    for item, unit in measurement:gmatch("(%d+[.,]?%d*) *([a-zA-Z\"\']*)") do
+
+      -- just in case the pattern above matches some things that tonumber()
+      -- disagrees are valid numbers, we'll bail here if we don't get a valid
+      -- number.
+      item_num = tonumber(item)
+      if not item_num then
+        return nil
       end
 
-      local feet
-      local inches
+      -- case shouldn't matter for units, so just lower case everything before
+      -- comparing.
+      unit = unit:lower()
 
-      if m:sub(-2) == "in" or m:sub(-1) == "\"" or m:sub(-6) == "inches" or m:sub(-4) == "inch" then
-
---have to check for inches only
-        if (num .. "in" == m) or (num .. "\"" == m) or (num .. "inches" == m) or (num .. "inch" == m) then
-          return round((tonumber(num) * 0.0254),2)
-        end
-
-        feet = num
-        m = string.sub(measurement, string.len(tostring(feet))+1)
-
-        local index = 0
-        for c in m:gmatch"." do
-          if tonumber(c) ~= nil then
-            break
-          end
-          index = index + 1
-        end
-
-        m = m:sub(index+1)
-        inches = numeric_prefix(m, true)
-        num = round((tonumber(feet) * 0.3048) + (tonumber(inches) * 0.0254),2)
-      elseif m:sub(-2) == "ft" or m:sub(-1) == "\'" or m:sub(-4) == "feet" then
-        feet = num
-        num = round((tonumber(feet) * 0.3048),2)
+      if unit == "m" or unit == "meter" or unit == "meters" then
+        sum = sum + item_num
+      elseif unit == "cm" then
+        sum = sum + item_num * 0.01
+      elseif (unit == "ft" or unit == "feet" or unit == "foot" or
+              unit == "'") then
+        sum = sum + item_num * 0.3048
+      elseif (unit == "in" or unit == "inches" or unit == "inch" or
+              unit == "\"" or unit == "''") then
+        sum = sum + item_num * 0.0254
       else
-        feet = num
-        m = string.sub(measurement, string.len(tostring(feet))+1)
-
-        local index = 0
-        for c in m:gmatch"." do
-          if tonumber(c) ~= nil then
-            break
-          end
-          index = index + 1
-        end
-
-        if index ~= 0 then
---crappy data case.  7'6 or 7ft6
-          m = m:sub(index+1)
-          inches = numeric_prefix(m, true)
-          if inches then
-            num = round((tonumber(feet) * 0.3048) + (tonumber(inches) * 0.0254),2)
-          else
-            num = round((tonumber(feet) * 0.3048),2)
-          end
-        end
+        -- unknown unit! bail!
+        return nil
       end
-      return round(tonumber(num),2)
+
+      -- increment counter, so we can check how many parts we parsed (mainly to
+      -- make sure it's not none at all).
+      count = count + 1
+    end
+
+    if count > 0 then
+      -- if we got here, then the units seem valid. yay! now we round to two
+      -- decimal digits, because precision of less than a centimeter seems
+      -- unnecessary.
+      return round(sum, 2)
     end
   end
   return nil

--- a/src/mjolnir/luatagtransform.cc
+++ b/src/mjolnir/luatagtransform.cc
@@ -51,6 +51,16 @@ void stackdump_g(lua_State* l) {
   printf("\n"); /* end the listing */
 }
 
+std::string to_string(OSMType t) {
+  if (t == OSMType::kNode) {
+    return "node";
+  } else if (t == OSMType::kWay) {
+    return "way";
+  } else {
+    return "relation";
+  }
+}
+
 } // namespace
 
 LuaTagTransform::LuaTagTransform(const std::string& lua) {
@@ -71,7 +81,7 @@ LuaTagTransform::~LuaTagTransform() {
   }
 }
 
-Tags LuaTagTransform::Transform(OSMType type, const Tags& maptags) {
+Tags LuaTagTransform::Transform(OSMType type, uint64_t osmid, const Tags& maptags) {
 
   // grab the proper function out of the lua code
   Tags result;
@@ -97,8 +107,14 @@ Tags LuaTagTransform::Transform(OSMType type, const Tags& maptags) {
 
     // call lua
     if (lua_pcall(state_, 2, type == OSMType::kWay ? 4 : 2, 0)) {
-      LOG_ERROR("Failed to execute lua function for basic tag processing:" +
-                std::string(lua_tostring(state_, -1)));
+      const char *lua_error_message = lua_tostring(state_, 1);
+      // if the Lua code fails hard, such as throwing an interpreter error or
+      // running out of memory, then this indicates a programming logic error
+      // and the program should stop with as informative an error message as
+      // it's possible to give.
+      throw std::runtime_error((boost::format("Failed to execute lua function "
+            "for basic tag processing in %1% %2%: %3%")
+          % to_string(type) % osmid % lua_error_message).str());
     }
 
     // TODO:  if we dont care about it we stop looking.  Look for filter = 1

--- a/src/mjolnir/luatagtransform.cc
+++ b/src/mjolnir/luatagtransform.cc
@@ -107,14 +107,15 @@ Tags LuaTagTransform::Transform(OSMType type, uint64_t osmid, const Tags& maptag
 
     // call lua
     if (lua_pcall(state_, 2, type == OSMType::kWay ? 4 : 2, 0)) {
-      const char *lua_error_message = lua_tostring(state_, 1);
+      const char* lua_error_message = lua_tostring(state_, 1);
       // if the Lua code fails hard, such as throwing an interpreter error or
       // running out of memory, then this indicates a programming logic error
       // and the program should stop with as informative an error message as
       // it's possible to give.
       throw std::runtime_error((boost::format("Failed to execute lua function "
-            "for basic tag processing in %1% %2%: %3%")
-          % to_string(type) % osmid % lua_error_message).str());
+                                              "for basic tag processing in %1% %2%: %3%") %
+                                to_string(type) % osmid % lua_error_message)
+                                   .str());
     }
 
     // TODO:  if we dont care about it we stop looking.  Look for filter = 1

--- a/src/mjolnir/pbfadminparser.cc
+++ b/src/mjolnir/pbfadminparser.cc
@@ -81,7 +81,7 @@ public:
                                  const OSMPBF::Tags& tags,
                                  const std::vector<OSMPBF::Member>& members) override {
     // Get tags
-    auto results = lua_.Transform(OSMType::kRelation, tags);
+    auto results = lua_.Transform(OSMType::kRelation, osmid, tags);
     if (results.size() == 0) {
       return;
     }

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -1399,7 +1399,8 @@ public:
                                  const OSMPBF::Tags& tags,
                                  const std::vector<OSMPBF::Member>& members) override {
     // Get tags
-    Tags results = tags.empty() ? empty_relation_results_ : lua_.Transform(OSMType::kRelation, osmid, tags);
+    Tags results =
+        tags.empty() ? empty_relation_results_ : lua_.Transform(OSMType::kRelation, osmid, tags);
     if (results.size() == 0) {
       return;
     }

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -117,9 +117,9 @@ public:
     use_direction_on_ways_ = pt.get<bool>("data_processing.use_direction_on_ways", false);
     allow_alt_name_ = pt.get<bool>("data_processing.allow_alt_name", false);
 
-    empty_node_results_ = lua_.Transform(OSMType::kNode, {});
-    empty_way_results_ = lua_.Transform(OSMType::kWay, {});
-    empty_relation_results_ = lua_.Transform(OSMType::kRelation, {});
+    empty_node_results_ = lua_.Transform(OSMType::kNode, 0, {});
+    empty_way_results_ = lua_.Transform(OSMType::kWay, 0, {});
+    empty_relation_results_ = lua_.Transform(OSMType::kRelation, 0, {});
   }
 
   static std::string get_lua(const boost::property_tree::ptree& pt) {
@@ -141,7 +141,7 @@ public:
     if (bss_nodes_) {
       // Get tags - do't bother with Lua callout if the taglist is empty
       if (tags.size() > 0) {
-        results = lua_.Transform(OSMType::kNode, tags);
+        results = lua_.Transform(OSMType::kNode, osmid, tags);
       } else {
         results = empty_node_results_;
       }
@@ -168,7 +168,7 @@ public:
     // Get tags if not already available.  Don't bother calling Lua if there
     // are no OSM tags to process.
     if (tags.size() > 0) {
-      results = results ? results : lua_.Transform(OSMType::kNode, tags);
+      results = results ? results : lua_.Transform(OSMType::kNode, osmid, tags);
     } else {
       results = results ? results : empty_node_results_;
     }
@@ -326,7 +326,7 @@ public:
 
     // Transform tags. If no results that means the way does not have tags
     // suitable for use in routing.
-    Tags results = tags.size() == 0 ? empty_way_results_ : lua_.Transform(OSMType::kWay, tags);
+    Tags results = tags.size() == 0 ? empty_way_results_ : lua_.Transform(OSMType::kWay, osmid, tags);
     if (results.size() == 0) {
       return;
     }
@@ -1399,7 +1399,7 @@ public:
                                  const OSMPBF::Tags& tags,
                                  const std::vector<OSMPBF::Member>& members) override {
     // Get tags
-    Tags results = tags.empty() ? empty_relation_results_ : lua_.Transform(OSMType::kRelation, tags);
+    Tags results = tags.empty() ? empty_relation_results_ : lua_.Transform(OSMType::kRelation, osmid, tags);
     if (results.size() == 0) {
       return;
     }

--- a/test/lua.cc
+++ b/test/lua.cc
@@ -16,7 +16,7 @@ TEST(Lua, ZeroMantissa) {
   // Check that decimals are properly parsed
   tags.insert({"highway", "primary"});
   tags.insert({"maxheight", "2.0"});
-  auto results = lua.Transform(mjolnir::OSMType::kWay, tags);
+  auto results = lua.Transform(mjolnir::OSMType::kWay, 1, tags);
   ASSERT_FLOAT_EQ(2.0f, std::stof(results["maxheight"]));
 }
 
@@ -95,7 +95,7 @@ TEST(Lua, NumberDoublePeriod) {
   mjolnir::Tags tags;
   tags.insert({"highway", "tertiary"});
   tags.insert({"maxheight", "3..35"});
-  auto results = lua.Transform(mjolnir::OSMType::kWay, tags);
+  auto results = lua.Transform(mjolnir::OSMType::kWay, 1, tags);
 
   // check that the maxheight isn't present...
   ASSERT_TRUE(results.count("maxheight") == 0);

--- a/test/lua.cc
+++ b/test/lua.cc
@@ -19,6 +19,90 @@ TEST(Lua, ZeroMantissa) {
   auto results = lua.Transform(mjolnir::OSMType::kWay, tags);
   ASSERT_FLOAT_EQ(2.0f, std::stof(results["maxheight"]));
 }
+
+void assert_height_parses(std::string maxheight, float expected) {
+  mjolnir::LuaTagTransform lua(std::string(lua_graph_lua, lua_graph_lua + lua_graph_lua_len));
+
+  mjolnir::Tags tags;
+  tags.insert({"highway", "tertiary"});
+  tags.insert({"maxheight", maxheight});
+  auto results = lua.Transform(mjolnir::OSMType::kWay, 1, tags);
+  ASSERT_TRUE(results.count("maxheight") == 1);
+  ASSERT_FLOAT_EQ(expected, std::stof(results["maxheight"]));
+}
+
+TEST(Lua, DefaultMeters) {
+  // default for a number without units should be meters
+  assert_height_parses("1.0", 1.0f);
+  assert_height_parses("1", 1.0f);
+  assert_height_parses("1.1", 1.1f);
+}
+
+TEST(Lua, ExplicitMeters) {
+  // check all the common ways of writing meters
+  assert_height_parses("1m", 1.0f);
+
+  // there could be spaces, or not.
+  assert_height_parses("1.1 m", 1.1f);
+  assert_height_parses("1.1m", 1.1f);
+  assert_height_parses("1 m", 1.0f);
+
+  // but the units can change if they're plural
+  assert_height_parses("1 meter", 1.0f);
+  assert_height_parses("2meters", 2.0f);
+}
+
+TEST(Lua, UnitsCaseInsensitive) {
+  // case doesn't matter for units
+  assert_height_parses("1 METERS", 1.0f);
+}
+
+TEST(Lua, Centimeters) {
+  // yes, this exists in the data...
+  assert_height_parses("100cm", 1.0f);
+}
+
+TEST(Lua, EuropeanDecimal) {
+  // it's common to see numbers written using the European convention of a
+  // comma as the decimal separator.
+  assert_height_parses("1,1", 1.1f);
+}
+
+TEST(Lua, FeetAndInches) {
+  // there are a bunch of different commonly-used ways of writing heights in
+  // feet and inches in OSM. here's a few, cropped from taginfo and generalised
+  // to their generic formats.
+  assert_height_parses("1ft1in", 0.33f);
+  assert_height_parses("2 feet 1 inch", 0.64f);
+  assert_height_parses("1 foot 6 inches", 0.46f);
+  assert_height_parses("1.1 ft", 0.34f);
+  assert_height_parses("1 ft", 0.3f);
+
+  // feet and inches can also be written with single and double quotes (' and ")
+  // and even with two single quotes (' and '').
+  assert_height_parses("1'", 0.3f);
+  assert_height_parses("1.1\"", 0.03f);
+  assert_height_parses("1' 1\"", 0.33f);
+  assert_height_parses("1'1\"", 0.33f);
+  assert_height_parses("1'1''", 0.33f);
+}
+
+TEST(Lua, NumberDoublePeriod) {
+  // Way 25494427 version 14 has a "maxheight" tag value of 3..35 with the two
+  // dots. This probably shouldn't be parsed?
+  mjolnir::LuaTagTransform lua(std::string(lua_graph_lua, lua_graph_lua + lua_graph_lua_len));
+
+  mjolnir::Tags tags;
+  tags.insert({"highway", "tertiary"});
+  tags.insert({"maxheight", "3..35"});
+  auto results = lua.Transform(mjolnir::OSMType::kWay, tags);
+
+  // check that the maxheight isn't present...
+  ASSERT_TRUE(results.count("maxheight") == 0);
+
+  // ... but that the results aren't completely empty
+  ASSERT_TRUE(results.size() > 0);
+}
 } // namespace
 
 // TODO: sweet jesus add more tests of this class!

--- a/valhalla/mjolnir/luatagtransform.h
+++ b/valhalla/mjolnir/luatagtransform.h
@@ -29,7 +29,7 @@ public:
 
   ~LuaTagTransform();
 
-  Tags Transform(OSMType type, const Tags& tags);
+  Tags Transform(OSMType type, uint64_t osmid, const Tags& tags);
 
 protected:
   lua_State* state_;


### PR DESCRIPTION
The `numeric_prefix` function in Lua was accepting any number of digits and dots (`.`), however Lua's `tonumber` function would return `nil` for anything with more than one dot. This was happening in way 25494427, which had `maxheight=3..35`. Fixed the parser by allowing only a single dot before breaking the loop.

# Issue

What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
