### PR TITLE
Add maneuver.instruction in osrm response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,7 @@
    * ADDED: Moves incident serializer logic into a generic serializer [#2621](https://github.com/valhalla/valhalla/pull/2621)
    * ADDED: Incident loading singleton for continually refreshing incident tiles[#2573](https://github.com/valhalla/valhalla/pull/2573)
    * ADDED: One shot mode to valhalla_service so you can run a single request of any type without starting a server [#2624](https://github.com/valhalla/valhalla/pull/2624)
+   * ADDED: Adds text instructions to OSRM output [#2625](https://github.com/valhalla/valhalla/pull/2625)
 
 ## Release Date: 2019-11-21 Valhalla 3.0.9
 * **Bug Fix**

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -972,7 +972,8 @@ json::MapPtr osrm_maneuver(const valhalla::DirectionsLeg::Maneuver& maneuver,
                            const std::string& mode,
                            const std::string& prev_mode,
                            const bool rotary,
-                           const bool prev_rotary) {
+                           const bool prev_rotary,
+                           const valhalla::Options& options) {
   auto osrm_man = json::map({});
 
   // Set the location
@@ -995,6 +996,10 @@ json::MapPtr osrm_maneuver(const valhalla::DirectionsLeg::Maneuver& maneuver,
     modifier = turn_modifier(maneuver, etp, in_brg, out_brg, arrive_maneuver);
     if (!modifier.empty())
       osrm_man->emplace("modifier", modifier);
+  }
+
+  if (options.directions_type() == DirectionsType::instructions) {
+    osrm_man->emplace("instruction", maneuver.text_instruction());
   }
 
   // TODO - logic to convert maneuver types from Valhalla into OSRM maneuver types.
@@ -1351,7 +1356,7 @@ json::ArrayPtr serialize_legs(const google::protobuf::RepeatedPtrField<valhalla:
       step->emplace("maneuver",
                     osrm_maneuver(maneuver, &etp, shape[maneuver.begin_shape_index()],
                                   depart_maneuver, arrive_maneuver, prev_intersection_count, mode,
-                                  prev_mode, rotary, prev_rotary));
+                                  prev_mode, rotary, prev_rotary, options));
 
       // Add destinations
       const auto& sign = maneuver.sign();


### PR DESCRIPTION
# Issue

Adds text instructions to OSRM output when directions type is set to `instructions`. This mirrors a common implementation of OSRM when combined with [osrm-text-instructions](https://github.com/Project-OSRM/osrm-text-instructions/).

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
