### PR TITLE
Add support for sub-edge traffic/congestion

### DIFF
--- a/valhalla/baldr/traffictile.h
+++ b/valhalla/baldr/traffictile.h
@@ -81,7 +81,7 @@ struct Speed {
 
   inline bool closed() const volatile {
     return valid() && (speed1_kmh == 0 || (breakpoint1 < 255 && speed2_kmh == 0) ||
-                       (breakpoint2 < 255 && speed3_kmh));
+                       (breakpoint2 < 255 && speed3_kmh == 0));
   }
 
   // Get age of record in seconds (based on the bucket

--- a/valhalla/baldr/traffictile.h
+++ b/valhalla/baldr/traffictile.h
@@ -80,7 +80,8 @@ struct Speed {
   }
 
   inline bool closed() const volatile {
-    return valid() && speed_kmh == 0;
+    return valid() && (speed1_kmh == 0 || (breakpoint1 < 255 && speed2_kmh == 0) ||
+                       (breakpoint2 < 255 && speed3_kmh));
   }
 
   // Get age of record in seconds (based on the bucket
@@ -107,7 +108,7 @@ struct TileHeader {
 // change and shouldn't be done lightly.
 static_assert(sizeof(TileHeader) == sizeof(uint64_t) * 4,
               "traffic:TileHeader type size different than expected");
-static_assert(sizeof(Speed) == sizeof(uint16_t),
+static_assert(sizeof(Speed) == sizeof(uint64_t),
               "traffic::Speed type size is different than expected");
 #endif // C_ONLY_INTERFACE
 

--- a/valhalla/baldr/traffictile.h
+++ b/valhalla/baldr/traffictile.h
@@ -62,10 +62,18 @@ inline uint16_t valhalla_traffic_seconds_to_age_bucket(const int seconds) {
 }
 
 struct Speed {
-  uint16_t speed_kmh : 8;        // km/h - so max range is 0-255km/h
-  uint16_t congestion_level : 3; // 0 - unknown, 1-6 - low-high, 7 - unused
-  uint16_t age_bucket : 4;       // Age bucket for the speed record (see SPEED_AGE_BUCKET_SIZE)
-  uint16_t spare : 1;            // TODO: reserved for later use
+  uint32_t speed1_kmh : 8; // 0-255km/h
+  uint32_t speed2_kmh : 8;
+  uint32_t speed3_kmh : 8;
+  uint32_t breakpoint1 : 8; // position = length * breakpoint1 * 255
+
+  uint32_t breakpoint2 : 8; // position = length * breakpoint2 * 255
+  uint32_t congestion1 : 6; // Stores 0 (unknown), or 1->63 (no congestion->max congestion)
+  uint32_t congestion2 : 6; //
+  uint32_t congestion3 : 6; //
+  uint32_t age_bucket : 4;  // Age bucket for the speed record (see SPEED_AGE_BUCKET_SIZE)
+  uint32_t spare : 2;
+
 #ifndef C_ONLY_INTERFACE
   inline bool valid() const volatile {
     return age_bucket != INVALID_SPEED_AGE_BUCKET;


### PR DESCRIPTION
# Issue

Sometimes, you get traffic data from an external source that doesn't neatly line up with where Valhalla edge geometry start/stops.

This PR adds support for 3 sub-sections per edge, which adjustable offsets.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
