### PR TITLE
Fix dereferencing of end for std::lower_bound and possible UB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
    * FIXED: Fix segfault: Do not combine last turn channel maneuver. [#2463](https://github.com/valhalla/valhalla/pull/2463)
    * FIXED: Remove extraneous whitespaces from ja-JP.json. [#2471](https://github.com/valhalla/valhalla/pull/2471)
    * FIXED: Checks protobuf serialization/parsing success [#2477](https://github.com/valhalla/valhalla/pull/2477)
+   * FIXED: Fix dereferencing of end for std::lower_bound in sequence and possible UB [#2488](https://github.com/valhalla/valhalla/pull/2488)
 
 * **Enhancement**
    * ADDED: Add explicit include for sstream to be compatible with msvc_x64 toolset. [#2449](https://github.com/valhalla/valhalla/pull/2449)

--- a/valhalla/midgard/sequence.h
+++ b/valhalla/midgard/sequence.h
@@ -468,6 +468,11 @@ public:
     // if we did find it return the iterator to it
     auto* found = std::lower_bound(static_cast<const T*>(memmap),
                                    static_cast<const T*>(memmap) + memmap.size(), target, predicate);
+    // if we got to the end, no element we have
+    if (found == static_cast<const T*>(memmap) + memmap.size()) {
+      return end();
+    }
+
     if (!(predicate(target, *found) || predicate(*found, target))) {
       return at(found - static_cast<const T*>(memmap));
     }


### PR DESCRIPTION
Fixes UB and segfault when std::lower_bound returns end.
