### PR TITLE
Do not allocate memory in skadi if we don't need it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,8 @@
    * CHANGED: Switch to LuaJIT for lua scripting - speeds up file parsing [#2352](https://github.com/valhalla/valhalla/pull/2352)
    * ADDED: Ability to create OpenLR records from raw data. [2356](https://github.com/valhalla/valhalla/pull/2356)
    * ADDED: Revamp length phrases [2359](https://github.com/valhalla/valhalla/pull/2359)
-
+   * CHANGED: Do not allocate memory in skadi if we don't need it. [#2373](https://github.com/valhalla/valhalla/pull/2373)
+   
 ## Release Date: 2019-11-21 Valhalla 3.0.9
 * **Bug Fix**
    * FIXED: Changed reachability computation to consider both directions of travel wrt candidate edges [#1965](https://github.com/valhalla/valhalla/pull/1965)

--- a/src/skadi/sample.cc
+++ b/src/skadi/sample.cc
@@ -107,8 +107,7 @@ namespace valhalla {
 namespace skadi {
 
 ::valhalla::skadi::sample::sample(const std::string& data_source)
-    : mapped_cache(TILE_COUNT), unzipped_cache(-1, std::vector<int16_t>(HGT_PIXELS)),
-      data_source(data_source) {
+    : mapped_cache(TILE_COUNT), unzipped_cache(-1, std::vector<int16_t>()), data_source(data_source) {
   // messy but needed
   while (this->data_source.size() &&
          this->data_source.back() == filesystem::path::preferred_separator) {
@@ -169,6 +168,7 @@ const int16_t* sample::source(uint16_t index) const {
 
   // for setting where to write the uncompressed data to
   auto dst_func = [this](z_stream& s) -> int {
+    unzipped_cache.second.resize(HGT_PIXELS);
     s.next_out = static_cast<Byte*>(static_cast<void*>(unzipped_cache.second.data()));
     s.avail_out = HGT_BYTES;
     return Z_FINISH; // we know the output will hold all the input


### PR DESCRIPTION
# Issue

`skadi::sample` unconditionally allocates ~26mb of memory even if we never use it.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
