### PR TITLE
Support restricted class in intersection annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,7 @@
    * ADDED: Added flexibility to remove the use of the admindb and to use the country and state iso from the tiles; [#2579](https://github.com/valhalla/valhalla/pull/2579)
    * ADDED: Added toll gates and collection points (gantry) to the node;  [#2532](https://github.com/valhalla/valhalla/pull/2532)
    * ADDED: Added osrm serialization for rest/service areas and admins. [#2594](https://github.com/valhalla/valhalla/pull/2594)
+   * ADDED: Support restricted class in intersection annotations [#2589](https://github.com/valhalla/valhalla/pull/2589)
 
 ## Release Date: 2019-11-21 Valhalla 3.0.9
 * **Bug Fix**

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -563,10 +563,9 @@ json::ArrayPtr intersections(const valhalla::DirectionsLeg::Maneuver& maneuver,
         classes.push_back("ferry");
       }
 
-      /** TODO
-      if ( ) {
+      if (curr_edge->destination_only()) {
         classes.push_back("restricted");
-      } */
+      }
       if (classes.size() > 0) {
         auto class_list = json::array({});
         for (const auto& cl : classes) {

--- a/test/gurka/test_restricted_area.cc
+++ b/test/gurka/test_restricted_area.cc
@@ -1,0 +1,52 @@
+#include "gurka.h"
+
+#include <gtest/gtest.h>
+
+using namespace valhalla;
+
+namespace {
+
+class IntersectionTest : public ::testing::Test {
+protected:
+  static gurka::map map;
+
+  static void SetUpTestSuite() {
+    const std::string ascii_map = R"(
+          X
+          |
+      A---B---C---D
+              |
+              Y
+    )";
+    const gurka::ways ways = {
+        {"AB", {{"highway", "primary"}}},  {"BC", {{"highway", "primary"}, {"access", "private"}}},
+        {"CD", {{"highway", "primary"}}},  {"BX", {{"highway", "motorway"}}},
+        {"CY", {{"highway", "motorway"}}},
+    };
+
+    const auto layout = gurka::detail::map_to_coordinates(ascii_map, 10);
+    map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_intersections_class_restricted");
+  }
+};
+
+gurka::map IntersectionTest::map = {};
+
+TEST_F(IntersectionTest, RestrictedClass) {
+  std::string from = "A", to = "Y";
+  valhalla::Api raw_result = gurka::route(map, "A", "Y", "auto");
+  // Convert raw api response OSRM formatted JSON
+  rapidjson::Document response = gurka::convert_to_json(raw_result, valhalla::Options_Format_osrm);
+
+  auto steps = response["routes"][0]["legs"][0]["steps"].GetArray();
+  // First step, should have 2 intersections, with the second onehaving a
+  // single "restricted" class
+  // restricted
+  ASSERT_EQ(steps[0]["intersections"].Size(), 2);
+  EXPECT_EQ(steps[0]["intersections"][1]["classes"][0].GetString(), std::string("restricted"));
+
+  // Intersection on last step should have the motoroway class
+  ASSERT_EQ(steps[1]["intersections"].Size(), 1);
+  EXPECT_EQ(steps[1]["intersections"][0]["classes"][0].GetString(), std::string("motorway"));
+}
+
+} // namespace

--- a/test/gurka/test_restricted_area.cc
+++ b/test/gurka/test_restricted_area.cc
@@ -6,47 +6,89 @@ using namespace valhalla;
 
 namespace {
 
-class IntersectionTest : public ::testing::Test {
+class RestrictedTest : public ::testing::Test {
 protected:
   static gurka::map map;
 
   static void SetUpTestSuite() {
     const std::string ascii_map = R"(
-          X
-          |
-      A---B---C---D
-              |
-              Y
+          H       I       J
+          |       |       |
+      A---B---C---D---E---F---G
+              |       |
+              K       L
     )";
-    const gurka::ways ways = {
-        {"AB", {{"highway", "primary"}}},  {"BC", {{"highway", "primary"}, {"access", "private"}}},
-        {"CD", {{"highway", "primary"}}},  {"BX", {{"highway", "motorway"}}},
-        {"CY", {{"highway", "motorway"}}},
-    };
+    const gurka::ways ways = {{"AB", {{"highway", "primary"}}},
+                              {"BC", {{"highway", "primary"}, {"access", "private"}}},
+                              {"CD", {{"highway", "primary"}}},
+                              {"DE", {{"highway", "primary"}}},
+                              {"EF", {{"highway", "primary"}}},
+                              {"FG", {{"highway", "primary"}}},
+                              {"CK", {{"highway", "motorway"}}},
+                              {"DI", {{"highway", "primary"}, {"access", "delivery"}}},
+                              {"EL", {{"highway", "primary"}, {"access", "destination"}}},
+                              {"FJ", {{"highway", "primary"}, {"access", "customers"}}}};
 
     const auto layout = gurka::detail::map_to_coordinates(ascii_map, 10);
     map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_intersections_class_restricted");
   }
 };
 
-gurka::map IntersectionTest::map = {};
+gurka::map RestrictedTest::map = {};
 
-TEST_F(IntersectionTest, RestrictedClass) {
-  std::string from = "A", to = "Y";
-  valhalla::Api raw_result = gurka::route(map, "A", "Y", "auto");
+TEST_F(RestrictedTest, AccessPrivate) {
+  valhalla::Api raw_result = gurka::route(map, "A", "K", "auto");
   // Convert raw api response OSRM formatted JSON
   rapidjson::Document response = gurka::convert_to_json(raw_result, valhalla::Options_Format_osrm);
 
   auto steps = response["routes"][0]["legs"][0]["steps"].GetArray();
-  // First step, should have 2 intersections, with the second onehaving a
+  // First step, should have 2 intersections, with the second one having a
   // single "restricted" class
-  // restricted
   ASSERT_EQ(steps[0]["intersections"].Size(), 2);
   EXPECT_EQ(steps[0]["intersections"][1]["classes"][0].GetString(), std::string("restricted"));
 
   // Intersection on last step should have the motoroway class
   ASSERT_EQ(steps[1]["intersections"].Size(), 1);
   EXPECT_EQ(steps[1]["intersections"][0]["classes"][0].GetString(), std::string("motorway"));
+}
+
+TEST_F(RestrictedTest, AccessDelivery) {
+  valhalla::Api raw_result = gurka::route(map, "C", "I", "auto");
+  // Convert raw api response OSRM formatted JSON
+  rapidjson::Document response = gurka::convert_to_json(raw_result, valhalla::Options_Format_osrm);
+
+  auto steps = response["routes"][0]["legs"][0]["steps"].GetArray();
+  ASSERT_EQ(steps[0]["intersections"].Size(), 1);
+  EXPECT_FALSE(steps[0]["intersections"][0].HasMember("classes"));
+
+  ASSERT_EQ(steps[1]["intersections"].Size(), 1);
+  EXPECT_EQ(steps[1]["intersections"][0]["classes"][0].GetString(), std::string("restricted"));
+}
+
+TEST_F(RestrictedTest, AccessDestination) {
+  valhalla::Api raw_result = gurka::route(map, "D", "L", "auto");
+  // Convert raw api response OSRM formatted JSON
+  rapidjson::Document response = gurka::convert_to_json(raw_result, valhalla::Options_Format_osrm);
+
+  auto steps = response["routes"][0]["legs"][0]["steps"].GetArray();
+  ASSERT_EQ(steps[0]["intersections"].Size(), 1);
+  EXPECT_FALSE(steps[0]["intersections"][0].HasMember("classes"));
+
+  ASSERT_EQ(steps[1]["intersections"].Size(), 1);
+  EXPECT_EQ(steps[1]["intersections"][0]["classes"][0].GetString(), std::string("restricted"));
+}
+
+TEST_F(RestrictedTest, AccessCustomers) {
+  valhalla::Api raw_result = gurka::route(map, "E", "J", "auto");
+  // Convert raw api response OSRM formatted JSON
+  rapidjson::Document response = gurka::convert_to_json(raw_result, valhalla::Options_Format_osrm);
+
+  auto steps = response["routes"][0]["legs"][0]["steps"].GetArray();
+  ASSERT_EQ(steps[0]["intersections"].Size(), 1);
+  EXPECT_FALSE(steps[0]["intersections"][0].HasMember("classes"));
+
+  ASSERT_EQ(steps[1]["intersections"].Size(), 1);
+  EXPECT_EQ(steps[1]["intersections"][0]["classes"][0].GetString(), std::string("restricted"));
 }
 
 } // namespace


### PR DESCRIPTION
Added support for restricted road class in intersection annotations.
Fixes #2588
