### PR TITLE
dont check restrictions when there are none

### DIFF
--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -435,9 +435,9 @@ public:
                                    int& restriction_idx) const {
     // If this edge won't have a restruction for this mode of travel we are allowed
     if (edge->access_restriction() & auto_type) {
-      return true; 
+      return true;
     }
-    
+
     // There is 1 or more restrictions here so we need to find them
     const std::vector<baldr::AccessRestriction>& restrictions =
         tile->GetAccessRestrictions(edgeid.id(), auto_type);

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -426,21 +426,21 @@ public:
                                                   baldr::DateTime::get_tz_db().from_index(tz_index));
   }
 
-  inline bool EvaluateRestrictions(uint16_t auto_type,
+  inline bool EvaluateRestrictions(uint16_t mode,
                                    const baldr::DirectedEdge* edge,
                                    const baldr::GraphTile*& tile,
                                    const baldr::GraphId& edgeid,
                                    const uint64_t current_time,
                                    const uint32_t tz_index,
                                    int& restriction_idx) const {
-    // If this edge won't have a restruction for this mode of travel we are allowed
-    if (edge->access_restriction() & auto_type) {
+    // If this edge won't have a restriction for this mode of travel we are allowed
+    if (edge->access_restriction() & mode) {
       return true;
     }
 
     // There is 1 or more restrictions here so we need to find them
     const std::vector<baldr::AccessRestriction>& restrictions =
-        tile->GetAccessRestrictions(edgeid.id(), auto_type);
+        tile->GetAccessRestrictions(edgeid.id(), mode);
     bool time_allowed = false;
     for (int i = 0, n = static_cast<int>(restrictions.size()); i < n; ++i) {
       const auto& restriction = restrictions[i];


### PR DESCRIPTION
this is a slightly performance improvement to avoid looking at restriction information when we already know there shouldnt be any for your mode of travel. this has been a "bug" for a long time.

the previous code said, if there are any restrictions on this edge lets check for which ones match our mode. but we can shortcut this and quickly say, using the mask, whether or not there should be any restrictions for the mode we are interested it. this should mildly benefit routes on data that has a lot of restructions for modes of travel that arent subject to those restrictions