### PR TITLE
fix(traffic-tile-version): Locks down traffic tile format

### DIFF
--- a/src/baldr/CMakeLists.txt
+++ b/src/baldr/CMakeLists.txt
@@ -25,17 +25,6 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/date_time_windows_zones.h
 
 file(GLOB headers ${VALHALLA_SOURCE_DIR}/valhalla/baldr/*.h)
 
-# Builds a checksum of the traffictile header and store it in `traffic_tile_version.h`
-set(GENERATED_VERSION_HEADER "${CMAKE_CURRENT_BINARY_DIR}/traffic_tile_version.h")
-message("Generating traffictile version header")
-configure_file(${VALHALLA_SOURCE_DIR}/valhalla/baldr/traffictile.h
-               ${CMAKE_CURRENT_BINARY_DIR}/traffictile.h.junk)
-file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/traffictile.h.junk)
-
-file(SHA1 ${VALHALLA_SOURCE_DIR}/valhalla/baldr/traffictile.h traffic_tile_version_full)
-string(SUBSTRING ${traffic_tile_version_full} 0 4 traffic_tile_version_short)
-file(WRITE ${GENERATED_VERSION_HEADER} "const uint32_t TRAFFIC_TILE_VERSION = 0x${traffic_tile_version_short};")
-
 set(includes
     ${VALHALLA_SOURCE_DIR}
      ${VALHALLA_SOURCE_DIR}/valhalla
@@ -83,7 +72,6 @@ set(sources
     verbal_text_formatter_factory.cc)
 
 list(APPEND sources
-    ${GENERATED_VERSION_HEADER}
     #basic timezone stuff
     ${CMAKE_CURRENT_BINARY_DIR}/date_time_africa.h
     ${CMAKE_CURRENT_BINARY_DIR}/date_time_antarctica.h

--- a/test/gurka/test_traffic.cc
+++ b/test/gurka/test_traffic.cc
@@ -87,7 +87,7 @@ void update_all_edges_but_bd(const valhalla::gurka::map& map, uint16_t new_speed
 }
 
 void blank_traffic(const valhalla::gurka::map& map,
-                   uint32_t traffic_tile_version = TRAFFIC_TILE_VERSION) {
+                   uint32_t traffic_tile_version = valhalla::baldr::TRAFFIC_TILE_VERSION) {
   const auto& traffic_extract = map.config.get<std::string>("mjolnir.traffic_extract");
   mtar_t tar;
   auto tar_open_result = mtar_open(&tar, traffic_extract.c_str(), "w");

--- a/test/traffictile.cc
+++ b/test/traffictile.cc
@@ -34,8 +34,8 @@ TEST(Traffic, TileConstruction) {
   EXPECT_EQ(speed.get_speed(0), 98);
   EXPECT_EQ(speed.get_speed(1), UNKNOWN_TRAFFIC_SPEED_RAW << 1);
 
-  // Verify the version (Expect this value to change when traffictile.h is updated)
-  EXPECT_EQ(0xab6e, TRAFFIC_TILE_VERSION);
+  // Verify the version
+  EXPECT_EQ(3, TRAFFIC_TILE_VERSION);
   // Test with an invalid version
   testdata.header.traffic_tile_version = 78;
   auto const volatile& invalid_speed = tile.trafficspeed(2);

--- a/valhalla/baldr/traffictile.h
+++ b/valhalla/baldr/traffictile.h
@@ -17,6 +17,7 @@
 #else
 #include <stdint.h>
 #endif
+#include "valhalla.h"
 
 #ifndef C_ONLY_INTERFACE
 namespace valhalla {
@@ -33,7 +34,7 @@ using std::uint64_t;
 // the spare bits available.
 // This is more of a break-the-glass escape hatch for when the current format has
 // reached its limits
-const uint8_t TRAFFIC_TILE_VERSION = 3;
+const uint8_t TRAFFIC_TILE_VERSION = VALHALLA_VERSION_MAJOR;
 
 // This value _of bitfield_ (not in kph) signals that the live speed is not known (max value of 7 bit
 // number)

--- a/valhalla/baldr/traffictile.h
+++ b/valhalla/baldr/traffictile.h
@@ -17,7 +17,6 @@
 #else
 #include <stdint.h>
 #endif
-#include "baldr/traffic_tile_version.h"
 
 #ifndef C_ONLY_INTERFACE
 namespace valhalla {
@@ -27,6 +26,14 @@ using std::uint16_t;
 using std::uint32_t;
 using std::uint64_t;
 #endif
+
+// The version of traffic tile format
+// This is not intended to allow for easy migration between in-compatible data-formats
+// Changes are still expected to be applied in a backwards compatible way by using
+// the spare bits available.
+// This is more of a break-the-glass escape hatch for when the current format has
+// reached its limits
+const uint8_t TRAFFIC_TILE_VERSION = 3;
 
 // This value _of bitfield_ (not in kph) signals that the live speed is not known (max value of 7 bit
 // number)


### PR DESCRIPTION
and formalises process of changing format. Approach is same as the
regular data tiles, i.e. forward compatible by only using spare bits.

There's a 'break-the-glass' solution for when the format can move no
more, and a new TRAFFIC_TILE_VERSION must be created

Fixes https://github.com/valhalla/valhalla/issues/2500
