### PR TITLE
Fixes includes for projects using Valhalla as a library

### DIFF
--- a/valhalla/midgard/sequence.h
+++ b/valhalla/midgard/sequence.h
@@ -21,7 +21,7 @@
 #include <utility>
 #include <vector>
 
-#include "filesystem.h"
+#include <valhalla/filesystem.h>
 
 #ifdef _MSC_VER
 #include <io.h>

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -21,7 +21,7 @@
 #include <valhalla/thor/edgestatus.h>
 
 #include <memory>
-#include <third_party/rapidjson/include/rapidjson/document.h>
+#include <rapidjson/document.h>
 #include <unordered_map>
 
 namespace valhalla {


### PR DESCRIPTION
# Issue

I use Valhalla as a library in other C++ projects, I noticed these includes didn't work when using from its installed location after doing a `make install`. I checked the macOS build and cross-compiled for Android after making these changes it looks good.
