### PR TITLE
Make tile building reproducible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
    * FIXED: Remove extraneous whitespaces from ja-JP.json. [#2471](https://github.com/valhalla/valhalla/pull/2471)
    * FIXED: Checks protobuf serialization/parsing success [#2477](https://github.com/valhalla/valhalla/pull/2477)
    * FIXED: Fix dereferencing of end for std::lower_bound in sequence and possible UB [#2488](https://github.com/valhalla/valhalla/pull/2488)
+   * FIXED: Make tile building reproducible: fix UB-s [#2480](https://github.com/valhalla/valhalla/pull/2480)
 
 * **Enhancement**
    * ADDED: Add explicit include for sstream to be compatible with msvc_x64 toolset. [#2449](https://github.com/valhalla/valhalla/pull/2449)

--- a/src/baldr/directededge.cc
+++ b/src/baldr/directededge.cc
@@ -502,6 +502,8 @@ void DirectedEdge::set_shortcut(const uint32_t shortcut) {
 void DirectedEdge::set_superseded(const uint32_t superseded) {
   if (superseded > kMaxShortcutsFromNode) {
     LOG_WARN("Exceeding max shortcut edges from a node: " + std::to_string(superseded));
+  } else if (superseded == 0) {
+    superseded_ = 0;
   } else {
     superseded_ = (1 << (superseded - 1));
   }

--- a/src/mjolnir/graphvalidator.cc
+++ b/src/mjolnir/graphvalidator.cc
@@ -622,9 +622,6 @@ void GraphValidator::Validate(const boost::property_tree::ptree& pt) {
     LOG_WARN((boost::format("Possible duplicates at level: %1% = %2%") % std::to_string(level) %
               duplicates[level])
                  .str());
-    if (densities[level].empty()) {
-      continue;
-    }
     // Get the average density and the max density
     float max_density = 0.0f;
     float sum = 0.0f;

--- a/src/mjolnir/graphvalidator.cc
+++ b/src/mjolnir/graphvalidator.cc
@@ -622,6 +622,9 @@ void GraphValidator::Validate(const boost::property_tree::ptree& pt) {
     LOG_WARN((boost::format("Possible duplicates at level: %1% = %2%") % std::to_string(level) %
               duplicates[level])
                  .str());
+    if (densities[level].empty()) {
+      continue;
+    }
     // Get the average density and the max density
     float max_density = 0.0f;
     float sum = 0.0f;

--- a/test/gurka/test_reproduce_tile_build.cc
+++ b/test/gurka/test_reproduce_tile_build.cc
@@ -1,0 +1,99 @@
+#include "gurka.h"
+#include <gtest/gtest.h>
+
+#if !defined(VALHALLA_SOURCE_DIR)
+#define VALHALLA_SOURCE_DIR
+#endif
+
+using namespace valhalla;
+using namespace valhalla::baldr;
+
+void assert_tile_equalish(const GraphTile& a, const GraphTile& b) {
+  // expected size
+  ASSERT_EQ(a.header()->end_offset(), b.header()->end_offset());
+
+  // check the first chunk after the header
+  ASSERT_EQ(memcmp(reinterpret_cast<const char*>(a.header()) + sizeof(GraphTileHeader),
+                   reinterpret_cast<const char*>(b.header()) + sizeof(GraphTileHeader),
+                   (reinterpret_cast<const char*>(b.GetBin(0, 0).begin()) -
+                    reinterpret_cast<const char*>(b.header())) -
+                       sizeof(GraphTileHeader)),
+            0);
+
+  // check the stuff after the bins
+  ASSERT_EQ(memcmp(reinterpret_cast<const char*>(a.header()) + a.header()->edgeinfo_offset(),
+                   reinterpret_cast<const char*>(b.header()) + b.header()->edgeinfo_offset(),
+                   b.header()->end_offset() - b.header()->edgeinfo_offset()),
+            0);
+
+  // if the header is as expected
+  const auto *ah = a.header(), *bh = b.header();
+  if (ah->access_restriction_count() == bh->access_restriction_count() &&
+      ah->admincount() == bh->admincount() &&
+      ah->complex_restriction_forward_offset() == bh->complex_restriction_forward_offset() &&
+      ah->complex_restriction_reverse_offset() == bh->complex_restriction_reverse_offset() &&
+      ah->date_created() == bh->date_created() && ah->density() == bh->density() &&
+      ah->departurecount() == bh->departurecount() &&
+      ah->directededgecount() == bh->directededgecount() &&
+      ah->edgeinfo_offset() == bh->edgeinfo_offset() && ah->exit_quality() == bh->exit_quality() &&
+      ah->graphid() == bh->graphid() && ah->name_quality() == bh->name_quality() &&
+      ah->nodecount() == bh->nodecount() && ah->routecount() == bh->routecount() &&
+      ah->signcount() == bh->signcount() && ah->speed_quality() == bh->speed_quality() &&
+      ah->stopcount() == bh->stopcount() && ah->textlist_offset() == bh->textlist_offset() &&
+      ah->schedulecount() == bh->schedulecount() && ah->version() == bh->version()) {
+    // make sure the edges' shape and names match
+    for (size_t i = 0; i < ah->directededgecount(); ++i) {
+      auto a_info = a.edgeinfo(a.directededge(i)->edgeinfo_offset());
+      auto b_info = b.edgeinfo(b.directededge(i)->edgeinfo_offset());
+      ASSERT_EQ(a_info.encoded_shape(), b_info.encoded_shape());
+      ASSERT_EQ(a_info.GetNames().size(), b_info.GetNames().size());
+      for (size_t j = 0; j < a_info.GetNames().size(); ++j)
+        ASSERT_EQ(a_info.GetNames()[j], b_info.GetNames()[j]);
+    }
+  } else {
+    FAIL() << "not equal";
+  }
+}
+
+// 1. build tiles with the same input twice
+// 2. check that the same tile sets are generated
+TEST(GraphTileBuilder, TestBuildIsReproducible) {
+  const auto build_tiles = [](const std::string& dir) -> gurka::map {
+    const std::string ascii_map = R"(A-----B)";
+    const gurka::ways ways = {
+        {"ABA", {{"highway", "motorway"}}},
+    };
+    const auto layout = gurka::detail::map_to_coordinates(ascii_map, 10);
+    const std::string workdir = "test/data/gurka_reproduce_tile_build/" + dir;
+    auto map = gurka::buildtiles(layout, ways, {}, {}, workdir, {});
+    return map;
+  };
+
+  const auto first_map = build_tiles("1");
+  const auto second_map = build_tiles("2");
+
+  baldr::GraphReader first_reader(first_map.config.get_child("mjolnir"));
+  baldr::GraphReader second_reader(second_map.config.get_child("mjolnir"));
+  const auto first_tiles = first_reader.GetTileSet();
+  ASSERT_EQ(first_tiles.size(), second_reader.GetTileSet().size())
+      << "Got different tiles sets: tile count mismatch";
+  for (auto tile_id : first_tiles) {
+    const auto* first_tile = first_reader.GetGraphTile(tile_id);
+    ASSERT_TRUE(second_reader.DoesTileExist(tile_id))
+        << "Tile " << GraphTile::FileSuffix(tile_id) << " isn't found in the second tile set";
+    const auto* second_tile = second_reader.GetGraphTile(tile_id);
+
+    // human readable check
+    assert_tile_equalish(*first_tile, *second_tile);
+
+    // check that raw tiles are equal
+    auto raw_tile_bytes = [](const GraphTile* tile) -> std::string {
+      const auto header = tile->header();
+      return std::string(reinterpret_cast<const char*>(header), header->end_offset());
+    };
+    const auto first_raw_tile = raw_tile_bytes(first_tile);
+    const auto second_raw_tile = raw_tile_bytes(second_tile);
+    EXPECT_EQ(first_raw_tile, second_raw_tile)
+        << "Tile{" << GraphTile::FileSuffix(tile_id) << "} mismatch";
+  }
+}

--- a/test/gurka/test_reproduce_tile_build.cc
+++ b/test/gurka/test_reproduce_tile_build.cc
@@ -27,31 +27,36 @@ void assert_tile_equalish(const GraphTile& a, const GraphTile& b) {
             0);
 
   // if the header is as expected
-  const auto *ah = a.header(), *bh = b.header();
-  if (ah->access_restriction_count() == bh->access_restriction_count() &&
-      ah->admincount() == bh->admincount() &&
-      ah->complex_restriction_forward_offset() == bh->complex_restriction_forward_offset() &&
-      ah->complex_restriction_reverse_offset() == bh->complex_restriction_reverse_offset() &&
-      ah->date_created() == bh->date_created() && ah->density() == bh->density() &&
-      ah->departurecount() == bh->departurecount() &&
-      ah->directededgecount() == bh->directededgecount() &&
-      ah->edgeinfo_offset() == bh->edgeinfo_offset() && ah->exit_quality() == bh->exit_quality() &&
-      ah->graphid() == bh->graphid() && ah->name_quality() == bh->name_quality() &&
-      ah->nodecount() == bh->nodecount() && ah->routecount() == bh->routecount() &&
-      ah->signcount() == bh->signcount() && ah->speed_quality() == bh->speed_quality() &&
-      ah->stopcount() == bh->stopcount() && ah->textlist_offset() == bh->textlist_offset() &&
-      ah->schedulecount() == bh->schedulecount() && ah->version() == bh->version()) {
-    // make sure the edges' shape and names match
-    for (size_t i = 0; i < ah->directededgecount(); ++i) {
-      auto a_info = a.edgeinfo(a.directededge(i)->edgeinfo_offset());
-      auto b_info = b.edgeinfo(b.directededge(i)->edgeinfo_offset());
-      ASSERT_EQ(a_info.encoded_shape(), b_info.encoded_shape());
-      ASSERT_EQ(a_info.GetNames().size(), b_info.GetNames().size());
-      for (size_t j = 0; j < a_info.GetNames().size(); ++j)
-        ASSERT_EQ(a_info.GetNames()[j], b_info.GetNames()[j]);
-    }
-  } else {
-    FAIL() << "not equal";
+  const GraphTileHeader *ah = a.header(), *bh = b.header();
+  ASSERT_EQ(ah->access_restriction_count(), bh->access_restriction_count());
+  ASSERT_EQ(ah->admincount(), bh->admincount());
+  ASSERT_EQ(ah->complex_restriction_forward_offset(), bh->complex_restriction_forward_offset());
+  ASSERT_EQ(ah->complex_restriction_reverse_offset(), bh->complex_restriction_reverse_offset());
+  ASSERT_EQ(ah->date_created(), bh->date_created());
+  ASSERT_EQ(ah->density(), bh->density());
+  ASSERT_EQ(ah->departurecount(), bh->departurecount());
+  ASSERT_EQ(ah->directededgecount(), bh->directededgecount());
+  ASSERT_EQ(ah->edgeinfo_offset(), bh->edgeinfo_offset());
+  ASSERT_EQ(ah->exit_quality(), bh->exit_quality());
+  ASSERT_EQ(ah->graphid(), bh->graphid());
+  ASSERT_EQ(ah->name_quality(), bh->name_quality());
+  ASSERT_EQ(ah->nodecount(), bh->nodecount());
+  ASSERT_EQ(ah->routecount(), bh->routecount());
+  ASSERT_EQ(ah->signcount(), bh->signcount());
+  ASSERT_EQ(ah->speed_quality(), bh->speed_quality());
+  ASSERT_EQ(ah->stopcount(), bh->stopcount());
+  ASSERT_EQ(ah->textlist_offset(), bh->textlist_offset());
+  ASSERT_EQ(ah->schedulecount(), bh->schedulecount());
+  ASSERT_EQ(ah->version(), bh->version());
+
+  // make sure the edges' shape and names match
+  for (size_t i = 0; i < ah->directededgecount(); ++i) {
+    const EdgeInfo a_info = a.edgeinfo(a.directededge(i)->edgeinfo_offset());
+    const EdgeInfo b_info = b.edgeinfo(b.directededge(i)->edgeinfo_offset());
+    ASSERT_EQ(a_info.encoded_shape(), b_info.encoded_shape());
+    ASSERT_EQ(a_info.GetNames().size(), b_info.GetNames().size());
+    for (size_t j = 0; j < a_info.GetNames().size(); ++j)
+      ASSERT_EQ(a_info.GetNames()[j], b_info.GetNames()[j]);
   }
 }
 

--- a/valhalla/baldr/admin.h
+++ b/valhalla/baldr/admin.h
@@ -58,11 +58,11 @@ public:
   uint32_t country_offset() const;
 
 protected:
-  uint32_t country_offset_;       // country name offset
-  uint32_t state_offset_;         // state name offset
-  char country_iso_[kCountryIso]; // country ISO3166-1
-  char state_iso_[kStateIso];     // state ISO3166-2
-  char spare_[3];                 // spare for byte alignment
+  uint32_t country_offset_;         // country name offset
+  uint32_t state_offset_;           // state name offset
+  char country_iso_[kCountryIso]{}; // country ISO3166-1
+  char state_iso_[kStateIso]{};     // state ISO3166-2
+  char spare_[3]{};                 // spare for byte alignment
 };
 
 } // namespace baldr


### PR DESCRIPTION
# Issue
At the moment if you try to run `valhalla_build_tiles` a few times with the same input data(config, pbfs) you'll get different tilesets(tile hash sums are different). The PR fixes that behavior

Example of how to compare tilesets
```sh
cd ${PATH_TO_FIRST_TILESETS} && find . -type f -exec md5 {} + | sort -k 2 > ../first_hash.txt && cd -
cd ${PATH_TO_SECOND_TILESETS} && find . -type f -exec md5 {} + | sort -k 2 > ../second_hash.txt && cd -
diff first_hash.txt second_hash.txt # must be empty after this PR
```

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
