### PR TITLE
Invalid match indexes cause out of vector bounds lookup

### DIFF
--- a/src/thor/trace_route_action.cc
+++ b/src/thor/trace_route_action.cc
@@ -401,10 +401,12 @@ void thor_worker_t::build_route(
           next_segment && segment->edgeid != next_segment->edgeid && segment->target < 1.f;
       if (uturn_onto || uturn_off_of) {
         // Protect against invalid match indexes
-        midgard::PointLL first_match_ll = segment->first_match_idx < 0 ? midgard::PointLL() :
-                  match_results[segment->first_match_idx].lnglat;
-        midgard::PointLL last_match_ll = segment->last_match_idx < 0 ? midgard::PointLL() :
-                  match_results[segment->last_match_idx].lnglat;
+        midgard::PointLL first_match_ll = segment->first_match_idx < 0
+                                              ? midgard::PointLL()
+                                              : match_results[segment->first_match_idx].lnglat;
+        midgard::PointLL last_match_ll = segment->last_match_idx < 0
+                                             ? midgard::PointLL()
+                                             : match_results[segment->last_match_idx].lnglat;
         edge_trimming[i] = {{uturn_onto, first_match_ll, segment->source},
                             {uturn_off_of, last_match_ll, segment->target}};
       }

--- a/src/thor/trace_route_action.cc
+++ b/src/thor/trace_route_action.cc
@@ -400,10 +400,13 @@ void thor_worker_t::build_route(
       bool uturn_off_of =
           next_segment && segment->edgeid != next_segment->edgeid && segment->target < 1.f;
       if (uturn_onto || uturn_off_of) {
-        edge_trimming[i] = {{uturn_onto, match_results[segment->first_match_idx].lnglat,
-                             segment->source},
-                            {uturn_off_of, match_results[segment->last_match_idx].lnglat,
-                             segment->target}};
+        // Protect against invalid match indexes
+        midgard::PointLL first_match_ll = segment->first_match_idx < 0 ? midgard::PointLL() :
+                  match_results[segment->first_match_idx].lnglat;
+        midgard::PointLL last_match_ll = segment->last_match_idx < 0 ? midgard::PointLL() :
+                  match_results[segment->last_match_idx].lnglat;
+        edge_trimming[i] = {{uturn_onto, first_match_ll, segment->source},
+                            {uturn_off_of, last_match_ll, segment->target}};
       }
     }
 


### PR DESCRIPTION
Protect against invalid match indexes in Uturns when setting edge_trimming lnglat.

Fixes #2439 

# Issue

What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
