### PR TITLE
Save roundabout exit's begin bearing when combining it with enter maneuver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,7 @@
    * CHANGED: Speed up parseways stage by avoiding multiple string comparisons [#2518](https://github.com/valhalla/valhalla/pull/2518)
    * CHANGED: Speed up enhance stage by avoiding GraphTileBuilder copying [#2468](https://github.com/valhalla/valhalla/pull/2468)
    * CHANGED: Refactor mapmatching configuration to use a struct (instead of `boost::property_tree::ptree`). [#2485](https://github.com/valhalla/valhalla/pull/2485)
+   * ADDED: Save exit maneuver's begin heading when combining enter & exit roundabout maneuvers. [#2554](https://github.com/valhalla/valhalla/pull/2554)
 
 ## Release Date: 2019-11-21 Valhalla 3.0.9
 * **Bug Fix**

--- a/src/odin/maneuver.cc
+++ b/src/odin/maneuver.cc
@@ -119,7 +119,7 @@ Maneuver::Maneuver()
       bss_maneuver_type_(DirectionsLeg_Maneuver_BssManeuverType_kNoneAction),
       include_verbal_pre_transition_length_(false), contains_obvious_maneuver_(false),
       has_combined_enter_exit_roundabout_(false), roundabout_length_(0.0f),
-      roundabout_exit_length_(0.0f) {
+      roundabout_exit_length_(0.0f), roundabout_exit_begin_heading_(0) {
   street_names_ = std::make_unique<StreetNames>();
   begin_street_names_ = std::make_unique<StreetNames>();
   cross_street_names_ = std::make_unique<StreetNames>();
@@ -331,6 +331,14 @@ uint32_t Maneuver::end_heading() const {
 
 void Maneuver::set_end_heading(uint32_t endHeading) {
   end_heading_ = endHeading;
+}
+
+uint32_t Maneuver::roundabout_exit_begin_heading() const {
+  return roundabout_exit_begin_heading_;
+}
+
+void Maneuver::set_roundabout_exit_begin_heading(uint32_t beginHeading) {
+  roundabout_exit_begin_heading_ = beginHeading;
 }
 
 uint32_t Maneuver::begin_node_index() const {

--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -2560,6 +2560,11 @@ void ManeuversBuilder::ProcessRoundabouts(std::list<Maneuver>& maneuvers) {
           // Set the roundabout exit length
           curr_man->set_roundabout_exit_length(next_man->length());
 
+          // Store the next maneuver's begin heading. This can be used to
+          // calculate correct turn angles when exit roundabout maneuver is
+          // suppressed
+          curr_man->set_roundabout_exit_begin_heading(next_man->begin_heading());
+
           // Set the traversable_outbound_intersecting_edge booleans
           curr_man->set_has_left_traversable_outbound_intersecting_edge(
               next_man->has_left_traversable_outbound_intersecting_edge());

--- a/valhalla/odin/maneuver.h
+++ b/valhalla/odin/maneuver.h
@@ -101,6 +101,9 @@ public:
   uint32_t end_heading() const;
   void set_end_heading(uint32_t endHeading);
 
+  uint32_t roundabout_exit_begin_heading() const;
+  void set_roundabout_exit_begin_heading(uint32_t beginHeading);
+
   uint32_t begin_node_index() const;
   void set_begin_node_index(uint32_t beginNodeIndex);
 
@@ -355,6 +358,7 @@ protected:
   DirectionsLeg_Maneuver_CardinalDirection begin_cardinal_direction_;
   uint32_t begin_heading_;
   uint32_t end_heading_;
+  uint32_t roundabout_exit_begin_heading_;
   uint32_t begin_node_index_;
   uint32_t end_node_index_;
   uint32_t begin_shape_index_;


### PR DESCRIPTION
Store the begin bearing as a separate attribute of the combined
maneuver. This can be helpful for generating roundabout guidance
instructions.

Fixes #2548
