### PR TITLE
Zero initialize EdgeInfoInner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,8 @@
    * FIXED: Checks protobuf serialization/parsing success [#2477](https://github.com/valhalla/valhalla/pull/2477)
    * FIXED: Fix dereferencing of end for std::lower_bound in sequence and possible UB [#2488](https://github.com/valhalla/valhalla/pull/2488)
    * FIXED: Make tile building reproducible: fix UB-s [#2480](https://github.com/valhalla/valhalla/pull/2480)
-
+   * FIXED: Zero initialize EdgeInfoInner.spare0_. Uninitialized spare0_ field produced UB which causes gurka_reproduce_tile_build to fail intermittently. [2499](https://github.com/valhalla/valhalla/pull/2499) 
+   
 * **Enhancement**
    * ADDED: Add explicit include for sstream to be compatible with msvc_x64 toolset. [#2449](https://github.com/valhalla/valhalla/pull/2449)
    * ADDED: Add ability to provide custom implementation for candidate collection in CandidateQuery. [#2328](https://github.com/valhalla/valhalla/pull/2328)

--- a/valhalla/mjolnir/edgeinfobuilder.h
+++ b/valhalla/mjolnir/edgeinfobuilder.h
@@ -105,7 +105,7 @@ public:
 
 protected:
   // Fixed size information
-  baldr::EdgeInfo::EdgeInfoInner ei_;
+  baldr::EdgeInfo::EdgeInfoInner ei_{};
 
   // Where we optionally keep the last 2 bytes of a 64bit wayid
   uint8_t extended_wayid2_;


### PR DESCRIPTION
This is done to zero initialize EdgeInfoInner.spare0_. Uninitialized `spare0_` field produced UB => flaky `gurka_reproduce_tile_build` test => flaky CI

# Issue

What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
