### PR TITLE
Improve german destination_verbal_alert phrases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
    * FIXED: Drop unused CHANGELOG validation script, straggling NodeJS references [#2506](https://github.com/valhalla/valhalla/pull/2506)
    * FIXED: Fix missing nullptr checks in graphreader and loki::Reach (causing segfault during routing with not all levels of tiles availble) [#2504](https://github.com/valhalla/valhalla/pull/2504)
    * FIXED: Fix mismatch of triplegedge roadclass and directededge roadclass [#2507](https://github.com/valhalla/valhalla/pull/2507)
+   * FIXED: Improve german destination_verbal_alert phrases [#2509](https://github.com/valhalla/valhalla/pull/2509)
 
 * **Enhancement**
    * ADDED: Add explicit include for sstream to be compatible with msvc_x64 toolset. [#2449](https://github.com/valhalla/valhalla/pull/2449)

--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -325,10 +325,10 @@
     },
     "destination_verbal_alert": {
       "phrases": {
-        "0": "Ziel fast erreicht.",
-        "1": "<DESTINATION> fast erreicht.",
-        "2": "Gleich befindet sich das Ziel auf der <RELATIVE_DIRECTION> Seite.",
-        "3": "Gleich befindet sich <DESTINATION> auf der <RELATIVE_DIRECTION> Seite."
+        "0": "Das Ziel wird erreicht.",
+        "1": "<DESTINATION> wird erreicht.",
+        "2": "Das Ziel befindet sich auf der <RELATIVE_DIRECTION> Seite.",
+        "3": "<DESTINATION> befindet sich auf der <RELATIVE_DIRECTION> Seite."
       },
       "relative_directions": [
         "linken",


### PR DESCRIPTION
# Issue

Tweaks the German localization destination_verbal_alert phrases. Improves the alert instruction to be more sensible when combined with the `approach_verbal_alert` phrase `In <LENGTH>, <CURRENT_VERBAL_CUE>`.  


## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
