### PR TITLE
Emit incident ID as a string rather than a numeric value to avoid limits to numeric parsing by some clients

### DIFF
--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -1603,7 +1603,7 @@ TEST(RouteSerializerOsrm, testserializeIncidents) {
     expected_json.Parse(R"({
       "incidents": [
         {
-          "id": 18446744073709551615,
+          "id": "18446744073709551615",
           "type": "weather",
           "iso_3166_1_alpha2": "AU",
           "creation_time": "2020-08-12T14:17:09Z",
@@ -1690,7 +1690,7 @@ TEST(RouteSerializerOsrm, testserializeIncidentsMultipleIncidentsSingleEdge) {
     expected_json.Parse(R"({
       "incidents": [
         {
-          "id": 1337,
+          "id": "1337",
           "description": "Fooo",
           "creation_time": "2020-08-12T14:17:09Z",
           "type": "weather",
@@ -1700,7 +1700,7 @@ TEST(RouteSerializerOsrm, testserializeIncidentsMultipleIncidentsSingleEdge) {
           "geometry_index_end": 92
         },
         {
-          "id": 2448,
+          "id": "2448",
           "creation_time": "2020-08-12T14:16:40Z",
           "start_time": "2020-08-12T14:18:20Z",
           "end_time": "2020-08-12T14:46:40Z",

--- a/src/tyr/serializers.cc
+++ b/src/tyr/serializers.cc
@@ -146,7 +146,7 @@ void serializeIncidentProperties(rapidjson::Writer<rapidjson::StringBuffer>& wri
                                  const std::string& road_class,
                                  const std::string& key_prefix) {
   writer.Key(key_prefix + "id");
-  writer.Uint64(incident_metadata.id());
+  writer.String(std::to_string(incident_metadata.id()));
   {
     // Type is mandatory
     writer.Key(key_prefix + "type");


### PR DESCRIPTION
javascript is trash m'k