### PR TITLE
openlr: Explicitly check for linear reference option for Valhalla serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
    * FIXED: Obvious maneuvers. [#2436](https://github.com/valhalla/valhalla/pull/2436)
    * FIXED: Base64 encoding/decoding [#2452](https://github.com/valhalla/valhalla/pull/2452)
    * FIXED: Added post roundabout instruction when enter/exit roundabout maneuvers are combined [#2454](https://github.com/valhalla/valhalla/pull/2454)
+   * FIXED: openlr: Explicitly check for linear reference option for Valhalla serialization. [#2458](https://github.com/valhalla/valhalla/pull/2458)
 
 * **Enhancement**
    * ADDED: Add explicit include for sstream to be compatible with msvc_x64 toolset. [#2449](https://github.com/valhalla/valhalla/pull/2449)

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -1283,12 +1283,8 @@ std::string serialize(valhalla::Api& api) {
       // NOTE(mookerji): confidence value here is a placeholder for future implementation.
       route->emplace("confidence", json::fp_t{1, 1});
     }
-    const bool linear_reference =
-        options.linear_references() &&
-        (options.action() == Options::trace_route || options.action() == Options::route);
-    if (linear_reference) {
-      route->emplace("linear_references", route_references(api.trip().routes(i), options));
-    }
+    // Add linear references, if applicable
+    route_references(route, api.trip().routes(i), options);
 
     // Concatenated route geometry
     route_geometry(route, api.directions().routes(i), options);

--- a/src/tyr/route_serializer_valhalla.cc
+++ b/src/tyr/route_serializer_valhalla.cc
@@ -563,22 +563,21 @@ legs(const google::protobuf::RepeatedPtrField<valhalla::DirectionsLeg>& directio
 
 std::string serialize(const Api& api) {
   // build up the json object
-  auto json = json::map(
-      {{"trip",
-        json::map({{"locations", locations(api.directions().routes(0).legs())},
-                   {"linear_references", tyr::route_references(api.trip().routes(0), api.options())},
-                   {"summary", summary(api.directions().routes(0).legs())},
-                   {"legs", legs(api.directions().routes(0).legs())},
-                   {"status_message", string("Found route between points")},
-                   {"status", static_cast<uint64_t>(0)}, // 0 success
-                   {"units", valhalla::Options_Units_Enum_Name(api.options().units())},
-                   {"language", api.options().language()}})}});
+  auto trip_json = json::map({{"locations", locations(api.directions().routes(0).legs())},
+                              {"summary", summary(api.directions().routes(0).legs())},
+                              {"legs", legs(api.directions().routes(0).legs())},
+                              {"status_message", string("Found route between points")},
+                              {"status", static_cast<uint64_t>(0)}, // 0 success
+                              {"units", valhalla::Options_Units_Enum_Name(api.options().units())},
+                              {"language", api.options().language()}});
+  tyr::route_references(trip_json, api.trip().routes(0), api.options());
+  auto json = json::map({{"trip", trip_json}});
   if (api.options().has_id()) {
     json->emplace("id", api.options().id());
   }
   std::stringstream ss;
   ss << *json;
   return ss.str();
-}
+} // namespace
 } // namespace valhalla_serializers
 } // namespace

--- a/src/tyr/route_serializer_valhalla.cc
+++ b/src/tyr/route_serializer_valhalla.cc
@@ -578,6 +578,6 @@ std::string serialize(const Api& api) {
   std::stringstream ss;
   ss << *json;
   return ss.str();
-} // namespace
+}
 } // namespace valhalla_serializers
 } // namespace

--- a/src/tyr/serializers.cc
+++ b/src/tyr/serializers.cc
@@ -41,9 +41,6 @@ void route_references(json::MapPtr& route_json, const TripRoute& route, const Op
   if (!linear_reference) {
     return;
   }
-  if (options.costing() != Costing::auto_) {
-    route_json->emplace("linear_references", json::array({}));
-  }
   json::ArrayPtr references = json::array({});
   for (const TripLeg& leg : route.legs()) {
     for (const std::string& openlr : midgard::openlr_edges(leg)) {

--- a/src/tyr/serializers.cc
+++ b/src/tyr/serializers.cc
@@ -34,9 +34,15 @@ midgard::PointLL to_ll(const LatLng& ll) {
 } // namespace
 namespace valhalla {
 namespace tyr {
-json::ArrayPtr route_references(const TripRoute& route, const Options& options) {
+void route_references(json::MapPtr& route_json, const TripRoute& route, const Options& options) {
+  const bool linear_reference =
+      options.linear_references() &&
+      (options.action() == Options::trace_route || options.action() == Options::route);
+  if (!linear_reference) {
+    return;
+  }
   if (options.costing() != Costing::auto_) {
-    json::array({});
+    route_json->emplace("linear_references", json::array({}));
   }
   json::ArrayPtr references = json::array({});
   for (const TripLeg& leg : route.legs()) {
@@ -44,7 +50,7 @@ json::ArrayPtr route_references(const TripRoute& route, const Options& options) 
       references->emplace_back(openlr);
     }
   }
-  return references;
+  route_json->emplace("linear_references", references);
 }
 } // namespace tyr
 } // namespace valhalla

--- a/test/mapmatch.cc
+++ b/test/mapmatch.cc
@@ -1474,7 +1474,7 @@ TEST(Mapmatch, openlr_parameter_falsy_api) {
     const auto& matches = response.get_child("matchings");
     EXPECT_EQ(matches.size(), 1);
     for (const auto& match : matches) {
-      EXPECT_FALSE(match.second.get_child_optional("linear_references"));
+      EXPECT_THROW(match.second.get_child("linear_references"), std::runtime_error);
     }
   }
 }
@@ -1488,7 +1488,7 @@ TEST(Mapmatch, openlr_parameter_falsy_native_api) {
   tyr::actor_t actor(conf, true);
   for (const auto& request : requests) {
     const auto& response = json_to_pt(actor.trace_route(request));
-    EXPECT_FALSE(response.get_child_optional("linear_references"));
+    EXPECT_THROW(response.get_child("trip.linear_references"), std::runtime_error);
   }
 }
 } // namespace

--- a/valhalla/tyr/serializers.h
+++ b/valhalla/tyr/serializers.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include <valhalla/baldr/graphreader.h>
+#include <valhalla/baldr/json.h>
 #include <valhalla/baldr/location.h>
 #include <valhalla/baldr/pathlocation.h>
 #include <valhalla/meili/match_result.h>
@@ -100,8 +101,9 @@ std::string serializeTraceAttributes(
 
 // Return a JSON array of OpenLR 1.5 line location references for each edge of a map matching
 // result. For the time being, result is only non-empty for auto costing requests.
-baldr::json::ArrayPtr route_references(const valhalla::TripRoute& route,
-                                       const valhalla::Options& options);
+void route_references(baldr::json::MapPtr& route_json,
+                      const TripRoute& route,
+                      const Options& options);
 
 } // namespace tyr
 } // namespace valhalla


### PR DESCRIPTION
In a prior PR (link below) we added OpenLR encoding for trace_route edges but apparently did not
check for the API option, defaulting to adding OpenLR linear references to the response. This fixes
this issue and adds the options checking to the library function filling out references.

Follow up to: 
https://github.com/valhalla/valhalla/pull/2424

/cc @kevinkreiser