### PR TITLE
Ensure edge.is_urban is set for serializing is_urban

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@
    * CHANGED: Refactor mapmatching configuration to use a struct (instead of `boost::property_tree::ptree`). [#2485](https://github.com/valhalla/valhalla/pull/2485)
    * ADDED: Save exit maneuver's begin heading when combining enter & exit roundabout maneuvers. [#2554](https://github.com/valhalla/valhalla/pull/2554)
    * ADDED: Added new urban flag that can be set if edge is within city boundaries to data processing; new use_urban_tag config option; added to osrm response within intersections. [#2522](https://github.com/valhalla/valhalla/pull/2522)
+   * ADDED: Use edge.is_urban is set for serializing is_urban. [#2568](https://github.com/valhalla/valhalla/pull/2568)
 
 ## Release Date: 2019-11-21 Valhalla 3.0.9
 * **Bug Fix**

--- a/proto/trip.proto
+++ b/proto/trip.proto
@@ -226,6 +226,7 @@ message TripLeg {
     optional float default_speed = 44;       // km/h
     optional Restriction restriction = 45;
     optional bool destination_only = 46;
+    optional bool is_urban = 47; // uses edge density to decide if edge is in an urban area
   }
 
   message IntersectingEdge {

--- a/src/thor/attributes_controller.cc
+++ b/src/thor/attributes_controller.cc
@@ -72,9 +72,10 @@ const std::unordered_map<std::string, bool> AttributesController::kDefaultAttrib
     {kEdgeTruckRoute, true},
     {kEdgeDefaultSpeed, true},
     {kEdgeDestinationOnly, true},
-    {kNodeIncidents, false},
+    {kEdgeIsUrban, false},
 
     // Node keys
+    {kNodeIncidents, false},
     {kNodeIntersectingEdgeBeginHeading, true},
     {kNodeIntersectingEdgeFromEdgeNameConsistency, true},
     {kNodeIntersectingEdgeToEdgeNameConsistency, true},

--- a/src/thor/triplegbuilder.cc
+++ b/src/thor/triplegbuilder.cc
@@ -758,6 +758,11 @@ TripLeg_Edge* AddTripEdge(const AttributesController& controller,
     trip_edge->set_density(directededge->density());
   }
 
+  if (controller.attributes.at(kEdgeIsUrban)) {
+    bool is_urban = (directededge->density() > 8) ? true : false;
+    trip_edge->set_is_urban(is_urban);
+  }
+
   if (controller.attributes.at(kEdgeSpeedLimit)) {
     trip_edge->set_speed_limit(edgeinfo.speed_limit());
   }

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -394,9 +394,8 @@ json::ArrayPtr intersections(const valhalla::DirectionsLeg::Maneuver& maneuver,
     intersection->emplace("location", loc);
     intersection->emplace("geometry_index", static_cast<uint64_t>(shape_index));
     if (!arrive_maneuver) {
-      if (curr_edge->has_density()) {
-        bool is_urban = (curr_edge->density() > 8) ? true : false;
-        intersection->emplace("is_urban", is_urban);
+      if (curr_edge->has_is_urban()) {
+        intersection->emplace("is_urban", curr_edge->is_urban());
       }
     }
     if (node->cost().transition_cost().seconds() > 0)

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -394,8 +394,10 @@ json::ArrayPtr intersections(const valhalla::DirectionsLeg::Maneuver& maneuver,
     intersection->emplace("location", loc);
     intersection->emplace("geometry_index", static_cast<uint64_t>(shape_index));
     if (!arrive_maneuver) {
-      bool is_urban = (curr_edge->density() > 8) ? true : false;
-      intersection->emplace("is_urban", is_urban);
+      if (curr_edge->has_density()) {
+        bool is_urban = (curr_edge->density() > 8) ? true : false;
+        intersection->emplace("is_urban", is_urban);
+      }
     }
     if (node->cost().transition_cost().seconds() > 0)
       intersection->emplace("turn_duration", json::fp_t{node->cost().transition_cost().seconds(), 3});

--- a/test/urban.cc
+++ b/test/urban.cc
@@ -96,7 +96,6 @@ TEST(Urban2, test_urban) {
   auto json_str = serializeDirections(response);
   rapidjson::Document json;
   json.Parse(json_str);
-  std::cout << "json :: " << json_str << std::endl;
 
   ASSERT_FALSE(json.HasParseError());
 
@@ -126,7 +125,6 @@ TEST(Urban2, test_urban_excluded_by_default) {
   auto json_str = serializeDirections(response);
   rapidjson::Document json;
   json.Parse(json_str);
-  std::cout << "json :: " << json_str << std::endl;
 
   ASSERT_FALSE(json.HasParseError());
 

--- a/test/urban.cc
+++ b/test/urban.cc
@@ -115,6 +115,34 @@ TEST(Urban2, test_density) {
   }
 }
 
+TEST(Urban2, test_density_excluded) {
+  bool is_urban;
+  route_tester tester;
+  std::string request =
+      R"({"locations":[{"lat":52.10160225589803,"lon":5.116925239562988},{"lat":52.09403591712907,"lon":5.113234519958496}],"costing":"auto","units":"miles","format":"osrm","filters":{"action":"exclude","attributes":["edge.density"]}})";
+  auto response = tester.test(request);
+
+  // get the osrm json
+  auto json_str = serializeDirections(response);
+  rapidjson::Document json;
+  json.Parse(json_str);
+  std::cout << "json :: " << json_str << std::endl;
+
+  ASSERT_FALSE(json.HasParseError());
+
+  // loop over all routes all legs
+  for (const auto& route : json["routes"].GetArray()) {
+    for (const auto& leg : route["legs"].GetArray()) {
+      for (const auto& step : leg["steps"].GetArray()) {
+        for (const auto& intersection : step["intersections"].GetArray()) {
+          EXPECT_EQ(intersection.HasMember("is_urban"), false);
+        }
+        EXPECT_EQ(is_urban, true);
+      }
+    }
+  }
+}
+
 } // namespace
 
 int main(int argc, char* argv[]) {

--- a/test/urban.cc
+++ b/test/urban.cc
@@ -115,7 +115,6 @@ TEST(Urban2, test_urban) {
 }
 
 TEST(Urban2, test_urban_excluded_by_default) {
-  bool is_urban;
   route_tester tester;
   std::string request =
       R"({"locations":[{"lat":52.10160225589803,"lon":5.116925239562988},{"lat":52.09403591712907,"lon":5.113234519958496}],"costing":"auto","units":"miles","format":"osrm"})";

--- a/test/urban.cc
+++ b/test/urban.cc
@@ -85,11 +85,11 @@ struct route_tester {
 };
 
 // http://localhost:8002/route?json={"locations":[{"lat":52.10160225589803,"lon":5.116925239562988},{"lat":52.09403591712907,"lon":5.113234519958496}],"costing":"auto","directions_options":{"units":"miles","format":"osrm"}}&access_token=
-TEST(Urban2, test_density) {
+TEST(Urban2, test_urban) {
   bool is_urban;
   route_tester tester;
   std::string request =
-      R"({"locations":[{"lat":52.10160225589803,"lon":5.116925239562988},{"lat":52.09403591712907,"lon":5.113234519958496}],"costing":"auto","directions_options":{"units":"miles","format":"osrm"}})";
+      R"({"locations":[{"lat":52.10160225589803,"lon":5.116925239562988},{"lat":52.09403591712907,"lon":5.113234519958496}],"costing":"auto","units":"miles","format":"osrm","filters":{"action":"include","attributes":["edge.is_urban"]}})";
   auto response = tester.test(request);
 
   // get the osrm json
@@ -115,11 +115,11 @@ TEST(Urban2, test_density) {
   }
 }
 
-TEST(Urban2, test_density_excluded) {
+TEST(Urban2, test_urban_excluded_by_default) {
   bool is_urban;
   route_tester tester;
   std::string request =
-      R"({"locations":[{"lat":52.10160225589803,"lon":5.116925239562988},{"lat":52.09403591712907,"lon":5.113234519958496}],"costing":"auto","units":"miles","format":"osrm","filters":{"action":"exclude","attributes":["edge.density"]}})";
+      R"({"locations":[{"lat":52.10160225589803,"lon":5.116925239562988},{"lat":52.09403591712907,"lon":5.113234519958496}],"costing":"auto","units":"miles","format":"osrm"})";
   auto response = tester.test(request);
 
   // get the osrm json

--- a/test/urban.cc
+++ b/test/urban.cc
@@ -106,9 +106,9 @@ TEST(Urban2, test_urban) {
         for (const auto& intersection : step["intersections"].GetArray()) {
           if (intersection.HasMember("is_urban")) {
             is_urban = intersection["is_urban"].GetBool();
+            EXPECT_EQ(is_urban, true);
           }
         }
-        EXPECT_EQ(is_urban, true);
       }
     }
   }
@@ -135,7 +135,6 @@ TEST(Urban2, test_urban_excluded_by_default) {
         for (const auto& intersection : step["intersections"].GetArray()) {
           EXPECT_EQ(intersection.HasMember("is_urban"), false);
         }
-        EXPECT_EQ(is_urban, true);
       }
     }
   }

--- a/valhalla/odin/enhancedtrippath.h
+++ b/valhalla/odin/enhancedtrippath.h
@@ -347,8 +347,12 @@ public:
     return mutable_edge_->destination_only();
   }
 
-  bool has_density() const {
-    return mutable_edge_->has_density();
+  bool has_is_urban() const {
+    return mutable_edge_->has_is_urban();
+  }
+
+  bool is_urban() const {
+    return mutable_edge_->is_urban();
   }
 
   bool IsUnnamed() const;

--- a/valhalla/odin/enhancedtrippath.h
+++ b/valhalla/odin/enhancedtrippath.h
@@ -347,6 +347,10 @@ public:
     return mutable_edge_->destination_only();
   }
 
+  bool has_density() const {
+    return mutable_edge_->has_density();
+  }
+
   bool IsUnnamed() const;
 
   // Use

--- a/valhalla/thor/attributes_controller.h
+++ b/valhalla/thor/attributes_controller.h
@@ -69,6 +69,7 @@ const std::string kEdgeTruckSpeed = "edge.truck_speed";
 const std::string kEdgeTruckRoute = "edge.truck_route";
 const std::string kEdgeDefaultSpeed = "edge.default_speed";
 const std::string kEdgeDestinationOnly = "edge.destination_only";
+const std::string kEdgeIsUrban = "edge.is_urban";
 
 // Node keys
 const std::string kNodeIntersectingEdgeBeginHeading = "node.intersecting_edge.begin_heading";


### PR DESCRIPTION
# Issue

#2522 introduced a new is_urban flag to the osrm response, which uses the edge's `density` field to infer whether a road is considered to be urban or not. However, as it's an optional field, in the serializer we should be checking `edge.has_density` to ensure it has been populated before adding it to the response.

This also allows excluding is_urban flag from the response if you don't want it, by setting the exclude filter attribute for edge.density.
 

## Tasklist

 - [x] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
