### PR TITLE
Uturns for Trucks as a Last Resort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
    * FIXED: Make single-thread tile building reproducible: fix seed for shuffle, use concurrency configuration from the mjolnir section. [#2515](https://github.com/valhalla/valhalla/pull/2515)
    * FIXED: Transcoding of c++ location to pbf location used path edges in the place of filtered edges. [#2542](https://github.com/valhalla/valhalla/pull/2542)
    * FIXED: Add back whitelisting action types. [#2545](https://github.com/valhalla/valhalla/pull/2545)
+   * FIXED: Allow uturns for truck costing now that we have derived deadends marked in the edge label [#2559](https://github.com/valhalla/valhalla/pull/2559)
 
 * **Enhancement**
    * ADDED: Add explicit include for sstream to be compatible with msvc_x64 toolset. [#2449](https://github.com/valhalla/valhalla/pull/2449)

--- a/src/sif/truckcost.cc
+++ b/src/sif/truckcost.cc
@@ -428,8 +428,8 @@ inline bool TruckCost::Allowed(const baldr::DirectedEdge* edge,
       return false;
   }
   // Check access, U-turn, and simple turn restriction.
-  // TODO - perhaps allow U-turns at dead-end nodes?
-  if (!(edge->forwardaccess() & kTruckAccess) || (pred.opp_local_idx() == edge->localedgeidx()) ||
+  if (!(edge->forwardaccess() & kTruckAccess) ||
+      (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
       (pred.restrictions() & (1 << edge->localedgeidx())) ||
       edge->surface() == Surface::kImpassable || IsUserAvoidEdge(edgeid) ||
       (!allow_destination_only_ && !pred.destonly() && edge->destonly())) {
@@ -455,8 +455,8 @@ bool TruckCost::AllowedReverse(const baldr::DirectedEdge* edge,
       return false;
   }
   // Check access, U-turn, and simple turn restriction.
-  // TODO - perhaps allow U-turns at dead-end nodes?
-  if (!(opp_edge->forwardaccess() & kTruckAccess) || (pred.opp_local_idx() == edge->localedgeidx()) ||
+  if (!(opp_edge->forwardaccess() & kTruckAccess) ||
+      (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
       (opp_edge->restrictions() & (1 << pred.opp_local_idx())) ||
       opp_edge->surface() == Surface::kImpassable || IsUserAvoidEdge(opp_edgeid) ||
       (!allow_destination_only_ && !pred.destonly() && opp_edge->destonly())) {

--- a/test/gurka/gurka.h
+++ b/test/gurka/gurka.h
@@ -186,12 +186,9 @@ build_valhalla_route_request(const map& map,
   speed_types.PushBack("constrained", allocator);
   speed_types.PushBack("predicted", allocator);
 
-  // add the options using the pointer method
-  for (const auto& kv : options) {
-    if (kv.first.find("/date_time/type") != std::string::npos && kv.second == "0") {
-      speed_types.PushBack("current", allocator);
-    }
-    rapidjson::Pointer(kv.first).Set(doc, kv.second);
+  auto found = options.find("/date_time/type");
+  if (found != options.cend() && found->second == "0") {
+    speed_types.PushBack("current", allocator);
   }
 
   doc.AddMember("locations", locations, allocator);
@@ -202,6 +199,11 @@ build_valhalla_route_request(const map& map,
   co.AddMember("speed_types", speed_types, allocator);
   costing_options.AddMember(rapidjson::Value(costing, allocator), co, allocator);
   doc.AddMember("costing_options", costing_options, allocator);
+
+  // we do this last so that options are additive/overwrite
+  for (const auto& kv : options) {
+    rapidjson::Pointer(kv.first).Set(doc, kv.second);
+  }
 
   rapidjson::StringBuffer sb;
   rapidjson::Writer<rapidjson::StringBuffer> writer(sb);

--- a/test/gurka/test_route.cc
+++ b/test/gurka/test_route.cc
@@ -1,0 +1,22 @@
+#include "gurka.h"
+#include <gtest/gtest.h>
+
+using namespace valhalla;
+
+/*************************************************************/
+TEST(Standalone, TruckRegression) {
+
+  const std::string ascii_map = R"(A---1---------------B--------2)";
+
+  const gurka::ways ways = {
+      {"AB", {{"highway", "service"}}},
+  };
+
+  const double gridsize = 10;
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, gridsize);
+  auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/truck_regression");
+  auto result = gurka::route(map, {"1", "2", "1"}, "truck", {{"/locations/1/type", "break_through"}});
+  // Annoyingly because its a node snap at a break through, it starts on AB ends a leg at the end of
+  // AB and then starts the next leg at the end of AB and then uturns and goes back on BA
+  gurka::assert::raw::expect_path(result, {"AB", "AB", "AB"});
+}


### PR DESCRIPTION
So a long time ago the data building pipeline would mark deadends.. maybe it still does, but we dont use them for the graph traversal algorithms anymore. Now we derive deadends via costings allowed method and we purposely allow uturns where there are derived (by way of costing rules) deadends for a given mode of travel. When we did this, we never turned it on for trucks, which can cause some strange stuff to happen in the case of multipoint routes. Specifically if you have a mutlipoint route and you set a type of `*through` for the midpoint. The router will do the first leg and then force the second leg to start on the edge you ended on (that is the defintion of `through`). In the case that the edge is a dead end, the route will fail for trucks beause they disallowed all uturns.

We've added a test with exactly the case above and enabled uturns for trucks in the case that costing has determined we've reached a deadend.