### PR TITLE
install specific boost version on bionic

### DIFF
--- a/docker/install-shared-deps.sh
+++ b/docker/install-shared-deps.sh
@@ -8,6 +8,12 @@ apt-get update --assume-yes
 apt-get install --assume-yes software-properties-common
 add-apt-repository ppa:valhalla-core/valhalla
 
+# The latest version of boost in bionic has a regression we need to avoid
+boost_version=
+if [ $(grep -Fc bionic /etc/lsb-release) -gt 0 ]; then
+    boost_version="1.62"
+fi
+
 readonly primeserver_version=0.6.7
 
 # Now, go through and install the build dependencies
@@ -26,7 +32,7 @@ env DEBIAN_FRONTEND=noninteractive apt-get install --yes --quiet \
     git \
     jq \
     lcov \
-    libboost-all-dev \
+    libboost${boost_version}-all-dev \
     libcurl4-openssl-dev \
     libgeos++-dev \
     libgeos-dev \


### PR DESCRIPTION
there is some strange behavior with the latest boost that comes in bionic (1.65). good news is that it also comes with 1.62 so we install that. actually even on focal you get 1.68 (which is broken as welll) and 1.71 (which works fine). so whatever may be wrong there. good news is we have options :smile: 

ive already updated both the latest tags and the versioned tags in dockerhub in advance of merging this pr