### PR TITLE
Gurka expect_route refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@
    * ADDED: `street_side_max_distance`, `display_lat` and `display_lon` to `locations` in input for better control of routing side of street [#1769](https://github.com/valhalla/valhalla/pull/1769)
    * ADDED: Add addtional exit phrases. [#2421](https://github.com/valhalla/valhalla/pull/2421)
    * ADDED: Add Japanese locale, update German. [#2432](https://github.com/valhalla/valhalla/pull/2432)
+   * ADDED: Gurka expect_route refactor [#2435](https://github.com/valhalla/valhalla/pull/2435)
 
 ## Release Date: 2019-11-21 Valhalla 3.0.9
 * **Bug Fix**

--- a/test/gurka/README.md
+++ b/test/gurka/README.md
@@ -189,6 +189,8 @@ void expect_instructions_at_maneuver_index(
 void expect_path_length(const valhalla::Api& result,
                         const float expected_length_km,
                         const float error_margin = 0);
+
+void expect_path(const valhalla::Api& result, const std::vector<std::string>& expected_names);
 ```
 
 ## `gurka::assert::osrm`

--- a/test/gurka/README.md
+++ b/test/gurka/README.md
@@ -199,7 +199,7 @@ These functions will first serialize the raw `valhalla::Api` object into a JSON 
 (using `tyr::serializeDirections`), then perform assertions within the JSON document only.
 
 ```cpp
-void expect_route(valhalla::Api& raw_result,
+void expect_steps(valhalla::Api& raw_result,
                   const std::vector<std::string>& expected_names,
                   bool dedupe = true);
 

--- a/test/gurka/gurka.h
+++ b/test/gurka/gurka.h
@@ -696,10 +696,10 @@ namespace osrm {
  * Tests if a found path traverses the expected roads in the expected order
  *
  * @param result the result of a /route or /match request
- * @param expected_names the names of the roads the path should traverse in order
+ * @param expected_names the names of the step roads the path should traverse in order
  * @param dedupe whether subsequent same-name roads should appear multiple times or not (default not)
  */
-void expect_route(valhalla::Api& raw_result,
+void expect_steps(valhalla::Api& raw_result,
                   const std::vector<std::string>& expected_names,
                   bool dedupe = true) {
 

--- a/test/gurka/gurka.h
+++ b/test/gurka/gurka.h
@@ -29,6 +29,8 @@
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 
+#include <valhalla/proto/trip.pb.h>
+
 #include <osmium/builder/attr.hpp>
 #include <osmium/builder/osm_object_builder.hpp>
 #include <osmium/io/pbf_output.hpp>
@@ -693,7 +695,7 @@ namespace assert {
 namespace osrm {
 
 /**
- * Tests if a found path traverses the expected roads in the expected order
+ * Tests if a found path traverses the expected steps in the expected order
  *
  * @param result the result of a /route or /match request
  * @param expected_names the names of the step roads the path should traverse in order
@@ -747,7 +749,7 @@ void expect_steps(valhalla::Api& raw_result,
     actual_names.erase(last, actual_names.end());
   }
 
-  EXPECT_EQ(actual_names, expected_names) << "Actual path didn't match expected path";
+  EXPECT_EQ(actual_names, expected_names) << "Actual steps didn't match expected steps";
 }
 /**
  * Tests if a found path traverses the expected roads in the expected order
@@ -926,6 +928,40 @@ void expect_eta(const valhalla::Api& result,
   } else {
     EXPECT_NEAR(static_cast<float>(eta_sec), expected_eta_seconds, error_margin);
   }
+}
+
+std::string
+to_string(const ::google::protobuf::RepeatedPtrField<::valhalla::StreetName>& street_names) {
+  std::string str;
+
+  for (const auto& street_name : street_names) {
+    if (!str.empty()) {
+      str += "/";
+    }
+    str += street_name.value();
+  }
+  return str;
+}
+
+/**
+ * Tests if a found path traverses the expected edges in the expected order
+ *
+ * @param result the result of a /route or /match request
+ * @param expected_names the names of the edges the path should traverse in order
+ */
+void expect_path(const valhalla::Api& result, const std::vector<std::string>& expected_names) {
+  EXPECT_EQ(result.trip().routes_size(), 1);
+
+  std::vector<std::string> actual_names;
+  for (const auto& leg : result.trip().routes(0).legs()) {
+    for (const auto& node : leg.node()) {
+      if (node.has_edge()) {
+        actual_names.push_back(to_string(node.edge().name()));
+      }
+    }
+  }
+
+  EXPECT_EQ(actual_names, expected_names) << "Actual path didn't match expected path";
 }
 
 } // namespace raw

--- a/test/gurka/test_accessibility.cc
+++ b/test/gurka/test_accessibility.cc
@@ -38,33 +38,33 @@ gurka::map Accessibility::map = {};
 /*************************************************************/
 TEST_F(Accessibility, Auto1) {
   auto result = gurka::route(map, "C", "F", "auto");
-  gurka::assert::osrm::expect_route(result, {"BC", "AB", "ADG", "DEF"});
+  gurka::assert::osrm::expect_steps(result, {"BC", "AB", "ADG", "DEF"});
 }
 TEST_F(Accessibility, Auto2) {
   auto result = gurka::route(map, "C", "I", "auto");
-  gurka::assert::osrm::expect_route(result, {"BC", "AB", "ADG", "GHI"});
+  gurka::assert::osrm::expect_steps(result, {"BC", "AB", "ADG", "GHI"});
 }
 TEST_F(Accessibility, WalkUsesShortcut1) {
   auto result = gurka::route(map, "C", "F", "pedestrian");
-  gurka::assert::osrm::expect_route(result, {"BC", "BE", "DEF"});
+  gurka::assert::osrm::expect_steps(result, {"BC", "BE", "DEF"});
 }
 TEST_F(Accessibility, WalkUsesBothShortcuts) {
   auto result = gurka::route(map, "C", "I", "pedestrian");
-  gurka::assert::osrm::expect_route(result, {"BC", "BE", "EI"});
+  gurka::assert::osrm::expect_steps(result, {"BC", "BE", "EI"});
 }
 TEST_F(Accessibility, BikeUsesShortcut) {
   auto result = gurka::route(map, "C", "F", "bicycle");
-  gurka::assert::osrm::expect_route(result, {"BC", "BE", "DEF"});
+  gurka::assert::osrm::expect_steps(result, {"BC", "BE", "DEF"});
 }
 TEST_F(Accessibility, BikeAvoidsSecondShortcut) {
   auto result = gurka::route(map, "C", "I", "bicycle");
-  gurka::assert::osrm::expect_route(result, {"BC", "BE", "EH", "GHI"});
+  gurka::assert::osrm::expect_steps(result, {"BC", "BE", "EH", "GHI"});
 }
 TEST_F(Accessibility, WalkAvoidsMotorway) {
   auto result = gurka::route(map, "A", "G", "pedestrian");
-  gurka::assert::osrm::expect_route(result, {"AB", "BE", "EH", "GHI"});
+  gurka::assert::osrm::expect_steps(result, {"AB", "BE", "EH", "GHI"});
 }
 TEST_F(Accessibility, AutoUsesMotorway) {
   auto result = gurka::route(map, "A", "G", "auto");
-  gurka::assert::osrm::expect_route(result, {"ADG"});
+  gurka::assert::osrm::expect_steps(result, {"ADG"});
 }

--- a/test/gurka/test_accessibility.cc
+++ b/test/gurka/test_accessibility.cc
@@ -39,32 +39,40 @@ gurka::map Accessibility::map = {};
 TEST_F(Accessibility, Auto1) {
   auto result = gurka::route(map, "C", "F", "auto");
   gurka::assert::osrm::expect_steps(result, {"BC", "AB", "ADG", "DEF"});
+  gurka::assert::raw::expect_path(result, {"BC", "AB", "ADG", "DEF", "DEF"});
 }
 TEST_F(Accessibility, Auto2) {
   auto result = gurka::route(map, "C", "I", "auto");
   gurka::assert::osrm::expect_steps(result, {"BC", "AB", "ADG", "GHI"});
+  gurka::assert::raw::expect_path(result, {"BC", "AB", "ADG", "ADG", "GHI", "GHI"});
 }
 TEST_F(Accessibility, WalkUsesShortcut1) {
   auto result = gurka::route(map, "C", "F", "pedestrian");
   gurka::assert::osrm::expect_steps(result, {"BC", "BE", "DEF"});
+  gurka::assert::raw::expect_path(result, {"BC", "BE", "DEF"});
 }
 TEST_F(Accessibility, WalkUsesBothShortcuts) {
   auto result = gurka::route(map, "C", "I", "pedestrian");
   gurka::assert::osrm::expect_steps(result, {"BC", "BE", "EI"});
+  gurka::assert::raw::expect_path(result, {"BC", "BE", "EI"});
 }
 TEST_F(Accessibility, BikeUsesShortcut) {
   auto result = gurka::route(map, "C", "F", "bicycle");
   gurka::assert::osrm::expect_steps(result, {"BC", "BE", "DEF"});
+  gurka::assert::raw::expect_path(result, {"BC", "BE", "DEF"});
 }
 TEST_F(Accessibility, BikeAvoidsSecondShortcut) {
   auto result = gurka::route(map, "C", "I", "bicycle");
   gurka::assert::osrm::expect_steps(result, {"BC", "BE", "EH", "GHI"});
+  gurka::assert::raw::expect_path(result, {"BC", "BE", "EH", "GHI"});
 }
 TEST_F(Accessibility, WalkAvoidsMotorway) {
   auto result = gurka::route(map, "A", "G", "pedestrian");
   gurka::assert::osrm::expect_steps(result, {"AB", "BE", "EH", "GHI"});
+  gurka::assert::raw::expect_path(result, {"AB", "BE", "EH", "GHI"});
 }
 TEST_F(Accessibility, AutoUsesMotorway) {
   auto result = gurka::route(map, "A", "G", "auto");
   gurka::assert::osrm::expect_steps(result, {"ADG"});
+  gurka::assert::raw::expect_path(result, {"ADG", "ADG"});
 }

--- a/test/gurka/test_conditional_restrictions.cc
+++ b/test/gurka/test_conditional_restrictions.cc
@@ -81,11 +81,13 @@ gurka::map ConditionalRestrictions::map = {};
 TEST_F(ConditionalRestrictions, NoRestrictionAutoNoDate) {
   auto result = gurka::route(map, "A", "E", "auto");
   gurka::assert::osrm::expect_steps(result, {"AB", "BC", "CE"});
+  gurka::assert::raw::expect_path(result, {"AB", "BC", "CE"});
 }
 
 TEST_F(ConditionalRestrictions, NoRestrictionAuto) {
   auto result = gurka::route(map, "A", "E", "auto", "2020-04-15T06:00");
   gurka::assert::osrm::expect_steps(result, {"AB", "BC", "CE"});
+  gurka::assert::raw::expect_path(result, {"AB", "BC", "CE"});
 }
 
 TEST_F(ConditionalRestrictions, RestrictionAuto) {
@@ -106,13 +108,13 @@ TEST_F(ConditionalRestrictions, RestrictionAuto) {
 TEST_F(ConditionalRestrictions, NoRestrictionBikeNoDate) {
   auto result = gurka::route(map, "A", "E", "bicycle");
   gurka::assert::osrm::expect_steps(result, {"AD", "DE"});
-  ;
+  gurka::assert::raw::expect_path(result, {"AD", "DE"});
 }
 
 TEST_F(ConditionalRestrictions, NoRestrictionBike) {
   auto result = gurka::route(map, "A", "E", "bicycle", "2020-04-02T12:00");
   gurka::assert::osrm::expect_steps(result, {"AD", "DE"});
-  ;
+  gurka::assert::raw::expect_path(result, {"AD", "DE"});
 }
 
 TEST_F(ConditionalRestrictions, RestrictionBike) {
@@ -133,11 +135,13 @@ TEST_F(ConditionalRestrictions, RestrictionBike) {
 TEST_F(ConditionalRestrictions, NoRestrictionPedestrianNoDate) {
   auto result = gurka::route(map, "A", "E", "pedestrian");
   gurka::assert::osrm::expect_steps(result, {"AD", "DE"});
+  gurka::assert::raw::expect_path(result, {"AD", "DE"});
 }
 
 TEST_F(ConditionalRestrictions, NoRestrictionPedestrian) {
   auto result = gurka::route(map, "A", "E", "pedestrian", "2020-04-02T20:00");
   gurka::assert::osrm::expect_steps(result, {"AD", "DE"});
+  gurka::assert::raw::expect_path(result, {"AD", "DE"});
 }
 
 TEST_F(ConditionalRestrictions, RestrictionPedestrian) {

--- a/test/gurka/test_conditional_restrictions.cc
+++ b/test/gurka/test_conditional_restrictions.cc
@@ -80,12 +80,12 @@ gurka::map ConditionalRestrictions::map = {};
 
 TEST_F(ConditionalRestrictions, NoRestrictionAutoNoDate) {
   auto result = gurka::route(map, "A", "E", "auto");
-  gurka::assert::osrm::expect_route(result, {"AB", "BC", "CE"});
+  gurka::assert::osrm::expect_steps(result, {"AB", "BC", "CE"});
 }
 
 TEST_F(ConditionalRestrictions, NoRestrictionAuto) {
   auto result = gurka::route(map, "A", "E", "auto", "2020-04-15T06:00");
-  gurka::assert::osrm::expect_route(result, {"AB", "BC", "CE"});
+  gurka::assert::osrm::expect_steps(result, {"AB", "BC", "CE"});
 }
 
 TEST_F(ConditionalRestrictions, RestrictionAuto) {
@@ -105,13 +105,13 @@ TEST_F(ConditionalRestrictions, RestrictionAuto) {
 
 TEST_F(ConditionalRestrictions, NoRestrictionBikeNoDate) {
   auto result = gurka::route(map, "A", "E", "bicycle");
-  gurka::assert::osrm::expect_route(result, {"AD", "DE"});
+  gurka::assert::osrm::expect_steps(result, {"AD", "DE"});
   ;
 }
 
 TEST_F(ConditionalRestrictions, NoRestrictionBike) {
   auto result = gurka::route(map, "A", "E", "bicycle", "2020-04-02T12:00");
-  gurka::assert::osrm::expect_route(result, {"AD", "DE"});
+  gurka::assert::osrm::expect_steps(result, {"AD", "DE"});
   ;
 }
 
@@ -132,12 +132,12 @@ TEST_F(ConditionalRestrictions, RestrictionBike) {
 
 TEST_F(ConditionalRestrictions, NoRestrictionPedestrianNoDate) {
   auto result = gurka::route(map, "A", "E", "pedestrian");
-  gurka::assert::osrm::expect_route(result, {"AD", "DE"});
+  gurka::assert::osrm::expect_steps(result, {"AD", "DE"});
 }
 
 TEST_F(ConditionalRestrictions, NoRestrictionPedestrian) {
   auto result = gurka::route(map, "A", "E", "pedestrian", "2020-04-02T20:00");
-  gurka::assert::osrm::expect_route(result, {"AD", "DE"});
+  gurka::assert::osrm::expect_steps(result, {"AD", "DE"});
 }
 
 TEST_F(ConditionalRestrictions, RestrictionPedestrian) {

--- a/test/gurka/test_mtb_access.cc
+++ b/test/gurka/test_mtb_access.cc
@@ -39,5 +39,5 @@ gurka::map MtbAccess::map = {};
 
 TEST_F(MtbAccess, CheckMtbAccess) {
   auto result = gurka::route(map, "A", "C", "bicycle");
-  gurka::assert::osrm::expect_route(result, {"AB", "BC"});
+  gurka::assert::osrm::expect_steps(result, {"AB", "BC"});
 }

--- a/test/gurka/test_mtb_access.cc
+++ b/test/gurka/test_mtb_access.cc
@@ -40,4 +40,5 @@ gurka::map MtbAccess::map = {};
 TEST_F(MtbAccess, CheckMtbAccess) {
   auto result = gurka::route(map, "A", "C", "bicycle");
   gurka::assert::osrm::expect_steps(result, {"AB", "BC"});
+  gurka::assert::raw::expect_path(result, {"AB", "BC"});
 }

--- a/test/gurka/test_search_filter.cc
+++ b/test/gurka/test_search_filter.cc
@@ -49,7 +49,7 @@ TEST_F(SearchFilter, Unfiltered) {
   auto result = gurka::route(map, request);
 
   // should take the shortest path
-  gurka::assert::osrm::expect_route(result, {"AB", "BC"});
+  gurka::assert::osrm::expect_steps(result, {"AB", "BC"});
 }
 TEST_F(SearchFilter, Heading) {
   auto from = "1";
@@ -64,7 +64,7 @@ TEST_F(SearchFilter, Heading) {
   auto result = gurka::route(map, request);
 
   // should take the long way around starting southbound due to heading at origin
-  gurka::assert::osrm::expect_route(result, {"AB", "AD", "CD", "BC"});
+  gurka::assert::osrm::expect_steps(result, {"AB", "AD", "CD", "BC"});
 }
 TEST_F(SearchFilter, PreferredSide) {
   auto from = "1";
@@ -79,7 +79,7 @@ TEST_F(SearchFilter, PreferredSide) {
   auto result = gurka::route(map, request);
 
   // should take the long way around starting southbound due to preferred side at destination
-  gurka::assert::osrm::expect_route(result, {"AB", "AD", "CD", "BC"});
+  gurka::assert::osrm::expect_steps(result, {"AB", "AD", "CD", "BC"});
 }
 TEST_F(SearchFilter, MaxRoadClass) {
   auto from = "1";
@@ -93,7 +93,7 @@ TEST_F(SearchFilter, MaxRoadClass) {
        std::to_string(map.nodes.at(to).lat()) % std::to_string(map.nodes.at(to).lng()))
           .str();
   auto result = gurka::route(map, request);
-  gurka::assert::osrm::expect_route(result, {"AD", "AB", "BC"});
+  gurka::assert::osrm::expect_steps(result, {"AD", "AB", "BC"});
 }
 TEST_F(SearchFilter, MinRoadClass) {
   auto from = "1";
@@ -106,7 +106,7 @@ TEST_F(SearchFilter, MinRoadClass) {
        std::to_string(map.nodes.at(to).lat()) % std::to_string(map.nodes.at(to).lng()))
           .str();
   auto result = gurka::route(map, request);
-  gurka::assert::osrm::expect_route(result, {"AB"});
+  gurka::assert::osrm::expect_steps(result, {"AB"});
 }
 TEST_F(SearchFilter, ExcludeTunnel) {
   auto from = "2";
@@ -117,7 +117,7 @@ TEST_F(SearchFilter, ExcludeTunnel) {
        std::to_string(map.nodes.at(to).lat()) % std::to_string(map.nodes.at(to).lng()))
           .str();
   auto result_unfiltered = gurka::route(map, request_unfiltered);
-  gurka::assert::osrm::expect_route(result_unfiltered, {"BC", "AB"});
+  gurka::assert::osrm::expect_steps(result_unfiltered, {"BC", "AB"});
 
   const std::string& request_filtered =
       (boost::format(
@@ -126,7 +126,7 @@ TEST_F(SearchFilter, ExcludeTunnel) {
        std::to_string(map.nodes.at(to).lat()) % std::to_string(map.nodes.at(to).lng()))
           .str();
   auto result_filtered = gurka::route(map, request_filtered);
-  gurka::assert::osrm::expect_route(result_filtered, {"AD", "AB"});
+  gurka::assert::osrm::expect_steps(result_filtered, {"AD", "AB"});
 }
 TEST_F(SearchFilter, ExcludeBridge) {
   auto from = "6";
@@ -137,7 +137,7 @@ TEST_F(SearchFilter, ExcludeBridge) {
        std::to_string(map.nodes.at(to).lat()) % std::to_string(map.nodes.at(to).lng()))
           .str();
   auto result_unfiltered = gurka::route(map, request_unfiltered);
-  gurka::assert::osrm::expect_route(result_unfiltered, {"EF", "DE", "CD"});
+  gurka::assert::osrm::expect_steps(result_unfiltered, {"EF", "DE", "CD"});
 
   const std::string& request_filtered =
       (boost::format(
@@ -146,7 +146,7 @@ TEST_F(SearchFilter, ExcludeBridge) {
        std::to_string(map.nodes.at(to).lat()) % std::to_string(map.nodes.at(to).lng()))
           .str();
   auto result_filtered = gurka::route(map, request_filtered);
-  gurka::assert::osrm::expect_route(result_filtered, {"AD", "CD"});
+  gurka::assert::osrm::expect_steps(result_filtered, {"AD", "CD"});
 }
 TEST_F(SearchFilter, ExcludeRamp) {
   auto from = "5";
@@ -157,7 +157,7 @@ TEST_F(SearchFilter, ExcludeRamp) {
        std::to_string(map.nodes.at(to).lat()) % std::to_string(map.nodes.at(to).lng()))
           .str();
   auto result_unfiltered = gurka::route(map, request_unfiltered);
-  gurka::assert::osrm::expect_route(result_unfiltered, {"AF", "AB", "BC"});
+  gurka::assert::osrm::expect_steps(result_unfiltered, {"AF", "AB", "BC"});
 
   const std::string& request_filtered =
       (boost::format(
@@ -167,5 +167,5 @@ TEST_F(SearchFilter, ExcludeRamp) {
           .str();
   auto result_filtered = gurka::route(map, request_filtered);
 
-  gurka::assert::osrm::expect_route(result_filtered, {"AD", "AB", "BC"});
+  gurka::assert::osrm::expect_steps(result_filtered, {"AD", "AB", "BC"});
 }

--- a/test/gurka/test_search_filter.cc
+++ b/test/gurka/test_search_filter.cc
@@ -50,6 +50,7 @@ TEST_F(SearchFilter, Unfiltered) {
 
   // should take the shortest path
   gurka::assert::osrm::expect_steps(result, {"AB", "BC"});
+  gurka::assert::raw::expect_path(result, {"AB", "BC"});
 }
 TEST_F(SearchFilter, Heading) {
   auto from = "1";
@@ -65,6 +66,7 @@ TEST_F(SearchFilter, Heading) {
 
   // should take the long way around starting southbound due to heading at origin
   gurka::assert::osrm::expect_steps(result, {"AB", "AD", "CD", "BC"});
+  gurka::assert::raw::expect_path(result, {"AB", "AD", "CD", "BC"});
 }
 TEST_F(SearchFilter, PreferredSide) {
   auto from = "1";
@@ -80,6 +82,7 @@ TEST_F(SearchFilter, PreferredSide) {
 
   // should take the long way around starting southbound due to preferred side at destination
   gurka::assert::osrm::expect_steps(result, {"AB", "AD", "CD", "BC"});
+  gurka::assert::raw::expect_path(result, {"AB", "AD", "CD", "BC"});
 }
 TEST_F(SearchFilter, MaxRoadClass) {
   auto from = "1";
@@ -94,6 +97,7 @@ TEST_F(SearchFilter, MaxRoadClass) {
           .str();
   auto result = gurka::route(map, request);
   gurka::assert::osrm::expect_steps(result, {"AD", "AB", "BC"});
+  gurka::assert::raw::expect_path(result, {"AD", "AB", "BC"});
 }
 TEST_F(SearchFilter, MinRoadClass) {
   auto from = "1";
@@ -107,6 +111,7 @@ TEST_F(SearchFilter, MinRoadClass) {
           .str();
   auto result = gurka::route(map, request);
   gurka::assert::osrm::expect_steps(result, {"AB"});
+  gurka::assert::raw::expect_path(result, {"AB"});
 }
 TEST_F(SearchFilter, ExcludeTunnel) {
   auto from = "2";
@@ -118,6 +123,7 @@ TEST_F(SearchFilter, ExcludeTunnel) {
           .str();
   auto result_unfiltered = gurka::route(map, request_unfiltered);
   gurka::assert::osrm::expect_steps(result_unfiltered, {"BC", "AB"});
+  gurka::assert::raw::expect_path(result_unfiltered, {"BC", "AB"});
 
   const std::string& request_filtered =
       (boost::format(
@@ -127,6 +133,7 @@ TEST_F(SearchFilter, ExcludeTunnel) {
           .str();
   auto result_filtered = gurka::route(map, request_filtered);
   gurka::assert::osrm::expect_steps(result_filtered, {"AD", "AB"});
+  gurka::assert::raw::expect_path(result_filtered, {"AD", "AB"});
 }
 TEST_F(SearchFilter, ExcludeBridge) {
   auto from = "6";
@@ -138,6 +145,7 @@ TEST_F(SearchFilter, ExcludeBridge) {
           .str();
   auto result_unfiltered = gurka::route(map, request_unfiltered);
   gurka::assert::osrm::expect_steps(result_unfiltered, {"EF", "DE", "CD"});
+  gurka::assert::raw::expect_path(result_unfiltered, {"EF", "DE", "CD"});
 
   const std::string& request_filtered =
       (boost::format(
@@ -147,6 +155,7 @@ TEST_F(SearchFilter, ExcludeBridge) {
           .str();
   auto result_filtered = gurka::route(map, request_filtered);
   gurka::assert::osrm::expect_steps(result_filtered, {"AD", "CD"});
+  gurka::assert::raw::expect_path(result_filtered, {"AD", "CD"});
 }
 TEST_F(SearchFilter, ExcludeRamp) {
   auto from = "5";
@@ -158,6 +167,7 @@ TEST_F(SearchFilter, ExcludeRamp) {
           .str();
   auto result_unfiltered = gurka::route(map, request_unfiltered);
   gurka::assert::osrm::expect_steps(result_unfiltered, {"AF", "AB", "BC"});
+  gurka::assert::raw::expect_path(result_unfiltered, {"AF", "AB", "BC"});
 
   const std::string& request_filtered =
       (boost::format(
@@ -168,4 +178,5 @@ TEST_F(SearchFilter, ExcludeRamp) {
   auto result_filtered = gurka::route(map, request_filtered);
 
   gurka::assert::osrm::expect_steps(result_filtered, {"AD", "AB", "BC"});
+  gurka::assert::raw::expect_path(result_filtered, {"AD", "AB", "BC"});
 }

--- a/test/gurka/test_simple_restrictions.cc
+++ b/test/gurka/test_simple_restrictions.cc
@@ -37,13 +37,13 @@ gurka::map SimpleRestrictions::map = {};
 /*************************************************************/
 TEST_F(SimpleRestrictions, ForceDetour) {
   auto result = gurka::route(map, "C", "F", "auto");
-  gurka::assert::osrm::expect_route(result, {"BC", "AB", "ADG", "DEF"});
+  gurka::assert::osrm::expect_steps(result, {"BC", "AB", "ADG", "DEF"});
 }
 TEST_F(SimpleRestrictions, NoDetourWhenReversed) {
   auto result = gurka::route(map, "F", "C", "auto");
-  gurka::assert::osrm::expect_route(result, {"DEF", "BE", "BC"});
+  gurka::assert::osrm::expect_steps(result, {"DEF", "BE", "BC"});
 }
 TEST_F(SimpleRestrictions, NoDetourFromDifferentStart) {
   auto result = gurka::route(map, "1", "F", "auto");
-  gurka::assert::osrm::expect_route(result, {"AB", "BE", "DEF"});
+  gurka::assert::osrm::expect_steps(result, {"AB", "BE", "DEF"});
 }

--- a/test/gurka/test_simple_restrictions.cc
+++ b/test/gurka/test_simple_restrictions.cc
@@ -38,12 +38,15 @@ gurka::map SimpleRestrictions::map = {};
 TEST_F(SimpleRestrictions, ForceDetour) {
   auto result = gurka::route(map, "C", "F", "auto");
   gurka::assert::osrm::expect_steps(result, {"BC", "AB", "ADG", "DEF"});
+  gurka::assert::raw::expect_path(result, {"BC", "AB", "ADG", "DEF", "DEF"});
 }
 TEST_F(SimpleRestrictions, NoDetourWhenReversed) {
   auto result = gurka::route(map, "F", "C", "auto");
   gurka::assert::osrm::expect_steps(result, {"DEF", "BE", "BC"});
+  gurka::assert::raw::expect_path(result, {"DEF", "BE", "BC"});
 }
 TEST_F(SimpleRestrictions, NoDetourFromDifferentStart) {
   auto result = gurka::route(map, "1", "F", "auto");
   gurka::assert::osrm::expect_steps(result, {"AB", "BE", "DEF"});
+  gurka::assert::raw::expect_path(result, {"AB", "BE", "DEF"});
 }

--- a/test/gurka/test_traffic.cc
+++ b/test/gurka/test_traffic.cc
@@ -144,7 +144,7 @@ TEST(Traffic, BasicUpdates) {
     // Do a route with initial traffic
     {
       auto result = gurka::route(map, "A", "C", "auto", "current", clean_reader);
-      gurka::assert::osrm::expect_route(result, {"AB", "BC"});
+      gurka::assert::osrm::expect_steps(result, {"AB", "BC"});
       gurka::assert::raw::expect_eta(result, 361.5);
     }
     // Make some updates to the traffic .tar file.
@@ -156,14 +156,14 @@ TEST(Traffic, BasicUpdates) {
     // it's noticed the changes in the live traffic file
     {
       auto result = gurka::route(map, "A", "C", "auto", "current", clean_reader);
-      gurka::assert::osrm::expect_route(result, {"AB", "BC"});
+      gurka::assert::osrm::expect_steps(result, {"AB", "BC"});
       gurka::assert::raw::expect_eta(result, 145.5);
     }
     // Next, set the speed to the highest possible to ensure nothing breaks
     update_bd_traffic_speed(map, valhalla::baldr::kMaxSpeedKph);
     {
       auto result = gurka::route(map, "A", "C", "auto", "current", clean_reader);
-      gurka::assert::osrm::expect_route(result, {"AB", "BC"});
+      gurka::assert::osrm::expect_steps(result, {"AB", "BC"});
       gurka::assert::raw::expect_eta(result, 15.617648);
     }
     // Back to previous speed
@@ -172,26 +172,26 @@ TEST(Traffic, BasicUpdates) {
     // results aren't used
     {
       auto result = gurka::route(map, "A", "C", "auto", "", clean_reader);
-      gurka::assert::osrm::expect_route(result, {"AB", "BC"});
+      gurka::assert::osrm::expect_steps(result, {"AB", "BC"});
       gurka::assert::raw::expect_eta(result, 361.5);
     }
     // Now do another route with the same (not restarted) actor to see if
     // it's noticed the changes in the live traffic file
     {
       auto result = gurka::route(map, "B", "D", "auto", "current", clean_reader);
-      gurka::assert::osrm::expect_route(result, {"BC", "CE", "DE"});
+      gurka::assert::osrm::expect_steps(result, {"BC", "CE", "DE"});
       gurka::assert::raw::expect_eta(result, 172.8, 0.01);
     }
     {
       auto result = gurka::route(map, "D", "B", "auto", "current", clean_reader);
-      gurka::assert::osrm::expect_route(result, {"BD"});
+      gurka::assert::osrm::expect_steps(result, {"BD"});
       gurka::assert::raw::expect_eta(result, 28.8, 0.01);
     }
     // Repeat the B->D route, but this time with no timestamp - this should
     // disable using live traffc and the road should be open again.
     {
       auto result = gurka::route(map, "B", "D", "auto", "", clean_reader);
-      gurka::assert::osrm::expect_route(result, {"BD"});
+      gurka::assert::osrm::expect_steps(result, {"BD"});
       gurka::assert::raw::expect_eta(result, 72);
     }
   }

--- a/test/gurka/test_traffic.cc
+++ b/test/gurka/test_traffic.cc
@@ -145,6 +145,7 @@ TEST(Traffic, BasicUpdates) {
     {
       auto result = gurka::route(map, "A", "C", "auto", "current", clean_reader);
       gurka::assert::osrm::expect_steps(result, {"AB", "BC"});
+      gurka::assert::raw::expect_path(result, {"AB", "BC"});
       gurka::assert::raw::expect_eta(result, 361.5);
     }
     // Make some updates to the traffic .tar file.
@@ -157,6 +158,7 @@ TEST(Traffic, BasicUpdates) {
     {
       auto result = gurka::route(map, "A", "C", "auto", "current", clean_reader);
       gurka::assert::osrm::expect_steps(result, {"AB", "BC"});
+      gurka::assert::raw::expect_path(result, {"AB", "BC"});
       gurka::assert::raw::expect_eta(result, 145.5);
     }
     // Next, set the speed to the highest possible to ensure nothing breaks
@@ -164,6 +166,7 @@ TEST(Traffic, BasicUpdates) {
     {
       auto result = gurka::route(map, "A", "C", "auto", "current", clean_reader);
       gurka::assert::osrm::expect_steps(result, {"AB", "BC"});
+      gurka::assert::raw::expect_path(result, {"AB", "BC"});
       gurka::assert::raw::expect_eta(result, 15.617648);
     }
     // Back to previous speed
@@ -173,6 +176,7 @@ TEST(Traffic, BasicUpdates) {
     {
       auto result = gurka::route(map, "A", "C", "auto", "", clean_reader);
       gurka::assert::osrm::expect_steps(result, {"AB", "BC"});
+      gurka::assert::raw::expect_path(result, {"AB", "BC"});
       gurka::assert::raw::expect_eta(result, 361.5);
     }
     // Now do another route with the same (not restarted) actor to see if
@@ -180,11 +184,13 @@ TEST(Traffic, BasicUpdates) {
     {
       auto result = gurka::route(map, "B", "D", "auto", "current", clean_reader);
       gurka::assert::osrm::expect_steps(result, {"BC", "CE", "DE"});
+      gurka::assert::raw::expect_path(result, {"BC", "CE", "DE"});
       gurka::assert::raw::expect_eta(result, 172.8, 0.01);
     }
     {
       auto result = gurka::route(map, "D", "B", "auto", "current", clean_reader);
       gurka::assert::osrm::expect_steps(result, {"BD"});
+      gurka::assert::raw::expect_path(result, {"BD"});
       gurka::assert::raw::expect_eta(result, 28.8, 0.01);
     }
     // Repeat the B->D route, but this time with no timestamp - this should
@@ -192,6 +198,7 @@ TEST(Traffic, BasicUpdates) {
     {
       auto result = gurka::route(map, "B", "D", "auto", "", clean_reader);
       gurka::assert::osrm::expect_steps(result, {"BD"});
+      gurka::assert::raw::expect_path(result, {"BD"});
       gurka::assert::raw::expect_eta(result, 72);
     }
   }

--- a/test/gurka/test_turns.cc
+++ b/test/gurka/test_turns.cc
@@ -18,7 +18,7 @@ TEST(Standalone, TurnStraight) {
 
   auto result = gurka::route(map, "A", "C", "auto");
 
-  gurka::assert::osrm::expect_route(result, {"ABC"});
+  gurka::assert::osrm::expect_steps(result, {"ABC"});
   gurka::assert::raw::expect_path_length(result, 1.0, .001);
 }
 /*************************************************************/
@@ -61,7 +61,7 @@ TEST_F(Turns, TurnRight) {
 
   auto result = gurka::route(map_1, "A", "D", "auto");
 
-  gurka::assert::osrm::expect_route(result, {"ABC", "BD"});
+  gurka::assert::osrm::expect_steps(result, {"ABC", "BD"});
 
   gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
                                                 DirectionsLeg_Maneuver_Type_kRight,
@@ -73,7 +73,7 @@ TEST_F(Turns, TurnLeft) {
 
   auto result = gurka::route(map_2, "C", "D", "auto");
 
-  gurka::assert::osrm::expect_route(result, {"FEBC", "FDB"});
+  gurka::assert::osrm::expect_steps(result, {"FEBC", "FDB"});
 
   gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
                                                 DirectionsLeg_Maneuver_Type_kLeft,

--- a/test/gurka/test_turns.cc
+++ b/test/gurka/test_turns.cc
@@ -19,6 +19,7 @@ TEST(Standalone, TurnStraight) {
   auto result = gurka::route(map, "A", "C", "auto");
 
   gurka::assert::osrm::expect_steps(result, {"ABC"});
+  gurka::assert::raw::expect_path(result, {"ABC", "ABC"});
   gurka::assert::raw::expect_path_length(result, 1.0, .001);
 }
 /*************************************************************/
@@ -62,6 +63,7 @@ TEST_F(Turns, TurnRight) {
   auto result = gurka::route(map_1, "A", "D", "auto");
 
   gurka::assert::osrm::expect_steps(result, {"ABC", "BD"});
+  gurka::assert::raw::expect_path(result, {"ABC", "BD"});
 
   gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
                                                 DirectionsLeg_Maneuver_Type_kRight,
@@ -74,6 +76,7 @@ TEST_F(Turns, TurnLeft) {
   auto result = gurka::route(map_2, "C", "D", "auto");
 
   gurka::assert::osrm::expect_steps(result, {"FEBC", "FDB"});
+  gurka::assert::raw::expect_path(result, {"FEBC", "FDB"});
 
   gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
                                                 DirectionsLeg_Maneuver_Type_kLeft,

--- a/test/gurka/test_use_direction_on_ways.cc
+++ b/test/gurka/test_use_direction_on_ways.cc
@@ -51,7 +51,7 @@ gurka::map UseDirectionOnWays::map = {};
 
 TEST_F(UseDirectionOnWays, CheckNamesAndRefs) {
   auto result = gurka::route(map, "A", "E", "auto");
-  gurka::assert::osrm::expect_route(result, {"AB", "BC", "CD", "DE"});
+  gurka::assert::osrm::expect_steps(result, {"AB", "BC", "CD", "DE"});
 
   // test direction is used correctly
   EXPECT_EQ(result.directions().routes(0).legs(0).maneuver(0).street_name_size(), 3);

--- a/test/gurka/test_use_direction_on_ways.cc
+++ b/test/gurka/test_use_direction_on_ways.cc
@@ -52,6 +52,9 @@ gurka::map UseDirectionOnWays::map = {};
 TEST_F(UseDirectionOnWays, CheckNamesAndRefs) {
   auto result = gurka::route(map, "A", "E", "auto");
   gurka::assert::osrm::expect_steps(result, {"AB", "BC", "CD", "DE"});
+  gurka::assert::raw::expect_path(result,
+                                  {"AB/US 30 East/US 222 North", "BC/I-95 North/US 40 East",
+                                   "CD/US 15 South/I-80 West", "DE/US 119 South/I-99 North/US XX"});
 
   // test direction is used correctly
   EXPECT_EQ(result.directions().routes(0).legs(0).maneuver(0).street_name_size(), 3);


### PR DESCRIPTION
# Issue

Need to change expect_route to be expect_steps.
Need to add expect_path that will use the Valhalla trip edge names
Need to update tests to have calls to both or just one as needed

## Tasklist

 - [x] Add tests
 - [x] Add #fixes with the issue number that this PR addresses
 - [x] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)
