### PR TITLE
Add Incidents to TripLeg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,7 @@
    * ADDED: Support restricted class in intersection annotations [#2589](https://github.com/valhalla/valhalla/pull/2589)
    * ADDED: Added trail type trace [#2606](https://github.com/valhalla/valhalla/pull/2606)
    * ADDED: Added tunnel names to the edges as a tagged name.  [#2608](https://github.com/valhalla/valhalla/pull/2608)
+   * CHANGED: Moved incidents to the trip leg and cut the shape of the leg at that location [#2610](https://github.com/valhalla/valhalla/pull/2610)
 
 ## Release Date: 2019-11-21 Valhalla 3.0.9
 * **Bug Fix**

--- a/proto/trip.proto
+++ b/proto/trip.proto
@@ -287,31 +287,6 @@ message TripLeg {
     optional PathCost cost = 12;             // how much cost did it take at this node in the path
     repeated PathCost recosts = 13;          // how much cost did it take at this node in the path for optional recostings
     optional BikeShareStationInfo bss_info = 14;
-
-    message Incident {
-      enum Type {
-        NOT_SET = 0;
-        ACCIDENT = 1;
-        CONGESTION = 2;
-        CONSTRUCTION = 3;
-        DISABLED_VEHICLE = 4;
-        LANE_RESTRICTION = 5;
-        MASS_TRANSIT = 6;
-        MISCELLANEOUS = 7;
-        OTHER_NEWS = 8;
-        PLANNED_EVENT = 9;
-        ROAD_CLOSURE = 10;
-        ROAD_HAZARD = 11;
-        WEATHER = 12;
-      };
-      optional Type type = 1;
-      optional string description = 2;
-      optional uint64 start_time = 3;     // START_TIME as seconds since epoch UTC
-      optional uint64 end_time = 4;       // END_TIME seconds since epoch UTC
-      optional uint64 creation_time = 5;  // time the incident was created/updated in seconds since epoch UTC
-      optional uint64 id = 6;             // An id that can be used for joining incidents in route with map
-    };
-    repeated Incident incidents = 15;
  }
 
   message Admin {
@@ -327,6 +302,32 @@ message TripLeg {
     repeated uint32 speed = 3 [packed=true]; // decimeters per sec
   }
 
+  message Incident {
+    enum Type {
+      NOT_SET = 0;
+      ACCIDENT = 1;
+      CONGESTION = 2;
+      CONSTRUCTION = 3;
+      DISABLED_VEHICLE = 4;
+      LANE_RESTRICTION = 5;
+      MASS_TRANSIT = 6;
+      MISCELLANEOUS = 7;
+      OTHER_NEWS = 8;
+      PLANNED_EVENT = 9;
+      ROAD_CLOSURE = 10;
+      ROAD_HAZARD = 11;
+      WEATHER = 12;
+    };
+    optional Type type = 1;
+    optional string description = 2;
+    optional uint64 start_time = 3;     // START_TIME as seconds since epoch UTC
+    optional uint64 end_time = 4;       // END_TIME seconds since epoch UTC
+    optional uint64 creation_time = 5;  // time the incident was created/updated in seconds since epoch UTC
+    optional uint64 id = 6;             // An id that can be used for joining incidents in route with map
+    optional uint32 begin_shape_index = 7;
+    optional uint32 end_shape_index = 8;
+  };
+
   optional uint64 osm_changeset = 1;
   optional uint64 trip_id = 2;
   optional uint32 leg_id = 3;
@@ -337,6 +338,7 @@ message TripLeg {
   optional string shape = 8;
   optional BoundingBox bbox = 9;
   optional ShapeAttributes shape_attributes = 10;
+  repeated Incident incidents = 11;
 }
 
 message TripRoute {

--- a/proto/trip.proto
+++ b/proto/trip.proto
@@ -231,6 +231,10 @@ message TripLeg {
     optional Restriction restriction = 45;
     optional bool destination_only = 46;
     optional bool is_urban = 47; // uses edge density to decide if edge is in an urban area
+    // for the part of the edge that is used in the path we must know where
+    // it starts and ends along the length of the edge as a percentage
+    optional float source_along_edge = 48;
+    optional float target_along_edge = 49;
   }
 
   message IntersectingEdge {

--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -346,7 +346,8 @@ GraphReader::GraphReader(const boost::property_tree::ptree& pt,
     : tile_extract_(get_extract_instance(pt)), tile_dir_(pt.get<std::string>("tile_dir", "")),
       tile_getter_(std::move(tile_getter)),
       max_concurrent_users_(pt.get<size_t>("max_concurrent_reader_users", 1)),
-      tile_url_(pt.get<std::string>("tile_url", "")), cache_(TileCacheFactory::createTileCache(pt)) {
+      tile_url_(pt.get<std::string>("tile_url", "")), cache_(TileCacheFactory::createTileCache(pt)),
+      simulate_incidents_(pt.get<bool>("simulate_incidents", 0)) {
   if (!tile_getter_ && !tile_url_.empty()) {
     tile_getter_ = std::make_unique<curl_tile_getter_t>(max_concurrent_users_,
                                                         pt.get<std::string>("user_agent", ""),

--- a/src/odin/enhancedtrippath.cc
+++ b/src/odin/enhancedtrippath.cc
@@ -1776,16 +1776,5 @@ std::string EnhancedTripLeg_Admin::ToString() const {
   return str;
 }
 
-const google::protobuf::RepeatedPtrField<valhalla::TripLeg_Node_Incident> empty;
-
-const google::protobuf::RepeatedPtrField<valhalla::TripLeg_Node_Incident>&
-EnhancedTripLeg_Node::incidents() const {
-  if (mutable_node_) {
-    return mutable_node_->incidents();
-  } else {
-    return empty;
-  }
-}
-
 } // namespace odin
 } // namespace valhalla

--- a/src/proto_conversions.cc
+++ b/src/proto_conversions.cc
@@ -4,45 +4,45 @@ using namespace valhalla;
 
 namespace valhalla {
 
-std::string incidentTypeToString(const TripLeg_Node_Incident_Type& incident_type) {
+std::string incidentTypeToString(const TripLeg::Incident::Type& incident_type) {
   switch (incident_type) {
-    case TripLeg_Node_Incident_Type_NOT_SET:
+    case TripLeg::Incident::NOT_SET:
       return "not_set";
       break;
-    case TripLeg_Node_Incident_Type_ACCIDENT:
+    case TripLeg::Incident::ACCIDENT:
       return "accident";
       break;
-    case TripLeg_Node_Incident_Type_CONGESTION:
+    case TripLeg::Incident::CONGESTION:
       return "congestion";
       break;
-    case TripLeg_Node_Incident_Type_CONSTRUCTION:
+    case TripLeg::Incident::CONSTRUCTION:
       return "construction";
       break;
-    case TripLeg_Node_Incident_Type_DISABLED_VEHICLE:
+    case TripLeg::Incident::DISABLED_VEHICLE:
       return "disabled_vehicle";
       break;
-    case TripLeg_Node_Incident_Type_LANE_RESTRICTION:
+    case TripLeg::Incident::LANE_RESTRICTION:
       return "lane_restriction";
       break;
-    case TripLeg_Node_Incident_Type_MASS_TRANSIT:
+    case TripLeg::Incident::MASS_TRANSIT:
       return "mass_transit";
       break;
-    case TripLeg_Node_Incident_Type_MISCELLANEOUS:
+    case TripLeg::Incident::MISCELLANEOUS:
       return "miscellaneous";
       break;
-    case TripLeg_Node_Incident_Type_OTHER_NEWS:
+    case TripLeg::Incident::OTHER_NEWS:
       return "other_news";
       break;
-    case TripLeg_Node_Incident_Type_PLANNED_EVENT:
+    case TripLeg::Incident::PLANNED_EVENT:
       return "planned_event";
       break;
-    case TripLeg_Node_Incident_Type_ROAD_CLOSURE:
+    case TripLeg::Incident::ROAD_CLOSURE:
       return "road_closure";
       break;
-    case TripLeg_Node_Incident_Type_ROAD_HAZARD:
+    case TripLeg::Incident::ROAD_HAZARD:
       return "road_hazard";
       break;
-    case TripLeg_Node_Incident_Type_WEATHER:
+    case TripLeg::Incident::WEATHER:
       return "weather";
       break;
   };

--- a/src/thor/attributes_controller.cc
+++ b/src/thor/attributes_controller.cc
@@ -75,7 +75,7 @@ const std::unordered_map<std::string, bool> AttributesController::kDefaultAttrib
     {kEdgeIsUrban, false},
 
     // Node keys
-    {kNodeIncidents, false},
+    {kIncidents, false},
     {kNodeIntersectingEdgeBeginHeading, true},
     {kNodeIntersectingEdgeFromEdgeNameConsistency, true},
     {kNodeIntersectingEdgeToEdgeNameConsistency, true},

--- a/src/thor/triplegbuilder.cc
+++ b/src/thor/triplegbuilder.cc
@@ -192,16 +192,19 @@ void SetShapeAttributes(const AttributesController& controller,
   }
 
   // sort the start and ends of the incidents along this edge
-  for (const auto& i : incidents) {
+  for (const auto& incident : incidents) {
     // if the incident is actually on the part of the edge we are using
-    if (i.start_offset > tgt_pct || i.end_offset < src_pct)
+    if (incident.start_offset > tgt_pct || incident.end_offset < src_pct)
       continue;
     // insert the start point and end points
-    for (auto offset : {std::max(i.start_offset, src_pct), std::min(i.end_offset, tgt_pct)}) {
+    for (auto offset : {
+             std::max(incident.start_offset, src_pct),
+             std::min(incident.end_offset, tgt_pct),
+         }) {
       // if this is clipped at the beginning of the edge then its not a new cut but we still need to
       // attach the incidents information to the leg
       if (offset == src_pct) {
-        UpdateIncident(leg, &i, shape_begin);
+        UpdateIncident(leg, &incident, shape_begin);
         continue;
       }
 
@@ -210,13 +213,13 @@ void SetShapeAttributes(const AttributesController& controller,
                                       [offset](const cut_t& c) { return c.percent_along < offset; });
       // there is already a cut here so we just add the incident
       if (itr != cuts.end() && itr->percent_along == offset) {
-        itr->incidents.push_back(&i);
+        itr->incidents.push_back(&incident);
       } // there wasnt a cut here so we need to make one
       else {
         cuts.insert(itr, cut_t{offset,
                                itr == cuts.end() ? speed : itr->speed,
                                itr == cuts.end() ? UNKNOWN_CONGESTION_VAL : itr->congestion,
-                               {&i}});
+                               {&incident}});
       }
     }
   }

--- a/src/thor/triplegbuilder_utils.h
+++ b/src/thor/triplegbuilder_utils.h
@@ -339,4 +339,172 @@ private:
   }
 };
 
+/**
+ * Add trip intersecting edge.
+ * @param  controller   Controller to determine which attributes to set.
+ * @param  directededge Directed edge on the path.
+ * @param  prev_de  Previous directed edge on the path.
+ * @param  local_edge_index  Index of the local intersecting path edge at intersection.
+ * @param  nodeinfo  Node information of the intersection.
+ * @param  trip_node  Trip node that will store the intersecting edge information.
+ * @param  intersecting_de Intersecting directed edge. Will be nullptr except when
+ *                         on the local hierarchy.
+ */
+void AddTripIntersectingEdge(const AttributesController& controller,
+                             const DirectedEdge* directededge,
+                             const DirectedEdge* prev_de,
+                             uint32_t local_edge_index,
+                             const NodeInfo* nodeinfo,
+                             TripLeg_Node* trip_node,
+                             const DirectedEdge* intersecting_de) {
+  TripLeg_IntersectingEdge* itersecting_edge = trip_node->add_intersecting_edge();
+
+  // Set the heading for the intersecting edge if requested
+  if (controller.attributes.at(kNodeIntersectingEdgeBeginHeading)) {
+    itersecting_edge->set_begin_heading(nodeinfo->heading(local_edge_index));
+  }
+
+  Traversability traversability = Traversability::kNone;
+  // Determine walkability
+  if (intersecting_de->forwardaccess() & kPedestrianAccess) {
+    traversability = (intersecting_de->reverseaccess() & kPedestrianAccess)
+                         ? Traversability::kBoth
+                         : Traversability::kForward;
+  } else {
+    traversability = (intersecting_de->reverseaccess() & kPedestrianAccess)
+                         ? Traversability::kBackward
+                         : Traversability::kNone;
+  }
+  // Set the walkability flag for the intersecting edge if requested
+  if (controller.attributes.at(kNodeIntersectingEdgeWalkability)) {
+    itersecting_edge->set_walkability(GetTripLegTraversability(traversability));
+  }
+
+  traversability = Traversability::kNone;
+  // Determine cyclability
+  if (intersecting_de->forwardaccess() & kBicycleAccess) {
+    traversability = (intersecting_de->reverseaccess() & kBicycleAccess) ? Traversability::kBoth
+                                                                         : Traversability::kForward;
+  } else {
+    traversability = (intersecting_de->reverseaccess() & kBicycleAccess) ? Traversability::kBackward
+                                                                         : Traversability::kNone;
+  }
+  // Set the cyclability flag for the intersecting edge if requested
+  if (controller.attributes.at(kNodeIntersectingEdgeCyclability)) {
+    itersecting_edge->set_cyclability(GetTripLegTraversability(traversability));
+  }
+
+  // Set the driveability flag for the intersecting edge if requested
+  if (controller.attributes.at(kNodeIntersectingEdgeDriveability)) {
+    itersecting_edge->set_driveability(
+        GetTripLegTraversability(nodeinfo->local_driveability(local_edge_index)));
+  }
+
+  // Set the previous/intersecting edge name consistency if requested
+  if (controller.attributes.at(kNodeIntersectingEdgeFromEdgeNameConsistency)) {
+    bool name_consistency =
+        (prev_de == nullptr) ? false : prev_de->name_consistency(local_edge_index);
+    itersecting_edge->set_prev_name_consistency(name_consistency);
+  }
+
+  // Set the current/intersecting edge name consistency if requested
+  if (controller.attributes.at(kNodeIntersectingEdgeToEdgeNameConsistency)) {
+    itersecting_edge->set_curr_name_consistency(directededge->name_consistency(local_edge_index));
+  }
+
+  // Set the use for the intersecting edge if requested
+  if (controller.attributes.at(kNodeIntersectingEdgeUse)) {
+    itersecting_edge->set_use(GetTripLegUse(intersecting_de->use()));
+  }
+
+  // Set the road class for the intersecting edge if requested
+  if (controller.attributes.at(kNodeIntersectingEdgeRoadClass)) {
+    itersecting_edge->set_road_class(GetRoadClass(intersecting_de->classification()));
+  }
+}
+
+/**
+ * Adds the intersecting edges in the graph at the current node. Skips edges which are on the path
+ * as well as those which are duplicates due to shortcut edges.
+ * @param controller               tells us what info we should add about the intersecting edges
+ * @param start_tile               the tile which contains the node
+ * @param node                     the node at which we are copying intersecting edges
+ * @param directededge             the current edge leaving the current node in the path
+ * @param prev_de                  the previous edge in the path
+ * @param prior_opp_local_index    opposing edge local index of previous edge in the path
+ * @param graphreader              graph reader for graph access
+ * @param trip_node                pbf node in the pbf structure we ar ebuilding
+ */
+void AddIntersectingEdges(const AttributesController& controller,
+                          const GraphTile* start_tile,
+                          const NodeInfo* node,
+                          const DirectedEdge* directededge,
+                          const DirectedEdge* prev_de,
+                          uint32_t prior_opp_local_index,
+                          GraphReader& graphreader,
+                          valhalla::TripLeg::Node* trip_node) {
+  // Add connected edges from the start node. Do this after the first trip
+  // edge is added
+  //
+  // Our path is from 1 to 2 to 3 (nodes) to ... n nodes.
+  // Each letter represents the edge info.
+  // So at node 2, we will store the edge info for D and we will store the
+  // intersecting edge info for B, C, E, F, and G.  We need to make sure
+  // that we don't store the edge info from A and D again.
+  //
+  //     (X)    (3)   (X)
+  //       \\   ||   //
+  //      C \\ D|| E//
+  //         \\ || //
+  //      B   \\||//   F
+  // (X)======= (2) ======(X)
+  //            ||\\
+  //          A || \\ G
+  //            ||  \\
+  //            (1)  (X)
+
+  // Iterate through edges on this level to find any intersecting edges
+  // Follow any upwards or downward transitions
+  const DirectedEdge* de = start_tile->directededge(node->edge_index());
+  for (uint32_t idx1 = 0; idx1 < node->edge_count(); ++idx1, de++) {
+
+    // Skip shortcut edges AND the opposing edge of the previous edge in the path AND
+    // the current edge in the path AND the superceded edge of the current edge in the path
+    // if the current edge in the path is a shortcut
+    if (de->is_shortcut() || de->localedgeidx() == prior_opp_local_index ||
+        de->localedgeidx() == directededge->localedgeidx() ||
+        (directededge->is_shortcut() && directededge->shortcut() & de->superseded())) {
+      continue;
+    }
+
+    // Add intersecting edges on the same hierarchy level and not on the path
+    AddTripIntersectingEdge(controller, directededge, prev_de, de->localedgeidx(), node, trip_node,
+                            de);
+  }
+
+  // Add intersecting edges on different levels (follow NodeTransitions)
+  if (node->transition_count() > 0) {
+    const NodeTransition* trans = start_tile->transition(node->transition_index());
+    for (uint32_t i = 0; i < node->transition_count(); ++i, ++trans) {
+      // Get the end node tile and its directed edges
+      GraphId endnode = trans->endnode();
+      const GraphTile* endtile = graphreader.GetGraphTile(endnode);
+      if (endtile == nullptr) {
+        continue;
+      }
+      const NodeInfo* nodeinfo2 = endtile->node(endnode);
+      const DirectedEdge* de2 = endtile->directededge(nodeinfo2->edge_index());
+      for (uint32_t idx2 = 0; idx2 < nodeinfo2->edge_count(); ++idx2, de2++) {
+        // Skip shortcut edges and edges on the path
+        if (de2->is_shortcut() || de2->localedgeidx() == prior_opp_local_index ||
+            de2->localedgeidx() == directededge->localedgeidx()) {
+          continue;
+        }
+        AddTripIntersectingEdge(controller, directededge, prev_de, de2->localedgeidx(), nodeinfo2,
+                                trip_node, de2);
+      }
+    }
+  }
+}
+
 } // namespace

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -665,7 +665,7 @@ valhalla::baldr::json::MapPtr serializeIncident(const TripLeg::Incident& inciden
 // Serializes incidents and adds to json-document
 void serializeIncidents(
     const google::protobuf::RepeatedPtrField<valhalla::TripLeg::Incident>& incidents,
-    json::MapPtr json_leg) {
+    json::MapPtr& json_leg) {
   if (incidents.empty()) {
     return;
   }

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -646,7 +646,7 @@ valhalla::baldr::json::MapPtr serializeIncident(const TripLeg::Incident& inciden
     metadata_json->emplace("start_time", static_cast<uint64_t>(incident.start_time()));
   }
   if (incident.type()) {
-    metadata_json->emplace("incident_type", valhalla::incidentTypeToString(incident.type()));
+    metadata_json->emplace("type", valhalla::incidentTypeToString(incident.type()));
   }
   if (incident.has_description() && !incident.description().empty()) {
     metadata_json->emplace("description", incident.description());
@@ -1592,7 +1592,7 @@ TEST(RouteSerializerOsrm, testAddsIncidents) {
           "creation_time": 1597241829,
           "start_time": 1597241929,
           "end_time": 1597243629,
-          "incident_type": "weather",
+          "type": "weather",
           "geometry_index_start": 42,
           "geometry_index_end": 42
         }
@@ -1656,7 +1656,7 @@ TEST(RouteSerializerOsrm, testAddsIncidentsMultipleIncidentsSingleEdge) {
           "id": 1337,
           "description": "Fooo",
           "creation_time": 1597241829,
-          "incident_type": "weather",
+          "type": "weather",
           "geometry_index_start": 87,
           "geometry_index_end": 92
         },
@@ -1665,7 +1665,7 @@ TEST(RouteSerializerOsrm, testAddsIncidentsMultipleIncidentsSingleEdge) {
           "creation_time": 1597241800,
           "start_time": 1597241900,
           "end_time": 1597243600,
-          "incident_type": "accident",
+          "type": "accident",
           "geometry_index_start": 21,
           "geometry_index_end": 104
         }

--- a/test/gurka/test_route_incidents.cc
+++ b/test/gurka/test_route_incidents.cc
@@ -30,14 +30,10 @@ protected:
     G----------------------H----------------------I)";
 
     // connect the ways via the nodes
-    const gurka::ways ways = {{"AB", {{"highway", "tertiary"}}},
-                              {"BC", {{"highway", "tertiary"}}},
-                              {"DEF", {{"highway", "primary"}}},
-                              {"GHI", {{"highway", "primary"}}},
-                              {"ADG", {{"highway", "motorway"}}},
-                              {"BE", {{"highway", "secondary"}}},
-                              {"EI", {{"highway", "service"}}},
-                              {"EH", {{"highway", "service"}}}};
+    const gurka::ways ways = {{"AB", {{"highway", "tertiary"}}},  {"BC", {{"highway", "tertiary"}}},
+                              {"DEF", {{"highway", "primary"}}},  {"GHI", {{"highway", "primary"}}},
+                              {"ADG", {{"highway", "motorway"}}}, {"BE", {{"highway", "secondary"}}},
+                              {"EI", {{"highway", "service"}}},   {"EH", {{"highway", "service"}}}};
 
     // generate the lls for the nodes in the map
     const auto layout = gurka::detail::map_to_coordinates(ascii_map, 10, {.2f, .2f});
@@ -45,7 +41,7 @@ protected:
     // make the tiles
     std::string tile_dir = "test/data/route_incidents";
     map = gurka::buildtiles(layout, ways, {}, {}, tile_dir,
-                                 {{"mjolnir.traffic_extract", tile_dir + "/traffic.tar"}});
+                            {{"mjolnir.traffic_extract", tile_dir + "/traffic.tar"}});
 
     // stage up some live traffic data
     valhalla_tests::utils::build_live_traffic_data(map.config);
@@ -59,23 +55,24 @@ gurka::map incidents::map = {};
 // a bit more work is needed if we want to do it for more than one tile at a time
 struct test_reader : public baldr::GraphReader {
   using baldr::GraphReader::GraphReader;
-  virtual std::shared_ptr<baldr::GraphReader::incident_tile_t> GetIncidentTile(const baldr::GraphId& tile_id) const {
+  virtual std::shared_ptr<baldr::GraphReader::incident_tile_t>
+  GetIncidentTile(const baldr::GraphId& tile_id) const {
     return incident_tile_;
   }
   std::shared_ptr<baldr::GraphReader::incident_tile_t> incident_tile_;
 };
 
-//via some macro magic we are inside the scope of the incidents class above
+// via some macro magic we are inside the scope of the incidents class above
 TEST_F(incidents, simple_cut) {
   // make our reader that we can manipulate
   map.config.put("mjolnir.simulate_incidents", true);
   test_reader reader(map.config.get_child("mjolnir"));
-  std::shared_ptr<baldr::GraphReader> graphreader(&reader, [](baldr::GraphReader*){});
+  std::shared_ptr<baldr::GraphReader> graphreader(&reader, [](baldr::GraphReader*) {});
 
   // modify traffic speed info to say that this edge has an incident
   auto edge_id = std::get<0>(gurka::findEdge(reader, map.nodes, "BC", "B"));
-  auto has_incident_cb = [edge_id](baldr::GraphReader& reader, baldr::TrafficTile& tile, int edge_index,
-                               valhalla::baldr::TrafficSpeed* current) -> void {
+  auto has_incident_cb = [edge_id](baldr::GraphReader& reader, baldr::TrafficTile& tile,
+                                   int edge_index, valhalla::baldr::TrafficSpeed* current) -> void {
     if (edge_id.Tile_Base() == tile.header->tile_id && edge_id.id() == edge_index)
       current->has_incidents = true;
   };
@@ -83,7 +80,7 @@ TEST_F(incidents, simple_cut) {
 
   // modify the incident tile to have incidents on this edge
   reader.incident_tile_.reset(new decltype(reader.incident_tile_)::element_type);
-  reader.incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_id.id(), .25, .75});
+  reader.incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_id.id(), .25, .75, 1234});
 
   // do the route
   auto result = gurka::route(map, {"C", "B"}, "auto", {}, graphreader);

--- a/test/gurka/test_route_incidents.cc
+++ b/test/gurka/test_route_incidents.cc
@@ -11,29 +11,31 @@ protected:
 
   static void SetUpTestSuite() {
     const std::string ascii_map = R"(
-    A----------1-----------B-----------2-----------C
-    |                      |
-    |                      |
-    |                      |
-    3                      4
-    |                      |
-    |                      |
-    |                      |
-    D----------5-----------E-----------6-----------F
-    |                      | \..
-    |                      |    \..
-    |                      |       \..
-    7                      8          9..
-    |                      |             \..
-    |                      |                \..
-    |                      |                   \..
-    G---------10-----------H-----------11---------I)";
+    A----------0----------B----------1----------C
+    |                     |
+    |                     |
+    |                     |
+    2                     3
+    |                     |
+    |                     |
+    |                     |
+    D----------4----------E----------5----------F
+    |                     |
+    |                     |
+    |                     |
+    6                     7
+    |                     |
+    |                     |
+    |                     |
+    G----------8----------H----------9----------I)";
 
     // connect the ways via the nodes
-    const gurka::ways ways = {{"AB", {{"highway", "tertiary"}}},  {"BC", {{"highway", "tertiary"}}},
-                              {"DEF", {{"highway", "primary"}}},  {"GHI", {{"highway", "primary"}}},
-                              {"ADG", {{"highway", "motorway"}}}, {"BE", {{"highway", "secondary"}}},
-                              {"EI", {{"highway", "service"}}},   {"EH", {{"highway", "service"}}}};
+    const gurka::ways ways = {
+        {"AB", {{"highway", "tertiary"}}},  {"BC", {{"highway", "tertiary"}}},
+        {"DEF", {{"highway", "primary"}}},  {"GHI", {{"highway", "primary"}}},
+        {"ADG", {{"highway", "motorway"}}}, {"BE", {{"highway", "secondary"}}},
+        {"EH", {{"highway", "service"}}},
+    };
 
     // generate the lls for the nodes in the map
     const auto layout = gurka::detail::map_to_coordinates(ascii_map, 10, {.2f, .2f});
@@ -69,6 +71,7 @@ void check_incident_locations(const valhalla::Api& api,
 
   // for every length we save the distance along the leg a given shape point is
   std::vector<std::vector<double>> leg_lengths;
+  size_t incident_count = 0;
   for (const auto& leg : api.trip().routes(0).legs()) {
     // keep the distances between shape points for this leg
     auto shape = midgard::decode<std::vector<midgard::PointLL>>(leg.shape());
@@ -81,9 +84,10 @@ void check_incident_locations(const valhalla::Api& api,
     // also check that incidents are in the right order
     uint32_t last_shape_index = 0;
     for (const auto& i : leg.incidents()) {
-      ASSERT_GE(i.begin_shape_index(), last_shape_index);
+      ASSERT_GE(i.begin_shape_index(), last_shape_index) << " leg incidents were out of order";
       last_shape_index = i.begin_shape_index();
     }
+    incident_count += leg.incidents_size();
   }
 
   // check all the incidents are in the right place in the route
@@ -97,17 +101,20 @@ void check_incident_locations(const valhalla::Api& api,
         break;
       }
     }
-    ASSERT_TRUE(incident != nullptr) << "Couldn't find incident";
+    ASSERT_TRUE(incident != nullptr) << "Couldn't find incident " << i.id << " on leg " << i.leg_index
+                                     << " on edge " << i.begin_edge_index;
 
     // check that we are on the right edges of the path
     const auto& begin_edge = leg.node(i.begin_edge_index).edge();
     ASSERT_TRUE(begin_edge.begin_shape_index() <= incident->begin_shape_index() &&
                 incident->begin_shape_index() <= begin_edge.end_shape_index())
-        << "Incident begins on wrong edge";
+        << "Incident " << i.id << " on leg " << i.leg_index << " on edge " << i.begin_edge_index
+        << " begins on wrong edge";
     const auto& end_edge = leg.node(i.end_edge_index).edge();
     ASSERT_TRUE(end_edge.begin_shape_index() <= incident->end_shape_index() &&
                 incident->end_shape_index() <= end_edge.end_shape_index())
-        << "Incident ends on wrong edge";
+        << "Incident " << i.id << " on leg " << i.leg_index << " on edge " << i.end_edge_index
+        << " ends on wrong edge";
 
     // check that we are on the right shape points
     const auto& lengths = leg_lengths[i.leg_index];
@@ -116,15 +123,20 @@ void check_incident_locations(const valhalla::Api& api,
     auto begin_edge_pct =
         (lengths[incident->begin_shape_index()] - lengths[begin_edge.begin_shape_index()]) /
         begin_edge_length;
-    ASSERT_NEAR(begin_edge_pct, i.begin_pct, .1)
-        << "Incident begins at wrong location along the edge";
+    ASSERT_NEAR(begin_edge_pct, i.begin_pct, .01)
+        << "Incident " << i.id << " on leg " << i.leg_index << " on edge " << i.begin_edge_index
+        << " begins at wrong location along the edge";
     auto end_edge_length =
         lengths[end_edge.end_shape_index()] - lengths[end_edge.begin_shape_index()];
     auto end_edge_pct =
         (lengths[incident->end_shape_index()] - lengths[end_edge.begin_shape_index()]) /
         end_edge_length;
-    ASSERT_NEAR(end_edge_pct, i.end_pct, .1) << "Incident ends at wrong location along the edge";
+    ASSERT_NEAR(end_edge_pct, i.end_pct, .1)
+        << "Incident " << i.id << " on leg " << i.leg_index << " on edge " << i.end_edge_index
+        << " ends at wrong location along the edge";
   }
+
+  ASSERT_EQ(incident_count, locations.size()) << "Expected number of incidents does not match actual";
 }
 
 // provides us an easy way to mock having incident tiles, each test can override the tile in question
@@ -164,7 +176,9 @@ std::shared_ptr<test_reader> setup_test(const gurka::map& map,
 
   // modify traffic speed info to say that this edge has an incident
   for (const auto& name : names) {
-    auto edge_id = std::get<0>(gurka::findEdge(*reader, map.nodes, name));
+    auto begin_node = name.substr(0, 1);
+    auto end_node = name.substr(1);
+    auto edge_id = std::get<0>(gurka::findEdgeByNodes(*reader, map.nodes, begin_node, end_node));
     auto has_incident_cb = [edge_id](baldr::GraphReader& reader, baldr::TrafficTile& tile,
                                      int edge_index, valhalla::baldr::TrafficSpeed* current) -> void {
       if (edge_id.Tile_Base() == tile.header->tile_id && edge_id.id() == edge_index)
@@ -188,7 +202,7 @@ TEST_F(incidents, simple_cut) {
 
   // modify the incident tile to have incidents on this edge
   reader->incident_tile_->emplace_back(
-      baldr::GraphReader::Incident{edge_ids.front().id(), .25, .75, 1234});
+      baldr::GraphReader::Incident{edge_ids[0].id(), .25, .75, 1234});
 
   // do the route
   auto result = gurka::route(map, {"C", "B"}, "auto",
@@ -208,8 +222,7 @@ TEST_F(incidents, whole_edge) {
   std::shared_ptr<baldr::GraphReader> graphreader(reader.get(), [](baldr::GraphReader*) {});
 
   // modify the incident tile to have incidents on this edge
-  reader->incident_tile_->emplace_back(
-      baldr::GraphReader::Incident{edge_ids.front().id(), 0., 1., 1234});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), 0., 1., 1234});
 
   // do the route
   auto result = gurka::route(map, {"C", "B"}, "auto",
@@ -229,8 +242,7 @@ TEST_F(incidents, left) {
   std::shared_ptr<baldr::GraphReader> graphreader(reader.get(), [](baldr::GraphReader*) {});
 
   // modify the incident tile to have incidents on this edge
-  reader->incident_tile_->emplace_back(
-      baldr::GraphReader::Incident{edge_ids.front().id(), 0., .5, 1234});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), 0., .5, 1234});
 
   // do the route
   auto result = gurka::route(map, {"C", "B"}, "auto",
@@ -250,8 +262,7 @@ TEST_F(incidents, right) {
   std::shared_ptr<baldr::GraphReader> graphreader(reader.get(), [](baldr::GraphReader*) {});
 
   // modify the incident tile to have incidents on this edge
-  reader->incident_tile_->emplace_back(
-      baldr::GraphReader::Incident{edge_ids.front().id(), .5, 1., 1234});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .5, 1., 1234});
 
   // do the route
   auto result = gurka::route(map, {"C", "B"}, "auto",
@@ -284,5 +295,389 @@ TEST_F(incidents, multiedge) {
   // check its right
   check_incident_locations(result, {
                                        {1234, 0, 0, .5, 2, .5},
+                                   });
+}
+
+TEST_F(incidents, multiincident) {
+  // mark the edges with incidents
+  std::vector<baldr::GraphId> edge_ids;
+  auto reader = setup_test(map, {"CB", "BE", "EH"}, edge_ids);
+  std::shared_ptr<baldr::GraphReader> graphreader(reader.get(), [](baldr::GraphReader*) {});
+
+  // modify the incident tile to have incidents on this edge
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .25, .4, 123});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .5, 1., 456});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[1].id(), 0., 1., 456});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[2].id(), 0., .5, 456});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[2].id(), .75, .9, 789});
+  reader->sort();
+
+  // do the route
+  auto result = gurka::route(map, {"C", "H"}, "auto",
+                             {{"/filters/action", "include"}, {"/filters/attributes/0", "incidents"}},
+                             graphreader);
+
+  // check its right
+  check_incident_locations(result, {
+                                       {123, 0, 0, .25, 0, .4},
+                                       {456, 0, 0, .5, 2, .5},
+                                       {789, 0, 2, .75, 2, .9},
+                                   });
+}
+
+TEST_F(incidents, interleaved) {
+  // mark the edges with incidents
+  std::vector<baldr::GraphId> edge_ids;
+  auto reader = setup_test(map, {"CB", "BE", "EH"}, edge_ids);
+  std::shared_ptr<baldr::GraphReader> graphreader(reader.get(), [](baldr::GraphReader*) {});
+
+  // modify the incident tile to have incidents on this edge
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .25, .75, 123});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .5, 1., 456});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[1].id(), 0., 1., 456});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[2].id(), 0., .5, 456});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[2].id(), .25, .9, 789});
+  reader->sort();
+
+  // do the route
+  auto result = gurka::route(map, {"C", "H"}, "auto",
+                             {{"/filters/action", "include"}, {"/filters/attributes/0", "incidents"}},
+                             graphreader);
+
+  // check its right
+  check_incident_locations(result, {
+                                       {123, 0, 0, .25, 0, .75},
+                                       {456, 0, 0, .5, 2, .5},
+                                       {789, 0, 2, .25, 2, .9},
+                                   });
+}
+
+TEST_F(incidents, collisions) {
+  // mark the edges with incidents
+  std::vector<baldr::GraphId> edge_ids;
+  auto reader = setup_test(map, {"CB", "BE", "EH"}, edge_ids);
+  std::shared_ptr<baldr::GraphReader> graphreader(reader.get(), [](baldr::GraphReader*) {});
+
+  // modify the incident tile to have incidents on this edge
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .25, .5, 123});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .5, 1., 456});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[1].id(), 0., 1., 456});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[2].id(), 0., .5, 456});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[2].id(), .5, .9, 789});
+  reader->sort();
+
+  // do the route
+  auto result = gurka::route(map, {"C", "H"}, "auto",
+                             {{"/filters/action", "include"}, {"/filters/attributes/0", "incidents"}},
+                             graphreader);
+
+  // check its right
+  check_incident_locations(result, {
+                                       {123, 0, 0, .25, 0, .5},
+                                       {456, 0, 0, .5, 2, .5},
+                                       {789, 0, 2, .5, 2, .9},
+                                   });
+}
+
+TEST_F(incidents, full_overlap) {
+  // mark the edges with incidents
+  std::vector<baldr::GraphId> edge_ids;
+  auto reader = setup_test(map, {"CB", "BE", "EH"}, edge_ids);
+  std::shared_ptr<baldr::GraphReader> graphreader(reader.get(), [](baldr::GraphReader*) {});
+
+  // modify the incident tile to have incidents on this edge
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .5, 1., 123});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .5, 1., 456});
+  reader->sort();
+
+  // do the route
+  auto result = gurka::route(map, {"C", "H"}, "auto",
+                             {{"/filters/action", "include"}, {"/filters/attributes/0", "incidents"}},
+                             graphreader);
+
+  // check its right
+  check_incident_locations(result, {
+                                       {123, 0, 0, .5, 0, 1.},
+                                       {456, 0, 0, .5, 0, 1.},
+                                   });
+}
+
+TEST_F(incidents, multileg) {
+  // mark the edges with incidents
+  std::vector<baldr::GraphId> edge_ids;
+  auto reader = setup_test(map, {"CB", "BE", "EH"}, edge_ids);
+  std::shared_ptr<baldr::GraphReader> graphreader(reader.get(), [](baldr::GraphReader*) {});
+
+  // modify the incident tile to have incidents on this edge
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .25, .75, 123});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .5, 1., 456});
+
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[1].id(), 0., 1., 456});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[1].id(), 0., 1., 789});
+
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[2].id(), 0., .5, 456});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[2].id(), 0., .9, 789});
+  reader->sort();
+
+  // do the route
+  auto result = gurka::route(map, {"C", "B", "E", "H"}, "auto",
+                             {{"/filters/action", "include"}, {"/filters/attributes/0", "incidents"}},
+                             graphreader);
+
+  // check its right
+  check_incident_locations(result, {
+                                       {123, 0, 0, .25, 0, .75},
+                                       {456, 0, 0, .5, 0, 1.},
+                                       {456, 1, 0, 0., 0, 1.},
+                                       {789, 1, 0, 0., 0, 1.},
+                                       {456, 2, 0, 0., 0, .5},
+                                       {789, 2, 0, 0., 0, .9},
+                                   });
+}
+
+TEST_F(incidents, clipped) {
+  // mark the edges with incidents
+  std::vector<baldr::GraphId> edge_ids;
+  auto reader = setup_test(map, {"CB", "BE", "EH", "HI"}, edge_ids);
+  std::shared_ptr<baldr::GraphReader> graphreader(reader.get(), [](baldr::GraphReader*) {});
+
+  // modify the incident tile to have incidents on this edge
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .25, .75, 123});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[3].id(), .25, .75, 456});
+  reader->sort();
+
+  // do the route
+  auto result = gurka::route(map, {"1", "9"}, "auto",
+                             {{"/filters/action", "include"}, {"/filters/attributes/0", "incidents"}},
+                             graphreader);
+
+  // check its right
+  check_incident_locations(result, {
+                                       {123, 0, 0, 0., 0, .5},
+                                       {456, 0, 3, .5, 3, 1.},
+                                   });
+}
+
+TEST_F(incidents, missed) {
+  // mark the edges with incidents
+  std::vector<baldr::GraphId> edge_ids;
+  auto reader = setup_test(map, {"CB", "BE", "EH", "HI"}, edge_ids);
+  std::shared_ptr<baldr::GraphReader> graphreader(reader.get(), [](baldr::GraphReader*) {});
+
+  // modify the incident tile to have incidents on this edge
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .1, .2, 123});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[3].id(), .6, .7, 456});
+  reader->sort();
+
+  // do the route
+  auto result = gurka::route(map, {"1", "9"}, "auto",
+                             {{"/filters/action", "include"}, {"/filters/attributes/0", "incidents"}},
+                             graphreader);
+
+  // check its right
+  check_incident_locations(result, {});
+}
+
+TEST_F(incidents, simple_point) {
+  // mark the edges with incidents
+  std::vector<baldr::GraphId> edge_ids;
+  auto reader = setup_test(map, {"CB"}, edge_ids);
+  std::shared_ptr<baldr::GraphReader> graphreader(reader.get(), [](baldr::GraphReader*) {});
+
+  // modify the incident tile to have incidents on this edge
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .25, .25, 123});
+  reader->sort();
+
+  // do the route
+  auto result = gurka::route(map, {"C", "B"}, "auto",
+                             {{"/filters/action", "include"}, {"/filters/attributes/0", "incidents"}},
+                             graphreader);
+
+  // check its right
+  check_incident_locations(result, {
+                                       {123, 0, 0, .25, 0, .25},
+                                   });
+}
+
+TEST_F(incidents, left_point) {
+  // mark the edges with incidents
+  std::vector<baldr::GraphId> edge_ids;
+  auto reader = setup_test(map, {"CB"}, edge_ids);
+  std::shared_ptr<baldr::GraphReader> graphreader(reader.get(), [](baldr::GraphReader*) {});
+
+  // modify the incident tile to have incidents on this edge
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), 0., 0., 123});
+  reader->sort();
+
+  // do the route
+  auto result = gurka::route(map, {"C", "H"}, "auto",
+                             {{"/filters/action", "include"}, {"/filters/attributes/0", "incidents"}},
+                             graphreader);
+
+  // check its right
+  check_incident_locations(result, {
+                                       {123, 0, 0, 0., 0, 0.},
+                                   });
+}
+
+TEST_F(incidents, right_point) {
+  // mark the edges with incidents
+  std::vector<baldr::GraphId> edge_ids;
+  auto reader = setup_test(map, {"CB"}, edge_ids);
+  std::shared_ptr<baldr::GraphReader> graphreader(reader.get(), [](baldr::GraphReader*) {});
+
+  // modify the incident tile to have incidents on this edge
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), 1., 1., 123});
+  reader->sort();
+
+  // do the route
+  auto result = gurka::route(map, {"C", "B"}, "auto",
+                             {{"/filters/action", "include"}, {"/filters/attributes/0", "incidents"}},
+                             graphreader);
+
+  // check its right
+  check_incident_locations(result, {
+                                       {123, 0, 0, 1., 0, 1.},
+                                   });
+}
+
+TEST_F(incidents, multipoint) {
+  // mark the edges with incidents
+  std::vector<baldr::GraphId> edge_ids;
+  auto reader = setup_test(map, {"CB", "BE", "EH"}, edge_ids);
+  std::shared_ptr<baldr::GraphReader> graphreader(reader.get(), [](baldr::GraphReader*) {});
+
+  // modify the incident tile to have incidents on this edge
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .5, .5, 123});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[1].id(), 0., 0., 456});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[2].id(), .2, .2, 789});
+  reader->sort();
+
+  // do the route
+  auto result = gurka::route(map, {"C", "H"}, "auto",
+                             {{"/filters/action", "include"}, {"/filters/attributes/0", "incidents"}},
+                             graphreader);
+
+  // check its right
+  check_incident_locations(result, {
+                                       {123, 0, 0, .5, 0, .5},
+                                       {456, 0, 1, 0., 1, 0.},
+                                       {789, 0, 2, .2, 2, .2},
+                                   });
+}
+
+TEST_F(incidents, point_collisions) {
+  // mark the edges with incidents
+  std::vector<baldr::GraphId> edge_ids;
+  auto reader = setup_test(map, {"CB", "BE", "EH"}, edge_ids);
+  std::shared_ptr<baldr::GraphReader> graphreader(reader.get(), [](baldr::GraphReader*) {});
+
+  // modify the incident tile to have incidents on this edge
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .5, .5, 123});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .5, .5, 456});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[1].id(), 1., 1., 789});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[1].id(), 1., 1., 987});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[2].id(), .9, .9, 654});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[2].id(), .9, .9, 321});
+  reader->sort();
+
+  // do the route
+  auto result = gurka::route(map, {"C", "H"}, "auto",
+                             {{"/filters/action", "include"}, {"/filters/attributes/0", "incidents"}},
+                             graphreader);
+
+  // check its right
+  check_incident_locations(result, {
+                                       {123, 0, 0, .5, 0, .5},
+                                       {456, 0, 0, .5, 0, .5},
+                                       {789, 0, 1, 1., 1, 1.},
+                                       {987, 0, 1, 1., 1, 1.},
+                                       {654, 0, 2, .9, 2, .9},
+                                       {321, 0, 2, .9, 2, .9},
+                                   });
+}
+
+TEST_F(incidents, point_shared) {
+  // mark the edges with incidents
+  std::vector<baldr::GraphId> edge_ids;
+  auto reader = setup_test(map, {"CB", "BE", "EH"}, edge_ids);
+  std::shared_ptr<baldr::GraphReader> graphreader(reader.get(), [](baldr::GraphReader*) {});
+
+  // modify the incident tile to have incidents on this edge
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), 1., 1., 123});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[1].id(), 0., 0., 123});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[1].id(), 1., 1., 456});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[2].id(), 0., 0., 456});
+  reader->sort();
+
+  // do the route
+  auto result = gurka::route(map, {"C", "H"}, "auto",
+                             {{"/filters/action", "include"}, {"/filters/attributes/0", "incidents"}},
+                             graphreader);
+
+  // check its right
+  check_incident_locations(result, {
+                                       {123, 0, 0, 1., 0, 1.},
+                                       {456, 0, 1, 1., 1, 1.},
+                                   });
+}
+
+TEST_F(incidents, armageddon) {
+  // mark the edges with incidents
+  std::vector<baldr::GraphId> edge_ids;
+  auto reader = setup_test(map, {"CB", "BE", "EH", "HI"}, edge_ids);
+  std::shared_ptr<baldr::GraphReader> graphreader(reader.get(), [](baldr::GraphReader*) {});
+
+  // modify the incident tile to have incidents on this edge
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .25, .75, 123});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .5, 1., 456});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .5, .5, 987});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .3, .3, 654});
+
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[1].id(), 0., 1., 456});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[1].id(), 0., 1., 789});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[1].id(), .6, .6, 321});
+
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[2].id(), 0., .5, 456});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[2].id(), 0., .6, 789});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[2].id(), .65, .65, 0});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[2].id(), .69, .69, 1});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[2].id(), .7, 1., 2});
+
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[3].id(), 0., .1, 2});
+
+  // out of bounds
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .25, .25, 4});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .1, .3, 5});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[3].id(), .9, .9, 6});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[3].id(), .6, .95, 7});
+
+  // clipped
+  /*reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .25, .25, 5});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .1, .3, 6});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[3].id(), .9, .9, 3});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[3].id(), .6, .95, 4});*/
+
+  reader->sort();
+
+  // do the route
+  auto result = gurka::route(map, {"1", "B", "E", "9"}, "auto",
+                             {{"/filters/action", "include"}, {"/filters/attributes/0", "incidents"}},
+                             graphreader);
+
+  // check its right
+  check_incident_locations(result, {
+                                       {123, 0, 0, .25, 0, .75},
+                                       {456, 0, 0, .5, 0, 1.},
+                                       {987, 0, 0, .5, 0, .5},
+                                       {654, 0, 0, .3, 0, .3},
+                                       {456, 1, 0, 0., 0, 1.},
+                                       {789, 1, 0, 0., 0, 1.},
+                                       {321, 1, 0, .6, 0, .6},
+                                       {456, 2, 0, 0., 0, .5},
+                                       {789, 2, 0, 0., 0, .6},
+                                       {0, 2, 0, .65, 0, .65},
+                                       {1, 2, 0, .69, 0, .69},
+                                       {2, 2, 0, .7, 1, .1},
                                    });
 }

--- a/test/gurka/test_route_incidents.cc
+++ b/test/gurka/test_route_incidents.cc
@@ -11,23 +11,23 @@ protected:
 
   static void SetUpTestSuite() {
     const std::string ascii_map = R"(
-    A----------------------B-----------------------C
+    A----------1-----------B-----------2-----------C
     |                      |
     |                      |
     |                      |
+    3                      4
     |                      |
     |                      |
     |                      |
-    |                      |
-    D----------------------E-----------------------F
+    D----------5-----------E-----------6-----------F
     |                      | \..
     |                      |    \..
     |                      |       \..
-    |                      |          \..
+    7                      8          9..
     |                      |             \..
     |                      |                \..
     |                      |                   \..
-    G----------------------H----------------------I)";
+    G---------10-----------H-----------11---------I)";
 
     // connect the ways via the nodes
     const gurka::ways ways = {{"AB", {{"highway", "tertiary"}}},  {"BC", {{"highway", "tertiary"}}},
@@ -51,10 +51,77 @@ protected:
 // initialize static member
 gurka::map incidents::map = {};
 
+// for asserting where the incident starts and ends on the route and how long it is
+struct incident_location {
+  uint64_t id;
+  uint32_t leg_index;
+  uint32_t begin_edge_index;
+  double begin_pct;
+  uint32_t end_edge_index;
+  double end_pct;
+};
+
+void check_incident_locations(const valhalla::Api& api,
+                              const std::vector<incident_location>& locations) {
+
+  // for every length we save the distance along the leg a given shape point is
+  std::vector<std::vector<double>> leg_lengths;
+  for (const auto& leg : api.trip().routes(0).legs()) {
+    auto shape = midgard::decode<std::vector<midgard::PointLL>>(leg.shape());
+    std::vector<double> lengths;
+    for (size_t i = 0; i < shape.size(); ++i) {
+      lengths.push_back(i == 0 ? 0.0 : shape[i - 1].Distance(shape[i]) + lengths.back());
+    }
+    leg_lengths.emplace_back(std::move(lengths));
+  }
+
+  // check all the incidents are in the right place in the route
+  for (const auto& i : locations) {
+    const auto& leg = api.trip().routes(0).legs(i.leg_index);
+    // find the incident
+    const valhalla::TripLeg::Incident* incident = nullptr;
+    for (int j = 0; j < leg.incidents_size(); ++j) {
+      if (leg.incidents(j).id() == i.id) {
+        incident = &leg.incidents(j);
+        break;
+      }
+    }
+    ASSERT_TRUE(incident != nullptr) << "Couldn't find incident";
+
+    // check that we are on the right edges of the path
+    const auto& begin_edge = leg.node(i.begin_edge_index).edge();
+    ASSERT_TRUE(begin_edge.begin_shape_index() <= incident->begin_shape_index() &&
+                incident->begin_shape_index() < begin_edge.end_shape_index())
+        << "Incident begins on wrong edge";
+    const auto& end_edge = leg.node(i.end_edge_index).edge();
+    ASSERT_TRUE(end_edge.begin_shape_index() < incident->end_shape_index() &&
+                incident->end_shape_index() <= end_edge.end_shape_index())
+        << "Incident ends on wrong edge";
+
+    // check that we are on the right shape points
+    const auto& lengths = leg_lengths[i.leg_index];
+    auto begin_edge_length =
+        lengths[begin_edge.end_shape_index()] - lengths[begin_edge.begin_shape_index()];
+    auto begin_edge_pct =
+        (lengths[incident->begin_shape_index()] - lengths[begin_edge.begin_shape_index()]) /
+        begin_edge_length;
+    ASSERT_NEAR(begin_edge_pct, i.begin_pct, .1)
+        << "Incident begins at wrong location along the edge";
+    auto end_edge_length =
+        lengths[end_edge.end_shape_index()] - lengths[end_edge.begin_shape_index()];
+    auto end_edge_pct =
+        (lengths[incident->end_shape_index()] - lengths[end_edge.begin_shape_index()]) /
+        end_edge_length;
+    ASSERT_NEAR(end_edge_pct, i.end_pct, .1) << "Incident ends at wrong location along the edge";
+  }
+}
+
 // provides us an easy way to mock having incident tiles, each test can override the tile in question
 // a bit more work is needed if we want to do it for more than one tile at a time
 struct test_reader : public baldr::GraphReader {
-  using baldr::GraphReader::GraphReader;
+  test_reader(const boost::property_tree::ptree& pt) : baldr::GraphReader(pt) {
+    tile_extract_.reset(new baldr::GraphReader::tile_extract_t(pt));
+  }
   virtual std::shared_ptr<baldr::GraphReader::incident_tile_t>
   GetIncidentTile(const baldr::GraphId& tile_id) const {
     return incident_tile_;
@@ -83,7 +150,12 @@ TEST_F(incidents, simple_cut) {
   reader.incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_id.id(), .25, .75, 1234});
 
   // do the route
-  auto result = gurka::route(map, {"C", "B"}, "auto", {}, graphreader);
-  gurka::assert::osrm::expect_steps(result, {"BC"});
-  gurka::assert::raw::expect_path(result, {"BC", "BC", "BC"});
+  auto result = gurka::route(map, {"C", "B"}, "auto",
+                             {{"/filters/action", "include"}, {"/filters/attributes/0", "incidents"}},
+                             graphreader);
+
+  // check its right
+  check_incident_locations(result, {
+                                       {1234, 0, 0, .25, 0, .75},
+                                   });
 }

--- a/test/gurka/test_route_incidents.cc
+++ b/test/gurka/test_route_incidents.cc
@@ -632,8 +632,9 @@ TEST_F(incidents, armageddon) {
   reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .25, .75, 123});
   reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .5, 1., 456});
   reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .5, .5, 987});
-  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .3, .3, 654});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), 1., 1., 666});
 
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[1].id(), .0, .0, 666});
   reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[1].id(), 0., 1., 456});
   reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[1].id(), 0., 1., 789});
   reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[1].id(), .6, .6, 321});
@@ -643,10 +644,13 @@ TEST_F(incidents, armageddon) {
   reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[2].id(), .65, .65, 0});
   reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[2].id(), .69, .69, 1});
   reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[2].id(), .7, 1., 2});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[2].id(), .8, 1., 3});
 
   reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[3].id(), 0., .1, 2});
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[3].id(), 0., .7, 3});
 
   // out of bounds
+  reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .3, .3, 654});
   reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .25, .25, 4});
   reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[0].id(), .1, .3, 5});
   reader->incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_ids[3].id(), .9, .9, 6});
@@ -667,10 +671,13 @@ TEST_F(incidents, armageddon) {
 
   // check its right
   check_incident_locations(result, {
-                                       {123, 0, 0, .25, 0, .75},
-                                       {456, 0, 0, .5, 0, 1.},
-                                       {987, 0, 0, .5, 0, .5},
-                                       {654, 0, 0, .3, 0, .3},
+                                       // first edge is only half the edge because we start in the
+                                       // middle of it
+                                       {123, 0, 0, .0, 0, .5},
+                                       {456, 0, 0, .0, 0, 1.},
+                                       {987, 0, 0, .0, 0, .0},
+                                       {666, 0, 0, 1., 0, 1.},
+                                       {666, 1, 0, 0., 0, 0.},
                                        {456, 1, 0, 0., 0, 1.},
                                        {789, 1, 0, 0., 0, 1.},
                                        {321, 1, 0, .6, 0, .6},
@@ -678,6 +685,7 @@ TEST_F(incidents, armageddon) {
                                        {789, 2, 0, 0., 0, .6},
                                        {0, 2, 0, .65, 0, .65},
                                        {1, 2, 0, .69, 0, .69},
-                                       {2, 2, 0, .7, 1, .1},
+                                       {2, 2, 0, .7, 1, .2},
+                                       {3, 2, 0, .8, 1, 1.},
                                    });
 }

--- a/test/gurka/test_route_incidents.cc
+++ b/test/gurka/test_route_incidents.cc
@@ -1,0 +1,92 @@
+#include <gtest/gtest.h>
+
+#include "gurka.h"
+#include "test/util/traffic_utils.h"
+
+using namespace valhalla;
+
+class incidents : public ::testing::Test {
+protected:
+  static gurka::map map;
+
+  static void SetUpTestSuite() {
+    const std::string ascii_map = R"(
+    A----------------------B-----------------------C
+    |                      |
+    |                      |
+    |                      |
+    |                      |
+    |                      |
+    |                      |
+    |                      |
+    D----------------------E-----------------------F
+    |                      | \..
+    |                      |    \..
+    |                      |       \..
+    |                      |          \..
+    |                      |             \..
+    |                      |                \..
+    |                      |                   \..
+    G----------------------H----------------------I)";
+
+    // connect the ways via the nodes
+    const gurka::ways ways = {{"AB", {{"highway", "tertiary"}}},
+                              {"BC", {{"highway", "tertiary"}}},
+                              {"DEF", {{"highway", "primary"}}},
+                              {"GHI", {{"highway", "primary"}}},
+                              {"ADG", {{"highway", "motorway"}}},
+                              {"BE", {{"highway", "secondary"}}},
+                              {"EI", {{"highway", "service"}}},
+                              {"EH", {{"highway", "service"}}}};
+
+    // generate the lls for the nodes in the map
+    const auto layout = gurka::detail::map_to_coordinates(ascii_map, 10, {.2f, .2f});
+
+    // make the tiles
+    std::string tile_dir = "test/data/route_incidents";
+    map = gurka::buildtiles(layout, ways, {}, {}, tile_dir,
+                                 {{"mjolnir.traffic_extract", tile_dir + "/traffic.tar"}});
+
+    // stage up some live traffic data
+    valhalla_tests::utils::build_live_traffic_data(map.config);
+  }
+};
+
+// initialize static member
+gurka::map incidents::map = {};
+
+// provides us an easy way to mock having incident tiles, each test can override the tile in question
+// a bit more work is needed if we want to do it for more than one tile at a time
+struct test_reader : public baldr::GraphReader {
+  using baldr::GraphReader::GraphReader;
+  virtual std::shared_ptr<baldr::GraphReader::incident_tile_t> GetIncidentTile(const baldr::GraphId& tile_id) const {
+    return incident_tile_;
+  }
+  std::shared_ptr<baldr::GraphReader::incident_tile_t> incident_tile_;
+};
+
+//via some macro magic we are inside the scope of the incidents class above
+TEST_F(incidents, simple_cut) {
+  // make our reader that we can manipulate
+  map.config.put("mjolnir.simulate_incidents", true);
+  test_reader reader(map.config.get_child("mjolnir"));
+  std::shared_ptr<baldr::GraphReader> graphreader(&reader, [](baldr::GraphReader*){});
+
+  // modify traffic speed info to say that this edge has an incident
+  auto edge_id = std::get<0>(gurka::findEdge(reader, map.nodes, "BC", "B"));
+  auto has_incident_cb = [edge_id](baldr::GraphReader& reader, baldr::TrafficTile& tile, int edge_index,
+                               valhalla::baldr::TrafficSpeed* current) -> void {
+    if (edge_id.Tile_Base() == tile.header->tile_id && edge_id.id() == edge_index)
+      current->has_incidents = true;
+  };
+  valhalla_tests::utils::customize_live_traffic_data(map.config, has_incident_cb);
+
+  // modify the incident tile to have incidents on this edge
+  reader.incident_tile_.reset(new decltype(reader.incident_tile_)::element_type);
+  reader.incident_tile_->emplace_back(baldr::GraphReader::Incident{edge_id.id(), .25, .75});
+
+  // do the route
+  auto result = gurka::route(map, {"C", "B"}, "auto", {}, graphreader);
+  gurka::assert::osrm::expect_steps(result, {"BC"});
+  gurka::assert::raw::expect_path(result, {"BC", "BC", "BC"});
+}

--- a/test/gurka/test_route_incidents.cc
+++ b/test/gurka/test_route_incidents.cc
@@ -139,11 +139,6 @@ void check_incident_locations(const valhalla::Api& api,
   ASSERT_EQ(incident_count, locations.size()) << "Expected number of incidents does not match actual";
 }
 
-std::shared_ptr<std::vector<int>> foo() {
-  std::vector<int> bar;
-  return std::shared_ptr<std::vector<int>>(&bar, [](auto*) {});
-}
-
 // provides us an easy way to mock having incident tiles, each test can override the tile in question
 // a bit more work is needed if we want to do it for more than one tile at a time
 struct test_reader : public baldr::GraphReader {

--- a/test/gurka/test_traffic.cc
+++ b/test/gurka/test_traffic.cc
@@ -49,9 +49,8 @@ TEST(Traffic, BasicUpdates) {
     printf("Make some updates to the traffic .tar file. "
            "Mostly just updates every edge in the file to 24km/h, except for one "
            "specific edge (B->D) where we simulate a closure (speed=0, congestion high)");
-    std::function<void(baldr::GraphReader&, baldr::TrafficTile&, int, valhalla::baldr::TrafficSpeed*)>
-        cb_setter_24kmh = [&map](baldr::GraphReader& reader, baldr::TrafficTile& tile, int index,
-                                 valhalla::baldr::TrafficSpeed* current) -> void {
+    auto cb_setter_24kmh = [&map](baldr::GraphReader& reader, baldr::TrafficTile& tile, int index,
+                                  valhalla::baldr::TrafficSpeed* current) -> void {
       baldr::GraphId tile_id(tile.header->tile_id);
       auto BD = gurka::findEdge(reader, map.nodes, "BD", "D", tile_id);
       current->breakpoint1 = 255;
@@ -74,9 +73,8 @@ TEST(Traffic, BasicUpdates) {
       gurka::assert::raw::expect_eta(result, 151.5);
     }
     printf("Next, set the speed to the highest possible to ensure nothing breaks");
-    std::function<void(baldr::GraphReader&, baldr::TrafficTile&, int, baldr::TrafficSpeed*)>
-        cb_setter_max = [&map](baldr::GraphReader& reader, baldr::TrafficTile& tile, int index,
-                               baldr::TrafficSpeed* current) -> void {
+    auto cb_setter_max = [&map](baldr::GraphReader& reader, baldr::TrafficTile& tile, int index,
+                                baldr::TrafficSpeed* current) -> void {
       baldr::GraphId tile_id(tile.header->tile_id);
       auto BD = gurka::findEdge(reader, map.nodes, "BD", "D", tile_id);
       current->breakpoint1 = 255;
@@ -187,23 +185,25 @@ TEST(Traffic, CutGeoms) {
 
   // then we add one portion of the edge having traffic
   {
-    valhalla::baldr::TrafficSpeed ts{valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
-                                     valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
-                                     valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
-                                     valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
-                                     0u,
-                                     0u,
-                                     0u,
-                                     0u,
-                                     0u};
+    valhalla::baldr::TrafficSpeed ts{
+        valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
+        valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
+        valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
+        valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
+        0u,
+        0u,
+        0u,
+        0u,
+        0u,
+        0u,
+    };
     ts.overall_speed = 42 >> 1;
     ts.speed1 = 42 >> 1;
     ts.congestion1 = baldr::MAX_CONGESTION_VAL - 1;
     ts.breakpoint1 = 127;
 
-    std::function<void(baldr::GraphReader&, baldr::TrafficTile&, int, baldr::TrafficSpeed*)>
-        cb_setter_speed = [&map, &ts](baldr::GraphReader& reader, baldr::TrafficTile& tile, int index,
-                                      baldr::TrafficSpeed* current) -> void {
+    auto cb_setter_speed = [&map, &ts](baldr::GraphReader& reader, baldr::TrafficTile& tile,
+                                       int index, baldr::TrafficSpeed* current) -> void {
       baldr::GraphId tile_id(tile.header->tile_id);
       auto BD = gurka::findEdge(reader, map.nodes, "BD", "D", tile_id);
       current->breakpoint1 = 255;
@@ -255,15 +255,18 @@ TEST(Traffic, CutGeoms) {
   // Another permutation of subsegments
   {
     {
-      valhalla::baldr::TrafficSpeed ts{valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
-                                       valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
-                                       valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
-                                       valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
-                                       0u,
-                                       0u,
-                                       0u,
-                                       0u,
-                                       0u};
+      valhalla::baldr::TrafficSpeed ts{
+          valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
+          valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
+          valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
+          valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
+          0u,
+          0u,
+          0u,
+          0u,
+          0u,
+          0u,
+      };
       ts.overall_speed = 30 >> 1;
 
       ts.speed1 = 20 >> 1;
@@ -274,9 +277,8 @@ TEST(Traffic, CutGeoms) {
       ts.congestion2 = 1; // low but not unknown - 0 = unknown
       ts.breakpoint2 = 200;
 
-      std::function<void(baldr::GraphReader&, baldr::TrafficTile&, int, baldr::TrafficSpeed*)>
-          cb_setter_speed = [&map, &ts](baldr::GraphReader& reader, baldr::TrafficTile& tile,
-                                        int index, baldr::TrafficSpeed* current) -> void {
+      auto cb_setter_speed = [&map, &ts](baldr::GraphReader& reader, baldr::TrafficTile& tile,
+                                         int index, baldr::TrafficSpeed* current) -> void {
         baldr::GraphId tile_id(tile.header->tile_id);
         auto BD = gurka::findEdge(reader, map.nodes, "BD", "D", tile_id);
         baldr::TrafficSpeed* existing =
@@ -336,15 +338,18 @@ TEST(Traffic, CutGeoms) {
   // Another permutation of subsegments
   {
     {
-      valhalla::baldr::TrafficSpeed ts{valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
-                                       valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
-                                       valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
-                                       valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
-                                       0u,
-                                       0u,
-                                       0u,
-                                       0u,
-                                       0u};
+      valhalla::baldr::TrafficSpeed ts{
+          valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
+          valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
+          valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
+          valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
+          0u,
+          0u,
+          0u,
+          0u,
+          0u,
+          0u,
+      };
       ts.overall_speed = 36 >> 1;
 
       ts.speed1 = 20 >> 1;
@@ -357,9 +362,8 @@ TEST(Traffic, CutGeoms) {
 
       ts.speed3 = 60 >> 1;
       ts.congestion3 = 1;
-      std::function<void(baldr::GraphReader&, baldr::TrafficTile&, int, baldr::TrafficSpeed*)>
-          cb_setter_speed = [&map, &ts](baldr::GraphReader& reader, baldr::TrafficTile& tile,
-                                        int index, baldr::TrafficSpeed* current) -> void {
+      auto cb_setter_speed = [&map, &ts](baldr::GraphReader& reader, baldr::TrafficTile& tile,
+                                         int index, baldr::TrafficSpeed* current) -> void {
         baldr::GraphId tile_id(tile.header->tile_id);
         auto BD = gurka::findEdge(reader, map.nodes, "BD", "D", tile_id);
         current->breakpoint1 = 255;
@@ -454,15 +458,18 @@ TEST(Traffic, CutGeoms) {
     }
     {
       {
-        valhalla::baldr::TrafficSpeed ts{valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
-                                         valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
-                                         valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
-                                         valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
-                                         0u,
-                                         0u,
-                                         0u,
-                                         0u,
-                                         0u};
+        valhalla::baldr::TrafficSpeed ts{
+            valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
+            valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
+            valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
+            valhalla::baldr::UNKNOWN_TRAFFIC_SPEED_RAW,
+            0u,
+            0u,
+            0u,
+            0u,
+            0u,
+            0u,
+        };
         ts.overall_speed = 36 >> 1;
 
         ts.speed1 = 20 >> 1;
@@ -475,9 +482,8 @@ TEST(Traffic, CutGeoms) {
 
         ts.speed3 = 60 >> 1;
         ts.congestion3 = 50;
-        std::function<void(baldr::GraphReader&, baldr::TrafficTile&, int, baldr::TrafficSpeed*)>
-            cb_setter_speed = [&map, &ts](baldr::GraphReader& reader, baldr::TrafficTile& tile,
-                                          int index, baldr::TrafficSpeed* current) -> void {
+        auto cb_setter_speed = [&map, &ts](baldr::GraphReader& reader, baldr::TrafficTile& tile,
+                                           int index, baldr::TrafficSpeed* current) -> void {
           baldr::GraphId tile_id(tile.header->tile_id);
           auto BD = gurka::findEdge(reader, map.nodes, "BD", "D", tile_id);
           current->breakpoint1 = 255;

--- a/test/util/traffic_utils.h
+++ b/test/util/traffic_utils.h
@@ -127,7 +127,7 @@ void build_live_traffic_data(const boost::property_tree::ptree& config,
 /*************************************************************/
 void customize_live_traffic_data(
     const boost::property_tree::ptree& config,
-    std::function<void(baldr::GraphReader&, baldr::TrafficTile&, int, baldr::TrafficSpeed*)>&
+    const std::function<void(baldr::GraphReader&, baldr::TrafficTile&, int, baldr::TrafficSpeed*)>&
         setter_cb) {
 
   // Now we have the tar-file and can go ahead with per edge customizations

--- a/valhalla/baldr/graphreader.h
+++ b/valhalla/baldr/graphreader.h
@@ -1,6 +1,7 @@
 #ifndef VALHALLA_BALDR_GRAPHREADER_H_
 #define VALHALLA_BALDR_GRAPHREADER_H_
 
+#include <algorithm>
 #include <cstdint>
 #include <memory>
 #include <mutex>
@@ -759,6 +760,51 @@ public:
    */
   int GetTimezone(const baldr::GraphId& node, const GraphTile*& tile);
 
+  // TODO: temporary until we have real incidents loaded from incident loading singleton
+  struct Incident {
+    uint32_t edge_index;
+    float start_offset;
+    float end_offset;
+  };
+  using incident_tile_t = std::vector<Incident>;
+
+  /**
+   * Returns an incident tile for the given tile id
+   * @param tile_id  the tile id for which incidents should be returned
+   * @return the incident tile for the tile id
+   */
+  virtual std::shared_ptr<incident_tile_t> GetIncidentTile(const GraphId& tile_id) const {
+    // TODO: hook this up to the incident loading singleton from the pr:
+    // https://github.com/valhalla/valhalla/pull/2573
+    // return incident_singleton_t::get(tile_id.Tile_Base());
+    return {};
+  }
+
+  /**
+   * Returns a vector of incidents for the given edge
+   * @param edge_id   which edge you need incidents for
+   * @param tile      which tile the edge lives in, is updated if not correct
+   * @return vector of incidents
+   */
+  std::vector<Incident> GetIncidents(const GraphId& edge_id, const GraphTile*& tile) {
+    // if we are not doing this for any reason then bail
+    std::shared_ptr<incident_tile_t> itile;
+    if (!simulate_incidents_ || !GetGraphTile(edge_id, tile) ||
+        !tile->trafficspeed(tile->directededge(edge_id)).has_incidents ||
+        !(itile = GetIncidentTile(edge_id))) {
+      return {};
+    }
+
+    // get the range of incidents we care about and hand it back, equal_range has no lambda option
+    auto begin = std::partition_point(itile->begin(), itile->end(), [&edge_id](const Incident& i) {
+      return i.edge_index < edge_id.id(); // first one that is >= the id we want
+    });
+    auto end = std::partition_point(begin, itile->end(), [&edge_id](const Incident& i) {
+      return i.edge_index <= edge_id.id(); // first one that is > the id we want
+    });
+    return std::vector<Incident>(begin, end);
+  }
+
 protected:
   // (Tar) extract of tiles - the contents are empty if not being used
   struct tile_extract_t {
@@ -785,6 +831,9 @@ protected:
   std::unordered_set<GraphId> _404s;
 
   std::unique_ptr<TileCache> cache_;
+
+  // TODO: delete me when incident singleton is ready
+  bool simulate_incidents_;
 };
 
 } // namespace baldr

--- a/valhalla/baldr/graphreader.h
+++ b/valhalla/baldr/graphreader.h
@@ -765,6 +765,7 @@ public:
     uint32_t edge_index;
     float start_offset;
     float end_offset;
+    uint64_t id;
   };
   using incident_tile_t = std::vector<Incident>;
 

--- a/valhalla/baldr/graphreader.h
+++ b/valhalla/baldr/graphreader.h
@@ -763,8 +763,8 @@ public:
   // TODO: temporary until we have real incidents loaded from incident loading singleton
   struct Incident {
     uint32_t edge_index;
-    float start_offset;
-    float end_offset;
+    double start_offset;
+    double end_offset;
     uint64_t id;
   };
   using incident_tile_t = std::vector<Incident>;

--- a/valhalla/odin/enhancedtrippath.h
+++ b/valhalla/odin/enhancedtrippath.h
@@ -692,8 +692,6 @@ public:
 
   std::string ToString() const;
 
-  const google::protobuf::RepeatedPtrField<valhalla::TripLeg_Node_Incident>& incidents() const;
-
 protected:
   TripLeg_Node* mutable_node_;
 };

--- a/valhalla/proto_conversions.h
+++ b/valhalla/proto_conversions.h
@@ -202,7 +202,7 @@ inline TripLeg_Use GetTripLegUse(const baldr::Use use) {
 }
 
 // Get the string representing the incident-type
-std::string incidentTypeToString(const TripLeg_Node_Incident_Type& incident_type);
+std::string incidentTypeToString(const TripLeg::Incident::Type& incident_type);
 
 // to use protobuflite we cant use descriptors which means we cant translate enums to strings
 // and so we reimplement the ones we use here. newer versions of protobuf provide these even

--- a/valhalla/thor/attributes_controller.h
+++ b/valhalla/thor/attributes_controller.h
@@ -108,7 +108,6 @@ const std::string kNodeTransitEgressInfoName = "node.transit_egress_info.name";
 const std::string kNodeTransitEgressInfoLatLon = "node.transit_egress_info.lat_lon";
 const std::string kNodeTimeZone = "node.time_zone";
 const std::string kNodeTransitionTime = "node.transition_time";
-const std::string kNodeIncidents = "node.incidents";
 
 // Top level: osm changeset, admin list, and full shape keys
 const std::string kOsmChangeset = "osm_changeset";
@@ -117,6 +116,9 @@ const std::string kAdminCountryText = "admin.country_text";
 const std::string kAdminStateCode = "admin.state_code";
 const std::string kAdminStateText = "admin.state_text";
 const std::string kShape = "shape";
+const std::string kIncidents = "incidents";
+
+// Map matching ones nested to points and top level ones
 const std::string kMatchedPoint = "matched.point";
 const std::string kMatchedType = "matched.type";
 const std::string kMatchedEdgeIndex = "matched.edge_index";


### PR DESCRIPTION
This code:

1. mocks out the interface in graphreader for getting incidents (per tile/edge)
2. it adds code to triplegbuilder to cut the edge shape where incidents occur
3. add the incident to the tripleg with the leg shape indices where it occurs