### PR TITLE
Add the remaining guide sign toward phrases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@
    * ADDED: Extend roundabout phrases. [2378](https://github.com/valhalla/valhalla/pull/2378)
    * ADDED: More roundabout phrase tests. [2382](https://github.com/valhalla/valhalla/pull/2382)
    * ADDED: Update the turn and continue phrases to include junction names and guide signs. [2386](https://github.com/valhalla/valhalla/pull/2386)
+   * ADDED: Add the remaining guide sign toward phrases [2389](https://github.com/valhalla/valhalla/pull/2389)
    
 ## Release Date: 2019-11-21 Valhalla 3.0.9
 * **Bug Fix**

--- a/locales/ca-ES.json
+++ b/locales/ca-ES.json
@@ -354,7 +354,8 @@
       "phrases": {
         "0": "Agafa el ferri.",
         "1": "Agafa <STREET_NAMES>.",
-        "2": "Agafa <STREET_NAMES> <FERRY_LABEL>."
+        "2": "Agafa <STREET_NAMES> <FERRY_LABEL>.",
+        "3": "Take the ferry toward <TOWARD_SIGN>."
       },
       "empty_street_name_labels": [
         "la vorera",
@@ -371,6 +372,9 @@
         ],
         "2": [
           "Agafa el Bridgeport - Port Jefferson Ferry."
+        ],
+        "3": [
+          "Take the ferry toward Cape May."
         ]
       }
     },
@@ -378,7 +382,8 @@
       "phrases": {
         "0": "Agafa el ferri.",
         "1": "Agafa el <STREET_NAMES>.",
-        "2": "Agafa el <STREET_NAMES> <FERRY_LABEL>."
+        "2": "Agafa el <STREET_NAMES> <FERRY_LABEL>.",
+        "3": "Take the ferry toward <TOWARD_SIGN>."
       },
       "empty_street_name_labels": [
         "la vorera",
@@ -395,6 +400,9 @@
         ],
         "2": [
           "Agafa el Bridgeport - Port Jefferson Ferry."
+        ],
+        "3": [
+          "Take the ferry toward Cape May."
         ]
       }
     },
@@ -1031,7 +1039,9 @@
         "0": "Enllaça.",
         "1": "Enllaça a <RELATIVE_DIRECTION>.",
         "2": "Enllaça amb <STREET_NAMES>.",
-        "3": "Enllaça a <RELATIVE_DIRECTION> amb <STREET_NAMES>."
+        "3": "Enllaça a <RELATIVE_DIRECTION> amb <STREET_NAMES>.",
+        "4": "Merge toward <TOWARD_SIGN>.",
+        "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
       "relative_directions": [
         "l'esquerra",
@@ -1054,6 +1064,12 @@
         ],
         "3": [
           "Enllaça a la dreta amb I 83 South."
+        ],
+        "4": [
+          "Merge toward Baltimore."
+        ],
+        "5": [
+          "Merge right toward Baltimore."
         ]
       }
     },
@@ -1062,7 +1078,9 @@
         "0": "Enllaça.",
         "1": "Enllaça a <RELATIVE_DIRECTION>.",
         "2": "Enllaça amb <STREET_NAMES>.",
-        "3": "Enllaça a <RELATIVE_DIRECTION> amb <STREET_NAMES>."
+        "3": "Enllaça a <RELATIVE_DIRECTION> amb <STREET_NAMES>.",
+        "4": "Merge toward <TOWARD_SIGN>.",
+        "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
       "relative_directions": [
         "l'esquerra",
@@ -1085,6 +1103,12 @@
         ],
         "3": [
           "Enllaça a la dreta amb I 83 South."
+        ],
+        "4": [
+          "Merge toward Baltimore."
+        ],
+        "5": [
+          "Merge right toward Baltimore."
         ]
       }
     },

--- a/locales/cs-CZ.json
+++ b/locales/cs-CZ.json
@@ -354,7 +354,8 @@
       "phrases": {
         "0": "Vjeďte na trajekt.",
         "1": "Vjeďte na <STREET_NAMES>.",
-        "2": "Vjeďte na <FERRY_LABEL> <STREET_NAMES>."
+        "2": "Vjeďte na <FERRY_LABEL> <STREET_NAMES>.",
+        "3": "Take the ferry toward <TOWARD_SIGN>."
       },
       "empty_street_name_labels": [
         "chodník",
@@ -371,6 +372,9 @@
         ],
         "2": [
           "Vjeďte na trajekt Bridgeport - Port Jefferson."
+        ],
+        "3": [
+          "Take the ferry toward Cape May."
         ]
       }
     },
@@ -378,7 +382,8 @@
       "phrases": {
         "0": "Vjeďte na trajekt.",
         "1": "Vjeďte na <STREET_NAMES>.",
-        "2": "Vjeďte na <FERRY_LABEL> <STREET_NAMES>."
+        "2": "Vjeďte na <FERRY_LABEL> <STREET_NAMES>.",
+        "3": "Take the ferry toward <TOWARD_SIGN>."
       },
       "empty_street_name_labels": [
         "chodník",
@@ -395,6 +400,9 @@
         ],
         "2": [
           "Vjeďte na trajekt Bridgeport - Port Jefferson."
+        ],
+        "3": [
+          "Take the ferry toward Cape May."
         ]
       }
     },
@@ -1031,7 +1039,9 @@
         "0": "Připojte se.",
         "1": "Připojte se <RELATIVE_DIRECTION>.",
         "2": "Připojte se na <STREET_NAMES>.",
-        "3": "Připojte se <RELATIVE_DIRECTION> na <STREET_NAMES>."
+        "3": "Připojte se <RELATIVE_DIRECTION> na <STREET_NAMES>.",
+        "4": "Merge toward <TOWARD_SIGN>.",
+        "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
       "relative_directions": [
         "vlevo",
@@ -1054,6 +1064,12 @@
         ],
         "3": [
           "Připojte se vpravo na I 83 South."
+        ],
+        "4": [
+          "Merge toward Baltimore."
+        ],
+        "5": [
+          "Merge right toward Baltimore."
         ]
       }
     },
@@ -1062,7 +1078,9 @@
         "0": "Připojte se.",
         "1": "Připojte se <RELATIVE_DIRECTION>.",
         "2": "Připojte se na <STREET_NAMES>.",
-        "3": "Připojte se <RELATIVE_DIRECTION> na <STREET_NAMES>."
+        "3": "Připojte se <RELATIVE_DIRECTION> na <STREET_NAMES>.",
+        "4": "Merge toward <TOWARD_SIGN>.",
+        "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
       "relative_directions": [
         "vlevo",
@@ -1085,6 +1103,12 @@
         ],
         "3": [
           "Připojte se vpravo na I 83 South."
+        ],
+        "4": [
+          "Merge toward Baltimore."
+        ],
+        "5": [
+          "Merge right toward Baltimore."
         ]
       }
     },

--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -354,7 +354,8 @@
       "phrases": {
         "0": "Die Fähre nehmen.",
         "1": "Die <STREET_NAMES> nehmen.",
-        "2": "Die <FERRY_LABEL> <STREET_NAMES> nehmen."
+        "2": "Die <FERRY_LABEL> <STREET_NAMES> nehmen.",
+        "3": "Take the ferry toward <TOWARD_SIGN>."
       },
       "empty_street_name_labels": [
         "Fußweg",
@@ -371,6 +372,9 @@
         ],
         "2": [
           "Take the Bridgeport - Port Jefferson Ferry."
+        ],
+        "3": [
+          "Take the ferry toward Cape May."
         ]
       }
     },
@@ -378,7 +382,8 @@
       "phrases": {
         "0": "Die Fähre nehmen.",
         "1": "Die <STREET_NAMES> nehmen.",
-        "2": "Die <FERRY_LABEL> <STREET_NAMES> nehmen."
+        "2": "Die <FERRY_LABEL> <STREET_NAMES> nehmen.",
+        "3": "Take the ferry toward <TOWARD_SIGN>."
       },
       "empty_street_name_labels": [
         "Fußweg",
@@ -395,6 +400,9 @@
         ],
         "2": [
           "Take the Bridgeport - Port Jefferson Ferry."
+        ],
+        "3": [
+          "Take the ferry toward Cape May."
         ]
       }
     },
@@ -1031,7 +1039,9 @@
         "0": "Einfädeln.",
         "1": "<RELATIVE_DIRECTION> einfädeln.",
         "2": "Auf <STREET_NAMES> einfädeln.",
-        "3": "<RELATIVE_DIRECTION> auf <STREET_NAMES> einfädeln."
+        "3": "<RELATIVE_DIRECTION> auf <STREET_NAMES> einfädeln.",
+        "4": "Merge toward <TOWARD_SIGN>.",
+        "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
       "relative_directions": [
         "Links",
@@ -1054,6 +1064,12 @@
         ],
         "3": [
           "Merge right onto I 83 South."
+        ],
+        "4": [
+          "Merge toward Baltimore."
+        ],
+        "5": [
+          "Merge right toward Baltimore."
         ]
       }
     },
@@ -1062,7 +1078,9 @@
         "0": "Einfädeln.",
         "1": "<RELATIVE_DIRECTION> einfädeln.",
         "2": "Auf <STREET_NAMES> einfädeln.",
-        "3": "<RELATIVE_DIRECTION> auf <STREET_NAMES> einfädeln."
+        "3": "<RELATIVE_DIRECTION> auf <STREET_NAMES> einfädeln.",
+        "4": "Merge toward <TOWARD_SIGN>.",
+        "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
       "relative_directions": [
         "Links",
@@ -1085,6 +1103,12 @@
         ],
         "3": [
           "Merge right onto I 83 South."
+        ],
+        "4": [
+          "Merge toward Baltimore."
+        ],
+        "5": [
+          "Merge right toward Baltimore."
         ]
       }
     },

--- a/locales/en-US-x-pirate.json
+++ b/locales/en-US-x-pirate.json
@@ -354,7 +354,8 @@
       "phrases": {
         "0": "Ahoy, me matey! Take the Black Pearl.",
         "1": "Ahoy, me matey! Take the <STREET_NAMES>.",
-        "2": "Ahoy, me matey! Take the <STREET_NAMES> <FERRY_LABEL>."
+        "2": "Ahoy, me matey! Take the <STREET_NAMES> <FERRY_LABEL>.",
+        "3": "Take the ferry toward <TOWARD_SIGN>."
       },
       "empty_street_name_labels": [
         "solid ground",
@@ -371,6 +372,9 @@
         ],
         "2": [
           "Ahoy, me matey! Take the Bridgeport - Port Jefferson Ferry."
+        ],
+        "3": [
+          "Take the ferry toward Cape May."
         ]
       }
     },
@@ -378,7 +382,8 @@
       "phrases": {
         "0": "Ahoy, me matey! Take the Black Pearl.",
         "1": "Ahoy, me matey! Take the <STREET_NAMES>.",
-        "2": "Ahoy, me matey! Take the <STREET_NAMES> <FERRY_LABEL>."
+        "2": "Ahoy, me matey! Take the <STREET_NAMES> <FERRY_LABEL>.",
+        "3": "Take the ferry toward <TOWARD_SIGN>."
       },
       "empty_street_name_labels": [
         "solid ground",
@@ -395,6 +400,9 @@
         ],
         "2": [
           "Ahoy, me matey! Take the Bridgeport - Port Jefferson Ferry."
+        ],
+        "3": [
+          "Take the ferry toward Cape May."
         ]
       }
     },
@@ -1031,7 +1039,9 @@
         "0": "Avast ye, merge.",
         "1": "Avast ye, merge to th' <RELATIVE_DIRECTION>.",
         "2": "Merge onto <STREET_NAMES> me matey.",
-        "3": "Merge to th' <RELATIVE_DIRECTION> onto <STREET_NAMES> me matey."
+        "3": "Merge to th' <RELATIVE_DIRECTION> onto <STREET_NAMES> me matey.",
+        "4": "Merge toward <TOWARD_SIGN>.",
+        "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
       "relative_directions": [
         "port",
@@ -1054,6 +1064,12 @@
         ],
         "3": [
           "Merge to th' starboard onto I 83 South me matey."
+        ],
+        "4": [
+          "Merge toward Baltimore."
+        ],
+        "5": [
+          "Merge right toward Baltimore."
         ]
       }
     },
@@ -1062,7 +1078,9 @@
         "0": "Avast ye, merge.",
         "1": "Avast ye, merge to th' <RELATIVE_DIRECTION>.",
         "2": "Merge onto <STREET_NAMES> me matey.",
-        "3": "Merge to th' <RELATIVE_DIRECTION> onto <STREET_NAMES> me matey."
+        "3": "Merge to th' <RELATIVE_DIRECTION> onto <STREET_NAMES> me matey.",
+        "4": "Merge toward <TOWARD_SIGN>.",
+        "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
       "relative_directions": [
         "port",
@@ -1085,6 +1103,12 @@
         ],
         "3": [
           "Merge to th' starboard onto I 83 South me matey."
+        ],
+        "4": [
+          "Merge toward Baltimore."
+        ],
+        "5": [
+          "Merge right toward Baltimore."
         ]
       }
     },

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -354,7 +354,8 @@
       "phrases": {
         "0": "Take the Ferry.",
         "1": "Take the <STREET_NAMES>.",
-        "2": "Take the <STREET_NAMES> <FERRY_LABEL>."
+        "2": "Take the <STREET_NAMES> <FERRY_LABEL>.",
+        "3": "Take the ferry toward <TOWARD_SIGN>."
       },
       "empty_street_name_labels": [
         "the walkway",
@@ -371,6 +372,9 @@
         ],
         "2": [
           "Take the Bridgeport - Port Jefferson Ferry."
+        ],
+        "3": [
+          "Take the ferry toward Cape May."
         ]
       }
     },
@@ -378,7 +382,8 @@
       "phrases": {
         "0": "Take the Ferry.",
         "1": "Take the <STREET_NAMES>.",
-        "2": "Take the <STREET_NAMES> <FERRY_LABEL>."
+        "2": "Take the <STREET_NAMES> <FERRY_LABEL>.",
+        "3": "Take the ferry toward <TOWARD_SIGN>."
       },
       "empty_street_name_labels": [
         "the walkway",
@@ -395,6 +400,9 @@
         ],
         "2": [
           "Take the Bridgeport - Port Jefferson Ferry."
+        ],
+        "3": [
+          "Take the ferry toward Cape May."
         ]
       }
     },
@@ -1031,7 +1039,9 @@
         "0": "Merge.",
         "1": "Merge <RELATIVE_DIRECTION>.",
         "2": "Merge onto <STREET_NAMES>.",
-        "3": "Merge <RELATIVE_DIRECTION> onto <STREET_NAMES>."
+        "3": "Merge <RELATIVE_DIRECTION> onto <STREET_NAMES>.",
+        "4": "Merge toward <TOWARD_SIGN>.",
+        "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
       "relative_directions": [
         "left",
@@ -1054,6 +1064,12 @@
         ],
         "3": [
           "Merge right onto I 83 South."
+        ],
+        "4": [
+          "Merge toward Baltimore."
+        ],
+        "5": [
+          "Merge right toward Baltimore."
         ]
       }
     },
@@ -1062,7 +1078,9 @@
         "0": "Merge.",
         "1": "Merge <RELATIVE_DIRECTION>.",
         "2": "Merge onto <STREET_NAMES>.",
-        "3": "Merge <RELATIVE_DIRECTION> onto <STREET_NAMES>."
+        "3": "Merge <RELATIVE_DIRECTION> onto <STREET_NAMES>.",
+        "4": "Merge toward <TOWARD_SIGN>.",
+        "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
       "relative_directions": [
         "left",
@@ -1085,6 +1103,12 @@
         ],
         "3": [
           "Merge right onto I 83 South."
+        ],
+        "4": [
+          "Merge toward Baltimore."
+        ],
+        "5": [
+          "Merge right toward Baltimore."
         ]
       }
     },

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -354,7 +354,8 @@
       "phrases": {
         "0": "Tomar el Ferry.",
         "1": "Tomar la <STREET_NAMES>.",
-        "2": "Tomar el <FERRY_LABEL> <STREET_NAMES>."
+        "2": "Tomar el <FERRY_LABEL> <STREET_NAMES>.",
+        "3": "Take the ferry toward <TOWARD_SIGN>."
       },
       "empty_street_name_labels": [
         "la acera",
@@ -371,6 +372,9 @@
         ],
         "2": [
           "Tomar el Ferry Bridgeport - Port Jefferson."
+        ],
+        "3": [
+          "Take the ferry toward Cape May."
         ]
       }
     },
@@ -378,7 +382,8 @@
       "phrases": {
         "0": "Tomar el Ferry.",
         "1": "Tomar la <STREET_NAMES>.",
-        "2": "Tomar el <FERRY_LABEL> <STREET_NAMES>."
+        "2": "Tomar el <FERRY_LABEL> <STREET_NAMES>.",
+        "3": "Take the ferry toward <TOWARD_SIGN>."
       },
       "empty_street_name_labels": [
         "la acera",
@@ -395,6 +400,9 @@
         ],
         "2": [
           "Tomar el Ferry Bridgeport - Port Jefferson."
+        ],
+        "3": [
+          "Take the ferry toward Cape May."
         ]
       }
     },
@@ -1031,7 +1039,9 @@
         "0": "Empalme.",
         "1": "Empalme a la <RELATIVE_DIRECTION>.",
         "2": "Empalme en <STREET_NAMES>.",
-        "3": "Empalme a la <RELATIVE_DIRECTION> en <STREET_NAMES>."
+        "3": "Empalme a la <RELATIVE_DIRECTION> en <STREET_NAMES>.",
+        "4": "Merge toward <TOWARD_SIGN>.",
+        "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
       "relative_directions": [
         "izquierda",
@@ -1054,6 +1064,12 @@
         ],
         "3": [
           "Empalme a la derecha en I 83 South."
+        ],
+        "4": [
+          "Merge toward Baltimore."
+        ],
+        "5": [
+          "Merge right toward Baltimore."
         ]
       }
     },
@@ -1062,7 +1078,9 @@
         "0": "Empalme.",
         "1": "Empalme a la <RELATIVE_DIRECTION>.",
         "2": "Empalme en <STREET_NAMES>.",
-        "3": "Empalme a la <RELATIVE_DIRECTION> en <STREET_NAMES>."
+        "3": "Empalme a la <RELATIVE_DIRECTION> en <STREET_NAMES>.",
+        "4": "Merge toward <TOWARD_SIGN>.",
+        "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
       "relative_directions": [
         "izquierda",
@@ -1085,6 +1103,12 @@
         ],
         "3": [
           "Empalme a la derecha en I 83 South."
+        ],
+        "4": [
+          "Merge toward Baltimore."
+        ],
+        "5": [
+          "Merge right toward Baltimore."
         ]
       }
     },

--- a/locales/fr-FR.json
+++ b/locales/fr-FR.json
@@ -354,7 +354,8 @@
       "phrases": {
         "0": "Prenez le ferry.",
         "1": "Prenez <STREET_NAMES>.",
-        "2": "Prenez la <STREET_NAMES> <FERRY_LABEL>."
+        "2": "Prenez la <STREET_NAMES> <FERRY_LABEL>.",
+        "3": "Take the ferry toward <TOWARD_SIGN>."
       },
       "empty_street_name_labels": [
         "l'allée",
@@ -371,6 +372,9 @@
         ],
         "2": [
           "Prenez Bridgeport - Port Jefferson Ferry."
+        ],
+        "3": [
+          "Take the ferry toward Cape May."
         ]
       }
     },
@@ -378,7 +382,8 @@
       "phrases": {
         "0": "Prenez le Ferry.",
         "1": "Prenez <STREET_NAMES>.",
-        "2": "Prenez <STREET_NAMES> <FERRY_LABEL>."
+        "2": "Prenez <STREET_NAMES> <FERRY_LABEL>.",
+        "3": "Take the ferry toward <TOWARD_SIGN>."
       },
       "empty_street_name_labels": [
         "l'allée",
@@ -395,6 +400,9 @@
         ],
         "2": [
           "Prenez Bridgeport - Port Jefferson Ferry."
+        ],
+        "3": [
+          "Take the ferry toward Cape May."
         ]
       }
     },
@@ -1031,7 +1039,9 @@
         "0": "Rejoignez.",
         "1": "Rejoignez à <RELATIVE_DIRECTION>.",
         "2": "Rejoignez <STREET_NAMES>.",
-        "3": "Rejoignez à <RELATIVE_DIRECTION> <STREET_NAMES>."
+        "3": "Rejoignez à <RELATIVE_DIRECTION> <STREET_NAMES>.",
+        "4": "Merge toward <TOWARD_SIGN>.",
+        "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
       "relative_directions": [
         "gauche",
@@ -1054,6 +1064,12 @@
         ],
         "3": [
           "Rejoignez à droite I 83 South."
+        ],
+        "4": [
+          "Merge toward Baltimore."
+        ],
+        "5": [
+          "Merge right toward Baltimore."
         ]
       }
     },
@@ -1062,7 +1078,9 @@
         "0": "Rejoignez.",
         "1": "Rejoignez à <RELATIVE_DIRECTION>.",
         "2": "Rejoignez <STREET_NAMES>.",
-        "3": "Rejoignez à <RELATIVE_DIRECTION> <STREET_NAMES>."
+        "3": "Rejoignez à <RELATIVE_DIRECTION> <STREET_NAMES>.",
+        "4": "Merge toward <TOWARD_SIGN>.",
+        "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
       "relative_directions": [
         "gauche",
@@ -1085,6 +1103,12 @@
         ],
         "3": [
           "Rejoignez à droite I 83 South."
+        ],
+        "4": [
+          "Merge toward Baltimore."
+        ],
+        "5": [
+          "Merge right toward Baltimore."
         ]
       }
     },

--- a/locales/hi-IN.json
+++ b/locales/hi-IN.json
@@ -354,7 +354,8 @@
       "phrases": {
         "0": "नौका लें.",
         "1": "<STREET_NAMES> लें.",
-        "2": "<STREET_NAMES> <FERRY_LABEL> नौका लें."
+        "2": "<STREET_NAMES> <FERRY_LABEL> नौका लें.",
+        "3": "Take the ferry toward <TOWARD_SIGN>."
       },
       "empty_street_name_labels": [
         "रास्ते",
@@ -371,6 +372,9 @@
         ],
         "2": [
           "Bridgeport - Port Jefferson नौका लें."
+        ],
+        "3": [
+          "Take the ferry toward Cape May."
         ]
       }
     },
@@ -378,7 +382,8 @@
       "phrases": {
         "0": "नौका लें.",
         "1": "<STREET_NAMES> लें.",
-        "2": "<STREET_NAMES> <FERRY_LABEL> नौका लें."
+        "2": "<STREET_NAMES> <FERRY_LABEL> नौका लें.",
+        "3": "Take the ferry toward <TOWARD_SIGN>."
       },
       "empty_street_name_labels": [
         "रास्ते",
@@ -395,6 +400,9 @@
         ],
         "2": [
           "Bridgeport - Port Jefferson नौका लें."
+        ],
+        "3": [
+          "Take the ferry toward Cape May."
         ]
       }
     },
@@ -1031,7 +1039,9 @@
         "0": "मिलें.",
         "1": "<RELATIVE_DIRECTION> मिलें.",
         "2": "<STREET_NAMES> पर मिलें.",
-        "3": "<STREET_NAMES> पर <RELATIVE_DIRECTION> मिलें."
+        "3": "<STREET_NAMES> पर <RELATIVE_DIRECTION> मिलें.",
+        "4": "Merge toward <TOWARD_SIGN>.",
+        "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
       "relative_directions": [
         "बाएं",
@@ -1054,6 +1064,12 @@
         ],
         "3": [
           "I 83 South पर दाएँ मिलें."
+        ],
+        "4": [
+          "Merge toward Baltimore."
+        ],
+        "5": [
+          "Merge right toward Baltimore."
         ]
       }
     },
@@ -1062,7 +1078,9 @@
         "0": "मिलें.",
         "1": "<RELATIVE_DIRECTION> मिलें.",
         "2": "<STREET_NAMES> पर मिलें.",
-        "3": "<STREET_NAMES> पर <RELATIVE_DIRECTION> मिलें."
+        "3": "<STREET_NAMES> पर <RELATIVE_DIRECTION> मिलें.",
+        "4": "Merge toward <TOWARD_SIGN>.",
+        "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
       "relative_directions": [
         "बाएं",
@@ -1085,6 +1103,12 @@
         ],
         "3": [
           "I 83 South पर दाएँ मिलें."
+        ],
+        "4": [
+          "Merge toward Baltimore."
+        ],
+        "5": [
+          "Merge right toward Baltimore."
         ]
       }
     },

--- a/locales/it-IT.json
+++ b/locales/it-IT.json
@@ -354,7 +354,8 @@
       "phrases": {
         "0": "Prendi il traghetto.",
         "1": "Prendi <STREET_NAMES>.",
-        "2": "Prendi <STREET_NAMES> <FERRY_LABEL>."
+        "2": "Prendi <STREET_NAMES> <FERRY_LABEL>.",
+        "3": "Take the ferry toward <TOWARD_SIGN>."
       },
       "empty_street_name_labels": [
         "il marciapiedi",
@@ -371,6 +372,9 @@
         ],
         "2": [
           "Prendi il Bridgeport - Port Jefferson traghetto."
+        ],
+        "3": [
+          "Take the ferry toward Cape May."
         ]
       }
     },
@@ -378,7 +382,8 @@
       "phrases": {
         "0": "Prendi il traghetto.",
         "1": "Prendi il <STREET_NAMES>.",
-        "2": "Prendi il <STREET_NAMES> <FERRY_LABEL>."
+        "2": "Prendi il <STREET_NAMES> <FERRY_LABEL>.",
+        "3": "Take the ferry toward <TOWARD_SIGN>."
       },
       "empty_street_name_labels": [
         "il marciapiedi",
@@ -395,6 +400,9 @@
         ],
         "2": [
           "Prendi il traghetto Bridgeport - Port Jefferson."
+        ],
+        "3": [
+          "Take the ferry toward Cape May."
         ]
       }
     },
@@ -1031,7 +1039,9 @@
         "0": "Entra.",
         "1": "Entra a <RELATIVE_DIRECTION>.",
         "2": "Entra in <STREET_NAMES>.",
-        "3": "Entra a <RELATIVE_DIRECTION> in <STREET_NAMES>."
+        "3": "Entra a <RELATIVE_DIRECTION> in <STREET_NAMES>.",
+        "4": "Merge toward <TOWARD_SIGN>.",
+        "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
       "relative_directions": [
         "sinistra",
@@ -1054,6 +1064,12 @@
         ],
         "3": [
           "Entra a destra in I 83 South."
+        ],
+        "4": [
+          "Merge toward Baltimore."
+        ],
+        "5": [
+          "Merge right toward Baltimore."
         ]
       }
     },
@@ -1062,7 +1078,9 @@
         "0": "Entra.",
         "1": "Entra a <RELATIVE_DIRECTION>.",
         "2": "Entra in <STREET_NAMES>.",
-        "3": "Entra a <RELATIVE_DIRECTION> in <STREET_NAMES>."
+        "3": "Entra a <RELATIVE_DIRECTION> in <STREET_NAMES>.",
+        "4": "Merge toward <TOWARD_SIGN>.",
+        "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
       "relative_directions": [
         "sinistra",
@@ -1085,6 +1103,12 @@
         ],
         "3": [
           "Entra a destra in I 83 South."
+        ],
+        "4": [
+          "Merge toward Baltimore."
+        ],
+        "5": [
+          "Merge right toward Baltimore."
         ]
       }
     },

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -354,7 +354,8 @@
       "phrases": {
         "0": "Pegue a Balsa.",
         "1": "Pegue a <STREET_NAMES>.",
-        "2": "Pegue a <FERRY_LABEL> <STREET_NAMES>."
+        "2": "Pegue a <FERRY_LABEL> <STREET_NAMES>.",
+        "3": "Take the ferry toward <TOWARD_SIGN>."
       },
       "empty_street_name_labels": [
         "a calçada",
@@ -371,6 +372,9 @@
         ],
         "2": [
           "Pegue a Balsa Cacilhas - Cais do Sodré."
+        ],
+        "3": [
+          "Take the ferry toward Cape May."
         ]
       }
     },
@@ -378,7 +382,8 @@
       "phrases": {
         "0": "Pegue a Balsa.",
         "1": "Pegue a <STREET_NAMES>.",
-        "2": "Pegue a <FERRY_LABEL> <STREET_NAMES>."
+        "2": "Pegue a <FERRY_LABEL> <STREET_NAMES>.",
+        "3": "Take the ferry toward <TOWARD_SIGN>."
       },
       "empty_street_name_labels": [
         "a calçada",
@@ -395,6 +400,9 @@
         ],
         "2": [
           "Pegue a Balsa Cacilhas - Cais do Sodré."
+        ],
+        "3": [
+          "Take the ferry toward Cape May."
         ]
       }
     },
@@ -1031,7 +1039,9 @@
         "0": "Entre.",
         "1": "Entre <RELATIVE_DIRECTION>.",
         "2": "Entre na <STREET_NAMES>.",
-        "3": "Entre <RELATIVE_DIRECTION> na <STREET_NAMES>."
+        "3": "Entre <RELATIVE_DIRECTION> na <STREET_NAMES>.",
+        "4": "Merge toward <TOWARD_SIGN>.",
+        "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
       "relative_directions": [
         "à esquerda",
@@ -1054,6 +1064,12 @@
         ],
         "3": [
           "Entre à direita na A22 Oeste/Marinha Grande."
+        ],
+        "4": [
+          "Merge toward Baltimore."
+        ],
+        "5": [
+          "Merge right toward Baltimore."
         ]
       }
     },
@@ -1062,7 +1078,9 @@
         "0": "Entre.",
         "1": "Entre <RELATIVE_DIRECTION>.",
         "2": "Entre na <STREET_NAMES>.",
-        "3": "Entre <RELATIVE_DIRECTION> na <STREET_NAMES>."
+        "3": "Entre <RELATIVE_DIRECTION> na <STREET_NAMES>.",
+        "4": "Merge toward <TOWARD_SIGN>.",
+        "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
       "relative_directions": [
         "à esquerda",
@@ -1085,6 +1103,12 @@
         ],
         "3": [
           "Entre à direita na A22 Oeste/Marinha Grande."
+        ],
+        "4": [
+          "Merge toward Baltimore."
+        ],
+        "5": [
+          "Merge right toward Baltimore."
         ]
       }
     },

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -354,7 +354,8 @@
       "phrases": {
         "0": "Apanhe o Barco.",
         "1": "Apanhe o <STREET_NAMES>.",
-        "2": "Apanhe o <FERRY_LABEL> <STREET_NAMES>."
+        "2": "Apanhe o <FERRY_LABEL> <STREET_NAMES>.",
+        "3": "Take the ferry toward <TOWARD_SIGN>."
       },
       "empty_street_name_labels": [
         "a via pedonal",
@@ -371,6 +372,9 @@
         ],
         "2": [
           "Apanhe o Barco Cacilhas - Cais do Sodré."
+        ],
+        "3": [
+          "Take the ferry toward Cape May."
         ]
       }
     },
@@ -378,7 +382,8 @@
       "phrases": {
         "0": "Apanhe o Barco.",
         "1": "Apanhe o <STREET_NAMES>.",
-        "2": "Apanhe o <FERRY_LABEL> <STREET_NAMES>."
+        "2": "Apanhe o <FERRY_LABEL> <STREET_NAMES>.",
+        "3": "Take the ferry toward <TOWARD_SIGN>."
       },
       "empty_street_name_labels": [
         "a via pedonal",
@@ -395,6 +400,9 @@
         ],
         "2": [
           "Apanhe o Barco Cacilhas - Cais do Sodré."
+        ],
+        "3": [
+          "Take the ferry toward Cape May."
         ]
       }
     },
@@ -1031,7 +1039,9 @@
         "0": "Junte-se.",
         "1": "Junte-se <RELATIVE_DIRECTION>.",
         "2": "Junte-se a <STREET_NAMES>.",
-        "3": "Junte-se <RELATIVE_DIRECTION> a <STREET_NAMES>."
+        "3": "Junte-se <RELATIVE_DIRECTION> a <STREET_NAMES>.",
+        "4": "Merge toward <TOWARD_SIGN>.",
+        "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
       "relative_directions": [
         "à esquerda",
@@ -1054,6 +1064,12 @@
         ],
         "3": [
           "Junte-se à direita a A22 Oeste/Marinha Grande."
+        ],
+        "4": [
+          "Merge toward Baltimore."
+        ],
+        "5": [
+          "Merge right toward Baltimore."
         ]
       }
     },
@@ -1062,7 +1078,9 @@
         "0": "Junte-se.",
         "1": "Junte-se <RELATIVE_DIRECTION>.",
         "2": "Junte-se a <STREET_NAMES>.",
-        "3": "Junte-se <RELATIVE_DIRECTION> a <STREET_NAMES>."
+        "3": "Junte-se <RELATIVE_DIRECTION> a <STREET_NAMES>.",
+        "4": "Merge toward <TOWARD_SIGN>.",
+        "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
       "relative_directions": [
         "à esquerda",
@@ -1085,6 +1103,12 @@
         ],
         "3": [
           "Junte-se à direita a A22 Oeste/Marinha Grande."
+        ],
+        "4": [
+          "Merge toward Baltimore."
+        ],
+        "5": [
+          "Merge right toward Baltimore."
         ]
       }
     },

--- a/locales/ru-RU.json
+++ b/locales/ru-RU.json
@@ -354,7 +354,8 @@
       "phrases": {
         "0": "Воспользуйтесь паромом.",
         "1": "Воспользуйтесь паромом <STREET_NAMES>.",
-        "2": "Воспользуйтесь <STREET_NAMES> <FERRY_LABEL>."
+        "2": "Воспользуйтесь <STREET_NAMES> <FERRY_LABEL>.",
+        "3": "Take the ferry toward <TOWARD_SIGN>."
       },
       "empty_street_name_labels": [
         "аллее",
@@ -371,6 +372,9 @@
         ],
         "2": [
           "Воспользуйтесь Bridgeport - Port Jefferson Ferry."
+        ],
+        "3": [
+          "Take the ferry toward Cape May."
         ]
       }
     },
@@ -378,7 +382,8 @@
       "phrases": {
         "0": "Воспользуйтесь паромом.",
         "1": "Воспользуйтесь паромом <STREET_NAMES>.",
-        "2": "Воспользуйтесь <STREET_NAMES> <FERRY_LABEL>."
+        "2": "Воспользуйтесь <STREET_NAMES> <FERRY_LABEL>.",
+        "3": "Take the ferry toward <TOWARD_SIGN>."
       },
       "empty_street_name_labels": [
         "аллее",
@@ -395,6 +400,9 @@
         ],
         "2": [
           "Воспользуйтесь Bridgeport - Port Jefferson Ferry."
+        ],
+        "3": [
+          "Take the ferry toward Cape May."
         ]
       }
     },
@@ -1031,7 +1039,9 @@
         "0": "Выезжайте.",
         "1": "Выезжайте <RELATIVE_DIRECTION>.",
         "2": "Выезжайте на <STREET_NAMES>.",
-        "3": "Выезжайте <RELATIVE_DIRECTION> на <STREET_NAMES>."
+        "3": "Выезжайте <RELATIVE_DIRECTION> на <STREET_NAMES>.",
+        "4": "Merge toward <TOWARD_SIGN>.",
+        "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
       "relative_directions": [
         "слева",
@@ -1054,6 +1064,12 @@
         ],
         "3": [
           "Выезжайте справа на I 83 South."
+        ],
+        "4": [
+          "Merge toward Baltimore."
+        ],
+        "5": [
+          "Merge right toward Baltimore."
         ]
       }
     },
@@ -1062,7 +1078,9 @@
         "0": "Выезжайте.",
         "1": "Выезжайте <RELATIVE_DIRECTION>.",
         "2": "Выезжайте на <STREET_NAMES>.",
-        "3": "Выезжайте <RELATIVE_DIRECTION> на <STREET_NAMES>."
+        "3": "Выезжайте <RELATIVE_DIRECTION> на <STREET_NAMES>.",
+        "4": "Merge toward <TOWARD_SIGN>.",
+        "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
       "relative_directions": [
         "слева",
@@ -1085,6 +1103,12 @@
         ],
         "3": [
           "Выезжайте справа на I 83 South."
+        ],
+        "4": [
+          "Merge toward Baltimore."
+        ],
+        "5": [
+          "Merge right toward Baltimore."
         ]
       }
     },

--- a/locales/sk-SK.json
+++ b/locales/sk-SK.json
@@ -354,7 +354,8 @@
       "phrases": {
         "0": "Vojdite na trajekt.",
         "1": "Vojdite na <STREET_NAMES>.",
-        "2": "Vojdite na <FERRY_LABEL> <STREET_NAMES>."
+        "2": "Vojdite na <FERRY_LABEL> <STREET_NAMES>.",
+        "3": "Take the ferry toward <TOWARD_SIGN>."
       },
       "empty_street_name_labels": [
         "chodník",
@@ -371,6 +372,9 @@
         ],
         "2": [
           "Vjeďte na trajekt Bridgeport - Port Jefferson."
+        ],
+        "3": [
+          "Take the ferry toward Cape May."
         ]
       }
     },
@@ -378,7 +382,8 @@
       "phrases": {
         "0": "Vojdite na trajekt.",
         "1": "Vojdite na <STREET_NAMES>.",
-        "2": "Vojdite na <FERRY_LABEL> <STREET_NAMES>."
+        "2": "Vojdite na <FERRY_LABEL> <STREET_NAMES>.",
+        "3": "Take the ferry toward <TOWARD_SIGN>."
       },
       "empty_street_name_labels": [
         "chodník",
@@ -395,6 +400,9 @@
         ],
         "2": [
           "Vjeďte na trajekt Bridgeport - Port Jefferson."
+        ],
+        "3": [
+          "Take the ferry toward Cape May."
         ]
       }
     },
@@ -1031,7 +1039,9 @@
         "0": "Pripojte sa.",
         "1": "Pripojte sa <RELATIVE_DIRECTION>.",
         "2": "Pripojte sa na <STREET_NAMES>.",
-        "3": "Pripojte sa <RELATIVE_DIRECTION> na <STREET_NAMES>."
+        "3": "Pripojte sa <RELATIVE_DIRECTION> na <STREET_NAMES>.",
+        "4": "Merge toward <TOWARD_SIGN>.",
+        "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
       "relative_directions": [
         "vľavo",
@@ -1054,6 +1064,12 @@
         ],
         "3": [
           "Připojte se vpravo na I 83 South."
+        ],
+        "4": [
+          "Merge toward Baltimore."
+        ],
+        "5": [
+          "Merge right toward Baltimore."
         ]
       }
     },
@@ -1062,7 +1078,9 @@
         "0": "Pripojte sa.",
         "1": "Pripojte sa <RELATIVE_DIRECTION>.",
         "2": "Pripojte sa na <STREET_NAMES>.",
-        "3": "Pripojte sa <RELATIVE_DIRECTION> na <STREET_NAMES>."
+        "3": "Pripojte sa <RELATIVE_DIRECTION> na <STREET_NAMES>.",
+        "4": "Merge toward <TOWARD_SIGN>.",
+        "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
       "relative_directions": [
         "vľavo",
@@ -1085,6 +1103,12 @@
         ],
         "3": [
           "Připojte se vpravo na I 83 South."
+        ],
+        "4": [
+          "Merge toward Baltimore."
+        ],
+        "5": [
+          "Merge right toward Baltimore."
         ]
       }
     },

--- a/locales/sl-SI.json
+++ b/locales/sl-SI.json
@@ -354,7 +354,8 @@
       "phrases": {
         "0": "Pojdite na trajekt.",
         "1": "Pojdite na <STREET_NAMES>.",
-        "2": "Pojdite na <FERRY_LABEL> <STREET_NAMES>."
+        "2": "Pojdite na <FERRY_LABEL> <STREET_NAMES>.",
+        "3": "Take the ferry toward <TOWARD_SIGN>."
       },
       "empty_street_name_labels": [
         "pešpot",
@@ -371,6 +372,9 @@
         ],
         "2": [
           "Pojdite na Bridgeport - Port Jefferson Ferry."
+        ],
+        "3": [
+          "Take the ferry toward Cape May."
         ]
       }
     },
@@ -378,7 +382,8 @@
       "phrases": {
         "0": "Pojdite na trajekt.",
         "1": "Pojdite na <STREET_NAMES>.",
-        "2": "Pojdite na <FERRY_LABEL> <STREET_NAMES>."
+        "2": "Pojdite na <FERRY_LABEL> <STREET_NAMES>.",
+        "3": "Take the ferry toward <TOWARD_SIGN>."
       },
       "empty_street_name_labels": [
         "pešpot",
@@ -395,6 +400,9 @@
         ],
         "2": [
           "Pojdite na Bridgeport - Port Jefferson Ferry."
+        ],
+        "3": [
+          "Take the ferry toward Cape May."
         ]
       }
     },
@@ -1031,7 +1039,9 @@
         "0": "Zapeljite na sosednjo pot.",
         "1": "Zapeljite <RELATIVE_DIRECTION> na sosednjo pot.",
         "2": "Zapeljite na <STREET_NAMES>.",
-        "3": "Zapeljite <RELATIVE_DIRECTION> na <STREET_NAMES>."
+        "3": "Zapeljite <RELATIVE_DIRECTION> na <STREET_NAMES>.",
+        "4": "Merge toward <TOWARD_SIGN>.",
+        "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
       "relative_directions": [
         "levo",
@@ -1054,6 +1064,12 @@
         ],
         "3": [
           "Zapeljite desno na I 83 South."
+        ],
+        "4": [
+          "Merge toward Baltimore."
+        ],
+        "5": [
+          "Merge right toward Baltimore."
         ]
       }
     },
@@ -1062,7 +1078,9 @@
         "0": "Zapeljite na sosednjo pot.",
         "1": "Zapeljite <RELATIVE_DIRECTION> na sosednjo pot.",
         "2": "Zapeljite na <STREET_NAMES>.",
-        "3": "Zapeljite <RELATIVE_DIRECTION> na <STREET_NAMES>."
+        "3": "Zapeljite <RELATIVE_DIRECTION> na <STREET_NAMES>.",
+        "4": "Merge toward <TOWARD_SIGN>.",
+        "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
       "relative_directions": [
         "levo",
@@ -1085,6 +1103,12 @@
         ],
         "3": [
           "Zapeljite desno na I 83 South."
+        ],
+        "4": [
+          "Merge toward Baltimore."
+        ],
+        "5": [
+          "Merge right toward Baltimore."
         ]
       }
     },

--- a/locales/sv-SE.json
+++ b/locales/sv-SE.json
@@ -354,7 +354,8 @@
       "phrases": {
         "0": "Ta färjan.",
         "1": "Ta <STREET_NAMES>.",
-        "2": "Ta <STREET_NAMES> <FERRY_LABEL>."
+        "2": "Ta <STREET_NAMES> <FERRY_LABEL>.",
+        "3": "Take the ferry toward <TOWARD_SIGN>."
       },
       "empty_street_name_labels": [
         "gångbanan",
@@ -371,6 +372,9 @@
         ],
         "2": [
           "Ta Bridgeport - Port Jefferson-färjan."
+        ],
+        "3": [
+          "Take the ferry toward Cape May."
         ]
       }
     },
@@ -378,7 +382,8 @@
       "phrases": {
         "0": "Ta färjan.",
         "1": "Ta <STREET_NAMES>.",
-        "2": "Ta <STREET_NAMES> <FERRY_LABEL>."
+        "2": "Ta <STREET_NAMES> <FERRY_LABEL>.",
+        "3": "Take the ferry toward <TOWARD_SIGN>."
       },
       "empty_street_name_labels": [
         "gångbanan",
@@ -395,6 +400,9 @@
         ],
         "2": [
           "Ta Bridgeport - Port Jefferson-färjan."
+        ],
+        "3": [
+          "Take the ferry toward Cape May."
         ]
       }
     },
@@ -1031,7 +1039,9 @@
         "0": "Anslut.",
         "1": "Anslut <RELATIVE_DIRECTION>.",
         "2": "Anslut till <STREET_NAMES>.",
-        "3": "Anslut <RELATIVE_DIRECTION> till <STREET_NAMES>."
+        "3": "Anslut <RELATIVE_DIRECTION> till <STREET_NAMES>.",
+        "4": "Merge toward <TOWARD_SIGN>.",
+        "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
       "relative_directions": [
         "vänster",
@@ -1054,6 +1064,12 @@
         ],
         "3": [
           "Anslut höger till I 83 South."
+        ],
+        "4": [
+          "Merge toward Baltimore."
+        ],
+        "5": [
+          "Merge right toward Baltimore."
         ]
       }
     },
@@ -1062,7 +1078,9 @@
         "0": "Anslut.",
         "1": "Anslut <RELATIVE_DIRECTION>.",
         "2": "Anslut till <STREET_NAMES>.",
-        "3": "Anslut <RELATIVE_DIRECTION> till <STREET_NAMES>."
+        "3": "Anslut <RELATIVE_DIRECTION> till <STREET_NAMES>.",
+        "4": "Merge toward <TOWARD_SIGN>.",
+        "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
       "relative_directions": [
         "vänster",
@@ -1085,6 +1103,12 @@
         ],
         "3": [
           "Anslut höger till I 83 South."
+        ],
+        "4": [
+          "Merge toward Baltimore."
+        ],
+        "5": [
+          "Merge right toward Baltimore."
         ]
       }
     },

--- a/src/odin/narrativebuilder.cc
+++ b/src/odin/narrativebuilder.cc
@@ -2461,13 +2461,14 @@ std::string NarrativeBuilder::FormMergeInstruction(Maneuver& maneuver,
   uint8_t phrase_id = 0;
   std::string guide_sign;
 
-  if (maneuver.HasGuideSign()) {
-    // Skip to the toward phrase - it takes priority over street names
+  if (!street_names.empty()) {
+    // Street names take priority over toward phrase
+    phrase_id = 2;
+  } else if (maneuver.HasGuideSign()) {
+    // Use toward phrase if street names is empty
     phrase_id = 4;
     // Assign guide sign
     guide_sign = maneuver.signs().GetGuideString(element_max_count, limit_by_consecutive_count);
-  } else if (!street_names.empty()) {
-    phrase_id = 2;
   }
 
   // Check for merge relative direction
@@ -2533,14 +2534,15 @@ std::string NarrativeBuilder::FormVerbalMergeInstruction(Maneuver& maneuver,
   uint8_t phrase_id = 0;
   std::string guide_sign;
 
-  if (maneuver.HasGuideSign()) {
-    // Skip to the toward phrase - it takes priority over street names
+  if (!street_names.empty()) {
+    // Street names take priority over toward phrase
+    phrase_id = 2;
+  } else if (maneuver.HasGuideSign()) {
+    // Use toward phrase if street names is empty
     phrase_id = 4;
     // Assign guide sign
     guide_sign = maneuver.signs().GetGuideString(element_max_count, limit_by_consecutive_count, delim,
                                                  maneuver.verbal_formatter());
-  } else if (!street_names.empty()) {
-    phrase_id = 2;
   }
 
   // Check for merge relative direction

--- a/test/gurka/test_instructions_ferry_toward.cc
+++ b/test/gurka/test_instructions_ferry_toward.cc
@@ -1,0 +1,88 @@
+#include "gurka.h"
+#include <gtest/gtest.h>
+
+#if !defined(VALHALLA_SOURCE_DIR)
+#define VALHALLA_SOURCE_DIR
+#endif
+
+using namespace valhalla;
+
+class InstructionsFerryToward : public ::testing::Test {
+protected:
+  static gurka::map map;
+
+  static void SetUpTestSuite() {
+    constexpr double gridsize_metres = 1000;
+
+    const std::string ascii_map = R"(
+          A--B----C--D
+    )";
+
+    const gurka::ways ways = {{"AB", {{"highway", "trunk"}, {"name", ""}, {"ref", "A1"}}},
+                              {"BC",
+                               {{"motor_vehicle", "yes"},
+                                {"motorcar", "yes"},
+                                {"bicycle", "yes"},
+                                {"foot", "yes"},
+                                {"horse", "no"},
+                                {"duration", "01:25"},
+                                {"route", "ferry"},
+                                {"operator", "Cape May-Lewes Ferry"},
+                                {"name", "Cape May-Lewes Ferry"},
+                                {"ref", "A1"},
+                                {"destination:forward", "Cape May"},
+                                {"destination:backward", "Lewes"}}},
+                              {"CD", {{"highway", "trunk"}, {"name", ""}, {"ref", "A1"}}}};
+
+    const auto layout =
+        gurka::detail::map_to_coordinates(ascii_map, gridsize_metres, {5.1079374, 52.0887174});
+
+    map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_instructions_ferry_toward",
+                            {{"mjolnir.admin",
+                              {VALHALLA_SOURCE_DIR "test/data/netherlands_admin.sqlite"}}});
+  }
+};
+
+gurka::map InstructionsFerryToward::map = {};
+
+///////////////////////////////////////////////////////////////////////////////
+// Take the ferry toward (forward)
+// "3": "Take the ferry toward <TOWARD_SIGN>."
+TEST_F(InstructionsFerryToward, TakeFerryTowardForward) {
+  auto result = gurka::route(map, "A", "D", "auto");
+
+  // Verify maneuver types
+  gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
+                                                DirectionsLeg_Maneuver_Type_kFerryEnter,
+                                                DirectionsLeg_Maneuver_Type_kFerryExit,
+                                                DirectionsLeg_Maneuver_Type_kDestination});
+  int maneuver_index = 1;
+
+  // Verify the ferry toward instructions
+  gurka::assert::raw::expect_instructions_at_maneuver_index(result, maneuver_index,
+                                                            "Take the ferry toward Cape May.",
+                                                            "Take the ferry toward Cape May.",
+                                                            "Take the ferry toward Cape May.",
+                                                            "Continue for 3 kilometers.");
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Take the ferry toward (backward)
+// "3": "Take the ferry toward <TOWARD_SIGN>."
+TEST_F(InstructionsFerryToward, TakeFerryTowardBackward) {
+  auto result = gurka::route(map, "D", "A", "auto");
+
+  // Verify maneuver types
+  gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
+                                                DirectionsLeg_Maneuver_Type_kFerryEnter,
+                                                DirectionsLeg_Maneuver_Type_kFerryExit,
+                                                DirectionsLeg_Maneuver_Type_kDestination});
+  int maneuver_index = 1;
+
+  // Verify the ferry toward instructions
+  gurka::assert::raw::expect_instructions_at_maneuver_index(result, maneuver_index,
+                                                            "Take the ferry toward Lewes.",
+                                                            "Take the ferry toward Lewes.",
+                                                            "Take the ferry toward Lewes.",
+                                                            "Continue for 3 kilometers.");
+}

--- a/test/gurka/test_instructions_keep_toward.cc
+++ b/test/gurka/test_instructions_keep_toward.cc
@@ -15,9 +15,9 @@ protected:
     constexpr double gridsize_metres = 1000;
 
     const std::string ascii_map = R"(
-                C--D
-          A--B<--G--H
-                E--F
+                C--D      J--K
+          A--B<--G--H--I<--N--O
+                E--F      L--M
     )";
 
     const gurka::ways ways = {{"AB", {{"highway", "motorway"}, {"name", ""}, {"ref", "A1"}}},
@@ -41,7 +41,32 @@ protected:
                                 {"ref", "B3"},
                                 {"destination", "New York;Philadelphia"},
                                 {"destination:ref", "B3"}}},
-                              {"GH", {{"highway", "motorway"}, {"name", ""}, {"ref", "B3"}}}};
+                              {"GH", {{"highway", "motorway"}, {"name", ""}, {"ref", "B3"}}},
+                              {"HI", {{"highway", "motorway"}, {"name", ""}, {"ref", "B3"}}},
+                              {"IJ",
+                               {{"highway", "motorway"},
+                                {"name", ""},
+                                {"ref", "C1"},
+                                {"junction:ref", "22A"},
+                                {"destination", "Harrisburg;Lancaster"},
+                                {"destination:ref", "C1"}}},
+                              {"JK", {{"highway", "motorway"}, {"name", ""}, {"ref", "C1"}}},
+                              {"IL",
+                               {{"highway", "motorway"},
+                                {"name", ""},
+                                {"ref", "C2"},
+                                {"junction:ref", "22C"},
+                                {"destination", "Baltimore;Washington"},
+                                {"destination:ref", "C2"}}},
+                              {"LM", {{"highway", "motorway"}, {"name", ""}, {"ref", "C2"}}},
+                              {"IN",
+                               {{"highway", "motorway"},
+                                {"name", ""},
+                                {"ref", "C3"},
+                                {"junction:ref", "22B"},
+                                {"destination", "New York;Philadelphia"},
+                                {"destination:ref", "C3"}}},
+                              {"NO", {{"highway", "motorway"}, {"name", ""}, {"ref", "C3"}}}};
 
     const auto layout =
         gurka::detail::map_to_coordinates(ascii_map, gridsize_metres, {5.1079374, 52.0887174});
@@ -115,4 +140,61 @@ TEST_F(InstructionsKeepToward, KeepStraightToward) {
                                             "Keep straight toward B3.",
                                             "Keep straight toward B3, New York.",
                                             "Continue for 4 kilometers.");
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Keep right to take exit number toward
+// "5": "Keep <RELATIVE_DIRECTION> to take exit <NUMBER_SIGN> toward <TOWARD_SIGN>.",
+TEST_F(InstructionsKeepToward, KeepRightExitNumberToward) {
+  auto result = gurka::route(map, "H", "M", "auto");
+
+  // Verify maneuver types
+  gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
+                                                DirectionsLeg_Maneuver_Type_kStayRight,
+                                                DirectionsLeg_Maneuver_Type_kDestination});
+  int maneuver_index = 1;
+
+  // Verify the keep right to take exit number toward instructions
+  gurka::assert::raw::expect_instructions_at_maneuver_index(
+      result, maneuver_index, "Keep right to take exit 22C toward C2/Baltimore/Washington.",
+      "Keep right to take exit 22C.", "Keep right to take exit 22C toward C2, Baltimore.",
+      "Continue for 4 kilometers.");
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Keep left to take exit number toward
+// "5": "Keep <RELATIVE_DIRECTION> to take exit <NUMBER_SIGN> toward <TOWARD_SIGN>.",
+TEST_F(InstructionsKeepToward, KeepLeftExitNumberToward) {
+  auto result = gurka::route(map, "H", "K", "auto");
+
+  // Verify maneuver types
+  gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
+                                                DirectionsLeg_Maneuver_Type_kStayLeft,
+                                                DirectionsLeg_Maneuver_Type_kDestination});
+  int maneuver_index = 1;
+
+  // Verify the keep left to take exit number toward instructions
+  gurka::assert::raw::expect_instructions_at_maneuver_index(
+      result, maneuver_index, "Keep left to take exit 22A toward C1/Harrisburg/Lancaster.",
+      "Keep left to take exit 22A.", "Keep left to take exit 22A toward C1, Harrisburg.",
+      "Continue for 4 kilometers.");
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Keep straight to take exit number toward
+// "5": "Keep <RELATIVE_DIRECTION> to take exit <NUMBER_SIGN> toward <TOWARD_SIGN>.",
+TEST_F(InstructionsKeepToward, KeepStraightExitNumberToward) {
+  auto result = gurka::route(map, "H", "O", "auto");
+
+  // Verify maneuver types
+  gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
+                                                DirectionsLeg_Maneuver_Type_kStayStraight,
+                                                DirectionsLeg_Maneuver_Type_kDestination});
+  int maneuver_index = 1;
+
+  // Verify the keep straight to take exit number toward instructions
+  gurka::assert::raw::expect_instructions_at_maneuver_index(
+      result, maneuver_index, "Keep straight to take exit 22B toward C3/New York/Philadelphia.",
+      "Keep straight to take exit 22B.", "Keep straight to take exit 22B toward C3, New York.",
+      "Continue for 4 kilometers.");
 }

--- a/test/gurka/test_instructions_keep_toward.cc
+++ b/test/gurka/test_instructions_keep_toward.cc
@@ -1,0 +1,69 @@
+#include "gurka.h"
+#include <gtest/gtest.h>
+
+#if !defined(VALHALLA_SOURCE_DIR)
+#define VALHALLA_SOURCE_DIR
+#endif
+
+using namespace valhalla;
+
+class InstructionsKeepToward : public ::testing::Test {
+protected:
+  static gurka::map map;
+
+  static void SetUpTestSuite() {
+    constexpr double gridsize_metres = 1000;
+
+    const std::string ascii_map = R"(
+                C--D
+          A--B<
+                E--F
+    )";
+
+    const gurka::ways ways = {{"AB", {{"highway", "motorway"}, {"name", ""}, {"ref", "A6"}}},
+                              {"BC",
+                               {{"highway", "motorway"},
+                                {"name", ""},
+                                {"ref", "A6"},
+                                {"destination", "Harrisburg;Lancaster"},
+                                {"destination:ref", "A6"}}},
+                              {"CD", {{"highway", "motorway"}, {"name", ""}, {"ref", "A6"}}},
+                              {"BE",
+                               {{"highway", "motorway"},
+                                {"name", ""},
+                                {"ref", "A66"},
+                                {"destination", "Baltimore;Washington"},
+                                {"destination:ref", "A66"}}},
+                              {"EF", {{"highway", "motorway"}, {"name", ""}, {"ref", "A66"}}}};
+
+    const auto layout =
+        gurka::detail::map_to_coordinates(ascii_map, gridsize_metres, {5.1079374, 52.0887174});
+
+    map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_instructions_keep_toward",
+                            {{"mjolnir.admin",
+                              {VALHALLA_SOURCE_DIR "test/data/netherlands_admin.sqlite"}}});
+  }
+};
+
+gurka::map InstructionsKeepToward::map = {};
+
+///////////////////////////////////////////////////////////////////////////////
+// Keep right toward
+// "4": "Keep <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+TEST_F(InstructionsKeepToward, TurnRightToward) {
+  auto result = gurka::route(map, "A", "F", "auto");
+
+  // Verify maneuver types
+  gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
+                                                DirectionsLeg_Maneuver_Type_kStayRight,
+                                                DirectionsLeg_Maneuver_Type_kDestination});
+  int maneuver_index = 1;
+
+  // Verify the turn right toward instructions
+  gurka::assert::raw::
+      expect_instructions_at_maneuver_index(result, maneuver_index,
+                                            "Keep right toward A66/Baltimore/Washington.",
+                                            "Keep right toward A66.",
+                                            "Keep right toward A66, Baltimore.",
+                                            "Continue for 4 kilometers.");
+}

--- a/test/gurka/test_instructions_keep_toward.cc
+++ b/test/gurka/test_instructions_keep_toward.cc
@@ -50,7 +50,7 @@ gurka::map InstructionsKeepToward::map = {};
 ///////////////////////////////////////////////////////////////////////////////
 // Keep right toward
 // "4": "Keep <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
-TEST_F(InstructionsKeepToward, TurnRightToward) {
+TEST_F(InstructionsKeepToward, KeepRightToward) {
   auto result = gurka::route(map, "A", "F", "auto");
 
   // Verify maneuver types

--- a/test/gurka/test_instructions_keep_toward.cc
+++ b/test/gurka/test_instructions_keep_toward.cc
@@ -59,7 +59,7 @@ TEST_F(InstructionsKeepToward, KeepRightToward) {
                                                 DirectionsLeg_Maneuver_Type_kDestination});
   int maneuver_index = 1;
 
-  // Verify the turn right toward instructions
+  // Verify the keep right toward instructions
   gurka::assert::raw::
       expect_instructions_at_maneuver_index(result, maneuver_index,
                                             "Keep right toward A66/Baltimore/Washington.",

--- a/test/gurka/test_instructions_keep_toward.cc
+++ b/test/gurka/test_instructions_keep_toward.cc
@@ -16,25 +16,32 @@ protected:
 
     const std::string ascii_map = R"(
                 C--D
-          A--B<
+          A--B<--G--H
                 E--F
     )";
 
-    const gurka::ways ways = {{"AB", {{"highway", "motorway"}, {"name", ""}, {"ref", "A6"}}},
+    const gurka::ways ways = {{"AB", {{"highway", "motorway"}, {"name", ""}, {"ref", "A1"}}},
                               {"BC",
                                {{"highway", "motorway"},
                                 {"name", ""},
-                                {"ref", "A6"},
+                                {"ref", "B1"},
                                 {"destination", "Harrisburg;Lancaster"},
-                                {"destination:ref", "A6"}}},
-                              {"CD", {{"highway", "motorway"}, {"name", ""}, {"ref", "A6"}}},
+                                {"destination:ref", "B1"}}},
+                              {"CD", {{"highway", "motorway"}, {"name", ""}, {"ref", "B1"}}},
                               {"BE",
                                {{"highway", "motorway"},
                                 {"name", ""},
-                                {"ref", "A66"},
+                                {"ref", "B2"},
                                 {"destination", "Baltimore;Washington"},
-                                {"destination:ref", "A66"}}},
-                              {"EF", {{"highway", "motorway"}, {"name", ""}, {"ref", "A66"}}}};
+                                {"destination:ref", "B2"}}},
+                              {"EF", {{"highway", "motorway"}, {"name", ""}, {"ref", "B2"}}},
+                              {"BG",
+                               {{"highway", "motorway"},
+                                {"name", ""},
+                                {"ref", "B3"},
+                                {"destination", "New York;Philadelphia"},
+                                {"destination:ref", "B3"}}},
+                              {"GH", {{"highway", "motorway"}, {"name", ""}, {"ref", "B3"}}}};
 
     const auto layout =
         gurka::detail::map_to_coordinates(ascii_map, gridsize_metres, {5.1079374, 52.0887174});
@@ -62,8 +69,50 @@ TEST_F(InstructionsKeepToward, KeepRightToward) {
   // Verify the keep right toward instructions
   gurka::assert::raw::
       expect_instructions_at_maneuver_index(result, maneuver_index,
-                                            "Keep right toward A66/Baltimore/Washington.",
-                                            "Keep right toward A66.",
-                                            "Keep right toward A66, Baltimore.",
+                                            "Keep right toward B2/Baltimore/Washington.",
+                                            "Keep right toward B2.",
+                                            "Keep right toward B2, Baltimore.",
+                                            "Continue for 4 kilometers.");
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Keep left toward
+// "4": "Keep <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+TEST_F(InstructionsKeepToward, KeepLeftToward) {
+  auto result = gurka::route(map, "A", "D", "auto");
+
+  // Verify maneuver types
+  gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
+                                                DirectionsLeg_Maneuver_Type_kStayLeft,
+                                                DirectionsLeg_Maneuver_Type_kDestination});
+  int maneuver_index = 1;
+
+  // Verify the keep left toward instructions
+  gurka::assert::raw::
+      expect_instructions_at_maneuver_index(result, maneuver_index,
+                                            "Keep left toward B1/Harrisburg/Lancaster.",
+                                            "Keep left toward B1.",
+                                            "Keep left toward B1, Harrisburg.",
+                                            "Continue for 4 kilometers.");
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Keep straight toward
+// "4": "Keep <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+TEST_F(InstructionsKeepToward, KeepStraightToward) {
+  auto result = gurka::route(map, "A", "H", "auto");
+
+  // Verify maneuver types
+  gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
+                                                DirectionsLeg_Maneuver_Type_kStayStraight,
+                                                DirectionsLeg_Maneuver_Type_kDestination});
+  int maneuver_index = 1;
+
+  // Verify the keep straight toward instructions
+  gurka::assert::raw::
+      expect_instructions_at_maneuver_index(result, maneuver_index,
+                                            "Keep straight toward B3/New York/Philadelphia.",
+                                            "Keep straight toward B3.",
+                                            "Keep straight toward B3, New York.",
                                             "Continue for 4 kilometers.");
 }

--- a/test/gurka/test_instructions_merge_toward.cc
+++ b/test/gurka/test_instructions_merge_toward.cc
@@ -1,0 +1,65 @@
+#include "gurka.h"
+#include <gtest/gtest.h>
+
+#if !defined(VALHALLA_SOURCE_DIR)
+#define VALHALLA_SOURCE_DIR
+#endif
+
+using namespace valhalla;
+
+class InstructionsMergeToward : public ::testing::Test {
+protected:
+  static gurka::map map;
+
+  static void SetUpTestSuite() {
+    constexpr double gridsize_metres = 1000;
+
+    const std::string ascii_map = R"(
+          A--B--C--D
+            /
+           E     
+    )";
+
+    const gurka::ways ways = {{"AB", {{"highway", "motorway"}, {"name", ""}, {"oneway", "yes"}}},
+                              {"BC",
+                               {{"highway", "motorway"},
+                                {"name", ""},
+                                {"oneway", "yes"},
+                                {"destination", "Harrisburg;Lancaster"},
+                                {"destination:ref", "A6"}}},
+                              {"CD", {{"highway", "motorway"}, {"name", ""}, {"oneway", "yes"}}},
+                              {"EB",
+                               {{"highway", "motorway_link"}, {"name", ""}, {"oneway", "yes"}}}};
+
+    const auto layout =
+        gurka::detail::map_to_coordinates(ascii_map, gridsize_metres, {5.1079374, 52.0887174});
+
+    map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_instructions_merge_toward",
+                            {{"mjolnir.admin",
+                              {VALHALLA_SOURCE_DIR "test/data/netherlands_admin.sqlite"}}});
+  }
+};
+
+gurka::map InstructionsMergeToward::map = {};
+
+///////////////////////////////////////////////////////////////////////////////
+// Merge left toward
+// "5" : "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+TEST_F(InstructionsMergeToward, MergeLeftToward) {
+  auto result = gurka::route(map, "E", "D", "auto");
+
+  // Verify maneuver types
+  gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
+                                                DirectionsLeg_Maneuver_Type_kMergeLeft,
+                                                DirectionsLeg_Maneuver_Type_kDestination});
+  int maneuver_index = 1;
+
+  // Verify the turn right toward
+  // instructions
+  gurka::assert::raw::
+      expect_instructions_at_maneuver_index(result, maneuver_index,
+                                            "Merge left toward A6/Harrisburg/Lancaster.",
+                                            "Merge left toward A6.",
+                                            "Merge left toward A6, Harrisburg.",
+                                            "Continue for 4 kilometers.");
+}

--- a/test/gurka/test_instructions_merge_toward.cc
+++ b/test/gurka/test_instructions_merge_toward.cc
@@ -54,8 +54,7 @@ TEST_F(InstructionsMergeToward, MergeLeftToward) {
                                                 DirectionsLeg_Maneuver_Type_kDestination});
   int maneuver_index = 1;
 
-  // Verify the turn right toward
-  // instructions
+  // Verify the merge left toward instructions
   gurka::assert::raw::
       expect_instructions_at_maneuver_index(result, maneuver_index,
                                             "Merge left toward A6/Harrisburg/Lancaster.",

--- a/test/narrative_dictionary.cc
+++ b/test/narrative_dictionary.cc
@@ -246,13 +246,17 @@ const std::map<std::string, std::string> kExpectedMergePhrases =
     {{"0", "Merge."},
      {"1", "Merge <RELATIVE_DIRECTION>."},
      {"2", "Merge onto <STREET_NAMES>."},
-     {"3", "Merge <RELATIVE_DIRECTION> onto <STREET_NAMES>."}};
+     {"3", "Merge <RELATIVE_DIRECTION> onto <STREET_NAMES>."},
+     {"4", "Merge toward <TOWARD_SIGN>."},
+     {"5", "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."}};
 
 const std::map<std::string, std::string> kExpectedMergeVerbalPhrases =
     {{"0", "Merge."},
      {"1", "Merge <RELATIVE_DIRECTION>."},
      {"2", "Merge onto <STREET_NAMES>."},
-     {"3", "Merge <RELATIVE_DIRECTION> onto <STREET_NAMES>."}};
+     {"3", "Merge <RELATIVE_DIRECTION> onto <STREET_NAMES>."},
+     {"4", "Merge toward <TOWARD_SIGN>."},
+     {"5", "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."}};
 
 const std::map<std::string, std::string> kExpectedEnterRoundaboutPhrases = {
     {"0", "Enter the roundabout."},
@@ -315,12 +319,14 @@ const std::map<std::string, std::string> kExpectedExitRoundaboutVerbalPhrases =
 const std::map<std::string, std::string> kExpectedEnterFerryPhrases =
     {{"0", "Take the Ferry."},
      {"1", "Take the <STREET_NAMES>."},
-     {"2", "Take the <STREET_NAMES> <FERRY_LABEL>."}};
+     {"2", "Take the <STREET_NAMES> <FERRY_LABEL>."},
+     {"3", "Take the ferry toward <TOWARD_SIGN>."}};
 
 const std::map<std::string, std::string> kExpectedEnterFerryVerbalPhrases =
     {{"0", "Take the Ferry."},
      {"1", "Take the <STREET_NAMES>."},
-     {"2", "Take the <STREET_NAMES> <FERRY_LABEL>."}};
+     {"2", "Take the <STREET_NAMES> <FERRY_LABEL>."},
+     {"3", "Take the ferry toward <TOWARD_SIGN>."}};
 
 const std::map<std::string, std::string> kExpectedTransitConnectionStartPhrases =
     {{"0", "Enter the station."},

--- a/valhalla/odin/narrativebuilder.h
+++ b/valhalla/odin/narrativebuilder.h
@@ -291,16 +291,21 @@ protected:
                                       const std::string& delim = kVerbalDelim);
 
   /////////////////////////////////////////////////////////////////////////////
-  std::string FormEnterFerryInstruction(Maneuver& maneuver);
+  std::string FormEnterFerryInstruction(Maneuver& maneuver,
+                                        bool limit_by_consecutive_count = kLimitByConseuctiveCount,
+                                        uint32_t element_max_count = kElementMaxCount);
 
   std::string
   FormVerbalAlertEnterFerryInstruction(Maneuver& maneuver,
+                                       bool limit_by_consecutive_count = kLimitByConseuctiveCount,
                                        uint32_t element_max_count = kVerbalAlertElementMaxCount,
                                        const std::string& delim = kVerbalDelim);
 
-  std::string FormVerbalEnterFerryInstruction(Maneuver& maneuver,
-                                              uint32_t element_max_count = kVerbalPreElementMaxCount,
-                                              const std::string& delim = kVerbalDelim);
+  std::string
+  FormVerbalEnterFerryInstruction(Maneuver& maneuver,
+                                  bool limit_by_consecutive_count = kLimitByConseuctiveCount,
+                                  uint32_t element_max_count = kVerbalPreElementMaxCount,
+                                  const std::string& delim = kVerbalDelim);
 
   /////////////////////////////////////////////////////////////////////////////
   std::string FormTransitConnectionStartInstruction(Maneuver& maneuver);

--- a/valhalla/odin/narrativebuilder.h
+++ b/valhalla/odin/narrativebuilder.h
@@ -249,14 +249,18 @@ protected:
                                                 const std::string& exit_toward_sign = "");
 
   /////////////////////////////////////////////////////////////////////////////
-  std::string FormMergeInstruction(Maneuver& maneuver);
+  std::string FormMergeInstruction(Maneuver& maneuver,
+                                   bool limit_by_consecutive_count = kLimitByConseuctiveCount,
+                                   uint32_t element_max_count = kElementMaxCount);
 
   std::string
   FormVerbalAlertMergeInstruction(Maneuver& maneuver,
+                                  bool limit_by_consecutive_count = kLimitByConseuctiveCount,
                                   uint32_t element_max_count = kVerbalAlertElementMaxCount,
                                   const std::string& delim = kVerbalDelim);
 
   std::string FormVerbalMergeInstruction(Maneuver& maneuver,
+                                         bool limit_by_consecutive_count = kLimitByConseuctiveCount,
                                          uint32_t element_max_count = kVerbalPreElementMaxCount,
                                          const std::string& delim = kVerbalDelim);
 

--- a/valhalla/odin/narrativebuilder.h
+++ b/valhalla/odin/narrativebuilder.h
@@ -223,7 +223,7 @@ protected:
                                         const std::string& relative_dir,
                                         const std::string& street_name,
                                         const std::string& exit_number_sign,
-                                        const std::string& exit_toward_sign);
+                                        const std::string& toward_sign);
 
   /////////////////////////////////////////////////////////////////////////////
   std::string FormKeepToStayOnInstruction(Maneuver& maneuver,


### PR DESCRIPTION
# Issue

Add guide sign toward phrases for the following phrase blocks:

1. keep
2. keep_verbal
3. merge
4. merge_verbal
5. enter_ferry
6. enter_ferry_verbal 

## Example#1
![image](https://user-images.githubusercontent.com/7515853/82911194-96ca1600-9f39-11ea-959c-eb9b2c804ff7.png)
``` diff
< BEFORE
< 33: Keep right to take A-66/Autovía Ruta de la Plata.
<    VERBAL_ALERT: Keep right to take A-66.
<    VERBAL_PRE: Keep right to take A-66, Autovía Ruta de la Plata.
> AFTER
> 33: Keep right toward A-66/León/Oviedo/A-52.
>    VERBAL_ALERT: Keep right toward A-66.
>    VERBAL_PRE: Keep right toward A-66, León.
```

## Example#2
``` diff
< BEFORE
< 3: Merge left.
<    VERBAL_PRE: Merge left.
> AFTER
> 3: Merge left toward US 22/Ebensburg/Hollidaysburg.
>    VERBAL_PRE: Merge left toward U.S. 22, Ebensburg.
```

## Tasklist

 - [x] RAD tests
 - [x] Add gurka tests
 - [x] Add #fixes with the issue number that this PR addresses
 - [x] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)

