### PR TITLE
docs: add luajit to macOS installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ To install on macOS, you need to install its dependencies with [Homebrew](http:/
 
 ```bash
 # install dependencies (automake & czmq are required by prime_server)
-brew install automake cmake libtool protobuf-c boost-python libspatialite pkg-config sqlite3 jq curl wget czmq lz4 node@10 npm spatialite-tools unzip
+brew install automake cmake libtool protobuf-c boost-python libspatialite pkg-config sqlite3 jq curl wget czmq lz4 node@10 npm spatialite-tools unzip luajit
 curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
 nvm use 10 # must use node 8.11.1 and up because of N-API
 npm install --ignore-scripts


### PR DESCRIPTION
This PR adds `luajit` to the macOS installation section of README.