### PR TITLE
Add utility functions to Signs class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@
    * FIXED: Seeing segfault when loading large osmdata data files before loading LuaJit. LuaJit fails to create luaL_newstate() Ref: [#2158](https://github.com/ntop/ntopng/issues/2158) Resolution is to load LuaJit before loading the data files. [#2383](https://github.com/valhalla/valhalla/pull/2383)
 
 * **Enhancement**
-   * ADDED: Add utility functions to Signs. [#2390](https://github.com/valhalla/valhalla/pull/2390)
    * ADDED: Add ability to provide custom implementation for candidate collection in CandidateQuery. [#2328](https://github.com/valhalla/valhalla/pull/2328)
    * ADDED: Cancellation of tile downloading. [#2319](https://github.com/valhalla/valhalla/pull/2319)
    * ADDED: Return the coordinates of the nodes isochrone input locations snapped to [#2111](https://github.com/valhalla/valhalla/pull/2111)
@@ -89,6 +88,7 @@
    * ADDED: Update the turn and continue phrases to include junction names and guide signs. [2386](https://github.com/valhalla/valhalla/pull/2386)
    * ADDED: Add the remaining guide sign toward phrases [2389](https://github.com/valhalla/valhalla/pull/2389)
    * ADDED: The ability to allow immediate uturns at trace points in a map matching request [#2380](https://github.com/valhalla/valhalla/pull/2380)
+   * ADDED: Add utility functions to Signs. [#2390](https://github.com/valhalla/valhalla/pull/2390)
 
 ## Release Date: 2019-11-21 Valhalla 3.0.9
 * **Bug Fix**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
    * FIXED: Seeing segfault when loading large osmdata data files before loading LuaJit. LuaJit fails to create luaL_newstate() Ref: [#2158](https://github.com/ntop/ntopng/issues/2158) Resolution is to load LuaJit before loading the data files. [#2383](https://github.com/valhalla/valhalla/pull/2383)
 
 * **Enhancement**
+   * ADDED: Add utility functions to Signs. [#2390](https://github.com/valhalla/valhalla/pull/2390)
    * ADDED: Add ability to provide custom implementation for candidate collection in CandidateQuery. [#2328](https://github.com/valhalla/valhalla/pull/2328)
    * ADDED: Cancellation of tile downloading. [#2319](https://github.com/valhalla/valhalla/pull/2319)
    * ADDED: Return the coordinates of the nodes isochrone input locations snapped to [#2111](https://github.com/valhalla/valhalla/pull/2111)

--- a/valhalla/odin/signs.h
+++ b/valhalla/odin/signs.h
@@ -24,6 +24,10 @@ public:
 
   static void CountAndSort(std::vector<Sign>* prev_signs, std::vector<Sign>* curr_signs);
 
+  static std::vector<Sign> TrimSigns(const std::vector<Sign>& signs,
+                                     uint32_t max_count = 0,
+                                     bool limit_by_consecutive_count = false);
+
   const std::vector<Sign>& exit_number_list() const;
   std::vector<Sign>* mutable_exit_number_list();
 
@@ -76,6 +80,9 @@ public:
                                    bool limit_by_consecutive_count = false,
                                    const std::string& delim = "/",
                                    const VerbalTextFormatter* verbal_formatter = nullptr) const;
+
+  std::vector<Sign> GetGuideSigns(uint32_t max_count = 0,
+                                  bool limit_by_consecutive_count = false) const;
 
   const std::vector<Sign>& junction_name_list() const;
   std::vector<Sign>* mutable_junction_name_list();


### PR DESCRIPTION
Added utility functions to Signs that return a list of signs instead of
a string but are functionally similar to ListToString & GetGuideString
APIs.

These APIs can be used in place of the string variants when we want to
control how the individual signs are used.

Added tests for the new APIs.