### PR TITLE
Remove superfluous const qualifier from function return signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Release Date: 2020-08-?? Valhalla 3.1.0
 * **Removed**
-   * REMOVED:  Remove Node bindings. [#2502](https://github.com/valhalla/valhalla/pull/2502)
+   * REMOVED: Remove Node bindings. [#2502](https://github.com/valhalla/valhalla/pull/2502)
    * REMOVED: appveyor builds. [#2544](https://github.com/valhalla/valhalla/issues/2544)
 
 * **Bug Fix**
@@ -85,6 +85,7 @@
    * FIXED: Multicue enter roundabout [#2556](https://github.com/valhalla/valhalla/pull/2556)
    * FIXED: Changed reachability computation to take into account live speed [#2597](https://github.com/valhalla/valhalla/pull/2597)
    * FIXED: Fixed a bug where the temp files were not getting read in if you started with the construct edges or build phase for valhalla_build_tiles. [#2601](https://github.com/valhalla/valhalla/pull/2601)
+   * FIXED: Removed superfluous const qualifier from odin/signs [#2609](https://github.com/valhalla/valhalla/pull/2609)
 
 * **Enhancement**
    * ADDED: Add ability to provide custom implementation for candidate collection in CandidateQuery. [#2328](https://github.com/valhalla/valhalla/pull/2328)

--- a/src/odin/signs.cc
+++ b/src/odin/signs.cc
@@ -114,10 +114,10 @@ std::vector<Sign>* Signs::mutable_guide_branch_list() {
   return &guide_branch_list_;
 }
 
-const std::string Signs::GetGuideBranchString(uint32_t max_count,
-                                              bool limit_by_consecutive_count,
-                                              const std::string& delim,
-                                              const VerbalTextFormatter* verbal_formatter) const {
+std::string Signs::GetGuideBranchString(uint32_t max_count,
+                                        bool limit_by_consecutive_count,
+                                        const std::string& delim,
+                                        const VerbalTextFormatter* verbal_formatter) const {
   return ListToString(guide_branch_list_, max_count, limit_by_consecutive_count, delim,
                       verbal_formatter);
 }
@@ -130,10 +130,10 @@ std::vector<Sign>* Signs::mutable_guide_toward_list() {
   return &guide_toward_list_;
 }
 
-const std::string Signs::GetGuideTowardString(uint32_t max_count,
-                                              bool limit_by_consecutive_count,
-                                              const std::string& delim,
-                                              const VerbalTextFormatter* verbal_formatter) const {
+std::string Signs::GetGuideTowardString(uint32_t max_count,
+                                        bool limit_by_consecutive_count,
+                                        const std::string& delim,
+                                        const VerbalTextFormatter* verbal_formatter) const {
   return ListToString(guide_toward_list_, max_count, limit_by_consecutive_count, delim,
                       verbal_formatter);
 }
@@ -175,10 +175,10 @@ std::vector<Sign> Signs::GetGuideSigns(uint32_t max_count, bool limit_by_consecu
   return {};
 }
 
-const std::string Signs::GetGuideString(uint32_t max_count,
-                                        bool limit_by_consecutive_count,
-                                        const std::string& delim,
-                                        const VerbalTextFormatter* verbal_formatter) const {
+std::string Signs::GetGuideString(uint32_t max_count,
+                                  bool limit_by_consecutive_count,
+                                  const std::string& delim,
+                                  const VerbalTextFormatter* verbal_formatter) const {
   std::string guide_string;
   // If both branch and toward exist
   // and either unlimited max count or max count is greater than 1
@@ -212,10 +212,10 @@ std::vector<Sign>* Signs::mutable_junction_name_list() {
   return &junction_name_list_;
 }
 
-const std::string Signs::GetJunctionNameString(uint32_t max_count,
-                                               bool limit_by_consecutive_count,
-                                               const std::string& delim,
-                                               const VerbalTextFormatter* verbal_formatter) const {
+std::string Signs::GetJunctionNameString(uint32_t max_count,
+                                         bool limit_by_consecutive_count,
+                                         const std::string& delim,
+                                         const VerbalTextFormatter* verbal_formatter) const {
   return ListToString(junction_name_list_, max_count, limit_by_consecutive_count, delim,
                       verbal_formatter);
 }

--- a/valhalla/odin/signs.h
+++ b/valhalla/odin/signs.h
@@ -63,23 +63,23 @@ public:
   const std::vector<Sign>& guide_branch_list() const;
   std::vector<Sign>* mutable_guide_branch_list();
 
-  const std::string GetGuideBranchString(uint32_t max_count = 0,
-                                         bool limit_by_consecutive_count = false,
-                                         const std::string& delim = "/",
-                                         const VerbalTextFormatter* verbal_formatter = nullptr) const;
+  std::string GetGuideBranchString(uint32_t max_count = 0,
+                                   bool limit_by_consecutive_count = false,
+                                   const std::string& delim = "/",
+                                   const VerbalTextFormatter* verbal_formatter = nullptr) const;
 
   const std::vector<Sign>& guide_toward_list() const;
   std::vector<Sign>* mutable_guide_toward_list();
 
-  const std::string GetGuideTowardString(uint32_t max_count = 0,
-                                         bool limit_by_consecutive_count = false,
-                                         const std::string& delim = "/",
-                                         const VerbalTextFormatter* verbal_formatter = nullptr) const;
-
-  const std::string GetGuideString(uint32_t max_count = 0,
+  std::string GetGuideTowardString(uint32_t max_count = 0,
                                    bool limit_by_consecutive_count = false,
                                    const std::string& delim = "/",
                                    const VerbalTextFormatter* verbal_formatter = nullptr) const;
+
+  std::string GetGuideString(uint32_t max_count = 0,
+                             bool limit_by_consecutive_count = false,
+                             const std::string& delim = "/",
+                             const VerbalTextFormatter* verbal_formatter = nullptr) const;
 
   std::vector<Sign> GetGuideSigns(uint32_t max_count = 0,
                                   bool limit_by_consecutive_count = false) const;
@@ -87,11 +87,10 @@ public:
   const std::vector<Sign>& junction_name_list() const;
   std::vector<Sign>* mutable_junction_name_list();
 
-  const std::string
-  GetJunctionNameString(uint32_t max_count = 0,
-                        bool limit_by_consecutive_count = false,
-                        const std::string& delim = "/",
-                        const VerbalTextFormatter* verbal_formatter = nullptr) const;
+  std::string GetJunctionNameString(uint32_t max_count = 0,
+                                    bool limit_by_consecutive_count = false,
+                                    const std::string& delim = "/",
+                                    const VerbalTextFormatter* verbal_formatter = nullptr) const;
 
   bool HasExit() const;
   bool HasExitNumber() const;


### PR DESCRIPTION
Returning by const-value prevents rvalue moves (C++11 and higher), which
can degrade performance, and offer almost no benefit. Removed few
instances of it from odin/signs module.

Fixes #2387 