### PR TITLE
Set conccurency = 1 to avoid bad_alloc

### DIFF
--- a/test/graphbuilder.cc
+++ b/test/graphbuilder.cc
@@ -48,8 +48,8 @@ const std::string ways_file = "test_ways_harrisburg.bin";
 // build tiles step that follows.
 TEST(GraphBuilder, TestConstructEdges) {
   ptree config;
-  config.put<std::string>("mjolnir.tile_dir", tile_dir);
-  config.put<size_t>("mjolnir.id_table_size", id_table_size);
+  config.put("mjolnir.tile_dir", tile_dir);
+  config.put("mjolnir.concurrency", 1);
   OSMData osm_data{0};
   osm_data.read_from_temp_files(tile_dir);
   std::map<baldr::GraphId, size_t> tiles =
@@ -73,7 +73,7 @@ TEST(GraphBuilder, TestConstructEdges) {
 TEST(graphbuilder, TestConstructEdgesSubset) {
   ptree config;
   config.put<std::string>("mjolnir.tile_dir", tile_dir);
-  config.put<size_t>("mjolnir.id_table_size", id_table_size);
+  config.put("mjolnir.concurrency", 1);
   OSMData osm_data{0};
   osm_data.read_from_temp_files(tile_dir);
   std::map<baldr::GraphId, size_t> tiles =


### PR DESCRIPTION
# Issue

What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.

Construct edges used all 36 cores and caused memory issues

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
