### PR TITLE
Fix missing nullptr checks in graphreader and loki::Reach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@
    * FIXED: Zero initialize EdgeInfoInner.spare0_. Uninitialized spare0_ field produced UB which causes gurka_reproduce_tile_build to fail intermittently. [2499](https://github.com/valhalla/valhalla/pull/2499)
    * FIXED: Drop unused CHANGELOG validation script, straggling NodeJS references [#2506](https://github.com/valhalla/valhalla/pull/2506)
 
+   * FIXED: Fix missing nullptr checks in graphreader and loki::Reach (causing segfault during routing with not all levels of tiles availble) [#2504](https://github.com/valhalla/valhalla/pull/2504)
+   
 * **Enhancement**
    * ADDED: Add explicit include for sstream to be compatible with msvc_x64 toolset. [#2449](https://github.com/valhalla/valhalla/pull/2449)
    * ADDED: Add ability to provide custom implementation for candidate collection in CandidateQuery. [#2328](https://github.com/valhalla/valhalla/pull/2328)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,6 @@
    * FIXED: Make tile building reproducible: fix UB-s [#2480](https://github.com/valhalla/valhalla/pull/2480)
    * FIXED: Zero initialize EdgeInfoInner.spare0_. Uninitialized spare0_ field produced UB which causes gurka_reproduce_tile_build to fail intermittently. [2499](https://github.com/valhalla/valhalla/pull/2499)
    * FIXED: Drop unused CHANGELOG validation script, straggling NodeJS references [#2506](https://github.com/valhalla/valhalla/pull/2506)
-
    * FIXED: Fix missing nullptr checks in graphreader and loki::Reach (causing segfault during routing with not all levels of tiles availble) [#2504](https://github.com/valhalla/valhalla/pull/2504)
    
 * **Enhancement**

--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -528,12 +528,10 @@ bool GraphReader::AreEdgesConnected(const GraphId& edge1, const GraphId& edge2) 
 
   // Get opposing edge to de2 and compare to both edge1 endnodes
   const DirectedEdge* de2_opp = GetOpposingEdge(edge2, t2);
-  if (de2_opp && (de2_opp->endnode() == de1->endnode() || de2_opp->endnode() == de1_opp->endnode() ||
-                  is_transition(de2_opp->endnode(), de1->endnode()) ||
-                  is_transition(de2_opp->endnode(), de1_opp->endnode()))) {
-    return true;
-  }
-  return false;
+  return de1_opp && de2_opp &&
+         (de2_opp->endnode() == de1->endnode() || de2_opp->endnode() == de1_opp->endnode() ||
+          is_transition(de2_opp->endnode(), de1->endnode()) ||
+          is_transition(de2_opp->endnode(), de1_opp->endnode()));
 }
 
 // Convenience method to determine if 2 directed edges are connected from

--- a/src/loki/reach.cc
+++ b/src/loki/reach.cc
@@ -172,6 +172,9 @@ directed_reach Reach::exact(const valhalla::baldr::DirectedEdge* edge,
   // fake up the input location
   const baldr::GraphTile* tile = nullptr;
   const auto* node = reader.GetEndNode(edge, tile);
+  if (node == nullptr) {
+    return reach;
+  }
   auto ll = node->latlng(tile->header()->base_ll());
   locations_.Mutable(0)->mutable_ll()->set_lng(ll.first);
   locations_.Mutable(0)->mutable_ll()->set_lat(ll.second);


### PR DESCRIPTION
# Issue

Routing could segfault if tiles of not all levels are loaded for a certain point (in reach)

This is a reduced version of https://github.com/valhalla/valhalla/pull/2493 (which is done from the fork)

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [x] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
