### PR TITLE
Optional OpenLR Encoded Path Edges in API Response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@
    * ADDED (back): Support for 64bit wide way ids in the edgeinfo structure with no impact to size for data sources with ids 32bits wide. [#2422](https://github.com/valhalla/valhalla/pull/2422)
    * ADDED: Support for 64bit osm node ids in parsing stage of tile building [#2422](https://github.com/valhalla/valhalla/pull/2422)
    * CHANGED: Point2/PointLL are now templated to allow for higher precision coordinate math when desired [#2429](https://github.com/valhalla/valhalla/pull/2429)
+   * ADDED: Optional OpenLR Encoded Path Edges in API Response [#2424](https://github.com/valhalla/valhalla/pull/2424)
 
 ## Release Date: 2019-11-21 Valhalla 3.0.9
 * **Bug Fix**

--- a/docs/api/map-matching/api-reference.md
+++ b/docs/api/map-matching/api-reference.md
@@ -57,6 +57,9 @@ You can also set `directions_options` to specify output units, language, and whe
 | `trace_options.gps_accuracy` | GPS accuracy in meters associated with supplied trace points. |
 | `trace_options.breakage_distance` | Breaking distance in meters between trace points. |
 | `trace_options.interpolation_distance` | Interpolation distance in meters beyond which trace points are merged together. |
+| `linear_references` | When present and `true`, the successful `trace_route` response will include a key `linear_references`. Its value is an array of base64-encoded [OpenLR location references][openlr], one for each graph edge of the road network matched by the input trace. |
+
+[openlr]: https://www.openlr-association.com/fileadmin/user_upload/openlr-whitepaper_v1.5.pdf
 
 ### Attribute filters (`trace_attributes` only)
 

--- a/docs/api/turn-by-turn/api-reference.md
+++ b/docs/api/turn-by-turn/api-reference.md
@@ -259,6 +259,9 @@ A multimodal request with a filter for certain Onestop IDs:
 | `date_time` | This is the local date and time at the location.<ul><li>`type`<ul><li>0 - Current departure time.</li><li>1 - Specified departure time</li><li>2 - Specified arrival time. Not yet implemented for multimodal costing method.</li></ul></li><li>`value` - the date and time is specified in ISO 8601 format (YYYY-MM-DDThh:mm) in the local time zone of departure or arrival.  For example "2016-07-03T08:06"</li></ul><ul><b>NOTE: This option is not supported for Valhalla's matrix service.</b><ul> |
 | `out_format` | Output format. If no `out_format` is specified, JSON is returned. Future work includes PBF (protocol buffer) support. |
 | `id` | Name your route request. If `id` is specified, the naming will be sent thru to the response. |
+| `linear_references` | When present and `true`, the successful `route` response will include a key `linear_references`. Its value is an array of base64-encoded [OpenLR location references][openlr], one for each graph edge of the road network matched by the input trace. |
+
+[openlr]: https://www.openlr-association.com/fileadmin/user_upload/openlr-whitepaper_v1.5.pdf
 
 ## Outputs of a route
 

--- a/proto/options.proto
+++ b/proto/options.proto
@@ -189,4 +189,5 @@ message Options {
   // 42 is reserved
   optional uint32 height_precision = 43 [default = 0];                    // Number of digits precision for heights returned
   optional bool roundabout_exits = 44 [default = true];                   // Whether to announce roundabout exit maneuvers
+  optional bool linear_references = 45;                                   // Include linear references for graph edges returned in certain responses.
 }

--- a/src/baldr/CMakeLists.txt
+++ b/src/baldr/CMakeLists.txt
@@ -48,6 +48,7 @@ set(sources
     edgetracker.cc
     merge.cc
     nodeinfo.cc
+    openlr.cc
     location.cc
     pathlocation.cc
     tilehierarchy.cc

--- a/src/baldr/openlr.cc
+++ b/src/baldr/openlr.cc
@@ -1,0 +1,97 @@
+#include <cmath>
+#include <string>
+#include <vector>
+
+#include "baldr/graphconstants.h"
+#include "baldr/openlr.h"
+#include "midgard/encoded.h"
+#include "midgard/pointll.h"
+
+#include "proto/trip.pb.h"
+#include "proto/tripcommon.pb.h"
+
+namespace valhalla {
+namespace midgard {
+
+using FormOfWay = OpenLR::LocationReferencePoint::FormOfWay;
+
+FormOfWay road_class_to_fow(const TripLeg::Node& node) {
+  const bool is_missing_rc = !node.has_edge() || !node.edge().has_road_class();
+  if (is_missing_rc || !node.edge().has_use()) {
+    return FormOfWay::OTHER;
+  }
+  const TripLeg::Use use = node.edge().use();
+  const RoadClass rc = node.edge().road_class();
+  const bool one_way =
+      node.edge().has_traversability() && node.edge().traversability() != TripLeg::kBoth;
+  if (node.edge().roundabout()) {
+    return FormOfWay::ROUNDABOUT;
+  } else if (use == TripLeg::kRampUse || use == TripLeg::kTurnChannelUse) {
+    return FormOfWay::SLIPROAD;
+  } else if (rc == RoadClass::kMotorway && one_way) {
+    return FormOfWay::MOTORWAY;
+  } else if (rc <= RoadClass::kTertiary && one_way) {
+    return FormOfWay::MULTIPLE_CARRIAGEWAY;
+  } else if (rc <= RoadClass::kTertiary) {
+    return FormOfWay::SINGLE_CARRIAGEWAY;
+  } else {
+    return FormOfWay::OTHER;
+  }
+}
+
+std::vector<std::string> openlr_edges(const TripLeg& leg) {
+  const std::vector<PointLL>& points = decode<std::vector<PointLL>>(leg.shape());
+  std::vector<std::string> openlrs;
+  openlrs.reserve(leg.node_size());
+  for (const TripLeg::Node& node : leg.node()) {
+    // OpenLR for an edge is composed of two points with the following semantics:
+    // - FRC = relative importance of the road, so use the rank order of the FormOfWay enum.
+    // - Bearing of last point in the segment must point inward (bearing rotated by 180deg),
+    //   in-order to follow OpenLR conventions.
+    const FormOfWay fow = road_class_to_fow(node);
+    const unsigned char frc = static_cast<unsigned char>(fow);
+    unsigned char lfrcnp = frc;
+    const PointLL& start = points.at(node.edge().begin_shape_index());
+    const PointLL& end = points.at(node.edge().end_shape_index());
+    float bearing_deg = start.Heading(end);
+    const float distance_meters = start.Distance(end);
+    std::vector<OpenLR::LocationReferencePoint> lrps;
+    lrps.emplace_back(start.lng(), start.lat(), bearing_deg, frc, fow, nullptr, distance_meters,
+                      lfrcnp);
+    bearing_deg = fmod(bearing_deg + 180., 360.);
+    lrps.emplace_back(end.lng(), end.lat(), bearing_deg, frc, fow, &lrps.back());
+    openlrs.emplace_back(OpenLR::LineLocation{lrps, 0, 0}.toBase64());
+  }
+  return openlrs;
+}
+
+std::vector<std::string> openlr_legs(const TripLeg& leg) {
+  const std::vector<PointLL>& points = decode<std::vector<PointLL>>(leg.shape());
+  float bearing_deg = 0;
+  float distance_meters = 0;
+  unsigned char lfrcnp = static_cast<unsigned char>(FormOfWay::OTHER);
+  std::vector<OpenLR::LocationReferencePoint> lrps;
+  for (std::size_t i = 0, num_nodes = leg.node_size(); i < num_nodes; ++i) {
+    // See comments above for openlr_edges
+    const TripLeg::Node& current = leg.node(i);
+    const PointLL& location = points.at(current.edge().end_shape_index());
+    const FormOfWay fow = road_class_to_fow(current);
+    const unsigned char frc = static_cast<unsigned char>(fow);
+    lfrcnp = std::min(lfrcnp, frc);
+    if (i == num_nodes - 1) {
+      bearing_deg = fmod(bearing_deg + 180., 360.);
+      lrps.emplace_back(location.lng(), location.lat(), bearing_deg, frc, fow,
+                        lrps.empty() ? nullptr : &lrps.back());
+    } else {
+      const PointLL& next_location = points.at(leg.node(i + 1).edge().end_shape_index());
+      bearing_deg = location.Heading(next_location);
+      distance_meters = location.Distance(next_location);
+    }
+    lrps.emplace_back(location.lng(), location.lat(), bearing_deg, frc, fow,
+                      lrps.empty() ? nullptr : &lrps.back(), distance_meters, lfrcnp);
+  }
+  return {OpenLR::LineLocation{lrps, 0, 0}.toBase64()};
+}
+
+} // namespace midgard
+} // namespace valhalla

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -158,95 +158,6 @@ OSRM output is described in: http://project-osrm.org/docs/v5.5.1/api/
 }
 */
 
-/**********OLD OSRM CODE - delete
-    const std::unordered_map<int, std::string> maneuver_type = {
-        { static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_kNone),             "0"
-},//NoTurn = 0, { static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_kContinue), "1"
-},//GoStraight, { static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_kBecomes), "1"
-},//GoStraight, { static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_kRampStraight), "1"
-},//GoStraight, { static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_kStayStraight), "1"
-},//GoStraight, { static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_kMerge), "1"
-},//GoStraight, { static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_kFerryEnter), "1"
-},//GoStraight, { static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_kFerryExit), "1"
-},//GoStraight, { static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_kSlightRight), "2"
-},//TurnSlightRight, { static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_kRight), "3"
-},//TurnRight, { static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_kRampRight), "3"
-},//TurnRight, { static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_kExitRight), "3"
-},//TurnRight, { static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_kStayRight), "3"
-},//TurnRight, { static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_kSharpRight), "4"
-},//TurnSharpRight, { static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_kUturnLeft), "5"
-},//UTurn, { static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_kUturnRight),       "5"
-},//UTurn, { static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_kSharpLeft),        "6"
-},//TurnSharpLeft, { static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_kLeft), "7"
-},//TurnLeft, { static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_kRampLeft), "7"
-},//TurnLeft, { static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_kExitLeft), "7"
-},//TurnLeft, { static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_kStayLeft), "7"
-},//TurnLeft, { static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_kSlightLeft), "8"
-},//TurnSlightLeft,
-        //{ static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_k),               "9"
-},//ReachViaLocation, {
-static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_kRoundaboutEnter),  "11"
-},//EnterRoundAbout, {
-static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_kRoundaboutExit),   "12"
-},//LeaveRoundAbout,
-        //{ static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_k),               "13"
-},//StayOnRoundAbout, { static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_kStart), "14"
-},//StartAtEndOfStreet, {
-static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_kStartRight),       "14"
-},//StartAtEndOfStreet, { static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_kStartLeft),
-"14" },//StartAtEndOfStreet, {
-static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_kDestination),      "15"
-},//ReachedYourDestination, {
-static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_kDestinationRight), "15"
-},//ReachedYourDestination, {
-static_cast<int>(valhalla::DirectionsLeg_Maneuver_Type_kDestinationLeft),  "15"
-},//ReachedYourDestination,
-        //{ static_cast<int>valhalla::DirectionsLeg_Maneuver_Type_k),                "16"
-},//EnterAgainstAllowedDirection,
-        //{ static_cast<int>valhalla::DirectionsLeg_Maneuver_Type_k),                "17"
-},//LeaveAgainstAllowedDirection
-    };
-
-    const std::unordered_map<int, std::string> cardinal_direction_string = {
-      { static_cast<int>(valhalla::DirectionsLeg_Maneuver_CardinalDirection_kNorth),     "N"
-}, { static_cast<int>(valhalla::DirectionsLeg_Maneuver_CardinalDirection_kNorthEast), "NE" },
-      { static_cast<int>(valhalla::DirectionsLeg_Maneuver_CardinalDirection_kEast),      "E"
-}, { static_cast<int>(valhalla::DirectionsLeg_Maneuver_CardinalDirection_kSouthEast), "SE" },
-      { static_cast<int>(valhalla::DirectionsLeg_Maneuver_CardinalDirection_kSouth),     "S"
-}, { static_cast<int>(valhalla::DirectionsLeg_Maneuver_CardinalDirection_kSouthWest), "SW" },
-      { static_cast<int>(valhalla::DirectionsLeg_Maneuver_CardinalDirection_kWest),      "W"
-}, { static_cast<int>(valhalla::DirectionsLeg_Maneuver_CardinalDirection_kNorthWest), "NW" }
-    };
-
-    json::ArrayPtr route_instructions(const
-google::protobuf::RepeatedPtrField<valhalla::DirectionsLeg>& legs){ auto route_instructions =
-json::array({}); for(const auto& leg : legs) { for(const auto& maneuver : leg.maneuver()) {
-          //if we dont know the type of maneuver then skip it
-          auto maneuver_text = maneuver_type.find(static_cast<int>(maneuver.type()));
-          if(maneuver_text == maneuver_type.end())
-            continue;
-
-          //length
-          std::ostringstream length;
-          length << static_cast<uint64_t>(maneuver.length()*1000.f) << "m";
-
-          //json
-          route_instructions->emplace_back(json::array({
-            maneuver_text->second, //maneuver type
-            (maneuver.street_name_size() ? maneuver.street_name(0) : string("")), //street name
-            static_cast<uint64_t>(maneuver.length() * 1000.f), //length in meters
-            static_cast<uint64_t>(maneuver.begin_shape_index()), //index in the shape
-            static_cast<uint64_t>(maneuver.time()), //time in seconds
-            length.str(), //length as a string with a unit suffix
-            cardinal_direction_string.find(static_cast<int>(maneuver.begin_cardinal_direction()))->second,
-// one of: N S E W NW NE SW SE static_cast<uint64_t>(maneuver.begin_heading())
-          }));
-        }
-      }
-      return route_instructions;
-    }
-**/
-
 // Add OSRM route summary information: distance, duration
 void route_summary(json::MapPtr& route,
                    const google::protobuf::RepeatedPtrField<valhalla::DirectionsLeg>& legs,
@@ -284,14 +195,12 @@ json::MapPtr geojson_shape(const std::vector<PointLL> shape) {
 }
 
 // Generate full shape of the route.
-std::vector<PointLL>
-full_shape(const google::protobuf::RepeatedPtrField<valhalla::DirectionsLeg>& legs,
-           const valhalla::Options& options) {
+std::vector<PointLL> full_shape(const valhalla::DirectionsRoute& directions,
+                                const valhalla::Options& options) {
   // If just one leg and it we want polyline6 then we just return the encoded leg shape
-  if (legs.size() == 1 && options.shape_format() == polyline6) {
-    return midgard::decode<std::vector<PointLL>>(legs.begin()->shape());
+  if (directions.legs().size() == 1 && options.shape_format() == polyline6) {
+    return midgard::decode<std::vector<PointLL>>(directions.legs().begin()->shape());
   }
-
   // TODO: there is a tricky way to do this... since the end of each leg is the same as the
   // beginning we essentially could just peel off the first encoded shape point of all the legs (but
   // the first) this way we wouldn't really have to do any decoding (would be far faster). it might
@@ -299,7 +208,7 @@ full_shape(const google::protobuf::RepeatedPtrField<valhalla::DirectionsLeg>& le
   // great!) have to have a look should make this a function in midgard probably so the logic is all
   // in the same place
   std::vector<PointLL> decoded;
-  for (const auto& leg : legs) {
+  for (const auto& leg : directions.legs()) {
     auto decoded_leg = midgard::decode<std::vector<PointLL>>(leg.shape());
     decoded.insert(decoded.end(), decoded.size() ? decoded_leg.begin() + 1 : decoded_leg.begin(),
                    decoded_leg.end());
@@ -308,16 +217,13 @@ full_shape(const google::protobuf::RepeatedPtrField<valhalla::DirectionsLeg>& le
 }
 
 // Generate simplified shape of the route.
-std::vector<PointLL>
-simplified_shape(const google::protobuf::RepeatedPtrField<valhalla::DirectionsLeg>& legs,
-                 const valhalla::Options& options) {
+std::vector<PointLL> simplified_shape(const valhalla::DirectionsRoute& directions,
+                                      const valhalla::Options& options) {
   Coordinate south_west(std::numeric_limits<int>::max(), std::numeric_limits<int>::max());
   Coordinate north_east(std::numeric_limits<int>::min(), std::numeric_limits<int>::min());
-
   std::vector<PointLL> simple_shape;
   std::unordered_set<size_t> indices;
-
-  for (const auto& leg : legs) {
+  for (const auto& leg : directions.legs()) {
     auto decoded_leg = midgard::decode<std::vector<PointLL>>(leg.shape());
     for (const auto& coord : decoded_leg) {
       south_west.lng = std::min(south_west.lng, toFixed(coord.lng()));
@@ -342,18 +248,14 @@ simplified_shape(const google::protobuf::RepeatedPtrField<valhalla::DirectionsLe
 }
 
 void route_geometry(json::MapPtr& route,
-                    const google::protobuf::RepeatedPtrField<valhalla::DirectionsLeg>& legs,
+                    const valhalla::DirectionsRoute& directions,
                     const valhalla::Options& options) {
-  // full geom = !has_generalize()
-  // simplified geom = has_generalize && generalize == 0
-  // no geom = has_generalize && generalize == -1
   std::vector<PointLL> shape;
   if (options.has_generalize() && options.generalize() == 0.0f) {
-    shape = simplified_shape(legs, options);
+    shape = simplified_shape(directions, options);
   } else if (!options.has_generalize() || (options.has_generalize() && options.generalize() > 0.0f)) {
-    shape = full_shape(legs, options);
+    shape = full_shape(directions, options);
   }
-
   if (options.shape_format() == geojson) {
     route->emplace("geometry", geojson_shape(shape));
   } else {
@@ -1377,13 +1279,19 @@ std::string serialize(valhalla::Api& api) {
   for (int i = 0; i < api.trip().routes_size(); ++i) {
     // Create a route to add to the array
     auto route = json::map({});
-
-    // TODO: phase 1, just hardcode score. phase 2: do real implementation
-    if (options.action() == valhalla::Options::trace_route)
+    if (options.action() == Options::trace_route) {
+      // NOTE(mookerji): confidence value here is a placeholder for future implementation.
       route->emplace("confidence", json::fp_t{1, 1});
+    }
+    const bool linear_reference =
+        options.linear_references() &&
+        (options.action() == Options::trace_route || options.action() == Options::route);
+    if (linear_reference) {
+      route->emplace("linear_references", route_references(api.trip().routes(i), options));
+    }
 
     // Concatenated route geometry
-    route_geometry(route, api.directions().routes(i).legs(), options);
+    route_geometry(route, api.directions().routes(i), options);
 
     // Other route summary information
     route_summary(route, api.directions().routes(i).legs(), imperial);

--- a/src/tyr/route_serializer_valhalla.cc
+++ b/src/tyr/route_serializer_valhalla.cc
@@ -564,17 +564,18 @@ legs(const google::protobuf::RepeatedPtrField<valhalla::DirectionsLeg>& directio
 std::string serialize(const Api& api) {
   // build up the json object
   auto json = json::map(
-      {{"trip", json::map({{"locations", locations(api.directions().routes(0).legs())},
-                           {"summary", summary(api.directions().routes(0).legs())},
-                           {"legs", legs(api.directions().routes(0).legs())},
-                           {"status_message", string("Found route between points")},
-                           {"status", static_cast<uint64_t>(0)}, // 0 success
-                           {"units", valhalla::Options_Units_Enum_Name(api.options().units())},
-                           {"language", api.options().language()}})}});
+      {{"trip",
+        json::map({{"locations", locations(api.directions().routes(0).legs())},
+                   {"linear_references", tyr::route_references(api.trip().routes(0), api.options())},
+                   {"summary", summary(api.directions().routes(0).legs())},
+                   {"legs", legs(api.directions().routes(0).legs())},
+                   {"status_message", string("Found route between points")},
+                   {"status", static_cast<uint64_t>(0)}, // 0 success
+                   {"units", valhalla::Options_Units_Enum_Name(api.options().units())},
+                   {"language", api.options().language()}})}});
   if (api.options().has_id()) {
     json->emplace("id", api.options().id());
   }
-
   std::stringstream ss;
   ss << *json;
   return ss.str();

--- a/src/tyr/serializers.cc
+++ b/src/tyr/serializers.cc
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "baldr/json.h"
+#include "baldr/openlr.h"
 #include "baldr/rapidjson_utils.h"
 #include "baldr/turn.h"
 #include "midgard/aabb2.h"
@@ -18,7 +19,8 @@
 #include "odin/util.h"
 #include "tyr/serializers.h"
 
-#include <valhalla/proto/options.pb.h>
+#include "proto/options.pb.h"
+#include "proto/trip.pb.h"
 
 using namespace valhalla;
 using namespace valhalla::baldr;
@@ -30,6 +32,22 @@ midgard::PointLL to_ll(const LatLng& ll) {
   return midgard::PointLL{ll.lng(), ll.lat()};
 }
 } // namespace
+namespace valhalla {
+namespace tyr {
+json::ArrayPtr route_references(const TripRoute& route, const Options& options) {
+  if (options.costing() != Costing::auto_) {
+    json::array({});
+  }
+  json::ArrayPtr references = json::array({});
+  for (const TripLeg& leg : route.legs()) {
+    for (const std::string& openlr : midgard::openlr_edges(leg)) {
+      references->emplace_back(openlr);
+    }
+  }
+  return references;
+}
+} // namespace tyr
+} // namespace valhalla
 
 namespace osrm {
 

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -660,6 +660,11 @@ void from_json(rapidjson::Document& doc, Options& options) {
     }
   }
 
+  auto linear_references = rapidjson::get_optional<bool>(doc, "/linear_references");
+  if (linear_references) {
+    options.set_linear_references(*linear_references);
+  }
+
   // parse map matching location input and encoded_polyline for height actions
   auto encoded_polyline = rapidjson::get_optional<std::string>(doc, "/encoded_polyline");
   if (encoded_polyline) {

--- a/test/mapmatch.cc
+++ b/test/mapmatch.cc
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <iostream>
 #include <random>
 #include <utility>
@@ -163,9 +164,6 @@ std::string output_shape(const valhalla::Api& api) {
 }
 
 void compare_results(const valhalla::Api& expected, const valhalla::Api& result) {
-  std::cout << output_shape(expected) << std::endl;
-  std::cout << output_shape(result) << std::endl;
-
   // check the number of routes match
   ASSERT_EQ(result.trip().routes_size(), expected.trip().routes_size())
       << "Expected " << expected.trip().routes_size() << " routes but got "
@@ -229,7 +227,6 @@ TEST(Mapmatch, test_matcher) {
     // get a route shape
     PointLL start, end;
     auto test_case = make_test_case(start, end);
-    std::cout << test_case << std::endl;
     boost::property_tree::ptree route;
     std::string route_json;
     try {
@@ -307,7 +304,6 @@ TEST(Mapmatch, test_matcher) {
                                  matched_edges.end() - 1);
     if (walked_it == walked_edges.end()) {
       if (looped) {
-        std::cout << "route had a possible loop" << std::endl;
         continue;
       }
       auto decoded_match = midgard::decode<std::vector<PointLL>>(matched.get<std::string>("shape"));
@@ -327,7 +323,6 @@ TEST(Mapmatch, test_matcher) {
       std::cout << geojson << std::endl;
       FAIL() << "The match did not match the walk";
     }
-    std::cout << "Iteration " << tested << " complete" << std::endl;
     ++tested;
   }
 }
@@ -724,7 +719,6 @@ TEST(Mapmatch, test_topk_fork_alternate) {
           {"lat":52.08511,"lon":5.15085,"accuracy":10,"time":2},
           {"lat":52.08533,"lon":5.15109,"accuracy":20,"time":4},
           {"lat":52.08539,"lon":5.15100,"accuracy":20,"time":6}]})");
-  std::cout << json << std::endl;
   auto matched = json_to_pt(json);
 
   /*** Primary path - left at the fork
@@ -1411,7 +1405,6 @@ TEST(Mapmatch, test_breakage_distance_error_handling) {
   // tests expected error_code for trace_route edge_walk
   auto expected_error_code = 172;
   tyr::actor_t actor(conf, true);
-
   try {
     auto response = json_to_pt(actor.trace_route(
         R"({"costing":"auto","shape_match":"edge_walk","shape":[
@@ -1426,10 +1419,82 @@ TEST(Mapmatch, test_breakage_distance_error_handling) {
   // If we get here then fail the test!
   FAIL() << "Expected trace_route breakage distance exceed exception was not found";
 }
+
+// Spot check OpenLR linear references when asked for
+TEST(Mapmatch, openlr_parameter_true_osrm_api) {
+  // clang-format off
+  const std::string request = R"({"costing":"auto","linear_references": true,"format":"osrm","shape_match":"map_snap","shape":[{"lon":5.08531221,"lat":52.0938563,"type":"break"},{"lon":5.0865867,"lat":52.0930211,"type":"break"}]})";
+  // clang-format on
+  tyr::actor_t actor(conf, true);
+  const auto& response = json_to_pt(actor.trace_route(request));
+  const auto& matches = response.get_child("matchings");
+  EXPECT_EQ(matches.size(), 1);
+  const std::vector<std::string>& expected = {
+      "CwOduyULYhtpAAAV//0bGQ==", "CwOdxCULYBtqAAAM//4bGg==", "CwOdySULXxtrAAAf//EbGw==",
+      "CwOd1yULVxtrAQBV/9AbGw==", "CwOduyULYj/gAAACAAA/EA==",
+  };
+  for (const auto& match : matches) {
+    const auto& references = match.second.get_child("linear_references");
+    EXPECT_EQ(references.size(), 5);
+    for (const auto& reference : references) {
+      const std::string& actual = reference.second.get_value<std::string>();
+      EXPECT_TRUE(std::find(expected.begin(), expected.end(), actual) != expected.end());
+    }
+  }
+}
+
+// Replica of above test, but uses the Valhalla's native API
+TEST(Mapmatch, openlr_parameter_true_native_api) {
+  // clang-format off
+  const std::string request = R"({"costing":"auto","linear_references": true,"shape_match":"map_snap","shape":[{"lon":5.08531221,"lat":52.0938563,"type":"break"},{"lon":5.0865867,"lat":52.0930211,"type":"break"}]})";
+  // clang-format on
+  tyr::actor_t actor(conf, true);
+  const auto& response = json_to_pt(actor.trace_route(request));
+  const std::vector<std::string>& expected = {
+      "CwOduyULYhtpAAAV//0bGQ==", "CwOdxCULYBtqAAAM//4bGg==", "CwOdySULXxtrAAAf//EbGw==",
+      "CwOd1yULVxtrAQBV/9AbGw==", "CwOduyULYj/gAAACAAA/EA==",
+  };
+  const auto& references = response.get_child("trip.linear_references");
+  EXPECT_EQ(references.size(), 5);
+  for (const auto& reference : references) {
+    const std::string& actual = reference.second.get_value<std::string>();
+    EXPECT_TRUE(std::find(expected.begin(), expected.end(), actual) != expected.end());
+  }
+}
+
+// Verify that OpenLR references are not present in API response when not asked for
+TEST(Mapmatch, openlr_parameter_falsy_api) {
+  const std::vector<std::string> requests = {
+      R"({"costing":"auto","linear_references":false,"format":"osrm","shape_match":"map_snap","shape":[{"lon":5.08531221,"lat":52.0938563,"type":"break"},{"lon":5.0865867,"lat":52.0930211,"type":"break"}]})",
+      R"({"costing":"auto","format":"osrm","shape_match":"map_snap","shape":[{"lon":5.08531221,"lat":52.0938563,"type":"break"},{"lon":5.0865867,"lat":52.0930211,"type":"break"}]})",
+  };
+  tyr::actor_t actor(conf, true);
+  for (const auto& request : requests) {
+    const auto& response = json_to_pt(actor.trace_route(request));
+    const auto& matches = response.get_child("matchings");
+    EXPECT_EQ(matches.size(), 1);
+    for (const auto& match : matches) {
+      EXPECT_FALSE(match.second.get_child_optional("linear_references"));
+    }
+  }
+}
+
+// Replica of above test, but uses the Valhalla's native API
+TEST(Mapmatch, openlr_parameter_falsy_native_api) {
+  const std::vector<std::string> requests = {
+      R"({"costing":"auto","linear_references":false,"shape_match":"map_snap","shape":[{"lon":5.08531221,"lat":52.0938563,"type":"break"},{"lon":5.0865867,"lat":52.0930211,"type":"break"}]})",
+      R"({"costing":"auto","shape_match":"map_snap","shape":[{"lon":5.08531221,"lat":52.0938563,"type":"break"},{"lon":5.0865867,"lat":52.0930211,"type":"break"}]})",
+  };
+  tyr::actor_t actor(conf, true);
+  for (const auto& request : requests) {
+    const auto& response = json_to_pt(actor.trace_route(request));
+    EXPECT_FALSE(response.get_child_optional("linear_references"));
+  }
+}
 } // namespace
 
 int main(int argc, char* argv[]) {
-  // midgard::logging::Configure({{"type", ""}}); // silence logs
+  midgard::logging::Configure({{"type", ""}});
   if (argc > 1 && std::string(argv[1]).find("gtest") == std::string::npos) {
     if (argc > 1)
       seed = std::stoi(argv[1]);

--- a/valhalla/baldr/openlr.h
+++ b/valhalla/baldr/openlr.h
@@ -3,6 +3,7 @@
 
 #include <valhalla/midgard/pointll.h>
 #include <valhalla/midgard/util.h>
+#include <valhalla/proto/trip.pb.h>
 
 #include <assert.h>
 #include <bitset>
@@ -320,6 +321,32 @@ struct LineLocation {
 };
 
 } // namespace OpenLR
+
+/**
+ * Maps Valhalla edge and road class to an OpenLR form-of-way.
+ *
+ * @param node   Node of single trip leg
+ * @return       OpenLR form-of-way classification. If this can't be determined
+ *               from the edge's road class or use information, will return FormOfWay::OTHER.
+ */
+OpenLR::LocationReferencePoint::FormOfWay road_class_to_fow(const TripLeg::Node& node);
+
+/**
+ * Compute base64-encoded OpenLR descriptor per-edge of a trip leg.
+ *
+ * @param   leg   TripPath leg
+ * @return        OpenLR descriptors for all edges in a path
+ */
+std::vector<std::string> openlr_edges(const TripLeg& leg);
+
+/**
+ * Compute base64-encoded OpenLR descriptor for an entire trip leg.
+ *
+ * @param   leg   TripPath leg
+ * @return        OpenLR descriptor for a single trip leg.
+ */
+std::vector<std::string> openlr_legs(const TripLeg& leg);
+
 } // namespace midgard
 } // namespace valhalla
 

--- a/valhalla/tyr/serializers.h
+++ b/valhalla/tyr/serializers.h
@@ -98,6 +98,11 @@ std::string serializeTraceAttributes(
     const thor::AttributesController& controller,
     std::vector<std::tuple<float, float, std::vector<meili::MatchResult>>>& results);
 
+// Return a JSON array of OpenLR 1.5 line location references for each edge of a map matching
+// result. For the time being, result is only non-empty for auto costing requests.
+baldr::json::ArrayPtr route_references(const valhalla::TripRoute& route,
+                                       const valhalla::Options& options);
+
 } // namespace tyr
 } // namespace valhalla
 


### PR DESCRIPTION
Adds support for a new request option 'linear_references=true|false', which adds an array of OpenLR references to the response body for `route` and `trace_route` Valhalla HTTP endpoints. 