### PR TITLE
fix(test::rand01): Ensures rand01 returns < 1.0

### DIFF
--- a/test/double_bucket_queue.cc
+++ b/test/double_bucket_queue.cc
@@ -147,8 +147,7 @@ void TrySimulation(DoubleBucketQueue& dbqueue,
       const auto newcost = std::floor(min_cost + 1 + test::rand01(gen) * max_increment_cost);
       if (i % 2 == 0 && !addedLabels.empty()) {
         // Decrease cost
-        const auto idx =
-            *std::next(addedLabels.begin(), test::rand01(gen) * (addedLabels.size() - 1));
+        const auto idx = *std::next(addedLabels.begin(), test::rand01(gen) * (addedLabels.size()));
         if (newcost < costs[idx]) {
           dbqueue.decrease(idx, newcost);
           costs[idx] = newcost;

--- a/test/test.h
+++ b/test/test.h
@@ -13,13 +13,13 @@
 
 namespace test {
 
-// Return a random number between 0 and 1
+// Return a random number inside [0, 1)
 inline float rand01(std::mt19937& gen) {
-  std::uniform_real_distribution<> dis(0, 1);
-  return static_cast<float>(dis(gen));
+  std::uniform_real_distribution<float> dis(0, 1);
+  return dis(gen);
 }
 
-inline std::string load_binary_file(const std::string filename) {
+inline std::string load_binary_file(const std::string& filename) {
   std::string bytes;
   std::ifstream input_pbf(filename, std::ios::in | std::ios::binary);
   if (input_pbf.is_open()) {


### PR DESCRIPTION
and reverts earlier workaround for rand01 sometimes returning 1.0
