### PR TITLE
Fix heading calculation for turn type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
    * FIXED: Improve german destination_verbal_alert phrases [#2509](https://github.com/valhalla/valhalla/pull/2509)
    * FIXED: Fixed logic so verbal keep instructions use branch exit sign info for ramps [#2520](https://github.com/valhalla/valhalla/pull/2520)
    * FIXED: Fix bug in trace_route for uturns causing garbage coordinates [#2517](https://github.com/valhalla/valhalla/pull/2517)
+   * FIXED: Simplify heading calculation for turn type. Remove undefined behavior case. [#2513](https://github.com/valhalla/valhalla/pull/2513)
 
 * **Enhancement**
    * ADDED: Add explicit include for sstream to be compatible with msvc_x64 toolset. [#2449](https://github.com/valhalla/valhalla/pull/2449)

--- a/src/mjolnir/graphenhancer.cc
+++ b/src/mjolnir/graphenhancer.cc
@@ -212,7 +212,7 @@ void GetTurnTypes(const DirectedEdge& directededge,
 
   // Get the heading value at the end of incoming edge based on edge shape
   auto incoming_shape = tile->edgeinfo(directededge.edgeinfo_offset()).shape();
-  if (directededge.forward())  {
+  if (directededge.forward()) {
     std::reverse(incoming_shape.begin(), incoming_shape.end());
   }
   uint32_t heading = std::round(
@@ -231,7 +231,7 @@ void GetTurnTypes(const DirectedEdge& directededge,
 
   // Iterate through outbound edges and get turn degrees from the candidate
   // edge onto outbound driveable edges.
-  const auto *diredge = tile->directededge(node->edge_index());
+  const auto* diredge = tile->directededge(node->edge_index());
   for (uint32_t i = 0; i < node->edge_count(); i++, diredge++) {
     // Skip opposing directed edge and any edge that is not a road. Skip any
     // edges that are not driveable outbound.
@@ -256,9 +256,7 @@ void GetTurnTypes(const DirectedEdge& directededge,
 }
 
 // Update the rightmost lane as needed.
-void EnhanceRightLane(const DirectedEdge directededge,
-                      const uint32_t idx,
-                      NodeInfo& startnodeinfo,
+void EnhanceRightLane(const DirectedEdge& directededge,
                       GraphTileBuilder& tilebuilder,
                       GraphReader& reader,
                       std::mutex& lock,
@@ -285,9 +283,7 @@ void EnhanceRightLane(const DirectedEdge directededge,
 }
 
 // Update the leftmost lane as needed.
-void EnhanceLeftLane(const DirectedEdge directededge,
-                     const uint32_t idx,
-                     NodeInfo& startnodeinfo,
+void EnhanceLeftLane(const DirectedEdge& directededge,
                      GraphTileBuilder& tilebuilder,
                      GraphReader& reader,
                      std::mutex& lock,
@@ -366,7 +362,6 @@ bool ProcessLanes(bool isLeft, bool endOnTurn, std::vector<uint16_t>& enhanced_t
 void UpdateTurnLanes(const OSMData& osmdata,
                      const uint32_t idx,
                      DirectedEdge& directededge,
-                     NodeInfo& startnodeinfo,
                      GraphTileBuilder& tilebuilder,
                      GraphReader& reader,
                      std::mutex& lock,
@@ -416,7 +411,7 @@ void UpdateTurnLanes(const OSMData& osmdata,
         // Should have a left.
         if (has_turn_left(outgoing_turn_type)) {
           // check for a right.
-          EnhanceRightLane(directededge, idx, startnodeinfo, tilebuilder, reader, lock, enhanced_tls);
+          EnhanceRightLane(directededge, tilebuilder, reader, lock, enhanced_tls);
         }
       }
     }
@@ -441,8 +436,7 @@ void UpdateTurnLanes(const OSMData& osmdata,
           // Should have a right.  check for a left.
           if (has_turn_right(outgoing_turn_type)) {
             // check for a left
-            EnhanceLeftLane(directededge, idx, startnodeinfo, tilebuilder, reader, lock,
-                            enhanced_tls);
+            EnhanceLeftLane(directededge, tilebuilder, reader, lock, enhanced_tls);
           }
         }
       }
@@ -468,9 +462,9 @@ void UpdateTurnLanes(const OSMData& osmdata,
 
         if (bUpdated) {
           // check for a right.
-          EnhanceRightLane(directededge, idx, startnodeinfo, tilebuilder, reader, lock, enhanced_tls);
+          EnhanceRightLane(directededge, tilebuilder, reader, lock, enhanced_tls);
           // check for a left
-          EnhanceLeftLane(directededge, idx, startnodeinfo, tilebuilder, reader, lock, enhanced_tls);
+          EnhanceLeftLane(directededge, tilebuilder, reader, lock, enhanced_tls);
         }
       }
     }
@@ -496,9 +490,9 @@ void UpdateTurnLanes(const OSMData& osmdata,
 
         if (bUpdated) {
           // check for a right.
-          EnhanceRightLane(directededge, idx, startnodeinfo, tilebuilder, reader, lock, enhanced_tls);
+          EnhanceRightLane(directededge, tilebuilder, reader, lock, enhanced_tls);
           // check for a left
-          EnhanceLeftLane(directededge, idx, startnodeinfo, tilebuilder, reader, lock, enhanced_tls);
+          EnhanceLeftLane(directededge, tilebuilder, reader, lock, enhanced_tls);
         }
       }
     }
@@ -1773,8 +1767,8 @@ void enhance(const boost::property_tree::ptree& pt,
         // Enhance and add turn lanes if not an internal edge.
         if (!directededge.internal() && directededge.turnlanes()) {
           // Update turn lanes.
-          UpdateTurnLanes(osmdata, nodeinfo.edge_index() + j, directededge, nodeinfo, tilebuilder,
-                          reader, lock, turn_lanes);
+          UpdateTurnLanes(osmdata, nodeinfo.edge_index() + j, directededge, tilebuilder, reader, lock,
+                          turn_lanes);
         }
 
         // Check for not_thru edge (only on low importance edges). Exclude

--- a/test/gurka/test_turn_lanes.cc
+++ b/test/gurka/test_turn_lanes.cc
@@ -1,0 +1,45 @@
+#include "gurka.h"
+#include <gtest/gtest.h>
+
+#include "odin/enhancedtrippath.h"
+
+using namespace valhalla;
+
+/*************************************************************/
+TEST(Standalone, TurnLanes) {
+
+  const std::string ascii_map = R"(
+    A----B----C
+         |
+         D)";
+
+  const gurka::ways ways = {{"ABC", {{"highway", "primary"}, {"lanes", "4"}}},
+                            {"DB",
+                             {{"highway", "primary"},
+                              {"lanes:forward", "3"},
+                              {"lanes:backward", "0"},
+                              {"turn:lanes", "left|none|none"}}}};
+
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100);
+  auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_turn_lanes_1");
+
+  auto result = gurka::route(map, "D", "C", "auto");
+
+  gurka::assert::osrm::expect_steps(result, {"DB", "ABC"});
+  gurka::assert::raw::expect_path(result, {"DB", "ABC"});
+
+  gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
+                                                DirectionsLeg_Maneuver_Type_kRight,
+                                                DirectionsLeg_Maneuver_Type_kDestination});
+  gurka::assert::raw::expect_path_length(result, 0.7, 0.001);
+
+  auto maneuver = result.directions().routes(0).legs(0).maneuver(1);
+  EXPECT_EQ(maneuver.type(), DirectionsLeg_Maneuver_Type_kRight);
+
+  odin::EnhancedTripLeg etl(*result.mutable_trip()->mutable_routes(0)->mutable_legs(0));
+  auto prev_edge = etl.GetPrevEdge(maneuver.begin_path_index());
+
+  ASSERT_TRUE(prev_edge);
+  EXPECT_EQ(prev_edge->turn_lanes_size(), 3);
+  EXPECT_EQ(prev_edge->TurnLanesToString(), "[ left | through | through;right ACTIVE ]");
+}


### PR DESCRIPTION
# Issue

What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.
Previous approach for heading calculation had some drawbacks wich caused UB and made code more complex.
The suggestion is to calculate the incoming heading for the endnode of the edge from the shape of this edge

## Tasklist

 - [x] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
