### PR TITLE
Minor fixes to tests

### DIFF
--- a/test/thor_worker.cc
+++ b/test/thor_worker.cc
@@ -8,7 +8,6 @@
 #include <thread>
 #include <unistd.h>
 
-using namespace prime_server;
 using namespace valhalla;
 using namespace valhalla::midgard;
 using namespace valhalla::thor;

--- a/valhalla/baldr/traffictile.h
+++ b/valhalla/baldr/traffictile.h
@@ -67,6 +67,7 @@ struct TrafficSpeed {
         return breakpoint2 < 255 && speed3 == 0;
       default:
         assert(false);
+        throw std::logic_error("Bad subsegment");
     }
   }
   /// Returns overall speed in kph across edge
@@ -92,6 +93,7 @@ struct TrafficSpeed {
         return speed3 << 1;
       default:
         assert(false);
+        throw std::logic_error("Bad subsegment");
     }
   }
 #endif


### PR DESCRIPTION
Fix two issues when building the tests:

- Remove `using namespace prime_server` from the `thor_worker` test. This does not appear to be needed, and causes a compile error when building without services enabled, since prime_server is not used in that case, and therefore the namespace is not known.

- Add something to some code paths that are meant to be unreachable so that the compiler (when building in release mode, in which the `assert` that would otherwise prevent these points from being reached, is a no-op) won't complain about execution falling off the end of the function (i.e. `-Wreturn-type` tripping). This seems to only show up when building the traffictile test.
