### PR TITLE
Fix segfault: Do not combine last turn channel maneuver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
    * FIXED: Base64 encoding/decoding [#2452](https://github.com/valhalla/valhalla/pull/2452)
    * FIXED: Added post roundabout instruction when enter/exit roundabout maneuvers are combined [#2454](https://github.com/valhalla/valhalla/pull/2454)
    * FIXED: openlr: Explicitly check for linear reference option for Valhalla serialization. [#2458](https://github.com/valhalla/valhalla/pull/2458)
+   * FIXED: Fix segfault: Do not combine last turn channel maneuver. [#2463](https://github.com/valhalla/valhalla/pull/2463)
 
 * **Enhancement**
    * ADDED: Add explicit include for sstream to be compatible with msvc_x64 toolset. [#2449](https://github.com/valhalla/valhalla/pull/2449)

--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -2336,7 +2336,7 @@ bool ManeuversBuilder::IsTurnChannelManeuverCombinable(std::list<Maneuver>::iter
                                                        bool start_man) const {
 
   // Current maneuver must be a turn channel and not equal to the next maneuver
-  if (curr_man->turn_channel() && (curr_man != next_man)) {
+  if (curr_man->turn_channel() && (curr_man != next_man) && !next_man->IsDestinationType()) {
 
     uint32_t new_turn_degree;
     if (start_man) {

--- a/test/gurka/test_instructions_roundabout.cc
+++ b/test/gurka/test_instructions_roundabout.cc
@@ -203,3 +203,73 @@ TEST_F(InstructionsRoundabout, RoundaboutExitSuppressed) {
                                                             "You have arrived at your destination.",
                                                             "");
 }
+
+/*************************************************************/
+TEST(InstructionsRoundaboutRegression, TurnChannelRoundaboutExitRegression) {
+  // Regression test for roundabout exit that is also a turn channel
+  // https://www.openstreetmap.org/query?lat=48.62346&lon=2.46777#map=18/48.62310/2.46813
+  const std::string ascii_map = R"(
+    K---L--------O---P
+        \       /
+         M     N
+         \    /
+    A     E--F
+    |    /    \
+    B---D      G---J
+    |    \    /
+    C     I--H
+
+  )";
+
+  const gurka::ways ways = {
+      {"ABC", {{"highway", "service"}}},
+      {"BD", {{"highway", "tertiary"}}},
+      {"DIHGFED", {{"highway", "secondary"}, {"junction", "roundabout"}, {"name", ""}}},
+      {"GJ", {{"highway", "secondary"}}},
+      {"KLOP", {{"highway", "trunk"}, {"oneway", "yes"}, {"name", "La Francilienne"}}},
+      {"LME",
+       {{"highway", "trunk_link"},
+        {"oneway", "yes"},
+        {"destination", "Corbeil-Esses-Centre; Z.I. de l'Apport Paris;Ports"},
+        {"junction:ref", "30"}}},
+      {"FNO", {{"highway", "trunk_link"}, {"oneway", "yes"}, {"name", ""}}},
+  };
+
+  const gurka::nodes nodes = {
+      {"L",
+       {{"highway", "motorway_junction"}, {"ref", "30"}, {"exit_to", "Corbeil-Essonnes centre"}}}};
+
+  const double gridsize = 10;
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, gridsize, {5.1079374, 52.0887174});
+
+  auto map = gurka::buildtiles(layout, ways, nodes, {}, "test/data/gurka_roundabouts_regression",
+                               {{"mjolnir.admin",
+                                 {VALHALLA_SOURCE_DIR "test/data/netherlands_admin.sqlite"}}});
+
+  auto from = "K";
+  const std::string& request =
+      (boost::format(
+           R"({"locations":[{"lat":52.08862730752708,"lon":5.107829332318943},{"lat":52.08843613199833,"lon":5.109036862850189}],"costing":"auto"})"))
+          .str();
+  auto result = gurka::route(map, request);
+  gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
+                                                DirectionsLeg_Maneuver_Type_kExitRight,
+                                                DirectionsLeg_Maneuver_Type_kRoundaboutEnter,
+                                                DirectionsLeg_Maneuver_Type_kRoundaboutExit,
+                                                DirectionsLeg_Maneuver_Type_kDestinationRight});
+  int maneuver_index = 2;
+
+  // Verify the enter_roundabout instructions
+  gurka::assert::raw::
+      expect_instructions_at_maneuver_index(result, maneuver_index,
+                                            "Enter the roundabout and take the 3rd exit.",
+                                            "Enter the roundabout and take the 3rd exit.",
+                                            "Enter the roundabout and take the 3rd exit.", "");
+
+  maneuver_index = 4;
+  // Verify the exit_roundabout is suppressed
+  gurka::assert::raw::expect_instructions_at_maneuver_index(result, maneuver_index,
+                                                            "Your destination is on the right.",
+                                                            "Your destination will be on the right.",
+                                                            "Your destination is on the right.", "");
+}

--- a/test/gurka/test_instructions_roundabout.cc
+++ b/test/gurka/test_instructions_roundabout.cc
@@ -210,9 +210,9 @@ TEST(InstructionsRoundaboutRegression, TurnChannelRoundaboutExitRegression) {
   // https://www.openstreetmap.org/query?lat=48.62346&lon=2.46777#map=18/48.62310/2.46813
   const std::string ascii_map = R"(
     K---L--------O---P
-        \       /
+    1   \       /
          M     N
-         \    /
+         \    /2
     A     E--F
     |    /    \
     B---D      G---J
@@ -246,10 +246,14 @@ TEST(InstructionsRoundaboutRegression, TurnChannelRoundaboutExitRegression) {
                                {{"mjolnir.admin",
                                  {VALHALLA_SOURCE_DIR "test/data/netherlands_admin.sqlite"}}});
 
+  auto from = "1";
+  auto to = "2";
   const std::string& request =
-      (boost::format(
-           R"({"locations":[{"lat":52.08862730752708,"lon":5.107829332318943},{"lat":52.08843613199833,"lon":5.109036862850189}],"costing":"auto"})"))
+      (boost::format(R"({"locations":[{"lat":%s,"lon":%s},{"lat":%s,"lon":%s}],"costing":"auto"})") %
+       std::to_string(map.nodes.at(from).lat()) % std::to_string(map.nodes.at(from).lng()) %
+       std::to_string(map.nodes.at(to).lat()) % std::to_string(map.nodes.at(to).lng()))
           .str();
+
   auto result = gurka::route(map, request);
   gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
                                                 DirectionsLeg_Maneuver_Type_kExitRight,

--- a/test/gurka/test_instructions_roundabout.cc
+++ b/test/gurka/test_instructions_roundabout.cc
@@ -246,7 +246,6 @@ TEST(InstructionsRoundaboutRegression, TurnChannelRoundaboutExitRegression) {
                                {{"mjolnir.admin",
                                  {VALHALLA_SOURCE_DIR "test/data/netherlands_admin.sqlite"}}});
 
-  auto from = "K";
   const std::string& request =
       (boost::format(
            R"({"locations":[{"lat":52.08862730752708,"lon":5.107829332318943},{"lat":52.08843613199833,"lon":5.109036862850189}],"costing":"auto"})"))


### PR DESCRIPTION
# Issue

Fixes an invalid access bug triggered by combining maneuvers at a turn channel that is also a roundabout exit. The fix is to simply skip the turn channel collapsing logic if the next maneuver is the last maneuver in the route.

Although the turn channel collapsing logic is not new and the bug has been in valhalla for a while, the segfault actually occurs further along in new code that was added to collapse roundabout exit maneuvers. The combination of collapsing the final maneuver, then collapsing again for roundabout_exits=false, triggers the bug.

Address sanitizer output: [asan.txt](https://github.com/valhalla/valhalla/files/4905270/asan.txt)

We haven't been able to craft a reproducible test case in gurka yet as it's been tricky getting the tags just right for a link to be marked as a turn_channel. I'll follow up with a test case in a future PR.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
