### PR TITLE
map matching uturn trimming fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
    * FIXED: Make single-thread tile building reproducible: fix seed for shuffle, use concurrency configuration from the mjolnir section. [#2515](https://github.com/valhalla/valhalla/pull/2515)
    * FIXED: Transcoding of c++ location to pbf location used path edges in the place of filtered edges. [#2542](https://github.com/valhalla/valhalla/pull/2542)
    * FIXED: Add back whitelisting action types. [#2545](https://github.com/valhalla/valhalla/pull/2545)
+   * FIXED: Map matching uturn trimming at the end of an edge where it wasn't needed. [#2558](https://github.com/valhalla/valhalla/pull/2558)
 
 * **Enhancement**
    * ADDED: Add explicit include for sstream to be compatible with msvc_x64 toolset. [#2449](https://github.com/valhalla/valhalla/pull/2449)

--- a/src/thor/route_action.cc
+++ b/src/thor/route_action.cc
@@ -75,7 +75,7 @@ void via_discontinuity(
     // Insert a second discontinuity so the next (opposing) edge is trimmed at the end from
     // 1-dist along to 1
     vias.insert({path_index + (flip_index ? 0 : 1),
-                 {{false, snap_ll, 1.0f - dist_along}, {true, PointLL(), 1.0f}}});
+                 {{true, snap_ll, 1.0f - dist_along}, {false, PointLL(), 1.0f}}});
   }
 }
 

--- a/test/gurka/test_match.cc
+++ b/test/gurka/test_match.cc
@@ -1,4 +1,6 @@
 #include "gurka.h"
+#include "midgard/encoded.h"
+#include "midgard/util.h"
 #include <gtest/gtest.h>
 
 using namespace valhalla;
@@ -105,4 +107,17 @@ D--3--4--C--5--6--E)";
 
   auto result =
       gurka::match(map, {"2", "6", "3"}, "via", "auto", R"({"penalize_immediate_uturn":false})");
+
+  auto shape =
+      midgard::decode<std::vector<midgard::PointLL>>(result.trip().routes(0).legs(0).shape());
+  // TODO: Remove the duplicate 6 when we fix odin to handle uturn maneuver generation with only one
+  // turn around point
+  auto expected_shape = decltype(shape){
+      map.nodes["2"], map.nodes["B"], map.nodes["C"], map.nodes["6"],
+      map.nodes["6"], map.nodes["C"], map.nodes["3"],
+  };
+  EXPECT_EQ(shape.size(), expected_shape.size());
+  for (int i = 0; i < shape.size(); ++i) {
+    EXPECT_TRUE(shape[i].ApproximatelyEqual(expected_shape[i]));
+  }
 }


### PR DESCRIPTION
when a uturn is detected in a map match we need to trim the edges shape where the uturn occurs. we recently fixed code that always set trimming information even when it wasnt needed. that fix assumed that the downstream code actually cared to whether or not that boolean telling it to trim was set. this was not the case..

this may fix #2552 