### PR TITLE
Refactor incident serializer to be reusable by code that doesn't have a TripLeg

### DIFF
--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -636,7 +636,11 @@ valhalla::baldr::json::RawJSON serializeIncident(const TripLeg::Incident& incide
   rapidjson::StringBuffer stringbuffer;
   rapidjson::Writer<rapidjson::StringBuffer> writer(stringbuffer);
   writer.StartObject();
-  osrm::serializeIncidentProperties(writer, incident, "", "");
+  osrm::serializeIncidentProperties(writer, incident.metadata(),
+                                    incident.has_begin_shape_index() ? incident.begin_shape_index()
+                                                                     : -1,
+                                    incident.has_end_shape_index() ? incident.end_shape_index() : -1,
+                                    "", "");
   writer.EndObject();
   return {stringbuffer.GetString()};
 }

--- a/src/tyr/serializers.cc
+++ b/src/tyr/serializers.cc
@@ -140,53 +140,54 @@ json::ArrayPtr waypoints(const valhalla::Trip& trip) {
 }
 
 void serializeIncidentProperties(rapidjson::Writer<rapidjson::StringBuffer>& writer,
-                                 const TripLeg::Incident& incident,
+                                 const valhalla::incidents::Metadata& incident_metadata,
+                                 const int begin_shape_index,
+                                 const int end_shape_index,
                                  const std::string& road_class,
                                  const std::string& key_prefix) {
-  const valhalla::incidents::Metadata& meta = incident.metadata();
   writer.Key(key_prefix + "id");
-  writer.Int64(meta.id());
+  writer.Int64(incident_metadata.id());
   {
     // Type is mandatory
     writer.Key(key_prefix + "type");
-    writer.String(std::string(valhalla::incidentTypeToString(meta.type())));
+    writer.String(std::string(valhalla::incidentTypeToString(incident_metadata.type())));
   }
-  if (!meta.iso_3166_1_alpha2().empty()) {
+  if (!incident_metadata.iso_3166_1_alpha2().empty()) {
     writer.Key(key_prefix + "iso_3166_1_alpha2");
-    writer.String(meta.iso_3166_1_alpha2());
+    writer.String(incident_metadata.iso_3166_1_alpha2());
   }
-  if (!meta.description().empty()) {
+  if (!incident_metadata.description().empty()) {
     writer.Key(key_prefix + "description");
-    writer.String(meta.description());
+    writer.String(incident_metadata.description());
   }
-  if (meta.creation_time()) {
+  if (incident_metadata.creation_time()) {
     writer.Key(key_prefix + "creation_time");
-    writer.String(baldr::DateTime::seconds_to_date_utc(meta.creation_time()));
+    writer.String(baldr::DateTime::seconds_to_date_utc(incident_metadata.creation_time()));
   }
-  if (meta.start_time() > 0) {
+  if (incident_metadata.start_time() > 0) {
     writer.Key(key_prefix + "start_time");
-    writer.String(baldr::DateTime::seconds_to_date_utc(meta.start_time()));
+    writer.String(baldr::DateTime::seconds_to_date_utc(incident_metadata.start_time()));
   }
-  if (meta.end_time()) {
+  if (incident_metadata.end_time()) {
     writer.Key(key_prefix + "end_time");
-    writer.String(baldr::DateTime::seconds_to_date_utc(meta.end_time()));
+    writer.String(baldr::DateTime::seconds_to_date_utc(incident_metadata.end_time()));
   }
-  if (meta.impact()) {
+  if (incident_metadata.impact()) {
     writer.Key(key_prefix + "impact");
-    writer.String(std::string(valhalla::incidentImpactToString(meta.impact())));
+    writer.String(std::string(valhalla::incidentImpactToString(incident_metadata.impact())));
   }
-  if (!meta.sub_type().empty()) {
+  if (!incident_metadata.sub_type().empty()) {
     writer.Key(key_prefix + "sub_type");
-    writer.String(meta.sub_type());
+    writer.String(incident_metadata.sub_type());
   }
-  if (!meta.sub_type_description().empty()) {
+  if (!incident_metadata.sub_type_description().empty()) {
     writer.Key(key_prefix + "sub_type_description");
-    writer.String(meta.sub_type_description());
+    writer.String(incident_metadata.sub_type_description());
   }
-  if (meta.alertc_codes_size() > 0) {
+  if (incident_metadata.alertc_codes_size() > 0) {
     writer.Key(key_prefix + "alertc_codes");
     writer.StartArray();
-    for (const auto& alertc_code : meta.alertc_codes()) {
+    for (const auto& alertc_code : incident_metadata.alertc_codes()) {
       writer.Int(static_cast<uint64_t>(alertc_code));
     }
     writer.EndArray();
@@ -194,35 +195,35 @@ void serializeIncidentProperties(rapidjson::Writer<rapidjson::StringBuffer>& wri
   {
     writer.Key(key_prefix + "lanes_blocked");
     writer.StartArray();
-    for (const auto& blocked_lane : meta.lanes_blocked()) {
+    for (const auto& blocked_lane : incident_metadata.lanes_blocked()) {
       writer.String(blocked_lane);
     }
     writer.EndArray();
   }
-  if (meta.road_closed()) {
+  if (incident_metadata.road_closed()) {
     writer.Key(key_prefix + "closed");
-    writer.Bool(meta.road_closed());
+    writer.Bool(incident_metadata.road_closed());
   }
   if (!road_class.empty()) {
     writer.Key(key_prefix + "class");
     writer.String(road_class);
   }
 
-  if (meta.has_congestion()) {
+  if (incident_metadata.has_congestion()) {
     writer.Key(key_prefix + "congestion");
     writer.StartObject();
     writer.Key("value");
-    writer.Int(meta.congestion().value());
+    writer.Int(incident_metadata.congestion().value());
     writer.EndObject();
   }
 
-  if (incident.has_begin_shape_index()) {
+  if (begin_shape_index >= 0) {
     writer.Key(key_prefix + "geometry_index_start");
-    writer.Int(incident.begin_shape_index());
+    writer.Int(begin_shape_index);
   }
-  if (incident.has_end_shape_index()) {
+  if (end_shape_index >= 0) {
     writer.Key(key_prefix + "geometry_index_end");
-    writer.Int(incident.end_shape_index());
+    writer.Int(end_shape_index);
   }
   // TODO Add test of lanes blocked and add missing properties
 }

--- a/valhalla/tyr/serializers.h
+++ b/valhalla/tyr/serializers.h
@@ -124,7 +124,9 @@ waypoints(const google::protobuf::RepeatedPtrField<valhalla::Location>& location
 valhalla::baldr::json::ArrayPtr waypoints(const valhalla::Trip& locations);
 
 void serializeIncidentProperties(rapidjson::Writer<rapidjson::StringBuffer>& writer,
-                                 const valhalla::TripLeg::Incident& incident,
+                                 const valhalla::incidents::Metadata& incident_metadata,
+                                 const int begin_shape_index,
+                                 const int end_shape_index,
                                  const std::string& road_class,
                                  const std::string& key_prefix);
 


### PR DESCRIPTION
# Issue

We don't want to tie incident serialization to a TripLeg for ... reasons. This PR is a simple refactor that removes TripLeg from
the serialization interface.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
