### PR TITLE
fix: clang-analyzer-core.CallAndMessage warnings

### DIFF
--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -528,12 +528,10 @@ bool GraphReader::AreEdgesConnected(const GraphId& edge1, const GraphId& edge2) 
 
   // Get opposing edge to de2 and compare to both edge1 endnodes
   const DirectedEdge* de2_opp = GetOpposingEdge(edge2, t2);
-  if (de2_opp && (de2_opp->endnode() == de1->endnode() || de2_opp->endnode() == de1_opp->endnode() ||
-                  is_transition(de2_opp->endnode(), de1->endnode()) ||
-                  is_transition(de2_opp->endnode(), de1_opp->endnode()))) {
-    return true;
-  }
-  return false;
+  return de1_opp && de2_opp &&
+         (de2_opp->endnode() == de1->endnode() || de2_opp->endnode() == de1_opp->endnode() ||
+          is_transition(de2_opp->endnode(), de1->endnode()) ||
+          is_transition(de2_opp->endnode(), de1_opp->endnode()));
 }
 
 // Convenience method to determine if 2 directed edges are connected from

--- a/src/loki/reach.cc
+++ b/src/loki/reach.cc
@@ -172,6 +172,9 @@ directed_reach Reach::exact(const valhalla::baldr::DirectedEdge* edge,
   // fake up the input location
   const baldr::GraphTile* tile = nullptr;
   const auto* node = reader.GetEndNode(edge, tile);
+  if (node == nullptr) {
+    return reach;
+  }
   auto ll = node->latlng(tile->header()->base_ll());
   locations_.Mutable(0)->mutable_ll()->set_lng(ll.first);
   locations_.Mutable(0)->mutable_ll()->set_lat(ll.second);

--- a/src/thor/astar.cc
+++ b/src/thor/astar.cc
@@ -228,7 +228,7 @@ void AStarPathAlgorithm::ExpandForward(GraphReader& graphreader,
 
   // Handle transitions - expand from the end node of each transition
   if (!from_transition && nodeinfo->transition_count() > 0) {
-    const NodeTransition* trans = tile->transition(nodeinfo->transition_index());
+    const NodeTransition* trans = tile->transition(nodeinfo->transition_index()); // NOLINT
     for (uint32_t i = 0; i < nodeinfo->transition_count(); ++i, ++trans) {
       if (trans->up()) {
         hierarchy_limits_[node.level()].up_transition_count++;

--- a/src/thor/costmatrix.cc
+++ b/src/thor/costmatrix.cc
@@ -357,6 +357,9 @@ void CostMatrix::ForwardSearch(const uint32_t index, const uint32_t n, GraphRead
 
     // Handle transitions - expand from the end node of the transition
     if (!from_transition && nodeinfo->transition_count() > 0) {
+      if (tile == nullptr) {
+        return;
+      }
       const NodeTransition* trans = tile->transition(nodeinfo->transition_index());
       for (uint32_t i = 0; i < nodeinfo->transition_count(); ++i, ++trans) {
         if (trans->up()) {

--- a/src/thor/multimodal.cc
+++ b/src/thor/multimodal.cc
@@ -526,6 +526,9 @@ bool MultiModalPathAlgorithm::ExpandForward(GraphReader& graphreader,
 
   // Handle transitions - expand from the end node each transition
   if (!from_transition && nodeinfo->transition_count() > 0) {
+    if (tile == nullptr) {
+      return false;
+    }
     const NodeTransition* trans = tile->transition(nodeinfo->transition_index());
     for (uint32_t i = 0; i < nodeinfo->transition_count(); ++i, ++trans) {
       ExpandForward(graphreader, trans->endnode(), pred, pred_idx, true, pc, tc, mode_costing,

--- a/src/thor/route_action.cc
+++ b/src/thor/route_action.cc
@@ -416,6 +416,9 @@ void thor_worker_t::path_arrive_by(Api& api, const std::string& costing) {
         // Form output information based on path edges
         if (api.trip().routes_size() == 0 || api.options().alternates() > 0)
           route = api.mutable_trip()->mutable_routes()->Add();
+        if (route == nullptr) {
+          continue;
+        }
         auto& leg = *route->mutable_legs()->Add();
         TripLegBuilder::Build(controller, *reader, mode_costing, path.begin(), path.end(), *origin,
                               *destination, throughs, leg, interrupt, &vias);
@@ -424,7 +427,9 @@ void thor_worker_t::path_arrive_by(Api& api, const std::string& costing) {
       }
     }
   }
-
+  if (route == nullptr) {
+    return;
+  }
   // Reverse the legs because protobuf only has adding to the end
   std::reverse(route->mutable_legs()->begin(), route->mutable_legs()->end());
 }
@@ -504,6 +509,9 @@ void thor_worker_t::path_depart_at(Api& api, const std::string& costing) {
         // Form output information based on path edges. vias are a route discontinuity map
         if (api.trip().routes_size() == 0 || api.options().alternates() > 0)
           route = api.mutable_trip()->mutable_routes()->Add();
+        if (route == nullptr) {
+          continue;
+        }
         auto& leg = *route->mutable_legs()->Add();
         thor::TripLegBuilder::Build(controller, *reader, mode_costing, path.begin(), path.end(),
                                     *origin, *destination, throughs, leg, interrupt, &vias);


### PR DESCRIPTION
It's very dangerous to forget to do checks pointers for nullptr, so this PR fix clang-analyzer-core.CallAndMessage warnings.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
