### PR TITLE
Fix all compiler warnings in sif and set to -Werror

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-*,performance*,-performance-move-const-arg'
+Checks:          'clang-*,performance*,-performance-move-const-arg,misc-unused-parameters'
 WarningsAsErrors: ''
 AnalyzeTemporaryDtors: false
 CheckOptions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@
    * FIXED: Removed superfluous const qualifier from odin/signs [#2609](https://github.com/valhalla/valhalla/pull/2609)
    * FIXED: Internal maneuver placement [#2600](https://github.com/valhalla/valhalla/pull/2600)
    * FIXED: Complete fr-FR.json locale. [#2614](https://github.com/valhalla/valhalla/pull/2614)
+   * FIXED: Fix all compiler warnings in sif and set to -Werror [#2642](https://github.com/valhalla/valhalla/pull/2642)
 
 * **Enhancement**
    * ADDED: Add ability to provide custom implementation for candidate collection in CandidateQuery. [#2328](https://github.com/valhalla/valhalla/pull/2328)

--- a/scripts/clang-tidy-only-diff.sh
+++ b/scripts/clang-tidy-only-diff.sh
@@ -48,12 +48,6 @@ readonly num_jobs="${1:-$(nproc)}"
 # -p Tells clang-tidy where to find the `compile_commands.json`.
 # `{}` specifies where `parallel` adds the command-line arguments.
 # `:::` separates the command `parallel` should execute from the arguments it should pass to the commands.
-{
-  while true; do
-    sleep 30
-    echo .
-  done
-} &
 parallel \
   -m \
   -j $num_jobs \

--- a/src/sif/CMakeLists.txt
+++ b/src/sif/CMakeLists.txt
@@ -13,6 +13,12 @@ set(sources
   dynamiccost.cc
   recost.cc)
 
+if (UNIX)
+  # Enables stricter compiler checks on a file-by-file basis
+  # which allows us to migrate piecemeal
+  set_source_files_properties(${sources} PROPERTIES COMPILE_FLAGS "-Werror")
+endif (UNIX)
+
 valhalla_module(NAME sif
   SOURCES ${sources}
   HEADERS ${headers}

--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -141,7 +141,7 @@ public:
    * limits).
    * @return  Returns true if the costing model allows multiple passes.
    */
-  virtual bool AllowMultiPass() const {
+  virtual bool AllowMultiPass() const override {
     return true;
   }
 
@@ -166,7 +166,7 @@ public:
                        const baldr::GraphId& edgeid,
                        const uint64_t current_time,
                        const uint32_t tz_index,
-                       int& restriction_idx) const;
+                       int& restriction_idx) const override;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
@@ -193,7 +193,7 @@ public:
                               const baldr::GraphId& opp_edgeid,
                               const uint64_t current_time,
                               const uint32_t tz_index,
-                              int& restriction_idx) const;
+                              int& restriction_idx) const override;
 
   /**
    * Only transit costings are valid for this method call, hence we throw
@@ -204,7 +204,7 @@ public:
    */
   virtual Cost EdgeCost(const baldr::DirectedEdge* edge,
                         const baldr::TransitDeparture* departure,
-                        const uint32_t curr_time) const {
+                        const uint32_t curr_time) const override {
     throw std::runtime_error("AutoCost::EdgeCost does not support transit edges");
   }
 
@@ -218,7 +218,7 @@ public:
    */
   virtual Cost EdgeCost(const baldr::DirectedEdge* edge,
                         const baldr::GraphTile* tile,
-                        const uint32_t seconds) const;
+                        const uint32_t seconds) const override;
 
   /**
    * Returns the cost to make the transition from the predecessor edge.
@@ -231,7 +231,7 @@ public:
    */
   virtual Cost TransitionCost(const baldr::DirectedEdge* edge,
                               const baldr::NodeInfo* node,
-                              const EdgeLabel& pred) const;
+                              const EdgeLabel& pred) const override;
 
   /**
    * Returns the cost to make the transition from the predecessor edge
@@ -245,7 +245,7 @@ public:
   virtual Cost TransitionCostReverse(const uint32_t idx,
                                      const baldr::NodeInfo* node,
                                      const baldr::DirectedEdge* pred,
-                                     const baldr::DirectedEdge* edge) const;
+                                     const baldr::DirectedEdge* edge) const override;
 
   /**
    * Get the cost factor for A* heuristics. This factor is multiplied
@@ -255,7 +255,7 @@ public:
    * assume the maximum speed is used to the destination such that the time
    * estimate is less than the least possible time along roads.
    */
-  virtual float AStarCostFactor() const {
+  virtual float AStarCostFactor() const override {
     return speedfactor_[kMaxAssumedSpeed];
   }
 
@@ -263,7 +263,7 @@ public:
    * Get the current travel type.
    * @return  Returns the current travel type.
    */
-  virtual uint8_t travel_type() const {
+  virtual uint8_t travel_type() const override {
     return static_cast<uint8_t>(type_);
   }
 
@@ -743,7 +743,7 @@ public:
                        const baldr::GraphId& edgeid,
                        const uint64_t current_time,
                        const uint32_t tz_index,
-                       int& restriction_idx) const;
+                       int& restriction_idx) const override;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
@@ -770,7 +770,7 @@ public:
                               const baldr::GraphId& opp_edgeid,
                               const uint64_t current_time,
                               const uint32_t tz_index,
-                              int& restriction_idx) const;
+                              int& restriction_idx) const override;
 
   /**
    * Function to be used in location searching which will
@@ -887,7 +887,7 @@ public:
                        const baldr::GraphId& edgeid,
                        const uint64_t current_time,
                        const uint32_t tz_index,
-                       int& restriction_idx) const;
+                       int& restriction_idx) const override;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
@@ -913,7 +913,7 @@ public:
                               const baldr::GraphId& opp_edgeid,
                               const uint64_t current_time,
                               const uint32_t tz_index,
-                              int& restriction_idx) const;
+                              int& restriction_idx) const override;
 
   /**
    * Returns the cost to traverse the edge and an estimate of the actual time
@@ -925,7 +925,7 @@ public:
    */
   virtual Cost EdgeCost(const baldr::DirectedEdge* edge,
                         const baldr::GraphTile* tile,
-                        const uint32_t seconds) const {
+                        const uint32_t seconds) const override {
     auto speed = tile->GetSpeed(edge, flow_mask_, seconds);
     float factor = (edge->use() == Use::kFerry) ? ferry_factor_ : density_factor_[edge->density()];
     if ((edge->forwardaccess() & kHOVAccess) && !(edge->forwardaccess() & kAutoAccess)) {
@@ -1052,7 +1052,7 @@ public:
                        const baldr::GraphId& edgeid,
                        const uint64_t current_time,
                        const uint32_t tz_index,
-                       int& restriction_idx) const;
+                       int& restriction_idx) const override;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
@@ -1078,7 +1078,7 @@ public:
                               const baldr::GraphId& opp_edgeid,
                               const uint64_t current_time,
                               const uint32_t tz_index,
-                              int& restriction_idx) const;
+                              int& restriction_idx) const override;
 
   /**
    * Returns the cost to traverse the edge and an estimate of the actual time
@@ -1090,7 +1090,7 @@ public:
    */
   virtual Cost EdgeCost(const baldr::DirectedEdge* edge,
                         const baldr::GraphTile* tile,
-                        const uint32_t seconds) const {
+                        const uint32_t seconds) const override {
     auto speed = tile->GetSpeed(edge, flow_mask_, seconds);
     float factor = (edge->use() == Use::kFerry) ? ferry_factor_ : density_factor_[edge->density()];
     if ((edge->forwardaccess() & kTaxiAccess) && !(edge->forwardaccess() & kAutoAccess)) {
@@ -1232,7 +1232,7 @@ public:
                        const baldr::GraphId& edgeid,
                        const uint64_t current_time,
                        const uint32_t tz_index,
-                       int& restriction_idx) const {
+                       int& restriction_idx) const override {
 
     // Note: this profile ignores closures in live traffic, so that check is not
     //       present, unlike other Allowed() implementations

--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -202,9 +202,9 @@ public:
    * @param curr_time
    * @return
    */
-  virtual Cost EdgeCost(const baldr::DirectedEdge* edge,
-                        const baldr::TransitDeparture* departure,
-                        const uint32_t curr_time) const override {
+  virtual Cost EdgeCost(const baldr::DirectedEdge*,
+                        const baldr::TransitDeparture*,
+                        const uint32_t) const override {
     throw std::runtime_error("AutoCost::EdgeCost does not support transit edges");
   }
 
@@ -1228,11 +1228,11 @@ public:
    */
   virtual bool Allowed(const baldr::DirectedEdge* edge,
                        const EdgeLabel& pred,
-                       const GraphTile* tile,
+                       const GraphTile*,
                        const baldr::GraphId& edgeid,
-                       const uint64_t current_time,
-                       const uint32_t tz_index,
-                       int& restriction_idx) const override {
+                       const uint64_t,
+                       const uint32_t,
+                       int&) const override {
 
     // Note: this profile ignores closures in live traffic, so that check is not
     //       present, unlike other Allowed() implementations

--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -250,7 +250,7 @@ public:
                        const baldr::GraphId& edgeid,
                        const uint64_t current_time,
                        const uint32_t tz_index,
-                       int& restriction_idx) const;
+                       int& restriction_idx) const override;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
@@ -277,7 +277,7 @@ public:
                               const baldr::GraphId& opp_edgeid,
                               const uint64_t current_time,
                               const uint32_t tz_index,
-                              int& restriction_idx) const;
+                              int& restriction_idx) const override;
 
   /**
    * Only transit costings are valid for this method call, hence we throw
@@ -288,7 +288,7 @@ public:
    */
   virtual Cost EdgeCost(const baldr::DirectedEdge* edge,
                         const baldr::TransitDeparture* departure,
-                        const uint32_t curr_time) const {
+                        const uint32_t curr_time) const override {
     throw std::runtime_error("BicycleCost::EdgeCost does not support transit edges");
   }
 
@@ -306,7 +306,7 @@ public:
    */
   virtual Cost EdgeCost(const baldr::DirectedEdge* edge,
                         const baldr::GraphTile* tile,
-                        const uint32_t seconds) const;
+                        const uint32_t seconds) const override;
 
   /**
    * Returns the cost to make the transition from the predecessor edge.
@@ -319,7 +319,7 @@ public:
    */
   virtual Cost TransitionCost(const baldr::DirectedEdge* edge,
                               const baldr::NodeInfo* node,
-                              const EdgeLabel& pred) const;
+                              const EdgeLabel& pred) const override;
 
   /**
    * Returns the cost to make the transition from the predecessor edge
@@ -333,7 +333,7 @@ public:
   virtual Cost TransitionCostReverse(const uint32_t idx,
                                      const baldr::NodeInfo* node,
                                      const baldr::DirectedEdge* pred,
-                                     const baldr::DirectedEdge* edge) const;
+                                     const baldr::DirectedEdge* edge) const override;
 
   /**
    * Get the cost factor for A* heuristics. This factor is multiplied
@@ -343,7 +343,7 @@ public:
    * assume the maximum speed is used to the destination such that the time
    * estimate is less than the least possible time along roads.
    */
-  virtual float AStarCostFactor() const {
+  virtual float AStarCostFactor() const override {
     // Assume max speed of 2 * the average speed set for costing
     return speedfactor_[2 * static_cast<uint32_t>(speed_)];
   }
@@ -352,7 +352,7 @@ public:
    * Get the current travel type.
    * @return  Returns the current travel type.
    */
-  virtual uint8_t travel_type() const {
+  virtual uint8_t travel_type() const override {
     return static_cast<uint8_t>(type_);
   }
 

--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -286,13 +286,13 @@ public:
    * @param curr_time
    * @return
    */
-  virtual Cost EdgeCost(const baldr::DirectedEdge* edge,
-                        const baldr::TransitDeparture* departure,
-                        const uint32_t curr_time) const override {
+  virtual Cost EdgeCost(const baldr::DirectedEdge*,
+                        const baldr::TransitDeparture*,
+                        const uint32_t) const override {
     throw std::runtime_error("BicycleCost::EdgeCost does not support transit edges");
   }
 
-  bool IsClosed(const baldr::DirectedEdge* edge, const baldr::GraphTile* tile) const override {
+  bool IsClosed(const baldr::DirectedEdge*, const baldr::GraphTile*) const override {
     return false;
   }
 

--- a/src/sif/dynamiccost.cc
+++ b/src/sif/dynamiccost.cc
@@ -87,9 +87,7 @@ Cost DynamicCost::EdgeCost(const baldr::DirectedEdge* edge, const baldr::GraphTi
 // Returns the cost to make the transition from the predecessor edge.
 // Defaults to 0. Costing models that wish to include edge transition
 // costs (i.e., intersection/turn costs) must override this method.
-Cost DynamicCost::TransitionCost(const DirectedEdge* edge,
-                                 const NodeInfo* node,
-                                 const EdgeLabel& pred) const {
+Cost DynamicCost::TransitionCost(const DirectedEdge*, const NodeInfo*, const EdgeLabel&) const {
   return {0.0f, 0.0f};
 }
 
@@ -97,10 +95,10 @@ Cost DynamicCost::TransitionCost(const DirectedEdge* edge,
 // when using a reverse search (from destination towards the origin).
 // Defaults to 0. Costing models that wish to include edge transition
 // costs (i.e., intersection/turn costs) must override this method.
-Cost DynamicCost::TransitionCostReverse(const uint32_t idx,
-                                        const baldr::NodeInfo* node,
-                                        const baldr::DirectedEdge* opp_edge,
-                                        const baldr::DirectedEdge* opp_pred_edge) const {
+Cost DynamicCost::TransitionCostReverse(const uint32_t,
+                                        const baldr::NodeInfo*,
+                                        const baldr::DirectedEdge*,
+                                        const baldr::DirectedEdge*) const {
   return {0.0f, 0.0f};
 }
 
@@ -189,16 +187,16 @@ bool DynamicCost::bicycle() const {
 }
 
 // Add to the exclude list.
-void DynamicCost::AddToExcludeList(const baldr::GraphTile*& tile) {
+void DynamicCost::AddToExcludeList(const baldr::GraphTile*&) {
 }
 
 // Checks if we should exclude or not.
-bool DynamicCost::IsExcluded(const baldr::GraphTile*& tile, const baldr::DirectedEdge* edge) {
+bool DynamicCost::IsExcluded(const baldr::GraphTile*&, const baldr::DirectedEdge*) {
   return false;
 }
 
 // Checks if we should exclude or not.
-bool DynamicCost::IsExcluded(const baldr::GraphTile*& tile, const baldr::NodeInfo* node) {
+bool DynamicCost::IsExcluded(const baldr::GraphTile*&, const baldr::NodeInfo*) {
   return false;
 }
 

--- a/src/sif/dynamiccost.cc
+++ b/src/sif/dynamiccost.cc
@@ -301,6 +301,10 @@ void ParseCostingOptions(const rapidjson::Document& doc,
       sif::ParsePedestrianCostOptions(doc, key, costing_options);
       break;
     }
+    case bikeshare: {
+      costing_options->set_costing(Costing::bikeshare); // Nothing to parse for this one
+      break;
+    }
     case transit: {
       sif::ParseTransitCostOptions(doc, key, costing_options);
       break;

--- a/src/sif/motorcyclecost.cc
+++ b/src/sif/motorcyclecost.cc
@@ -132,7 +132,7 @@ public:
    * limits).
    * @return  Returns true if the costing model allows multiple passes.
    */
-  virtual bool AllowMultiPass() const {
+  virtual bool AllowMultiPass() const override {
     return true;
   }
 
@@ -157,7 +157,7 @@ public:
                        const baldr::GraphId& edgeid,
                        const uint64_t current_time,
                        const uint32_t tz_index,
-                       int& restriction_idx) const;
+                       int& restriction_idx) const override;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
@@ -184,7 +184,7 @@ public:
                               const baldr::GraphId& opp_edgeid,
                               const uint64_t current_time,
                               const uint32_t tz_index,
-                              int& restriction_idx) const;
+                              int& restriction_idx) const override;
 
   /**
    * Only transit costings are valid for this method call, hence we throw
@@ -195,7 +195,7 @@ public:
    */
   virtual Cost EdgeCost(const baldr::DirectedEdge* edge,
                         const baldr::TransitDeparture* departure,
-                        const uint32_t curr_time) const {
+                        const uint32_t curr_time) const override {
     throw std::runtime_error("MotorcycleCost::EdgeCost does not support transit edges");
   }
 
@@ -209,7 +209,7 @@ public:
    */
   virtual Cost EdgeCost(const baldr::DirectedEdge* edge,
                         const baldr::GraphTile* tile,
-                        const uint32_t seconds) const;
+                        const uint32_t seconds) const override;
 
   /**
    * Returns the cost to make the transition from the predecessor edge.
@@ -250,7 +250,7 @@ public:
    * assume the maximum speed is used to the destination such that the time
    * estimate is less than the least possible time along roads.
    */
-  virtual float AStarCostFactor() const {
+  virtual float AStarCostFactor() const override {
     return speedfactor_[kMaxAssumedSpeed];
   }
 
@@ -258,7 +258,7 @@ public:
    * Get the current travel type.
    * @return  Returns the current travel type.
    */
-  virtual uint8_t travel_type() const {
+  virtual uint8_t travel_type() const override {
     return static_cast<uint8_t>(VehicleType::kMotorcycle);
   }
 

--- a/src/sif/motorcyclecost.cc
+++ b/src/sif/motorcyclecost.cc
@@ -193,9 +193,9 @@ public:
    * @param curr_time
    * @return
    */
-  virtual Cost EdgeCost(const baldr::DirectedEdge* edge,
-                        const baldr::TransitDeparture* departure,
-                        const uint32_t curr_time) const override {
+  virtual Cost EdgeCost(const baldr::DirectedEdge*,
+                        const baldr::TransitDeparture*,
+                        const uint32_t) const override {
     throw std::runtime_error("MotorcycleCost::EdgeCost does not support transit edges");
   }
 
@@ -438,7 +438,7 @@ Cost MotorcycleCost::EdgeCost(const baldr::DirectedEdge* edge,
 Cost MotorcycleCost::TransitionCost(const baldr::DirectedEdge* edge,
                                     const baldr::NodeInfo* node,
                                     const EdgeLabel& pred,
-                                    const bool has_traffic) const {
+                                    const bool) const {
   // Get the transition cost for country crossing, ferry, gate, toll booth,
   // destination only, alley, maneuver penalty
   uint32_t idx = pred.opp_local_idx();
@@ -484,7 +484,7 @@ Cost MotorcycleCost::TransitionCostReverse(const uint32_t idx,
                                            const baldr::NodeInfo* node,
                                            const baldr::DirectedEdge* pred,
                                            const baldr::DirectedEdge* edge,
-                                           const bool has_traffic) const {
+                                           const bool) const {
   // Get the transition cost for country crossing, ferry, gate, toll booth,
   // destination only, alley, maneuver penalty
   Cost c = base_transition_cost(node, edge, pred, idx);

--- a/src/sif/motorscootercost.cc
+++ b/src/sif/motorscootercost.cc
@@ -172,7 +172,7 @@ public:
    * limits).
    * @return  Returns true if the costing model allows multiple passes.
    */
-  virtual bool AllowMultiPass() const {
+  virtual bool AllowMultiPass() const override {
     return true;
   }
 
@@ -197,7 +197,7 @@ public:
                        const baldr::GraphId& edgeid,
                        const uint64_t current_time,
                        const uint32_t tz_index,
-                       int& restriction_idx) const;
+                       int& restriction_idx) const override;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
@@ -224,7 +224,7 @@ public:
                               const baldr::GraphId& opp_edgeid,
                               const uint64_t current_time,
                               const uint32_t tz_index,
-                              int& restriction_idx) const;
+                              int& restriction_idx) const override;
 
   /**
    * Only transit costings are valid for this method call, hence we throw
@@ -235,7 +235,7 @@ public:
    */
   virtual Cost EdgeCost(const baldr::DirectedEdge* edge,
                         const baldr::TransitDeparture* departure,
-                        const uint32_t curr_time) const {
+                        const uint32_t curr_time) const override {
     throw std::runtime_error("MotorScooterCost::EdgeCost does not support transit edges");
   }
 
@@ -249,7 +249,7 @@ public:
    */
   virtual Cost EdgeCost(const baldr::DirectedEdge* edge,
                         const baldr::GraphTile* tile,
-                        const uint32_t seconds) const;
+                        const uint32_t seconds) const override;
 
   /**
    * Returns the cost to make the transition from the predecessor edge.
@@ -262,7 +262,7 @@ public:
    */
   virtual Cost TransitionCost(const baldr::DirectedEdge* edge,
                               const baldr::NodeInfo* node,
-                              const EdgeLabel& pred) const;
+                              const EdgeLabel& pred) const override;
 
   /**
    * Returns the cost to make the transition from the predecessor edge
@@ -276,7 +276,7 @@ public:
   virtual Cost TransitionCostReverse(const uint32_t idx,
                                      const baldr::NodeInfo* node,
                                      const baldr::DirectedEdge* pred,
-                                     const baldr::DirectedEdge* edge) const;
+                                     const baldr::DirectedEdge* edge) const override;
 
   /**
    * Get the cost factor for A* heuristics. This factor is multiplied
@@ -286,7 +286,7 @@ public:
    * assume the maximum speed is used to the destination such that the time
    * estimate is less than the least possible time along roads.
    */
-  virtual float AStarCostFactor() const {
+  virtual float AStarCostFactor() const override {
     return speedfactor_[kMaxAssumedSpeed];
   }
 
@@ -294,7 +294,7 @@ public:
    * Get the current travel type.
    * @return  Returns the current travel type.
    */
-  virtual uint8_t travel_type() const {
+  virtual uint8_t travel_type() const override {
     return static_cast<uint8_t>(VehicleType::kMotorScooter);
   }
   /**

--- a/src/sif/motorscootercost.cc
+++ b/src/sif/motorscootercost.cc
@@ -233,9 +233,9 @@ public:
    * @param curr_time
    * @return
    */
-  virtual Cost EdgeCost(const baldr::DirectedEdge* edge,
-                        const baldr::TransitDeparture* departure,
-                        const uint32_t curr_time) const override {
+  virtual Cost EdgeCost(const baldr::DirectedEdge*,
+                        const baldr::TransitDeparture*,
+                        const uint32_t) const override {
     throw std::runtime_error("MotorScooterCost::EdgeCost does not support transit edges");
   }
 

--- a/src/sif/nocost.cc
+++ b/src/sif/nocost.cc
@@ -54,12 +54,12 @@ public:
    * @return Returns true if access is allowed, false if not.
    */
   virtual bool Allowed(const baldr::DirectedEdge* edge,
-                       const EdgeLabel& pred,
-                       const GraphTile* tile,
-                       const baldr::GraphId& edgeid,
-                       const uint64_t current_time,
-                       const uint32_t tz_index,
-                       int& restriction_idx) const override {
+                       const EdgeLabel&,
+                       const GraphTile*,
+                       const baldr::GraphId&,
+                       const uint64_t,
+                       const uint32_t,
+                       int&) const override {
     return !edge->is_shortcut();
   }
 
@@ -81,14 +81,14 @@ public:
    * @param  tz_index       timezone index for the node
    * @return  Returns true if access is allowed, false if not.
    */
-  virtual bool AllowedReverse(const baldr::DirectedEdge* edge,
-                              const EdgeLabel& pred,
+  virtual bool AllowedReverse(const baldr::DirectedEdge*,
+                              const EdgeLabel&,
                               const baldr::DirectedEdge* opp_edge,
-                              const GraphTile* tile,
-                              const baldr::GraphId& opp_edgeid,
-                              const uint64_t current_time,
-                              const uint32_t tz_index,
-                              int& restriction_idx) const override {
+                              const GraphTile*,
+                              const baldr::GraphId&,
+                              const uint64_t,
+                              const uint32_t,
+                              int&) const override {
     return !opp_edge->is_shortcut();
   }
 
@@ -98,7 +98,7 @@ public:
    * @param  node  Pointer to node information.
    * @return  Returns true if access is allowed, false if not.
    */
-  bool Allowed(const baldr::NodeInfo* node) const override {
+  bool Allowed(const baldr::NodeInfo*) const override {
     return true;
   }
 
@@ -108,11 +108,11 @@ public:
    * @param   edge  Pointer to edge information.
    * @return  Returns true if access is allowed, false if not.
    */
-  virtual bool IsAccessible(const baldr::DirectedEdge* edge) const override {
+  virtual bool IsAccessible(const baldr::DirectedEdge*) const override {
     return true;
   }
 
-  bool IsClosed(const baldr::DirectedEdge* edge, const baldr::GraphTile* tile) const override {
+  bool IsClosed(const baldr::DirectedEdge*, const baldr::GraphTile*) const override {
     return false;
   }
 
@@ -123,9 +123,9 @@ public:
    * @param curr_time
    * @return
    */
-  virtual Cost EdgeCost(const baldr::DirectedEdge* edge,
-                        const baldr::TransitDeparture* departure,
-                        const uint32_t curr_time) const override {
+  virtual Cost EdgeCost(const baldr::DirectedEdge*,
+                        const baldr::TransitDeparture*,
+                        const uint32_t) const override {
     throw std::runtime_error("NoCost::EdgeCost does not support transit edges");
   }
 
@@ -137,9 +137,8 @@ public:
    * @param   seconds Time of week in seconds.
    * @return  Returns the cost and time (seconds)
    */
-  virtual Cost EdgeCost(const baldr::DirectedEdge* edge,
-                        const baldr::GraphTile* tile,
-                        const uint32_t seconds) const override {
+  virtual Cost
+  EdgeCost(const baldr::DirectedEdge* edge, const baldr::GraphTile*, const uint32_t) const override {
     return {static_cast<float>(edge->length()), static_cast<float>(edge->length())};
   }
 
@@ -152,9 +151,9 @@ public:
    * @param  pred  Predecessor edge information.
    * @return  Returns the cost and time (seconds)
    */
-  virtual Cost TransitionCost(const baldr::DirectedEdge* edge,
-                              const baldr::NodeInfo* node,
-                              const EdgeLabel& pred) const override {
+  virtual Cost TransitionCost(const baldr::DirectedEdge*,
+                              const baldr::NodeInfo*,
+                              const EdgeLabel&) const override {
     return {};
   }
 
@@ -167,10 +166,10 @@ public:
    * @param  edge  the opposing predecessor in the reverse tree
    * @return  Returns the cost and time (seconds)
    */
-  virtual Cost TransitionCostReverse(const uint32_t idx,
-                                     const baldr::NodeInfo* node,
-                                     const baldr::DirectedEdge* pred,
-                                     const baldr::DirectedEdge* edge) const override {
+  virtual Cost TransitionCostReverse(const uint32_t,
+                                     const baldr::NodeInfo*,
+                                     const baldr::DirectedEdge*,
+                                     const baldr::DirectedEdge*) const override {
     return {};
   }
 
@@ -198,8 +197,8 @@ public:
   }
 };
 
-void ParseNoCostOptions(const rapidjson::Document& doc,
-                        const std::string& costing_options_key,
+void ParseNoCostOptions(const rapidjson::Document&,
+                        const std::string&,
                         CostingOptions* pbf_costing_options) {
   // this is probably not needed but its part of the contract for costing..
   pbf_costing_options->set_costing(Costing::none_);

--- a/src/sif/nocost.cc
+++ b/src/sif/nocost.cc
@@ -59,7 +59,7 @@ public:
                        const baldr::GraphId& edgeid,
                        const uint64_t current_time,
                        const uint32_t tz_index,
-                       int& restriction_idx) const {
+                       int& restriction_idx) const override {
     return !edge->is_shortcut();
   }
 
@@ -88,7 +88,7 @@ public:
                               const baldr::GraphId& opp_edgeid,
                               const uint64_t current_time,
                               const uint32_t tz_index,
-                              int& restriction_idx) const {
+                              int& restriction_idx) const override {
     return !opp_edge->is_shortcut();
   }
 
@@ -108,7 +108,7 @@ public:
    * @param   edge  Pointer to edge information.
    * @return  Returns true if access is allowed, false if not.
    */
-  virtual bool IsAccessible(const baldr::DirectedEdge* edge) const {
+  virtual bool IsAccessible(const baldr::DirectedEdge* edge) const override {
     return true;
   }
 
@@ -125,7 +125,7 @@ public:
    */
   virtual Cost EdgeCost(const baldr::DirectedEdge* edge,
                         const baldr::TransitDeparture* departure,
-                        const uint32_t curr_time) const {
+                        const uint32_t curr_time) const override {
     throw std::runtime_error("NoCost::EdgeCost does not support transit edges");
   }
 
@@ -139,7 +139,7 @@ public:
    */
   virtual Cost EdgeCost(const baldr::DirectedEdge* edge,
                         const baldr::GraphTile* tile,
-                        const uint32_t seconds) const {
+                        const uint32_t seconds) const override {
     return {static_cast<float>(edge->length()), static_cast<float>(edge->length())};
   }
 
@@ -154,7 +154,7 @@ public:
    */
   virtual Cost TransitionCost(const baldr::DirectedEdge* edge,
                               const baldr::NodeInfo* node,
-                              const EdgeLabel& pred) const {
+                              const EdgeLabel& pred) const override {
     return {};
   }
 
@@ -170,7 +170,7 @@ public:
   virtual Cost TransitionCostReverse(const uint32_t idx,
                                      const baldr::NodeInfo* node,
                                      const baldr::DirectedEdge* pred,
-                                     const baldr::DirectedEdge* edge) const {
+                                     const baldr::DirectedEdge* edge) const override {
     return {};
   }
 
@@ -182,7 +182,7 @@ public:
    * assume the maximum speed is used to the destination such that the time
    * estimate is less than the least possible time along roads.
    */
-  virtual float AStarCostFactor() const {
+  virtual float AStarCostFactor() const override {
     return 1.f;
   }
 

--- a/src/sif/pedestriancost.cc
+++ b/src/sif/pedestriancost.cc
@@ -264,13 +264,13 @@ public:
    * @param curr_time
    * @return
    */
-  virtual Cost EdgeCost(const baldr::DirectedEdge* edge,
-                        const baldr::TransitDeparture* departure,
-                        const uint32_t curr_time) const override {
+  virtual Cost EdgeCost(const baldr::DirectedEdge*,
+                        const baldr::TransitDeparture*,
+                        const uint32_t) const override {
     throw std::runtime_error("PedestrianCost::EdgeCost does not support transit edges");
   }
 
-  bool IsClosed(const baldr::DirectedEdge* edge, const baldr::GraphTile* tile) const override {
+  bool IsClosed(const baldr::DirectedEdge*, const baldr::GraphTile*) const override {
     return false;
   }
 

--- a/src/sif/pedestriancost.cc
+++ b/src/sif/pedestriancost.cc
@@ -918,8 +918,9 @@ public:
   using PedestrianCost::maneuver_penalty_;
 };
 
-TestPedestrianCost*
-make_pedestriancost_from_json(const std::string& property, float testVal, const std::string& type) {
+TestPedestrianCost* make_pedestriancost_from_json(const std::string& property,
+                                                  float testVal,
+                                                  const std::string& /*type*/) {
   std::stringstream ss;
   ss << R"({"costing_options":{"pedestrian":{")" << property << R"(":)" << testVal << "}}}";
   Api request;

--- a/src/sif/pedestriancost.cc
+++ b/src/sif/pedestriancost.cc
@@ -175,7 +175,7 @@ public:
    * limits).
    * @return  Returns true if the costing model allows multiple passes.
    */
-  virtual bool AllowMultiPass() const {
+  virtual bool AllowMultiPass() const override {
     return true;
   }
 
@@ -186,7 +186,7 @@ public:
    * meters per segment (e.g. from origin to a transit stop or from the last
    * transit stop to the destination).
    */
-  virtual void UseMaxMultiModalDistance() {
+  virtual void UseMaxMultiModalDistance() override {
     max_distance_ = transit_start_end_max_distance_;
   }
 
@@ -195,7 +195,7 @@ public:
    * to travel for this mode.  In this case, it is the max walking
    * distance you are willing to walk between transfers.
    */
-  virtual uint32_t GetMaxTransferDistanceMM() {
+  virtual uint32_t GetMaxTransferDistanceMM() override {
     return transit_transfer_max_distance_;
   }
 
@@ -203,7 +203,7 @@ public:
    * This method overrides the factor for this mode.  The higher the value
    * the more the mode is favored.
    */
-  virtual float GetModeFactor() {
+  virtual float GetModeFactor() override {
     return mode_factor_;
   }
 
@@ -228,7 +228,7 @@ public:
                        const baldr::GraphId& edgeid,
                        const uint64_t current_time,
                        const uint32_t tz_index,
-                       int& restriction_idx) const;
+                       int& restriction_idx) const override;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
@@ -255,7 +255,7 @@ public:
                               const baldr::GraphId& opp_edgeid,
                               const uint64_t current_time,
                               const uint32_t tz_index,
-                              int& restriction_idx) const;
+                              int& restriction_idx) const override;
 
   /**
    * Only transit costings are valid for this method call, hence we throw
@@ -266,7 +266,7 @@ public:
    */
   virtual Cost EdgeCost(const baldr::DirectedEdge* edge,
                         const baldr::TransitDeparture* departure,
-                        const uint32_t curr_time) const {
+                        const uint32_t curr_time) const override {
     throw std::runtime_error("PedestrianCost::EdgeCost does not support transit edges");
   }
 
@@ -284,7 +284,7 @@ public:
    */
   virtual Cost EdgeCost(const baldr::DirectedEdge* edge,
                         const baldr::GraphTile* tile,
-                        const uint32_t seconds) const;
+                        const uint32_t seconds) const override;
 
   /**
    * Returns the cost to make the transition from the predecessor edge.
@@ -297,7 +297,7 @@ public:
    */
   virtual Cost TransitionCost(const baldr::DirectedEdge* edge,
                               const baldr::NodeInfo* node,
-                              const EdgeLabel& pred) const;
+                              const EdgeLabel& pred) const override;
 
   /**
    * Returns the cost to make the transition from the predecessor edge
@@ -313,7 +313,7 @@ public:
   virtual Cost TransitionCostReverse(const uint32_t idx,
                                      const baldr::NodeInfo* node,
                                      const baldr::DirectedEdge* pred,
-                                     const baldr::DirectedEdge* edge) const;
+                                     const baldr::DirectedEdge* edge) const override;
 
   /**
    * Get the cost factor for A* heuristics. This factor is multiplied
@@ -323,7 +323,7 @@ public:
    * assume the maximum speed is used to the destination such that the time
    * estimate is less than the least possible time along roads.
    */
-  virtual float AStarCostFactor() const {
+  virtual float AStarCostFactor() const override {
     // On first pass use the walking speed plus a small factor to account for
     // favoring walkways, on the second pass use the the maximum ferry speed.
     if (pass_ == 0) {
@@ -353,7 +353,7 @@ public:
    * Get the current travel type.
    * @return  Returns the current travel type.
    */
-  virtual uint8_t travel_type() const {
+  virtual uint8_t travel_type() const override {
     return static_cast<uint8_t>(type_);
   }
 
@@ -432,7 +432,7 @@ public:
   sif::Cost base_transition_cost(const baldr::NodeInfo* node,
                                  const baldr::DirectedEdge* edge,
                                  const sif::EdgeLabel& pred,
-                                 const uint32_t idx) const {
+                                 const uint32_t idx) const override {
     // Cases with both time and penalty: country crossing, ferry, gate, toll booth
     sif::Cost c;
     if (node->type() == baldr::NodeType::kBorderControl) {
@@ -480,7 +480,7 @@ public:
   sif::Cost base_transition_cost(const baldr::NodeInfo* node,
                                  const baldr::DirectedEdge* edge,
                                  const baldr::DirectedEdge* pred,
-                                 const uint32_t idx) const {
+                                 const uint32_t idx) const override {
     // Cases with both time and penalty: country crossing, ferry, gate, toll booth
     sif::Cost c;
     if (node->type() == baldr::NodeType::kBorderControl) {

--- a/src/sif/transitcost.cc
+++ b/src/sif/transitcost.cc
@@ -71,19 +71,19 @@ public:
    * Get the wheelchair required flag.
    * @return  Returns true if wheelchair is required.
    */
-  bool wheelchair() const;
+  bool wheelchair() const override;
 
   /**
    * Get the bicycle required flag.
    * @return  Returns true if bicycle is required.
    */
-  bool bicycle() const;
+  bool bicycle() const override;
 
   /**
    * This method overrides the factor for this mode.  The higher the value
    * the more the mode is favored.
    */
-  virtual float GetModeFactor();
+  virtual float GetModeFactor() override;
 
   /**
    * Get the access mode used by this costing method.
@@ -111,7 +111,7 @@ public:
                        const baldr::GraphId& edgeid,
                        const uint64_t current_time,
                        const uint32_t tz_index,
-                       int& restriction_idx) const;
+                       int& restriction_idx) const override;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
@@ -137,7 +137,7 @@ public:
                               const baldr::GraphId& opp_edgeid,
                               const uint64_t current_time,
                               const uint32_t tz_index,
-                              int& restriction_idx) const;
+                              int& restriction_idx) const override;
 
   /**
    * Checks if access is allowed for the provided node. Node access can
@@ -145,7 +145,7 @@ public:
    * @param  node  Pointer to node information.
    * @return  Returns true if access is allowed, false if not.
    */
-  virtual bool Allowed(const baldr::NodeInfo* node) const;
+  virtual bool Allowed(const baldr::NodeInfo* node) const override;
 
   /**
    * Get the cost to traverse the specified directed edge using a transit
@@ -158,7 +158,7 @@ public:
    */
   virtual Cost EdgeCost(const baldr::DirectedEdge* edge,
                         const baldr::TransitDeparture* departure,
-                        const uint32_t curr_time) const;
+                        const uint32_t curr_time) const override;
 
   /**
    * Transit costing only works on transit edges, hence we throw
@@ -169,7 +169,7 @@ public:
    */
   virtual Cost EdgeCost(const baldr::DirectedEdge* edge,
                         const baldr::GraphTile* tile,
-                        const uint32_t seconds) const {
+                        const uint32_t seconds) const override {
     throw std::runtime_error("TransitCost::EdgeCost only supports transit edges");
   }
 
@@ -188,19 +188,19 @@ public:
    */
   virtual Cost TransitionCost(const baldr::DirectedEdge* edge,
                               const baldr::NodeInfo* node,
-                              const EdgeLabel& pred) const;
+                              const EdgeLabel& pred) const override;
 
   /**
    * Returns the transfer cost between 2 transit stops.
    * @return  Returns the transfer cost and time (seconds).
    */
-  virtual Cost TransferCost() const;
+  virtual Cost TransferCost() const override;
 
   /**
    * Returns the default transfer cost between 2 transit lines.
    * @return  Returns the transfer cost and time (seconds).
    */
-  virtual Cost DefaultTransferCost() const;
+  virtual Cost DefaultTransferCost() const override;
 
   /**
    * Get the cost factor for A* heuristics. This factor is multiplied
@@ -210,12 +210,12 @@ public:
    * assume the maximum speed is used to the destination such that the time
    * estimate is less than the least possible time along roads.
    */
-  virtual float AStarCostFactor() const;
+  virtual float AStarCostFactor() const override;
 
   /**
    * Override unit size since walking costs are higher range of vales
    */
-  virtual uint32_t UnitSize() const;
+  virtual uint32_t UnitSize() const override;
 
   /**
    * Function to be used in location searching which will
@@ -241,19 +241,19 @@ public:
   /**This method adds to the exclude list based on the
    * user inputed exclude and include lists.
    */
-  virtual void AddToExcludeList(const baldr::GraphTile*& tile);
+  virtual void AddToExcludeList(const baldr::GraphTile*& tile) override;
 
   /**
    * Checks if we should exclude or not.
    * @return  Returns true if we should exclude, false if not.
    */
-  virtual bool IsExcluded(const baldr::GraphTile*& tile, const baldr::DirectedEdge* edge);
+  virtual bool IsExcluded(const baldr::GraphTile*& tile, const baldr::DirectedEdge* edge) override;
 
   /**
    * Checks if we should exclude or not.
    * @return  Returns true if we should exclude, false if not.
    */
-  virtual bool IsExcluded(const baldr::GraphTile*& tile, const baldr::NodeInfo* node);
+  virtual bool IsExcluded(const baldr::GraphTile*& tile, const baldr::NodeInfo* node) override;
 
 public:
   // Are wheelchair or bicycle required

--- a/src/sif/transitcost.cc
+++ b/src/sif/transitcost.cc
@@ -167,13 +167,12 @@ public:
    * @param seconds
    * @return
    */
-  virtual Cost EdgeCost(const baldr::DirectedEdge* edge,
-                        const baldr::GraphTile* tile,
-                        const uint32_t seconds) const override {
+  virtual Cost
+  EdgeCost(const baldr::DirectedEdge*, const baldr::GraphTile*, const uint32_t) const override {
     throw std::runtime_error("TransitCost::EdgeCost only supports transit edges");
   }
 
-  bool IsClosed(const baldr::DirectedEdge* edge, const baldr::GraphTile* tile) const override {
+  bool IsClosed(const baldr::DirectedEdge*, const baldr::GraphTile*) const override {
     return false;
   }
 
@@ -521,12 +520,12 @@ uint32_t TransitCost::access_mode() const {
 
 // Check if access is allowed on the specified edge.
 bool TransitCost::Allowed(const baldr::DirectedEdge* edge,
-                          const EdgeLabel& pred,
+                          const EdgeLabel&,
                           const GraphTile* tile,
-                          const baldr::GraphId& edgeid,
-                          const uint64_t current_time,
-                          const uint32_t tz_index,
-                          int& restriction_idx) const {
+                          const baldr::GraphId&,
+                          const uint64_t,
+                          const uint32_t,
+                          int&) const {
   // TODO - obtain and check the access restrictions.
 
   if (exclude_stops_.size()) {
@@ -550,21 +549,21 @@ bool TransitCost::Allowed(const baldr::DirectedEdge* edge,
 
 // Checks if access is allowed for an edge on the reverse path (from
 // destination towards origin). Both opposing edges are provided.
-bool TransitCost::AllowedReverse(const baldr::DirectedEdge* edge,
-                                 const EdgeLabel& pred,
-                                 const baldr::DirectedEdge* opp_edge,
-                                 const GraphTile* tile,
-                                 const baldr::GraphId& opp_edgeid,
-                                 const uint64_t current_time,
-                                 const uint32_t tz_index,
-                                 int& restriction_idx) const {
+bool TransitCost::AllowedReverse(const baldr::DirectedEdge*,
+                                 const EdgeLabel&,
+                                 const baldr::DirectedEdge*,
+                                 const GraphTile*,
+                                 const baldr::GraphId&,
+                                 const uint64_t,
+                                 const uint32_t,
+                                 int&) const {
   // This method should not be called since time based routes do not use
   // bidirectional A*
   return false;
 }
 
 // Check if access is allowed at the specified node.
-bool TransitCost::Allowed(const baldr::NodeInfo* node) const {
+bool TransitCost::Allowed(const baldr::NodeInfo*) const {
   return true;
 }
 
@@ -590,7 +589,7 @@ Cost TransitCost::EdgeCost(const baldr::DirectedEdge* edge,
 
 // Returns the time (in seconds) to make the transition from the predecessor
 Cost TransitCost::TransitionCost(const baldr::DirectedEdge* edge,
-                                 const baldr::NodeInfo* node,
+                                 const baldr::NodeInfo*,
                                  const EdgeLabel& pred) const {
   if (pred.mode() == TravelMode::kPedestrian) {
     // Apply any mode-based penalties when boarding transit

--- a/src/sif/truckcost.cc
+++ b/src/sif/truckcost.cc
@@ -129,7 +129,7 @@ public:
    * limits).
    * @return  Returns true if the costing model allows multiple passes.
    */
-  virtual bool AllowMultiPass() const;
+  virtual bool AllowMultiPass() const override;
 
   /**
    * Checks if access is allowed for the provided directed edge.
@@ -152,7 +152,7 @@ public:
                        const baldr::GraphId& edgeid,
                        const uint64_t current_time,
                        const uint32_t tz_index,
-                       int& restriction_idx) const;
+                       int& restriction_idx) const override;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
@@ -179,12 +179,12 @@ public:
                               const baldr::GraphId& opp_edgeid,
                               const uint64_t current_time,
                               const uint32_t tz_index,
-                              int& restriction_idx) const;
+                              int& restriction_idx) const override;
 
   /**
    * Callback for Allowed doing mode  specific restriction checks
    */
-  virtual bool ModeSpecificAllowed(const baldr::AccessRestriction& restriction) const;
+  virtual bool ModeSpecificAllowed(const baldr::AccessRestriction& restriction) const override;
 
   /**
    * Only transit costings are valid for this method call, hence we throw
@@ -195,7 +195,7 @@ public:
    */
   virtual Cost EdgeCost(const baldr::DirectedEdge* edge,
                         const baldr::TransitDeparture* departure,
-                        const uint32_t curr_time) const {
+                        const uint32_t curr_time) const override {
     throw std::runtime_error("TruckCost::EdgeCost does not support transit edges");
   }
 
@@ -209,7 +209,7 @@ public:
    */
   virtual Cost EdgeCost(const baldr::DirectedEdge* edge,
                         const baldr::GraphTile* tile,
-                        const uint32_t seconds) const;
+                        const uint32_t seconds) const override;
 
   /**
    * Returns the cost to make the transition from the predecessor edge.
@@ -222,7 +222,7 @@ public:
    */
   virtual Cost TransitionCost(const baldr::DirectedEdge* edge,
                               const baldr::NodeInfo* node,
-                              const EdgeLabel& pred) const;
+                              const EdgeLabel& pred) const override;
 
   /**
    * Returns the cost to make the transition from the predecessor edge
@@ -236,7 +236,7 @@ public:
   virtual Cost TransitionCostReverse(const uint32_t idx,
                                      const baldr::NodeInfo* node,
                                      const baldr::DirectedEdge* pred,
-                                     const baldr::DirectedEdge* edge) const;
+                                     const baldr::DirectedEdge* edge) const override;
 
   /**
    * Get the cost factor for A* heuristics. This factor is multiplied
@@ -246,13 +246,13 @@ public:
    * assume the maximum speed is used to the destination such that the time
    * estimate is less than the least possible time along roads.
    */
-  virtual float AStarCostFactor() const;
+  virtual float AStarCostFactor() const override;
 
   /**
    * Get the current travel type.
    * @return  Returns the current travel type.
    */
-  virtual uint8_t travel_type() const;
+  virtual uint8_t travel_type() const override;
 
   /**
    * Function to be used in location searching which will

--- a/src/sif/truckcost.cc
+++ b/src/sif/truckcost.cc
@@ -193,9 +193,9 @@ public:
    * @param curr_time
    * @return
    */
-  virtual Cost EdgeCost(const baldr::DirectedEdge* edge,
-                        const baldr::TransitDeparture* departure,
-                        const uint32_t curr_time) const override {
+  virtual Cost EdgeCost(const baldr::DirectedEdge*,
+                        const baldr::TransitDeparture*,
+                        const uint32_t) const override {
     throw std::runtime_error("TruckCost::EdgeCost does not support transit edges");
   }
 

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -65,6 +65,9 @@ public:
 
   virtual ~DynamicCost();
 
+  DynamicCost(const DynamicCost&) = delete;
+  DynamicCost& operator=(const DynamicCost&) = delete;
+
   /**
    * Does the costing method allow multiple passes (with relaxed
    * hierarchy limits).


### PR DESCRIPTION
# Issue

Just some cleanup in sif to get rid of compiler warnings. Also sets all files in sif to -Werror so we avoid regressing these in the future.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
