### PR TITLE
Safiefy protobuf

### DIFF
--- a/src/odin/worker.cc
+++ b/src/odin/worker.cc
@@ -58,7 +58,7 @@ odin_worker_t::work(const std::list<zmq::message_t>& job,
     bool success = request.ParseFromArray(job.front().data(), job.front().size());
     if (!success) {
       LOG_ERROR("Failed parsing pbf in Odin::Worker");
-      throw valhalla_exception_t{401,
+      throw valhalla_exception_t{200,
                                  boost::optional<std::string>("Failed parsing pbf in Odin::Worker")};
     }
 

--- a/src/odin/worker.cc
+++ b/src/odin/worker.cc
@@ -55,7 +55,11 @@ odin_worker_t::work(const std::list<zmq::message_t>& job,
     service_worker_t::set_interrupt(&interrupt_function);
 
     // crack open the in progress request
-    request.ParseFromArray(job.front().data(), job.front().size());
+    bool success = request.ParseFromArray(job.front().data(), job.front().size());
+    if (!success) {
+      LOG_ERROR("Failed parsing pbf in Odin::Worker");
+      throw std::runtime_error("Failed parsing pbf in Odin::Worker");
+    }
 
     // narrate them and serialize them along
     narrate(request);

--- a/src/odin/worker.cc
+++ b/src/odin/worker.cc
@@ -58,7 +58,8 @@ odin_worker_t::work(const std::list<zmq::message_t>& job,
     bool success = request.ParseFromArray(job.front().data(), job.front().size());
     if (!success) {
       LOG_ERROR("Failed parsing pbf in Odin::Worker");
-      throw std::runtime_error("Failed parsing pbf in Odin::Worker");
+      throw valhalla_exception_t{401,
+                                 boost::optional<std::string>("Failed parsing pbf in Odin::Worker")};
     }
 
     // narrate them and serialize them along

--- a/src/thor/worker.cc
+++ b/src/thor/worker.cc
@@ -101,7 +101,7 @@ std::string serialize_to_pbf(Api& request) {
   if (!request.SerializeToString(&buf)) {
     LOG_ERROR("Failed serializing to pbf in Thor::Worker - trace_route");
     throw valhalla_exception_t{401, boost::optional<std::string>(
-                                        "Failed serializing to pbf in Thor::Worker - trace_route")};
+                                        "Failed serializing to pbf in Thor::Worker")};
   }
   return buf;
 };
@@ -121,7 +121,8 @@ thor_worker_t::work(const std::list<zmq::message_t>& job,
     bool success = request.ParseFromArray(job.front().data(), job.front().size());
     if (!success) {
       LOG_ERROR("Failed parsing pbf in Thor::Worker");
-      throw std::runtime_error("Failed parsing pbf in Thor::Worker");
+      throw valhalla_exception_t{401,
+                                 boost::optional<std::string>("Failed parsing pbf in Thor::Worker")};
     }
     const auto& options = request.options();
 

--- a/src/thor/worker.cc
+++ b/src/thor/worker.cc
@@ -108,7 +108,11 @@ thor_worker_t::work(const std::list<zmq::message_t>& job,
   Api request;
   try {
     // crack open the original request
-    request.ParseFromArray(job.front().data(), job.front().size());
+    bool success = request.ParseFromArray(job.front().data(), job.front().size());
+    if (!success) {
+      LOG_ERROR("Failed parsing pbf in Thor::Worker");
+      throw std::runtime_error("Failed parsing pbf in Thor::Worker");
+    }
     const auto& options = request.options();
 
     // Set the interrupt function

--- a/src/thor/worker.cc
+++ b/src/thor/worker.cc
@@ -96,6 +96,15 @@ thor_worker_t::thor_worker_t(const boost::property_tree::ptree& config,
 thor_worker_t::~thor_worker_t() {
 }
 
+std::string serialize_to_pbf(Api& request) {
+  std::string buf;
+  if (!request.SerializeToString(&buf)) {
+    LOG_ERROR("Failed serializing to pbf in Thor::Worker - trace_route");
+    throw std::runtime_error("Failed serializing to pbf in Thor::Worker - trace_route");
+  }
+  return buf;
+};
+
 #ifdef HAVE_HTTP
 prime_server::worker_t::result_t
 thor_worker_t::work(const std::list<zmq::message_t>& job,
@@ -128,7 +137,7 @@ thor_worker_t::work(const std::list<zmq::message_t>& job,
         break;
       case Options::optimized_route: {
         optimized_route(request);
-        result.messages.emplace_back(request.SerializeAsString());
+        result.messages.emplace_back(serialize_to_pbf(request));
         denominator = std::max(options.sources_size(), options.targets_size());
         break;
       }
@@ -138,13 +147,13 @@ thor_worker_t::work(const std::list<zmq::message_t>& job,
         break;
       case Options::route: {
         route(request);
-        result.messages.emplace_back(request.SerializeAsString());
+        result.messages.emplace_back(serialize_to_pbf(request));
         denominator = options.locations_size();
         break;
       }
       case Options::trace_route: {
         trace_route(request);
-        result.messages.emplace_back(request.SerializeAsString());
+        result.messages.emplace_back(serialize_to_pbf(request));
         denominator = trace.size() / 1100;
         break;
       }

--- a/src/thor/worker.cc
+++ b/src/thor/worker.cc
@@ -100,7 +100,8 @@ std::string serialize_to_pbf(Api& request) {
   std::string buf;
   if (!request.SerializeToString(&buf)) {
     LOG_ERROR("Failed serializing to pbf in Thor::Worker - trace_route");
-    throw std::runtime_error("Failed serializing to pbf in Thor::Worker - trace_route");
+    throw valhalla_exception_t{401, boost::optional<std::string>(
+                                        "Failed serializing to pbf in Thor::Worker - trace_route")};
   }
   return buf;
 };
@@ -184,10 +185,14 @@ thor_worker_t::work(const std::list<zmq::message_t>& job,
 
     return result;
   } catch (const valhalla_exception_t& e) {
-    valhalla::midgard::logging::Log("400::" + std::string(e.what()), " [ANALYTICS] ");
+    valhalla::midgard::logging::Log("400::" + std::string(e.what()) +
+                                        " request_id=" + std::to_string(info.id),
+                                    " [ANALYTICS] ");
     return jsonify_error(e, info, request);
   } catch (const std::exception& e) {
-    valhalla::midgard::logging::Log("400::" + std::string(e.what()), " [ANALYTICS] ");
+    valhalla::midgard::logging::Log("400::" + std::string(e.what()) +
+                                        " request_id=" + std::to_string(info.id),
+                                    " [ANALYTICS] ");
     return jsonify_error({499, std::string(e.what())}, info, request);
   }
 }

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -247,7 +247,7 @@ const std::unordered_map<unsigned, std::string> OSRM_ERRORS_CODES{
 
     // thor project 4xx
     {400, R"({"code":"InvalidService","message":"Service name is invalid."})"},
-    {401, R"({"code":"InvalidUrl","message":"URL string is invalid."})"},
+    {401, R"({"code":"InvalidUrl","message":"Failed to serialize route."})"},
 
     {420,
      R"({"code":"InvalidValue","message":"The successfully parsed query parameters are invalid."})"},


### PR DESCRIPTION
PR adds checks on protobuf serializing and de-serializing in the worker, and logs request-id of failing requests.

Produces log:
```
2020/07/17 18:31:10.483608 [INFO] Got Loki Request 0
2020/07/17 18:31:10.486783 [ANALYTICS] locations_count::2
2020/07/17 18:31:10.486822 [ANALYTICS] costing_type::auto
2020/07/17 18:31:10.486859 [ANALYTICS] total_location_distance::7.487539km
2020/07/17 18:31:10.622645 [INFO] Got Thor Request 0
2020/07/17 18:31:10.622708 [ERROR] Failed parsing pbf in Thor::Worker
2020/07/17 18:31:10.622739 [ANALYTICS] 400::Failed parsing pbf in Thor::Worker request_id=0
0 2020/07/17 18:31:10.622851 400 239
```