### PR TITLE
nit: Adds missing incident-string

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -172,7 +172,11 @@ set(valhalla_src
     ${valhalla_hdrs}
     ${libvalhalla_link_objects})
 
-set_source_files_properties(proto_conversions.cc PROPERTIES COMPILE_FLAGS "-Wall -Werror")
+if (UNIX)
+  # Enables stricter compiler checks on a file-by-file basis
+  # which allows us to migrate piecemeal
+  set_source_files_properties(proto_conversions.cc PROPERTIES COMPILE_FLAGS "-Wall -Werror")
+endif (UNIX)
 
 if (ENABLE_SERVICES)
   set(valhalla_hdrs ${valhalla_hdrs} ${VALHALLA_SOURCE_DIR}/valhalla/tile_server.h)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -172,6 +172,8 @@ set(valhalla_src
     ${valhalla_hdrs}
     ${libvalhalla_link_objects})
 
+set_source_files_properties(proto_conversions.cc PROPERTIES COMPILE_FLAGS "-Wall -Werror")
+
 if (ENABLE_SERVICES)
   set(valhalla_hdrs ${valhalla_hdrs} ${VALHALLA_SOURCE_DIR}/valhalla/tile_server.h)
   set(valhalla_src ${valhalla_src} tile_server.cc)

--- a/src/proto_conversions.cc
+++ b/src/proto_conversions.cc
@@ -6,6 +6,9 @@ namespace valhalla {
 
 std::string incidentTypeToString(const TripLeg_Node_Incident_Type& incident_type) {
   switch (incident_type) {
+    case TripLeg_Node_Incident_Type_NOT_SET:
+      return "not_set";
+      break;
     case TripLeg_Node_Incident_Type_ACCIDENT:
       return "accident";
       break;


### PR DESCRIPTION
How I miss that we don't use `-Wall` and `-Werror`.