### PR TITLE
Add abbreviations to locale files

### DIFF
--- a/locales/README.md
+++ b/locales/README.md
@@ -21,6 +21,21 @@ Follow these steps to start contributing a translation:
 
 Once a language is 100% translated, the project maintainers will be notified and we will make a PR with your updates. Thank you for your contribution!
 
+### Abbreviations
+
+Note: abbreviations are not translated in Transifex, these should be added to the locale JSON files directly.
+
+Locale files also include data about common abbreviations for cardinal directions, place names, and street types. These may be used by clients to shorten street names that appear in a text instruction displayed visually to a user.
+
+The format consists of key-value pairs where the key is the long form of the word and the value is the shortened form in the same language.
+
+The abbreviations come in three types:
+- `cardinal_directions`: Cardinal direction words as they appear in street names, e.g. 16th Street Northwest.
+- `road_labels`: [Street type designations](https://en.wikipedia.org/wiki/Street_or_road_name#Street_type_designations), such as those that appear as suffixes in English-speaking regions or prefixes in Spanish-speaking regions.
+- `miscellaneous`: Miscellaneous words that are frequently abbreviated in street or place names.
+
+The lists only include words commonly found in road names, and they only include abbreviations that a user would recognize instantly and unambiguously.
+
 ### Translating language files directly (Advanced)
 
 Follow these instructions if you prefer to edit the JSON files directly without Transifex.
@@ -66,4 +81,3 @@ Czech `aliases` entry example:
 
 #### Tag descriptions
 `TODO`
-

--- a/locales/ca-ES.json
+++ b/locales/ca-ES.json
@@ -3,6 +3,11 @@
   "aliases": [
     "ca"
   ],
+  "abbreviations": {
+    "cardinal_directions": {},
+    "miscellaneous": {},
+    "road_labels": {}
+  },
   "instructions": {
     "arrive": {
       "phrases": {

--- a/locales/cs-CZ.json
+++ b/locales/cs-CZ.json
@@ -3,6 +3,11 @@
   "aliases": [
     "cs"
   ],
+  "abbreviations": {
+    "cardinal_directions": {},
+    "miscellaneous": {},
+    "road_labels": {}
+  },
   "instructions": {
     "arrive": {
       "phrases": {

--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -3,6 +3,11 @@
   "aliases": [
     "de"
   ],
+  "abbreviations": {
+    "cardinal_directions": {},
+    "miscellaneous": {},
+    "road_labels": {}
+  },
   "instructions": {
     "arrive": {
       "phrases": {

--- a/locales/el-GR.json
+++ b/locales/el-GR.json
@@ -3,6 +3,11 @@
   "aliases": [
     "el"
   ],
+  "abbreviations": {
+    "cardinal_directions": {},
+    "miscellaneous": {},
+    "road_labels": {}
+  },
   "instructions": {
     "arrive": {
       "phrases": {

--- a/locales/en-US-x-pirate.json
+++ b/locales/en-US-x-pirate.json
@@ -3,6 +3,11 @@
   "aliases": [
     "pirate"
   ],
+  "abbreviations": {
+    "cardinal_directions": {},
+    "miscellaneous": {},
+    "road_labels": {}
+  },
   "instructions": {
     "arrive": {
       "phrases": {

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -3,6 +3,49 @@
   "aliases": [
     "en"
   ],
+  "abbreviations": {
+    "cardinal_directions": {
+      "North": "N",
+      "Northeast": "NE",
+      "East": "E",
+      "Southeast": "SE",
+      "South": "S",
+      "Southwest": "SW",
+      "West": "W",
+      "Northwest": "NW"
+    },
+    "miscellaneous": {
+      "International": "Int'l",
+      "Junior": "Jr",
+      "Memorial": "Mem",
+      "National": "Nat'l",
+      "Route": "Rte",
+      "Senior": "Sr"
+    },
+    "road_labels": {
+      "Avenue": "Ave",
+      "Boulevard": "Blvd",
+      "Bypass": "Byp",
+      "Circle": "Cir",
+      "Court": "Ct",
+      "Crescent": "Cres",
+      "Drive": "Dr",
+      "Expressway": "Expy",
+      "Freeway": "Fwy",
+      "Highway": "Hwy",
+      "Lane": "Ln",
+      "Motorway": "Mwy",
+      "Parkway": "Pky",
+      "Place": "Pl",
+      "Plaza": "Plz",
+      "Point": "Pt",
+      "Road": "Rd",
+      "Square": "Sq",
+      "Street": "St",
+      "Terrace": "Ter",
+      "Turnpike": "Tpk"
+    }
+  },
   "instructions": {
     "arrive": {
       "phrases": {

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -3,6 +3,11 @@
   "aliases": [
     "es"
   ],
+  "abbreviations": {
+    "cardinal_directions": {},
+    "miscellaneous": {},
+    "road_labels": {}
+  },
   "instructions": {
     "arrive": {
       "phrases": {

--- a/locales/fr-FR.json
+++ b/locales/fr-FR.json
@@ -3,6 +3,11 @@
   "aliases": [
     "fr"
   ],
+  "abbreviations": {
+    "cardinal_directions": {},
+    "miscellaneous": {},
+    "road_labels": {}
+  },
   "instructions": {
     "arrive": {
       "phrases": {

--- a/locales/hi-IN.json
+++ b/locales/hi-IN.json
@@ -3,6 +3,11 @@
   "aliases": [
     "hi"
   ],
+  "abbreviations": {
+    "cardinal_directions": {},
+    "miscellaneous": {},
+    "road_labels": {}
+  },
   "instructions": {
     "arrive": {
       "phrases": {

--- a/locales/it-IT.json
+++ b/locales/it-IT.json
@@ -3,6 +3,11 @@
   "aliases": [
     "it"
   ],
+  "abbreviations": {
+    "cardinal_directions": {},
+    "miscellaneous": {},
+    "road_labels": {}
+  },
   "instructions": {
     "arrive": {
       "phrases": {

--- a/locales/ja-JP.json
+++ b/locales/ja-JP.json
@@ -3,6 +3,11 @@
   "aliases": [
     "ja"
   ],
+  "abbreviations": {
+    "cardinal_directions": {},
+    "miscellaneous": {},
+    "road_labels": {}
+  },
   "instructions": {
     "arrive": {
       "phrases": {

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -3,6 +3,11 @@
   "aliases": [
     "ptbr"
   ],
+  "abbreviations": {
+    "cardinal_directions": {},
+    "miscellaneous": {},
+    "road_labels": {}
+  },
   "instructions": {
     "arrive": {
       "phrases": {

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -3,6 +3,11 @@
   "aliases": [
     "pt"
   ],
+  "abbreviations": {
+    "cardinal_directions": {},
+    "miscellaneous": {},
+    "road_labels": {}
+  },
   "instructions": {
     "arrive": {
       "phrases": {

--- a/locales/ru-RU.json
+++ b/locales/ru-RU.json
@@ -3,6 +3,11 @@
   "aliases": [
     "ru"
   ],
+  "abbreviations": {
+    "cardinal_directions": {},
+    "miscellaneous": {},
+    "road_labels": {}
+  },
   "instructions": {
     "arrive": {
       "phrases": {

--- a/locales/sk-SK.json
+++ b/locales/sk-SK.json
@@ -3,6 +3,11 @@
   "aliases": [
     "sk"
   ],
+  "abbreviations": {
+    "cardinal_directions": {},
+    "miscellaneous": {},
+    "road_labels": {}
+  },
   "instructions": {
     "arrive": {
       "phrases": {

--- a/locales/sl-SI.json
+++ b/locales/sl-SI.json
@@ -3,6 +3,11 @@
   "aliases": [
     "sl"
   ],
+  "abbreviations": {
+    "cardinal_directions": {},
+    "miscellaneous": {},
+    "road_labels": {}
+  },
   "instructions": {
     "arrive": {
       "phrases": {

--- a/locales/sv-SE.json
+++ b/locales/sv-SE.json
@@ -3,6 +3,11 @@
   "aliases": [
     "sv"
   ],
+  "abbreviations": {
+    "cardinal_directions": {},
+    "miscellaneous": {},
+    "road_labels": {}
+  },
   "instructions": {
     "arrive": {
       "phrases": {

--- a/src/odin/narrative_dictionary.cc
+++ b/src/odin/narrative_dictionary.cc
@@ -54,6 +54,22 @@ void NarrativeDictionary::Load(const boost::property_tree::ptree& narrative_pt) 
   }
 
   /////////////////////////////////////////////////////////////////////////////
+  LOG_TRACE("Populate cardinal_directions_abbreviation_subset...");
+  // Populate cardinal_directions_abbreviation_subset
+  Load(cardinal_directions_abbreviation_subset, narrative_pt.get_child("abbreviations"),
+       "cardinal_directions");
+
+  /////////////////////////////////////////////////////////////////////////////
+  LOG_TRACE("Populate miscellaneous_abbreviation_subset...");
+  // Populate miscellaneous_abbreviation_subset
+  Load(miscellaneous_abbreviation_subset, narrative_pt.get_child("abbreviations"), "miscellaneous");
+
+  /////////////////////////////////////////////////////////////////////////////
+  LOG_TRACE("Populate road_labels_abbreviation_subset...");
+  // Populate road_labels_abbreviation_subset
+  Load(road_labels_abbreviation_subset, narrative_pt.get_child("abbreviations"), "road_labels");
+
+  /////////////////////////////////////////////////////////////////////////////
   LOG_TRACE("Populate start_subset...");
   // Populate start_subset
   Load(start_subset, narrative_pt.get_child(kStartKey));
@@ -314,6 +330,14 @@ void NarrativeDictionary::Load(const boost::property_tree::ptree& narrative_pt) 
   LOG_TRACE("Populate approach_verbal_alert_subset...");
   // Populate approach_verbal_alert_subset
   Load(approach_verbal_alert_subset, narrative_pt.get_child(kApproachVerbalAlertKey));
+}
+
+void NarrativeDictionary::Load(AbbreviationSet& abbreviation_handle,
+                               const boost::property_tree::ptree& abbreviation_pt,
+                               const std::string& pt_key) {
+
+  abbreviation_handle.abbreviations =
+      as_unordered_map<std::string, std::string>(abbreviation_pt, pt_key);
 }
 
 void NarrativeDictionary::Load(PhraseSet& phrase_handle,

--- a/test/narrative_dictionary.cc
+++ b/test/narrative_dictionary.cc
@@ -35,6 +35,23 @@ const std::vector<std::string> kExpectedEmptyTransitNameLabels = {"tram",    "me
 const std::map<std::string, std::string> kExpectedTransitStopCountLabels = {{"one", "stop"},
                                                                             {"other", "stops"}};
 
+// Expected abbreviations
+const std::map<std::string, std::string> kExpectedCardinalDirectionAbbreviations =
+    {{"North", "N"}, {"Northeast", "NE"}, {"East", "E"}, {"Southeast", "SE"},
+     {"South", "S"}, {"Southwest", "SW"}, {"West", "W"}, {"Northwest", "NW"}};
+
+const std::map<std::string, std::string> kExpectedMiscellaneousAbbreviations =
+    {{"International", "Int'l"}, {"Junior", "Jr"}, {"Memorial", "Mem"},
+     {"National", "Nat'l"},      {"Route", "Rte"}, {"Senior", "Sr"}};
+
+const std::map<std::string, std::string> kExpectedRoadLabelAbbreviations =
+    {{"Avenue", "Ave"},  {"Boulevard", "Blvd"}, {"Bypass", "Byp"}, {"Circle", "Cir"},
+     {"Court", "Ct"},    {"Crescent", "Cres"},  {"Drive", "Dr"},   {"Expressway", "Expy"},
+     {"Freeway", "Fwy"}, {"Highway", "Hwy"},    {"Lane", "Ln"},    {"Motorway", "Mwy"},
+     {"Parkway", "Pky"}, {"Place", "Pl"},       {"Plaza", "Plz"},  {"Point", "Pt"},
+     {"Road", "Rd"},     {"Square", "Sq"},      {"Street", "St"},  {"Terrace", "Ter"},
+     {"Turnpike", "Tpk"}};
+
 // Expected phrases
 const std::map<std::string, std::string> kExpectedStartPhrases =
     {{"0", "Head <CARDINAL_DIRECTION>."},
@@ -403,6 +420,21 @@ void validate(const std::unordered_map<std::string, std::string>& test_target,
     const auto& test_target_item = test_target.at(expected_phrase.first);
     EXPECT_EQ(test_target_item, expected_phrase.second);
   }
+}
+
+TEST(NarrativeDictionary, test_abbreviations) {
+  const NarrativeDictionary& dictionary = GetNarrativeDictionary("en-US");
+
+  // Validate cardinal direction abbreviations
+  validate(dictionary.cardinal_directions_abbreviation_subset.abbreviations,
+           kExpectedCardinalDirectionAbbreviations);
+
+  // Validate miscellaneous abbreviations
+  validate(dictionary.miscellaneous_abbreviation_subset.abbreviations,
+           kExpectedMiscellaneousAbbreviations);
+
+  // Validate road label abbreviations
+  validate(dictionary.road_labels_abbreviation_subset.abbreviations, kExpectedRoadLabelAbbreviations);
 }
 
 TEST(NarrativeDictionary, test_en_US_start) {

--- a/valhalla/odin/narrative_dictionary.h
+++ b/valhalla/odin/narrative_dictionary.h
@@ -156,6 +156,10 @@ constexpr auto kTransitPlatformCountLabelTag = "<TRANSIT_STOP_COUNT_LABEL>";
 namespace valhalla {
 namespace odin {
 
+struct AbbreviationSet {
+  std::unordered_map<std::string, std::string> abbreviations;
+};
+
 struct PhraseSet {
   std::unordered_map<std::string, std::string> phrases;
 };
@@ -245,6 +249,11 @@ class NarrativeDictionary {
 public:
   NarrativeDictionary(const std::string& language_tag,
                       const boost::property_tree::ptree& narrative_pt);
+
+  // Abbreviations
+  AbbreviationSet cardinal_directions_abbreviation_subset;
+  AbbreviationSet miscellaneous_abbreviation_subset;
+  AbbreviationSet road_labels_abbreviation_subset;
 
   // Start
   StartSubset start_subset;
@@ -387,6 +396,17 @@ protected:
    *                       narrative instructions.
    */
   void Load(const boost::property_tree::ptree& narrative_pt);
+
+  /**
+   * Loads the localized abbreviations contained in the specified property tree.
+   *
+   * @param  abbreviation_handle  The 'abbreviations' structure to populate.
+   * @param  abbreviation_pt  The 'abbreviation' property tree.
+   * @param  pt_key Key into the 'abbreviation' property tree.
+   */
+  void Load(AbbreviationSet& abbreviation_handle,
+            const boost::property_tree::ptree& abbreviation_pt,
+            const std::string& pt_key);
 
   /**
    * Loads the phrases with the localized narrative instructions


### PR DESCRIPTION
# Issue

Adds common abbreviations to locale files. These are useful for clients that display textual instructions to the user and want to shorten street names with well-known abbreviated words. Note that only English abbreviations have been added in this PR.

One TODO for me is to figure out how Transifex will handle these new keys. Since abbreviations are not meant to be translated from English, I'm not sure yet how Transifex will display them or whether they will render the locale file invalid. 

## Tasklist

 - [X] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
