### PR TITLE
Refactor mapmatching configuration to use a struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@
    * ADDED: Migrated to Ubuntu 20.04 base-image [#2508](https://github.com/valhalla/valhalla/pull/2508)
    * CHANGED: Speed up parseways stage by avoiding multiple string comparisons [#2518](https://github.com/valhalla/valhalla/pull/2518)
    * CHANGED: Speed up enhance stage by avoiding GraphTileBuilder copying [#2468](https://github.com/valhalla/valhalla/pull/2468)
+   * CHANGED: Refactor mapmatching configuration to use a struct (instead of `boost::property_tree::ptree`). [#2485](https://github.com/valhalla/valhalla/pull/2485)
 
 ## Release Date: 2019-11-21 Valhalla 3.0.9
 * **Bug Fix**

--- a/src/meili/CMakeLists.txt
+++ b/src/meili/CMakeLists.txt
@@ -8,7 +8,8 @@ set(sources
   transition_cost_model.cc
   map_matcher.cc
   map_matcher_factory.cc
-  match_route.cc)
+  match_route.cc
+  config.cc)
 
 valhalla_module(NAME meili
   SOURCES ${sources}

--- a/src/meili/config.cc
+++ b/src/meili/config.cc
@@ -1,0 +1,112 @@
+#include "meili/config.h"
+
+#include "macro.h"
+#include "midgard/logging.h"
+
+#define NONNEGATIVE_VALUE_MSG(value, name)                                                           \
+  std::string("Expect '") + name + "' to be nonnegative (got: " + std::to_string(value) + ")"
+
+#define POSITIVE_VALUE_MSG(value, name)                                                              \
+  std::string("Expect '") + name + "' to be positive (got: " + std::to_string(value) + ")"
+
+namespace {
+template <typename T>
+inline void
+ReadParamOptional(T& value, const boost::property_tree::ptree& ptree, const std::string& name) {
+  if (auto item = ptree.get_optional<T>(name))
+    value = *item;
+}
+
+inline bool FindValue(const boost::property_tree::ptree& node, const std::string& value) {
+  return std::find_if(node.begin(), node.end(),
+                      [&value](const boost::property_tree::ptree::value_type& item) {
+                        return item.second.get_value<std::string>() == value;
+                      }) != node.end();
+}
+} // namespace
+
+namespace valhalla {
+namespace meili {
+
+Config::Config(const boost::property_tree::ptree& params) {
+  Read(params);
+}
+
+void Config::Read(const boost::property_tree::ptree& params) {
+  candidate_search.Read(params);
+  transition_cost.Read(params);
+  emission_cost.Read(params);
+  routing.Read(params);
+}
+
+void Config::CandidateSearch::Read(const boost::property_tree::ptree& params) {
+  ReadParamOptional(search_radius_meters, params, "default.search_radius");
+  CHECK_THROWS(search_radius_meters >= 0.f,
+               NONNEGATIVE_VALUE_MSG(search_radius_meters, "search_radius"));
+
+  if (const auto node = params.get_child_optional("customizable")) {
+    is_search_radius_customizable = FindValue(*node, "search_radius");
+  }
+
+  ReadParamOptional(max_search_radius_meters, params, "default.max_search_radius");
+  CHECK_THROWS(max_search_radius_meters > 0.f,
+               POSITIVE_VALUE_MSG(max_search_radius_meters, "max_search_radius"));
+
+  ReadParamOptional(cache_size, params, "grid.cache_size");
+  ReadParamOptional(grid_size, params, "grid.size");
+}
+
+void Config::TransitionCost::Read(const boost::property_tree::ptree& params) {
+  ReadParamOptional(beta, params, "default.beta");
+  CHECK_THROWS(beta > 0.f, POSITIVE_VALUE_MSG(beta, "beta"));
+
+  ReadParamOptional(breakage_distance_meters, params, "default.breakage_distance");
+  CHECK_THROWS(breakage_distance_meters > 0.f,
+               POSITIVE_VALUE_MSG(breakage_distance_meters, "breakage_distance"));
+
+  if (const auto node = params.get_child_optional("customizable")) {
+    is_breakage_distance_customizable = FindValue(*node, "breakage_distance");
+  }
+
+  ReadParamOptional(max_route_distance_factor, params, "default.max_route_distance_factor");
+  CHECK_THROWS(max_route_distance_factor > 0.f,
+               POSITIVE_VALUE_MSG(max_route_distance_factor, "max_route_distance_factor"));
+
+  ReadParamOptional(max_route_time_factor, params, "default.max_route_time_factor");
+  CHECK_THROWS(max_route_time_factor > 0.f,
+               POSITIVE_VALUE_MSG(max_route_time_factor, "max_route_time_factor"));
+
+  ReadParamOptional(turn_penalty_factor, params, "default.turn_penalty_factor");
+  CHECK_THROWS(turn_penalty_factor >= 0.f,
+               NONNEGATIVE_VALUE_MSG(turn_penalty_factor, "turn_penalty_factor"));
+
+  if (const auto node = params.get_child_optional("customizable")) {
+    is_turn_penalty_factor_customizable = FindValue(*node, "turn_penalty_factor");
+  }
+}
+
+void Config::EmissionCost::Read(const boost::property_tree::ptree& params) {
+  ReadParamOptional(sigma_z, params, "default.sigma_z");
+  CHECK_THROWS(sigma_z > 0.f, POSITIVE_VALUE_MSG(sigma_z, "sigma_z"));
+
+  ReadParamOptional(gps_accuracy_meters, params, "default.gps_accuracy");
+  CHECK_THROWS(gps_accuracy_meters >= 0.f,
+               NONNEGATIVE_VALUE_MSG(gps_accuracy_meters, "gps_accuracy"));
+
+  if (const auto node = params.get_child_optional("customizable")) {
+    is_gps_accuracy_customizable = FindValue(*node, "gps_accuracy");
+  }
+}
+
+void Config::Routing::Read(const boost::property_tree::ptree& params) {
+  ReadParamOptional(interpolation_distance_meters, params, "default.interpolation_distance");
+  CHECK_THROWS(interpolation_distance_meters > 0.f,
+               POSITIVE_VALUE_MSG(interpolation_distance_meters, "interpolation_distance"));
+
+  if (const auto node = params.get_child_optional("customizable")) {
+    is_interpolation_distance_customizable = FindValue(*node, "interpolation_distance");
+  }
+}
+
+} // namespace meili
+} // namespace valhalla

--- a/src/meili/map_matcher.cc
+++ b/src/meili/map_matcher.cc
@@ -492,21 +492,21 @@ struct path_t {
 namespace valhalla {
 namespace meili {
 
-MapMatcher::MapMatcher(const boost::property_tree::ptree& config,
+MapMatcher::MapMatcher(const Config& config,
                        baldr::GraphReader& graphreader,
                        CandidateQuery& candidatequery,
                        const sif::mode_costing_t& mode_costing,
                        sif::TravelMode travelmode)
     : config_(config), graphreader_(graphreader), candidatequery_(candidatequery),
       mode_costing_(mode_costing), travelmode_(travelmode), interrupt_(nullptr), vs_(), ts_(vs_),
-      container_(), emission_cost_model_(graphreader_, container_, config_),
+      container_(), emission_cost_model_(graphreader_, container_, config_.emission_cost),
       transition_cost_model_(graphreader_,
                              vs_,
                              ts_,
                              container_,
                              mode_costing_,
                              travelmode_,
-                             config_) {
+                             config_.transition_cost) {
   vs_.set_emission_cost_model(emission_cost_model_);
   vs_.set_transition_cost_model(transition_cost_model_);
 }
@@ -826,10 +826,10 @@ std::vector<MatchResults> MapMatcher::OfflineMatch(const std::vector<Measurement
 
 std::unordered_map<StateId::Time, std::vector<Measurement>>
 MapMatcher::AppendMeasurements(const std::vector<Measurement>& measurements) {
-  const float max_search_radius = config_.get<float>("max_search_radius"),
-              sq_max_search_radius = max_search_radius * max_search_radius;
-  const float interpolation_distance = config_.get<float>("interpolation_distance"),
-              sq_interpolation_distance = interpolation_distance * interpolation_distance;
+  const float sq_max_search_radius = config_.candidate_search.max_search_radius_meters *
+                                     config_.candidate_search.max_search_radius_meters;
+  const float sq_interpolation_distance =
+      config_.routing.interpolation_distance_meters * config_.routing.interpolation_distance_meters;
   std::unordered_map<StateId::Time, std::vector<Measurement>> interpolated;
 
   // Always match the first measurement

--- a/src/meili/map_matcher_factory.cc
+++ b/src/meili/map_matcher_factory.cc
@@ -27,13 +27,12 @@ namespace meili {
 
 MapMatcherFactory::MapMatcherFactory(const boost::property_tree::ptree& root,
                                      const std::shared_ptr<baldr::GraphReader>& graph_reader)
-    : config_(root.get_child("meili")), graphreader_(graph_reader),
-      max_grid_cache_size_(root.get<float>("meili.grid.cache_size")) {
+    : config_(root.get_child("meili")), graphreader_(graph_reader) {
   if (!graphreader_)
     graphreader_.reset(new baldr::GraphReader(root.get_child("mjolnir")));
   candidatequery_.reset(
-      new CandidateGridQuery(*graphreader_, local_tile_size() / root.get<size_t>("meili.grid.size"),
-                             local_tile_size() / root.get<size_t>("meili.grid.size")));
+      new CandidateGridQuery(*graphreader_, local_tile_size() / config_.candidate_search.grid_size,
+                             local_tile_size() / config_.candidate_search.grid_size));
 }
 
 MapMatcherFactory::~MapMatcherFactory() {
@@ -52,34 +51,26 @@ MapMatcher* MapMatcherFactory::Create(const Options& options) {
   return new MapMatcher(config, *graphreader_, *candidatequery_, mode_costing_, mode);
 }
 
-boost::property_tree::ptree MapMatcherFactory::MergeConfig(const Options& options) {
-  // Copy the default child config
-  auto config = config_.get_child("default");
-
-  // Get a list of customizable options
-  std::unordered_set<std::string> customizable;
-  for (const auto& item : config_.get_child("customizable")) {
-    customizable.insert(item.second.get_value<std::string>());
-  }
+Config MapMatcherFactory::MergeConfig(const Options& options) const {
+  // Copy the default config
+  auto config = config_;
 
   // Check for overrides of matcher related directions options. Override these values in config.
-  if (options.has_search_radius() && customizable.find("search_radius") != customizable.end()) {
-    config.put<float>("search_radius", options.search_radius());
+  if (options.has_search_radius() && config.candidate_search.is_search_radius_customizable) {
+    config.candidate_search.search_radius_meters = options.search_radius();
   }
   if (options.has_turn_penalty_factor() &&
-      customizable.find("turn_penalty_factor") != customizable.end()) {
-    config.put<float>("turn_penalty_factor", options.turn_penalty_factor());
+      config.transition_cost.is_turn_penalty_factor_customizable) {
+    config.transition_cost.turn_penalty_factor = options.turn_penalty_factor();
   }
-  if (options.has_gps_accuracy() && customizable.find("gps_accuracy") != customizable.end()) {
-    config.put<float>("gps_accuracy", options.gps_accuracy());
+  if (options.has_gps_accuracy() && config.emission_cost.is_gps_accuracy_customizable) {
+    config.emission_cost.gps_accuracy_meters = options.gps_accuracy();
   }
-  if (options.has_breakage_distance() &&
-      customizable.find("breakage_distance") != customizable.end()) {
-    config.put<float>("breakage_distance", options.breakage_distance());
+  if (options.has_breakage_distance() && config.transition_cost.is_breakage_distance_customizable) {
+    config.transition_cost.breakage_distance_meters = options.breakage_distance();
   }
-  if (options.has_interpolation_distance() &&
-      customizable.find("interpolation_distance") != customizable.end()) {
-    config.put<float>("interpolation_distance", options.interpolation_distance());
+  if (options.has_interpolation_distance() && config.routing.is_interpolation_distance_customizable) {
+    config.routing.interpolation_distance_meters = options.interpolation_distance();
   }
 
   // Give it back
@@ -91,7 +82,7 @@ void MapMatcherFactory::ClearFullCache() {
     graphreader_->Trim();
   }
 
-  if (candidatequery_->size() > max_grid_cache_size_) {
+  if (candidatequery_->size() > config_.candidate_search.cache_size) {
     candidatequery_->Clear();
   }
 }

--- a/src/meili/transition_cost_model.cc
+++ b/src/meili/transition_cost_model.cc
@@ -48,18 +48,18 @@ TransitionCostModel::TransitionCostModel(baldr::GraphReader& graphreader,
                                          const StateContainer& container,
                                          const sif::mode_costing_t& mode_costing,
                                          const sif::TravelMode travelmode,
-                                         const boost::property_tree::ptree& config)
+                                         const Config::TransitionCost& config)
     : TransitionCostModel(graphreader,
                           vs,
                           ts,
                           container,
                           mode_costing,
                           travelmode,
-                          config.get<float>("beta"),
-                          config.get<float>("breakage_distance"),
-                          config.get<float>("max_route_distance_factor"),
-                          config.get<float>("max_route_time_factor"),
-                          config.get<float>("turn_penalty_factor")) {
+                          config.beta,
+                          config.breakage_distance_meters,
+                          config.max_route_distance_factor,
+                          config.max_route_time_factor,
+                          config.turn_penalty_factor) {
 }
 
 float TransitionCostModel::operator()(const StateId& lhs, const StateId& rhs) const {

--- a/src/meili/valhalla_run_map_match.cc
+++ b/src/meili/valhalla_run_map_match.cc
@@ -52,8 +52,8 @@ int main(int argc, char* argv[]) {
   MapMatcherFactory matcher_factory(config);
   auto mapmatcher = matcher_factory.Create(costing);
 
-  const float default_gps_accuracy = mapmatcher->config().get<float>("gps_accuracy"),
-              default_search_radius = mapmatcher->config().get<float>("search_radius");
+  const float default_gps_accuracy = mapmatcher->config().emission_cost.gps_accuracy_meters,
+              default_search_radius = mapmatcher->config().candidate_search.search_radius_meters;
 
   size_t index = 0;
   for (auto measurements = ReadMeasurements(std::cin, default_gps_accuracy, default_search_radius);

--- a/src/thor/worker.cc
+++ b/src/thor/worker.cc
@@ -276,14 +276,16 @@ void thor_worker_t::parse_measurements(const Api& request) {
 
   // we require locations
   try {
-    auto default_accuracy = matcher->config().get<float>("gps_accuracy");
-    auto default_radius = matcher->config().get<float>("search_radius");
+    const auto& config = matcher->config();
     for (const auto& pt : options.shape()) {
-      trace.emplace_back(meili::Measurement{{pt.ll().lng(), pt.ll().lat()},
-                                            pt.has_accuracy() ? pt.accuracy() : default_accuracy,
-                                            pt.has_radius() ? pt.radius() : default_radius,
-                                            pt.time(),
-                                            PathLocation::fromPBF(pt.type())});
+      trace.emplace_back(
+          meili::Measurement{{pt.ll().lng(), pt.ll().lat()},
+                             pt.has_accuracy() ? pt.accuracy()
+                                               : config.emission_cost.gps_accuracy_meters,
+                             pt.has_radius() ? pt.radius()
+                                             : config.candidate_search.search_radius_meters,
+                             pt.time(),
+                             PathLocation::fromPBF(pt.type())});
     }
   } catch (...) { throw valhalla_exception_t{424}; }
 }

--- a/src/valhalla_path_comparison.cc
+++ b/src/valhalla_path_comparison.cc
@@ -316,9 +316,10 @@ int main(int argc, char* argv[]) {
     std::vector<Measurement> measurements;
     measurements.reserve(path.size());
     for (const auto& location : path) {
-      measurements.emplace_back(Measurement{{location.latlng_.lng(), location.latlng_.lat()},
-                                            matcher->config().get<float>("gps_accuracy") + 10,
-                                            matcher->config().get<float>("search_radius") + 10});
+      measurements.emplace_back(
+          Measurement{{location.latlng_.lng(), location.latlng_.lat()},
+                      matcher->config().emission_cost.gps_accuracy_meters + 10,
+                      matcher->config().candidate_search.search_radius_meters + 10});
     }
 
     auto results = matcher->OfflineMatch(measurements).front().results;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,7 +8,7 @@ set_target_properties(gmock_main PROPERTIES FOLDER "Dependencies")
 set(tests aabb2 access_restriction actor admin attributes_controller astar_bss complexrestriction countryaccess datetime directededge
   distanceapproximator double_bucket_queue edgecollapser edgestatus ellipse encode
   enhancedtrippath factory graphid graphtile graphtileheader gridded_data grid_range_query grid_traversal instructions
-  json laneconnectivity linesegment2 location logging maneuversbuilder map_matcher_factory mapmatch
+  json laneconnectivity linesegment2 location logging maneuversbuilder map_matcher_factory mapmatch mapmatch_config
   narrative_dictionary nodeinfo nodetransition obb2 openlr optimizer parse_request point2 pointll
   polyline2 predictedspeeds queue routing sample sequence sign signs streetname streetnames streetnames_factory
   streetnames_us streetname_us tilehierarchy tiles transitdeparture transitroute transitschedule

--- a/test/actor.cc
+++ b/test/actor.cc
@@ -3,12 +3,10 @@
 #include <stdexcept>
 #include <string>
 
-#include "baldr/rapidjson_utils.h"
-#include <boost/property_tree/ptree.hpp>
-
 #include "tyr/actor.h"
 
 #include "test.h"
+#include "utils.h"
 
 #if !defined(VALHALLA_SOURCE_DIR)
 #define VALHALLA_SOURCE_DIR
@@ -18,17 +16,9 @@ using namespace valhalla;
 
 namespace {
 
-boost::property_tree::ptree json_to_pt(const std::string& json) {
-  std::stringstream ss;
-  ss << json;
-  boost::property_tree::ptree pt;
-  rapidjson::read_json(ss, pt);
-  return pt;
-}
-
 boost::property_tree::ptree make_conf() {
   // fake up config against pine grove traffic extract
-  auto conf = json_to_pt(R"({
+  auto conf = test::json_to_pt(R"({
       "mjolnir":{"tile_dir":"test/traffic_matcher_tiles"},
       "loki":{
         "actions":["locate","route","sources_to_targets","optimized_route","isochrone","trace_route","trace_attributes","transit_available"],
@@ -74,7 +64,7 @@ TEST(Actor, Basic) {
   auto route_json = actor.route(R"({"locations":[{"lat":40.546115,"lon":-76.385076,"type":"break"},
           {"lat":40.544232,"lon":-76.385752,"type":"break"}],"costing":"auto"})");
   actor.cleanup();
-  auto route = json_to_pt(route_json);
+  auto route = test::json_to_pt(route_json);
   route_json.find("Tulpehocken");
 
   actor.trace_attributes(R"({"shape":[{"lat":40.546115,"lon":-76.385076},
@@ -83,7 +73,7 @@ TEST(Actor, Basic) {
   auto attributes_json = actor.trace_attributes(R"({"shape":[{"lat":40.546115,"lon":-76.385076},
       {"lat":40.544232,"lon":-76.385752}],"costing":"auto","shape_match":"map_snap"})");
   actor.cleanup();
-  auto attributes = json_to_pt(attributes_json);
+  auto attributes = test::json_to_pt(attributes_json);
   attributes_json.find("Tulpehocken");
 
   actor.transit_available(R"({"locations":[{"lat":35.647452, "lon":-79.597477, "radius":20},
@@ -93,7 +83,7 @@ TEST(Actor, Basic) {
       actor.transit_available(R"({"locations":[{"lat":35.647452, "lon":-79.597477, "radius":20},
       {"lat":34.766908, "lon":-80.325936,"radius":10}]})");
   actor.cleanup();
-  auto transit = json_to_pt(transit_json);
+  auto transit = test::json_to_pt(transit_json);
   transit_json.find(std::to_string(false));
 
   // TODO: test the rest of them

--- a/test/http_tiles.cc
+++ b/test/http_tiles.cc
@@ -1,15 +1,13 @@
 #include "test.h"
+#include "utils.h"
 
 #include "baldr/curl_tilegetter.h"
 #include "baldr/graphtile.h"
-#include "baldr/rapidjson_utils.h"
 #include "tyr/actor.h"
 #include "valhalla/filesystem.h"
 #include "valhalla/tile_server.h"
 
 #include <prime_server/prime_server.hpp>
-
-#include <boost/property_tree/ptree.hpp>
 
 #include <ostream>
 #include <stdexcept>
@@ -22,14 +20,6 @@ using namespace valhalla;
 
 zmq::context_t context;
 
-boost::property_tree::ptree json_to_pt(const std::string& json) {
-  std::stringstream ss;
-  ss << json;
-  boost::property_tree::ptree pt;
-  rapidjson::read_json(ss, pt);
-  return pt;
-}
-
 std::string get_tile_url() {
   std::ostringstream oss;
   oss << test_tile_server_t::server_url << "/route-tile/v1/" << baldr::GraphTile::kTilePathPattern
@@ -41,7 +31,7 @@ std::string get_tile_url() {
 boost::property_tree::ptree
 make_conf(const std::string& tile_dir, bool tile_url_gz, size_t curler_count) {
   // fake up config against pine grove traffic extract
-  auto conf = json_to_pt(R"({
+  auto conf = test::json_to_pt(R"({
       "mjolnir":{
         "user_agent":"MapboxNavigationNative"
       },
@@ -96,7 +86,7 @@ void test_route(const std::string& tile_dir, bool tile_url_gz) {
   auto route_json = actor.route(R"({"locations":[{"lat":52.09620,"lon": 5.11909,"type":"break"},
           {"lat":52.09585,"lon":5.11934,"type":"break"}],"costing":"auto"})");
   actor.cleanup();
-  auto route = json_to_pt(route_json);
+  auto route = test::json_to_pt(route_json);
 
   // TODO: check result
   // didn't find the right street names in the route?

--- a/test/isochrone.cc
+++ b/test/isochrone.cc
@@ -6,9 +6,9 @@
 #include "baldr/rapidjson_utils.h"
 #include "loki/worker.h"
 #include "thor/worker.h"
-#include <boost/property_tree/ptree.hpp>
 
 #include "test.h"
+#include "utils.h"
 
 using namespace valhalla;
 using namespace valhalla::thor;
@@ -20,15 +20,7 @@ using namespace valhalla::tyr;
 
 namespace {
 
-boost::property_tree::ptree json_to_pt(const std::string& json) {
-  std::stringstream ss;
-  ss << json;
-  boost::property_tree::ptree pt;
-  rapidjson::read_json(ss, pt);
-  return pt;
-}
-
-const auto config = json_to_pt(R"({
+const auto config = test::json_to_pt(R"({
     "mjolnir":{"tile_dir":"test/data/utrecht_tiles", "concurrency": 1},
     "loki":{
       "actions":["sources_to_targets"],

--- a/test/map_matcher_factory.cc
+++ b/test/map_matcher_factory.cc
@@ -10,6 +10,7 @@
 #include "meili/map_matcher_factory.h"
 
 #include "test.h"
+#include "utils.h"
 
 #if !defined(VALHALLA_SOURCE_DIR)
 #define VALHALLA_SOURCE_DIR
@@ -82,7 +83,7 @@ TEST(MapMatcherFactory, TestMapMatcherFactory) {
       config.put<int>("meili.default.search_radius", default_search_radius);
       auto matcher = factory.Create(options);
       EXPECT_EQ(matcher->travelmode(), sif::TravelMode::kPedestrian);
-      EXPECT_EQ(matcher->config().get<float>("search_radius"), preferred_search_radius)
+      EXPECT_EQ(matcher->config().candidate_search.search_radius_meters, preferred_search_radius)
           << "preference for pedestrian should override pedestrian config";
 
       delete matcher;
@@ -97,7 +98,7 @@ TEST(MapMatcherFactory, TestMapMatcherFactory) {
       options.set_search_radius(preferred_search_radius);
       auto matcher = factory.Create(options);
       EXPECT_EQ(matcher->travelmode(), sif::TravelMode::kPedestrian);
-      EXPECT_EQ(matcher->config().get<float>("search_radius"), preferred_search_radius)
+      EXPECT_EQ(matcher->config().candidate_search.search_radius_meters, preferred_search_radius)
           << "preference for universal should override config";
       delete matcher;
     }

--- a/test/mapmatch.cc
+++ b/test/mapmatch.cc
@@ -4,9 +4,6 @@
 #include <utility>
 #include <vector>
 
-#include "baldr/rapidjson_utils.h"
-#include <boost/property_tree/ptree.hpp>
-
 #include "baldr/json.h"
 #include "loki/worker.h"
 #include "midgard/distanceapproximator.h"
@@ -19,6 +16,7 @@
 #include "worker.h"
 
 #include "test.h"
+#include "utils.h"
 
 using namespace valhalla;
 using namespace valhalla::midgard;
@@ -67,16 +65,8 @@ std::string to_locations(const std::vector<PointLL>& shape,
   return locations;
 }
 
-boost::property_tree::ptree json_to_pt(const std::string& json) {
-  std::stringstream ss;
-  ss << json;
-  boost::property_tree::ptree pt;
-  rapidjson::read_json(ss, pt);
-  return pt;
-}
-
 // fake config
-const auto conf = json_to_pt(R"({
+const auto conf = test::json_to_pt(R"({
     "mjolnir":{"tile_dir":"test/data/utrecht_tiles", "concurrency": 1},
     "loki":{
       "actions":["locate","route","sources_to_targets","optimized_route","isochrone","trace_route","trace_attributes"],
@@ -231,7 +221,7 @@ TEST(Mapmatch, test_matcher) {
     std::string route_json;
     try {
       route_json = actor.route(test_case);
-      route = json_to_pt(route_json);
+      route = test::json_to_pt(route_json);
     } catch (...) {
       std::cout << "route failed" << std::endl;
       continue;
@@ -257,7 +247,7 @@ TEST(Mapmatch, test_matcher) {
       walked_json = actor.trace_attributes(
           R"({"date_time":{"type":1,"value":"2019-10-31T18:30"},"costing":"auto","shape_match":"edge_walk","encoded_polyline":")" +
           json_escape(encoded_shape) + "\"}");
-      walked = json_to_pt(walked_json);
+      walked = test::json_to_pt(walked_json);
     } catch (...) {
       std::cout << test_case << std::endl;
       std::cout << R"({"costing":"auto","shape_match":"edge_walk","encoded_polyline":")" +
@@ -293,7 +283,7 @@ TEST(Mapmatch, test_matcher) {
     auto simulation = simulate_gps(segments, accuracies, 50, 75.f, 1);
     auto locations = to_locations(simulation, accuracies, 1);
     // get a trace-attributes from the simulated gps
-    auto matched = json_to_pt(actor.trace_attributes(
+    auto matched = test::json_to_pt(actor.trace_attributes(
         R"({"costing":"auto","shape_match":"map_snap","shape":)" + locations + "}"));
     std::vector<uint64_t> matched_edges;
     for (const auto& edge : matched.get_child("edges"))
@@ -329,7 +319,7 @@ TEST(Mapmatch, test_matcher) {
 
 TEST(Mapmatch, test_distance_only) {
   tyr::actor_t actor(conf, true);
-  auto matched = json_to_pt(actor.trace_attributes(
+  auto matched = test::json_to_pt(actor.trace_attributes(
       R"({"trace_options":{"max_route_distance_factor":10,"max_route_time_factor":1,"turn_penalty_factor":0},
           "costing":"auto","shape_match":"map_snap","shape":[
           {"lat":52.09110,"lon":5.09806,"accuracy":10},
@@ -367,7 +357,7 @@ TEST(Mapmatch, test_trace_route_breaks) {
 
   tyr::actor_t actor(conf, true);
   for (size_t i = 0; i < test_cases.size(); ++i) {
-    auto matched = json_to_pt(actor.trace_route(test_cases[i]));
+    auto matched = test::json_to_pt(actor.trace_route(test_cases[i]));
     const auto& legs = matched.get_child("trip.legs");
     EXPECT_EQ(legs.size(), test_answers[i]);
   }
@@ -496,7 +486,7 @@ TEST(Mapmatch, test_disconnected_edges_expect_no_route) {
   tyr::actor_t actor(conf, true);
   for (size_t i = 0; i < test_cases.size(); ++i) {
     try {
-      auto matched = json_to_pt(actor.trace_route(test_cases[i]));
+      auto matched = test::json_to_pt(actor.trace_route(test_cases[i]));
     } catch (...) { EXPECT_EQ(illegal_path++, i) << "Expected no route but got one"; }
   }
 }
@@ -543,7 +533,7 @@ TEST(Mapmatch, test_matching_indices_and_waypoint_indices) {
 
   tyr::actor_t actor(conf, true);
   for (size_t i = 0; i < test_cases.size(); ++i) {
-    auto matched = json_to_pt(actor.trace_route(test_cases[i]));
+    auto matched = test::json_to_pt(actor.trace_route(test_cases[i]));
     const auto& tracepoints = matched.get_child("tracepoints");
     int j = 0;
     for (const auto& tracepoint : tracepoints) {
@@ -566,7 +556,7 @@ TEST(Mapmatch, test_matching_indices_and_waypoint_indices) {
 
 TEST(Mapmatch, test_time_rejection) {
   tyr::actor_t actor(conf, true);
-  auto matched = json_to_pt(actor.trace_attributes(
+  auto matched = test::json_to_pt(actor.trace_attributes(
       R"({"trace_options":{"max_route_distance_factor":10,"max_route_time_factor":3,"turn_penalty_factor":0},
           "costing":"auto","shape_match":"map_snap","shape":[
           {"lat":52.09110,"lon":5.09806,"accuracy":10,"time":2},
@@ -598,7 +588,7 @@ TEST(Mapmatch, test_trace_route_edge_walk_expected_error_code) {
   tyr::actor_t actor(conf, true);
 
   try {
-    auto response = json_to_pt(actor.trace_route(
+    auto response = test::json_to_pt(actor.trace_route(
         R"({"costing":"auto","shape_match":"edge_walk","shape":[
          {"lat":52.088548,"lon":5.15357,"accuracy":30,"time":2},
          {"lat":52.088627,"lon":5.153269,"accuracy":30,"time":4},
@@ -622,7 +612,7 @@ TEST(Mapmatch, test_trace_route_map_snap_expected_error_code) {
   tyr::actor_t actor(conf, true);
 
   try {
-    auto response = json_to_pt(actor.trace_route(
+    auto response = test::json_to_pt(actor.trace_route(
         R"({"costing":"auto","shape_match":"map_snap","shape":[
          {"lat":52.088548,"lon":5.15357,"radius":5,"time":2},
          {"lat":52.088627,"lon":5.153269,"radius":5,"time":4},
@@ -646,7 +636,7 @@ TEST(Mapmatch, test_trace_attributes_edge_walk_expected_error_code) {
   tyr::actor_t actor(conf, true);
 
   try {
-    auto response = json_to_pt(actor.trace_attributes(
+    auto response = test::json_to_pt(actor.trace_attributes(
         R"({"costing":"auto","shape_match":"edge_walk","shape":[
          {"lat":52.088548,"lon":5.15357,"accuracy":30,"time":2},
          {"lat":52.088627,"lon":5.153269,"accuracy":30,"time":4},
@@ -670,7 +660,7 @@ TEST(Mapmatch, test_trace_attributes_map_snap_expected_error_code) {
   tyr::actor_t actor(conf, true);
 
   try {
-    auto response = json_to_pt(actor.trace_attributes(
+    auto response = test::json_to_pt(actor.trace_attributes(
         R"({"costing":"auto","shape_match":"map_snap","shape":[
          {"lat":52.088548,"lon":5.15357,"radius":5,"time":2},
          {"lat":52.088627,"lon":5.153269,"radius":5,"time":4},
@@ -693,7 +683,7 @@ TEST(Mapmatch, test_topk_validate) {
   tyr::actor_t actor(conf, true);
 
   // tests a previous segfault due to using a claimed state
-  auto matched = json_to_pt(actor.trace_attributes(
+  auto matched = test::json_to_pt(actor.trace_attributes(
       R"({"costing":"auto","best_paths":2,"shape_match":"map_snap","shape":[
          {"lat":52.088548,"lon":5.15357,"accuracy":30,"time":2},
          {"lat":52.088627,"lon":5.153269,"accuracy":30,"time":4},
@@ -703,7 +693,7 @@ TEST(Mapmatch, test_topk_validate) {
          {"lat":52.08851,"lon":5.15249,"accuracy":30,"time":12}]})"));
 
   // this tests a fix for an infinite loop because there is only 1 result and we ask for 4
-  matched = json_to_pt(actor.trace_attributes(
+  matched = test::json_to_pt(actor.trace_attributes(
       R"({"costing":"auto","best_paths":4,"shape_match":"map_snap","shape":[
          {"lat":52.09579,"lon":5.13137,"accuracy":5,"time":2},
          {"lat":52.09652,"lon":5.13184,"accuracy":5,"time":4}]})"));
@@ -719,7 +709,7 @@ TEST(Mapmatch, test_topk_fork_alternate) {
           {"lat":52.08511,"lon":5.15085,"accuracy":10,"time":2},
           {"lat":52.08533,"lon":5.15109,"accuracy":20,"time":4},
           {"lat":52.08539,"lon":5.15100,"accuracy":20,"time":6}]})");
-  auto matched = json_to_pt(json);
+  auto matched = test::json_to_pt(json);
 
   /*** Primary path - left at the fork
     {"type":"FeatureCollection","features":[
@@ -774,7 +764,7 @@ TEST(Mapmatch, test_topk_fork_alternate) {
 TEST(Mapmatch, test_topk_loop_alternate) {
   // tests a loop in the road
   tyr::actor_t actor(conf, true);
-  auto matched = json_to_pt(actor.trace_attributes(
+  auto matched = test::json_to_pt(actor.trace_attributes(
       R"({"costing":"auto","best_paths":2,"shape_match":"map_snap","shape":[
            {"lat":52.0886,"lon":5.1535,"accuracy":10},
            {"lat":52.088619,"lon":5.15315,"accuracy":20},
@@ -849,7 +839,7 @@ TEST(Mapmatch, test_topk_loop_alternate) {
 TEST(Mapmatch, test_topk_frontage_alternate) {
   // tests a parallel frontage road
   tyr::actor_t actor(conf, true);
-  auto matched = json_to_pt(actor.trace_attributes(
+  auto matched = test::json_to_pt(actor.trace_attributes(
       R"({"costing":"auto","best_paths":2,"shape_match":"map_snap","shape":[
            {"lat":52.07956040090567,"lon":5.138160288333893,"accuracy":10,"time":2},
            {"lat":52.07957358807355,"lon":5.138508975505829,"accuracy":10,"time":4},
@@ -942,7 +932,7 @@ TEST(Mapmatch, test_now_matches) {
   auto route_json = actor.trace_route(test_case);
 
   // again with walking
-  auto route = json_to_pt(route_json);
+  auto route = test::json_to_pt(route_json);
   auto encoded_shape = route.get_child("trip.legs").front().second.get<std::string>("shape");
   test_case =
       R"({"date_time":{"type":0},"shape_match":"edge_walk","costing":"auto","encoded_polyline":")" +
@@ -1146,7 +1136,7 @@ TEST(Mapmatch, test_discontinuity_duration_trimming) {
 
   tyr::actor_t actor(conf, true);
   for (size_t i = 0; i < test_cases.size(); ++i) {
-    auto matched = json_to_pt(actor.trace_route(test_cases[i]));
+    auto matched = test::json_to_pt(actor.trace_route(test_cases[i]));
     const auto& routes = matched.get_child("matchings");
     EXPECT_EQ(routes.size(), test_ans_num_routes[i]);
     int j = 0, k = 0;
@@ -1179,7 +1169,7 @@ TEST(Mapmatch, test_transition_matching) {
   std::vector<float> durations{3.4, 5.0};
   tyr::actor_t actor(conf, true);
   for (size_t i = 0; i < test_cases.size(); ++i) {
-    auto matched = json_to_pt(actor.trace_route(test_cases[i]));
+    auto matched = test::json_to_pt(actor.trace_route(test_cases[i]));
     const auto& routes = matched.get_child("matchings");
     EXPECT_EQ(routes.size(), test_ans_num_routes[i]);
     for (const auto& route : routes) {
@@ -1275,7 +1265,7 @@ TEST(Mapmatch, test_degenerate_match) {
   tyr::actor_t actor(conf, true);
 
   for (size_t i = 0; i < test_cases.size(); ++i) {
-    auto matched = json_to_pt(actor.trace_route(test_cases[i]));
+    auto matched = test::json_to_pt(actor.trace_route(test_cases[i]));
     const auto& routes = matched.get_child("matchings");
     for (const auto& route : routes) {
       const auto& legs = route.second.get_child("legs");
@@ -1303,7 +1293,7 @@ TEST(Mapmatch, interpolation) {
   tyr::actor_t actor(conf, true);
 
   for (size_t i = 0; i < test_cases.size(); ++i) {
-    auto matched = json_to_pt(actor.trace_route(test_cases[i]));
+    auto matched = test::json_to_pt(actor.trace_route(test_cases[i]));
     const auto& routes = matched.get_child("matchings");
     ASSERT_EQ(1, routes.size());
     for (const auto& route : routes) {
@@ -1412,7 +1402,7 @@ TEST(Mapmatch, test_breakage_distance_error_handling) {
   auto expected_error_code = 172;
   tyr::actor_t actor(conf, true);
   try {
-    auto response = json_to_pt(actor.trace_route(
+    auto response = test::json_to_pt(actor.trace_route(
         R"({"costing":"auto","shape_match":"edge_walk","shape":[
          {"lat":52.0764279,"lon":5.0323097,"type":"break","radius":15},
          {"lat":52.1022785,"lon":5.1391531,"type":"break","radius":15}]})"));
@@ -1432,7 +1422,7 @@ TEST(Mapmatch, openlr_parameter_true_osrm_api) {
   const std::string request = R"({"costing":"auto","linear_references": true,"format":"osrm","shape_match":"map_snap","shape":[{"lon":5.08531221,"lat":52.0938563,"type":"break"},{"lon":5.0865867,"lat":52.0930211,"type":"break"}]})";
   // clang-format on
   tyr::actor_t actor(conf, true);
-  const auto& response = json_to_pt(actor.trace_route(request));
+  const auto& response = test::json_to_pt(actor.trace_route(request));
   const auto& matches = response.get_child("matchings");
   EXPECT_EQ(matches.size(), 1);
   const std::vector<std::string>& expected = {
@@ -1455,7 +1445,7 @@ TEST(Mapmatch, openlr_parameter_true_native_api) {
   const std::string request = R"({"costing":"auto","linear_references": true,"shape_match":"map_snap","shape":[{"lon":5.08531221,"lat":52.0938563,"type":"break"},{"lon":5.0865867,"lat":52.0930211,"type":"break"}]})";
   // clang-format on
   tyr::actor_t actor(conf, true);
-  const auto& response = json_to_pt(actor.trace_route(request));
+  const auto& response = test::json_to_pt(actor.trace_route(request));
   const std::vector<std::string>& expected = {
       "CwOduyULYhtpAAAV//0bGQ==", "CwOdxCULYBtqAAAM//4bGg==", "CwOdySULXxtrAAAf//EbGw==",
       "CwOd1yULVxtrAQBV/9AbGw==", "CwOduyULYj/gAAACAAA/EA==",
@@ -1476,7 +1466,7 @@ TEST(Mapmatch, openlr_parameter_falsy_api) {
   };
   tyr::actor_t actor(conf, true);
   for (const auto& request : requests) {
-    const auto& response = json_to_pt(actor.trace_route(request));
+    const auto& response = test::json_to_pt(actor.trace_route(request));
     const auto& matches = response.get_child("matchings");
     EXPECT_EQ(matches.size(), 1);
     for (const auto& match : matches) {
@@ -1493,7 +1483,7 @@ TEST(Mapmatch, openlr_parameter_falsy_native_api) {
   };
   tyr::actor_t actor(conf, true);
   for (const auto& request : requests) {
-    const auto& response = json_to_pt(actor.trace_route(request));
+    const auto& response = test::json_to_pt(actor.trace_route(request));
     EXPECT_THROW(response.get_child("trip.linear_references"), std::runtime_error);
   }
 }

--- a/test/mapmatch_config.cc
+++ b/test/mapmatch_config.cc
@@ -1,0 +1,133 @@
+#include "meili/config.h"
+
+#include "test.h"
+#include "utils.h"
+
+namespace {
+
+const auto fake_config = test::json_to_pt(R"({
+    "customizable": [
+      "search_radius",
+      "gps_accuracy"
+    ],
+    "mode": "auto",
+    "grid": {
+      "cache_size": 100500,
+      "size": 100
+    },
+    "default": {
+      "beta": 5,
+      "breakage_distance": 5000,
+      "gps_accuracy": 6,
+      "interpolation_distance": 5,
+      "max_route_distance_factor": 11,
+      "max_route_time_factor": 10,
+      "max_search_radius": 500,
+      "search_radius": 10,
+      "sigma_z": 5.1,
+      "turn_penalty_factor": 100
+    }
+  })");
+
+TEST(MapmatchConfig, check_read_all_params) {
+  valhalla::meili::Config config;
+  config.Read(fake_config);
+
+  // check candidate search params
+  const auto& candiate_search = config.candidate_search;
+  EXPECT_EQ(candiate_search.search_radius_meters, 10.f);
+  EXPECT_TRUE(candiate_search.is_search_radius_customizable);
+  EXPECT_EQ(candiate_search.max_search_radius_meters, 500.f);
+  EXPECT_EQ(candiate_search.grid_size, 100);
+  EXPECT_EQ(candiate_search.cache_size, 100500);
+
+  // check transition params
+  const auto& transition = config.transition_cost;
+  EXPECT_EQ(transition.beta, 5.f);
+  EXPECT_EQ(transition.breakage_distance_meters, 5000.f);
+  EXPECT_FALSE(transition.is_breakage_distance_customizable);
+  EXPECT_EQ(transition.turn_penalty_factor, 100.f);
+  EXPECT_FALSE(transition.is_turn_penalty_factor_customizable);
+  EXPECT_EQ(transition.max_route_time_factor, 10.f);
+  EXPECT_EQ(transition.max_route_distance_factor, 11.f);
+
+  // check emission params
+  const auto& emission = config.emission_cost;
+  EXPECT_EQ(emission.sigma_z, 5.1f);
+  EXPECT_EQ(emission.gps_accuracy_meters, 6.f);
+  EXPECT_TRUE(emission.is_gps_accuracy_customizable);
+
+  // check routing params
+  const auto& routing = config.routing;
+  EXPECT_EQ(routing.interpolation_distance_meters, 5.f);
+  EXPECT_FALSE(routing.is_interpolation_distance_customizable);
+}
+
+TEST(MapmatchConfig, validate_candidate_search_params) {
+  valhalla::meili::Config config;
+
+  auto pt = fake_config;
+  pt.put<float>("default.search_radius", -1.f);
+  EXPECT_THROW(config.Read(pt), std::exception);
+
+  pt = fake_config;
+  pt.put<float>("default.max_search_radius", -1.f);
+  EXPECT_THROW(config.Read(pt), std::exception);
+}
+
+TEST(MapmatchConfig, validate_emission_params) {
+  valhalla::meili::Config config;
+
+  auto pt = fake_config;
+  pt.put<float>("default.gps_accuracy", 0.f);
+  EXPECT_NO_THROW(config.Read(pt));
+
+  pt.put<float>("default.gps_accuracy", -1.f);
+  EXPECT_THROW(config.Read(pt), std::exception);
+
+  pt = fake_config;
+  pt.put<float>("default.sigma_z", -1.f);
+  EXPECT_THROW(config.Read(pt), std::exception);
+}
+
+TEST(MapmatchConfig, validate_transition_params) {
+  valhalla::meili::Config config;
+
+  auto pt = fake_config;
+  pt.put<float>("default.beta", -1.f);
+  EXPECT_THROW(config.Read(pt), std::exception);
+
+  pt = fake_config;
+  pt.put<float>("default.breakage_distance", -1.f);
+  EXPECT_THROW(config.Read(pt), std::exception);
+
+  pt = fake_config;
+  pt.put<float>("default.max_route_distance_factor", -1.f);
+  EXPECT_THROW(config.Read(pt), std::exception);
+
+  pt = fake_config;
+  pt.put<float>("default.max_route_time_factor", -1.f);
+  EXPECT_THROW(config.Read(pt), std::exception);
+
+  pt = fake_config;
+  pt.put<float>("default.turn_penalty_factor", 0.f);
+  EXPECT_NO_THROW(config.Read(pt));
+
+  pt.put<float>("default.turn_penalty_factor", -1.f);
+  EXPECT_THROW(config.Read(pt), std::exception);
+}
+
+TEST(MapmatchConfig, validate_routing_params) {
+  valhalla::meili::Config config;
+
+  auto pt = fake_config;
+  pt.put<float>("default.interpolation_distance", -1.f);
+  EXPECT_THROW(config.Read(pt), std::exception);
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/matrix.cc
+++ b/test/matrix.cc
@@ -1,11 +1,9 @@
 #include "test.h"
+#include "utils.h"
 
 #include <iostream>
 #include <string>
 #include <vector>
-
-#include "baldr/rapidjson_utils.h"
-#include <boost/property_tree/ptree.hpp>
 
 #include "loki/worker.h"
 #include "midgard/logging.h"
@@ -127,23 +125,6 @@ cost_ptr_t CreateSimpleCost(const CostingOptions& options) {
   return std::make_shared<SimpleCost>(options);
 }
 
-boost::property_tree::ptree json_to_pt(const std::string& json) {
-  std::stringstream ss;
-  ss << json;
-  boost::property_tree::ptree pt;
-  rapidjson::read_json(ss, pt);
-  return pt;
-}
-
-rapidjson::Document to_document(const std::string& request) {
-  rapidjson::Document d;
-  auto& allocator = d.GetAllocator();
-  d.Parse(request.c_str());
-  if (d.HasParseError())
-    throw valhalla_exception_t{100};
-  return d;
-}
-
 // Maximum edge score - base this on costing type.
 // Large values can cause very bad performance. Setting this back
 // to 2 hours for bike and pedestrian and 12 hours for driving routes.
@@ -193,7 +174,7 @@ void adjust_scores(Options& options) {
   }
 }
 
-const auto config = json_to_pt(R"({
+const auto config = test::json_to_pt(R"({
     "meili": { "default": { "breakage_distance": 2000} },
     "mjolnir":{"tile_dir":"test/data/utrecht_tiles", "concurrency": 1},
     "loki":{

--- a/test/predictive_traffic.cc
+++ b/test/predictive_traffic.cc
@@ -1,4 +1,5 @@
 #include "test.h"
+#include "utils.h"
 
 #include <iostream>
 #include <string>
@@ -11,24 +12,13 @@
 #include "midgard/util.h"
 #include "mjolnir/graphtilebuilder.h"
 
-#include "baldr/rapidjson_utils.h"
-#include <boost/property_tree/ptree.hpp>
-
 using namespace valhalla::baldr;
 using namespace valhalla::mjolnir;
 using namespace valhalla::midgard;
 
 namespace {
 
-boost::property_tree::ptree json_to_pt(const std::string& json) {
-  std::stringstream ss;
-  ss << json;
-  boost::property_tree::ptree pt;
-  rapidjson::read_json(ss, pt);
-  return pt;
-}
-
-const auto config = json_to_pt(R"({
+const auto config = test::json_to_pt(R"({
     "mjolnir":{"tile_dir":"test/data/utrecht_tiles", "concurrency": 1}
   })");
 

--- a/test/shape_attributes.cc
+++ b/test/shape_attributes.cc
@@ -1,10 +1,9 @@
 #include "test.h"
+#include "utils.h"
 
-#include <boost/property_tree/ptree.hpp>
 #include <iostream>
 #include <stdexcept>
 
-#include "baldr/rapidjson_utils.h"
 #include "midgard/distanceapproximator.h"
 #include "midgard/encoded.h"
 #include "midgard/logging.h"
@@ -20,16 +19,8 @@ using namespace valhalla::midgard;
 
 namespace {
 
-boost::property_tree::ptree json_to_pt(const std::string& json) {
-  std::stringstream ss;
-  ss << json;
-  boost::property_tree::ptree pt;
-  rapidjson::read_json(ss, pt);
-  return pt;
-}
-
 // fake config
-const auto conf = json_to_pt(R"({
+const auto conf = test::json_to_pt(R"({
     "mjolnir":{"tile_dir":"test/data/utrecht_tiles", "concurrency": 1},
     "loki":{
       "actions":["locate","route","sources_to_targets","optimized_route","isochrone","trace_route","trace_attributes"],

--- a/test/thor_worker.cc
+++ b/test/thor_worker.cc
@@ -1,10 +1,10 @@
 #include "test.h"
+#include "utils.h"
 
 #include "midgard/logging.h"
 #include "thor/attributes_controller.h"
 #include "thor/worker.h"
 #include "tyr/actor.h"
-#include <boost/property_tree/ptree.hpp>
 #include <thread>
 #include <unistd.h>
 
@@ -14,16 +14,8 @@ using namespace valhalla::thor;
 
 namespace {
 
-boost::property_tree::ptree json_to_pt(const std::string& json) {
-  std::stringstream ss;
-  ss << json;
-  boost::property_tree::ptree pt;
-  rapidjson::read_json(ss, pt);
-  return pt;
-}
-
 // fake config
-const auto conf = json_to_pt(R"({
+const auto conf = test::json_to_pt(R"({
     "mjolnir":{"tile_dir":"test/data/utrecht_tiles", "concurrency": 1},
     "loki":{
       "actions":["locate","route","sources_to_targets","optimized_route","isochrone","trace_route","trace_attributes"],
@@ -58,7 +50,7 @@ const auto conf = json_to_pt(R"({
 TEST(ThorWorker, test_parse_filter_attributes_defaults) {
   tyr::actor_t actor(conf, true);
 
-  auto result = json_to_pt(actor.trace_attributes(
+  auto result = test::json_to_pt(actor.trace_attributes(
       R"({"costing":"auto","shape_match":"map_snap","shape":[
           {"lat":52.09110,"lon":5.09806},
           {"lat":52.09098,"lon":5.09679}]})"));
@@ -96,7 +88,7 @@ TEST(ThorWorker, test_parse_filter_attributes_excludes) {
   std::vector<std::string> excluded_keys = {"shape", "trip.legs..shape", "trip.legs..shape"};
 
   for (size_t i = 0; i < test_cases.size(); ++i) {
-    auto result = json_to_pt(test_cases[i]);
+    auto result = test::json_to_pt(test_cases[i]);
     EXPECT_FALSE(result.get_child_optional(excluded_keys[i]))
         << "Expected excluded shape | found " + excluded_keys[i] + "=" +
                result.get<std::string>(excluded_keys[i]);
@@ -125,7 +117,7 @@ TEST(ThorWorker, test_parse_filter_attributes_includes) {
   std::vector<std::string> included_keys = {"shape", "trip.legs..shape", "trip.legs..shape"};
 
   for (size_t i = 0; i < test_cases.size(); ++i) {
-    auto result = json_to_pt(test_cases[i]);
+    auto result = test::json_to_pt(test_cases[i]);
     EXPECT_TRUE(result.get_child_optional(included_keys[i]))
         << "Expected " + included_keys[i] + " to be present";
   }
@@ -146,7 +138,7 @@ TEST(ThorWorker, test_linear_references) {
   };
   tyr::actor_t actor(conf, true);
   for (const auto& request : requests) {
-    auto result = json_to_pt(actor.route(request));
+    auto result = test::json_to_pt(actor.route(request));
     const auto& references = result.get_child("trip.linear_references");
     EXPECT_EQ(references.size(), 4);
     for (const auto& reference : references) {

--- a/test/timedep_paths.cc
+++ b/test/timedep_paths.cc
@@ -1,4 +1,5 @@
 #include "test.h"
+#include "utils.h"
 
 #include <iostream>
 #include <string>
@@ -11,7 +12,6 @@
 #include "thor/timedep.h"
 #include "thor/worker.h"
 #include "worker.h"
-#include <boost/property_tree/ptree.hpp>
 
 using namespace valhalla;
 using namespace valhalla::thor;
@@ -22,24 +22,6 @@ using namespace valhalla::midgard;
 using namespace valhalla::tyr;
 
 namespace {
-
-boost::property_tree::ptree json_to_pt(const std::string& json) {
-  std::stringstream ss;
-  ss << json;
-  boost::property_tree::ptree pt;
-  rapidjson::read_json(ss, pt);
-  return pt;
-}
-
-rapidjson::Document to_document(const std::string& request) {
-  rapidjson::Document d;
-  auto& allocator = d.GetAllocator();
-  d.Parse(request.c_str());
-  if (d.HasParseError())
-    throw valhalla_exception_t{100};
-  return d;
-}
-
 // Maximum edge score - base this on costing type.
 // Large values can cause very bad performance. Setting this back
 // to 2 hours for bike and pedestrian and 12 hours for driving routes.
@@ -89,7 +71,7 @@ void adjust_scores(Options& options) {
   }
 }
 
-const auto config = json_to_pt(R"({
+const auto config = test::json_to_pt(R"({
     "meili": {"default": {"breakage_distance": 2000}},
     "mjolnir":{"tile_dir":"test/data/utrecht_tiles", "concurrency": 1},
     "loki":{

--- a/test/trivial_paths.cc
+++ b/test/trivial_paths.cc
@@ -1,16 +1,15 @@
 #include "test.h"
+#include "utils.h"
 
 #include <iostream>
 #include <string>
 #include <vector>
 
-#include "baldr/rapidjson_utils.h"
 #include "loki/worker.h"
 #include "midgard/logging.h"
 #include "sif/autocost.h"
 #include "thor/astar.h"
 #include "thor/worker.h"
-#include <boost/property_tree/ptree.hpp>
 
 using namespace valhalla;
 using namespace valhalla::thor;
@@ -21,24 +20,6 @@ using namespace valhalla::midgard;
 using namespace valhalla::tyr;
 
 namespace {
-
-boost::property_tree::ptree json_to_pt(const std::string& json) {
-  std::stringstream ss;
-  ss << json;
-  boost::property_tree::ptree pt;
-  rapidjson::read_json(ss, pt);
-  return pt;
-}
-
-rapidjson::Document to_document(const std::string& request) {
-  rapidjson::Document d;
-  auto& allocator = d.GetAllocator();
-  d.Parse(request.c_str());
-  if (d.HasParseError())
-    throw valhalla_exception_t{100};
-  return d;
-}
-
 // Maximum edge score - base this on costing type.
 // Large values can cause very bad performance. Setting this back
 // to 2 hours for bike and pedestrian and 12 hours for driving routes.
@@ -88,7 +69,7 @@ void adjust_scores(Options& options) {
   }
 }
 
-const auto config = json_to_pt(R"({
+const auto config = test::json_to_pt(R"({
     "meili": {"default": {"breakage_distance": 2000}},
     "mjolnir":{"tile_dir":"test/data/utrecht_tiles", "concurrency": 1},
     "loki":{

--- a/test/utils.h
+++ b/test/utils.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "baldr/rapidjson_utils.h"
+#include "worker.h"
+
+#include <boost/property_tree/ptree.hpp>
+#include <sstream>
+
+namespace test {
+
+inline boost::property_tree::ptree json_to_pt(const std::string& json) {
+  std::stringstream ss;
+  ss << json;
+  boost::property_tree::ptree pt;
+  rapidjson::read_json(ss, pt);
+  return pt;
+}
+
+} // namespace test

--- a/valhalla/macro.h
+++ b/valhalla/macro.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <exception>
+
+#define CHECK_THROWS(condition, message)                                                             \
+  {                                                                                                  \
+    if (!(condition))                                                                                \
+      throw std::invalid_argument(message);                                                          \
+  }

--- a/valhalla/meili/config.h
+++ b/valhalla/meili/config.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <boost/property_tree/ptree.hpp>
+
+namespace valhalla {
+namespace meili {
+
+struct Config {
+  // create config with default parameters
+  Config() = default;
+  // read parameters from boost::ptree (use default values for missing params)
+  explicit Config(const boost::property_tree::ptree& params);
+  // override default config parameters
+  void Read(const boost::property_tree::ptree& params);
+
+  struct CandidateSearch {
+    // default search radius (meters) for measurements; it's used to determine maximum search radius
+    float search_radius_meters = 50.f;
+    // define if 'search_radius' option can be reassigned with user request
+    bool is_search_radius_customizable = true;
+    // maximum allowed difference (meters) between GPS point and corresponding route point
+    float max_search_radius_meters = 200.f;
+
+    size_t cache_size = 100240;
+    size_t grid_size = 500;
+
+    void Read(const boost::property_tree::ptree& params);
+  };
+
+  struct TransitionCost {
+    // beta parameter of exponential distribution
+    float beta = 3.f;
+    // maximum allowed difference (meters) between route distance and great circle distance
+    float breakage_distance_meters = 2000.f;
+    // define if 'breakage_distance' option can be reassigned with user request
+    bool is_breakage_distance_customizable = false;
+    // maximum allowed ratio of route distance to great circle distance
+    float max_route_distance_factor = 5.f;
+    // maximum allowed ratio of route time distance to the corresponding measurements time distance
+    float max_route_time_factor = 5.f;
+    // it's used to determine 'turn cost' depending on turn degree
+    float turn_penalty_factor = 200.f;
+    // define if 'turn_penalty_factor' option can be reassigned with user request
+    bool is_turn_penalty_factor_customizable = true;
+
+    void Read(const boost::property_tree::ptree& params);
+  };
+
+  struct EmissionCost {
+    // standard deviation of GPS measurements
+    float sigma_z = 4.07f;
+    // default accuracy (meters) of GPS measurements; it's used to determine maximum search radius
+    float gps_accuracy_meters = 5.f;
+    // define if 'gps_accuracy' option can be reassigned with user request
+    bool is_gps_accuracy_customizable = false;
+
+    void Read(const boost::property_tree::ptree& params);
+  };
+
+  struct Routing {
+    // interpolation distance (meters); threshold for merging close points together
+    float interpolation_distance_meters = 10.f;
+    // define if 'interpolation_distance' option can be reassigned with user request
+    bool is_interpolation_distance_customizable = false;
+
+    void Read(const boost::property_tree::ptree& params);
+  };
+
+  CandidateSearch candidate_search{};
+  TransitionCost transition_cost{};
+  EmissionCost emission_cost{};
+  Routing routing{};
+};
+
+} // namespace meili
+} // namespace valhalla

--- a/valhalla/meili/emission_cost_model.h
+++ b/valhalla/meili/emission_cost_model.h
@@ -2,6 +2,8 @@
 #define MMP_EMISSION_COST_MODEL_H_
 
 #include <functional>
+
+#include <valhalla/meili/config.h>
 #include <valhalla/meili/state.h>
 
 namespace valhalla {
@@ -22,8 +24,8 @@ public:
 
   EmissionCostModel(baldr::GraphReader& graphreader,
                     const StateContainer& container,
-                    const boost::property_tree::ptree& config)
-      : EmissionCostModel(graphreader, container, config.get<float>("sigma_z")) {
+                    const Config::EmissionCost& config)
+      : EmissionCostModel(graphreader, container, config.sigma_z) {
   }
 
   // given the *squared* great circle distance between a measurement and its candidate,

--- a/valhalla/meili/map_matcher.h
+++ b/valhalla/meili/map_matcher.h
@@ -5,11 +5,10 @@
 #include <unordered_set>
 #include <vector>
 
-#include <boost/property_tree/ptree.hpp>
-
 #include <valhalla/baldr/graphid.h>
 #include <valhalla/baldr/graphreader.h>
 #include <valhalla/meili/candidate_search.h>
+#include <valhalla/meili/config.h>
 #include <valhalla/meili/emission_cost_model.h>
 #include <valhalla/meili/match_result.h>
 #include <valhalla/meili/measurement.h>
@@ -25,7 +24,7 @@ namespace meili {
 // A facade that connects everything
 class MapMatcher final {
 public:
-  MapMatcher(const boost::property_tree::ptree& config,
+  MapMatcher(const Config& config,
              baldr::GraphReader& graphreader,
              CandidateQuery& candidatequery,
              const sif::mode_costing_t& mode_costing,
@@ -59,7 +58,7 @@ public:
     return travelmode_;
   }
 
-  const boost::property_tree::ptree& config() const {
+  const Config& config() const {
     return config_;
   }
 
@@ -88,7 +87,7 @@ private:
   void RemoveRedundancies(const std::vector<StateId>& result,
                           const std::vector<MatchResult>& results);
 
-  boost::property_tree::ptree config_;
+  Config config_;
 
   baldr::GraphReader& graphreader_;
 

--- a/valhalla/meili/map_matcher_factory.h
+++ b/valhalla/meili/map_matcher_factory.h
@@ -6,13 +6,13 @@
 #include <string>
 
 #include <boost/property_tree/ptree.hpp>
-#include <rapidjson/rapidjson.h>
 
 #include <valhalla/baldr/graphreader.h>
 #include <valhalla/sif/costconstants.h>
 #include <valhalla/sif/costfactory.h>
 
 #include <valhalla/meili/candidate_search.h>
+#include <valhalla/meili/config.h>
 #include <valhalla/meili/map_matcher.h>
 
 namespace valhalla {
@@ -41,7 +41,7 @@ public:
     return Create(options);
   }
 
-  boost::property_tree::ptree MergeConfig(const Options& options);
+  Config MergeConfig(const Options& options) const;
 
   void ClearFullCache();
 
@@ -50,7 +50,7 @@ public:
 private:
   typedef sif::cost_ptr_t (*factory_function_t)(const boost::property_tree::ptree&);
 
-  boost::property_tree::ptree config_;
+  Config config_;
 
   std::shared_ptr<baldr::GraphReader> graphreader_;
 
@@ -59,8 +59,6 @@ private:
   sif::CostFactory cost_factory_;
 
   std::shared_ptr<CandidateGridQuery> candidatequery_;
-
-  float max_grid_cache_size_;
 };
 
 } // namespace meili

--- a/valhalla/meili/transition_cost_model.h
+++ b/valhalla/meili/transition_cost_model.h
@@ -4,6 +4,7 @@
 #include <functional>
 
 #include <valhalla/baldr/graphreader.h>
+#include <valhalla/meili/config.h>
 #include <valhalla/meili/measurement.h>
 #include <valhalla/meili/state.h>
 #include <valhalla/meili/topk_search.h>
@@ -33,7 +34,7 @@ public:
                       const StateContainer& container,
                       const sif::mode_costing_t& mode_costing,
                       const sif::TravelMode travelmode,
-                      const boost::property_tree::ptree& config);
+                      const Config::TransitionCost& config);
 
   // we use the difference between the original two measurements and the distance along the route
   // network to compute a transition cost of a given candidate, transition_time may be added if


### PR DESCRIPTION
Add configuration struct for mapmatching. It can be initialized with default values or with `boost::property_tree` (if some parameters are missing -> use default values, don't throw any exception).

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)
