### PR TITLE
Enhanced turn lane information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,7 @@
    * ADDED: Add support of input file for one-shot mode of valhalla_service [#2648](https://github.com/valhalla/valhalla/pull/2648)
    * ADDED: Linear reference support to locate api [#2645](https://github.com/valhalla/valhalla/pull/2645)
    * ADDED: Implemented OSRM-like turn duration calculation for car. Uses it now in auto costing. [#2651](https://github.com/valhalla/valhalla/pull/2651)
+   * ADDED: Enhanced turn lane information in guidance [#2653](https://github.com/valhalla/valhalla/pull/2653)
 
 ## Release Date: 2019-11-21 Valhalla 3.0.9
 * **Bug Fix**

--- a/proto/tripcommon.proto
+++ b/proto/tripcommon.proto
@@ -131,8 +131,14 @@ message StreetName {
 }
 
 message TurnLane {
+  enum State {
+    kInvalid = 0;
+    kValid = 1;
+    kActive = 2;
+  }
   optional uint32 directions_mask = 1;
-  optional bool is_active = 2;
+  optional State state = 2 [default = kInvalid];
+  optional uint32 active_direction = 3;
 }
 
 enum RoadClass {

--- a/src/odin/enhancedtrippath.cc
+++ b/src/odin/enhancedtrippath.cc
@@ -838,6 +838,15 @@ std::string EnhancedTripLeg_Edge::TurnLanesToString() const {
     }
 
     uint16_t mask = turn_lane.directions_mask();
+    auto indication_to_str = [&turn_lane](uint16_t ind) -> std::string {
+      if (turn_lane.state() == TurnLane::kInvalid || turn_lane.active_direction() != ind) {
+        return kTurnLaneNames.at(ind);
+      }
+      // Surround valid/active lanes with a '*'
+      std::stringstream ss;
+      ss << "*" << kTurnLaneNames.at(ind) << "*";
+      return ss.str();
+    };
 
     // Process the turn lanes - from left to right
     // empty
@@ -853,77 +862,77 @@ std::string EnhancedTripLeg_Edge::TurnLanesToString() const {
       if ((mask & kTurnLaneReverse) && drive_on_right()) {
         if (prior_item)
           str += ";";
-        str += kTurnLaneNames.at(kTurnLaneReverse);
+        str += indication_to_str(kTurnLaneReverse);
         prior_item = true;
       }
       // sharp_left
       if (mask & kTurnLaneSharpLeft) {
         if (prior_item)
           str += ";";
-        str += kTurnLaneNames.at(kTurnLaneSharpLeft);
+        str += indication_to_str(kTurnLaneSharpLeft);
         prior_item = true;
       }
       // left
       if (mask & kTurnLaneLeft) {
         if (prior_item)
           str += ";";
-        str += kTurnLaneNames.at(kTurnLaneLeft);
+        str += indication_to_str(kTurnLaneLeft);
         prior_item = true;
       }
       // slight_left
       if (mask & kTurnLaneSlightLeft) {
         if (prior_item)
           str += ";";
-        str += kTurnLaneNames.at(kTurnLaneSlightLeft);
+        str += indication_to_str(kTurnLaneSlightLeft);
         prior_item = true;
       }
       // merge_to_left
       if (mask & kTurnLaneMergeToLeft) {
         if (prior_item)
           str += ";";
-        str += kTurnLaneNames.at(kTurnLaneMergeToLeft);
+        str += indication_to_str(kTurnLaneMergeToLeft);
         prior_item = true;
       }
       // through
       if (mask & kTurnLaneThrough) {
         if (prior_item)
           str += ";";
-        str += kTurnLaneNames.at(kTurnLaneThrough);
+        str += indication_to_str(kTurnLaneThrough);
         prior_item = true;
       }
       // merge_to_right
       if (mask & kTurnLaneMergeToRight) {
         if (prior_item)
           str += ";";
-        str += kTurnLaneNames.at(kTurnLaneMergeToRight);
+        str += indication_to_str(kTurnLaneMergeToRight);
         prior_item = true;
       }
       // slight_right
       if (mask & kTurnLaneSlightRight) {
         if (prior_item)
           str += ";";
-        str += kTurnLaneNames.at(kTurnLaneSlightRight);
+        str += indication_to_str(kTurnLaneSlightRight);
         prior_item = true;
       }
       // right
       if (mask & kTurnLaneRight) {
         if (prior_item)
           str += ";";
-        str += kTurnLaneNames.at(kTurnLaneRight);
+        str += indication_to_str(kTurnLaneRight);
         prior_item = true;
       }
       // sharp_right
       if (mask & kTurnLaneSharpRight) {
         if (prior_item)
           str += ";";
-        str += kTurnLaneNames.at(kTurnLaneSharpRight);
+        str += indication_to_str(kTurnLaneSharpRight);
         prior_item = true;
       }
       // reverse (right u-turn)
       if ((mask & kTurnLaneReverse) && !drive_on_right()) {
         if (prior_item)
           str += ";";
-        str += kTurnLaneNames.at(kTurnLaneReverse);
+        str += indication_to_str(kTurnLaneReverse);
         prior_item = true;
       }
     }
@@ -933,12 +942,6 @@ std::string EnhancedTripLeg_Edge::TurnLanesToString() const {
       str += " ACTIVE";
     } else if (turn_lane.state() == TurnLane::kValid) {
       str += " VALID";
-    }
-
-    // Append the active direction if the lane is active or valid
-    if (turn_lane.state() != TurnLane::kInvalid) {
-      str += ", ACTIVE_DIR ";
-      str += kTurnLaneNames.at(turn_lane.active_direction());
     }
   }
   str += " ]";

--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -2690,7 +2690,7 @@ void ManeuversBuilder::EnhanceSignlessInterchnages(std::list<Maneuver>& maneuver
 
 uint16_t
 ManeuversBuilder::GetExpectedTurnLaneDirection(std::unique_ptr<EnhancedTripLeg_Edge>& turn_lane_edge,
-                                               Maneuver& maneuver) const {
+                                               const Maneuver& maneuver) const {
   if (turn_lane_edge) {
     switch (maneuver.type()) {
       case valhalla::DirectionsLeg_Maneuver_Type_kUturnLeft:

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -590,7 +590,7 @@ json::ArrayPtr intersections(const valhalla::DirectionsLeg::Maneuver& maneuver,
         lane->emplace("active", is_active);
         lane->emplace("valid", is_valid);
         // Add active_indication for a valid lane
-        if (turn_lane.state() != ::valhalla::TurnLane::kInvalid) {
+        if (turn_lane.state() != TurnLane::kInvalid) {
           lane->emplace("active_indication", turn_lane_direction(turn_lane.active_direction()));
         }
 

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -589,9 +589,9 @@ json::ArrayPtr intersections(const valhalla::DirectionsLeg::Maneuver& maneuver,
         bool is_valid = is_active || turn_lane.state() == TurnLane::kValid;
         lane->emplace("active", is_active);
         lane->emplace("valid", is_valid);
-        // Add active_indication for a valid lane
+        // Add valid_indication for a valid & active lanes
         if (turn_lane.state() != TurnLane::kInvalid) {
-          lane->emplace("active_indication", turn_lane_direction(turn_lane.active_direction()));
+          lane->emplace("valid_indication", turn_lane_direction(turn_lane.active_direction()));
         }
 
         // Process 'indications' array - add indications from left to right

--- a/test/enhancedtrippath.cc
+++ b/test/enhancedtrippath.cc
@@ -145,6 +145,12 @@ TEST(EnhancedTripPathCalculateRightLeftIntersectingEdgeCounts, SharpLeftRightLef
                                               IntersectingEdgeCounts(5, 0, 0, 0, 1, 1, 0, 0));
 }
 
+TEST(EnhancedTripPathDefaultTurnLaneState, True) {
+  TripLeg_Edge edge;
+  edge.add_turn_lanes()->set_directions_mask(kTurnLaneLeft);
+  ASSERT_EQ(edge.mutable_turn_lanes(0)->state(), TurnLane::kInvalid);
+}
+
 void TryHasActiveTurnLane(std::unique_ptr<EnhancedTripLeg_Edge> edge, bool expected) {
   EXPECT_EQ(edge->HasActiveTurnLane(), expected);
 }
@@ -164,17 +170,17 @@ TEST(EnhancedTripPathHasActiveTurnLane, True) {
   edge.add_turn_lanes()->set_directions_mask(kTurnLaneRight);
 
   // Left active
-  edge.mutable_turn_lanes(0)->set_is_active(true);
+  edge.mutable_turn_lanes(0)->set_state(TurnLane::kActive);
   TryHasActiveTurnLane(std::make_unique<EnhancedTripLeg_Edge>(&edge), true);
 
   // Straight active
-  edge.mutable_turn_lanes(0)->set_is_active(false);
-  edge.mutable_turn_lanes(1)->set_is_active(true);
+  edge.mutable_turn_lanes(0)->set_state(TurnLane::kInvalid);
+  edge.mutable_turn_lanes(1)->set_state(TurnLane::kActive);
   TryHasActiveTurnLane(std::make_unique<EnhancedTripLeg_Edge>(&edge), true);
 
   // Right active
-  edge.mutable_turn_lanes(1)->set_is_active(false);
-  edge.mutable_turn_lanes(2)->set_is_active(true);
+  edge.mutable_turn_lanes(1)->set_state(TurnLane::kInvalid);
+  edge.mutable_turn_lanes(2)->set_state(TurnLane::kActive);
   TryHasActiveTurnLane(std::make_unique<EnhancedTripLeg_Edge>(&edge), true);
 }
 
@@ -204,7 +210,7 @@ TEST(EnhancedTripPathHasNonDirectionalTurnLane, True) {
 
 void ClearActiveTurnLanes(::google::protobuf::RepeatedPtrField<::valhalla::TurnLane>* turn_lanes) {
   for (auto& turn_lane : *(turn_lanes)) {
-    turn_lane.set_is_active(false);
+    turn_lane.clear_state();
   }
 }
 

--- a/test/gurka/test_instructions_internal_intersection.cc
+++ b/test/gurka/test_instructions_internal_intersection.cc
@@ -102,7 +102,7 @@ TEST_F(InstructionsInternalIntersection, DriveNorth_BrokenLandParkway_TurnLeft_P
   auto prev_edge = etl.GetPrevEdge(maneuver.begin_path_index());
   ASSERT_TRUE(prev_edge);
   EXPECT_EQ(prev_edge->turn_lanes_size(), 3);
-  EXPECT_EQ(prev_edge->TurnLanesToString(), "[ left ACTIVE | through | through ]");
+  EXPECT_EQ(prev_edge->TurnLanesToString(), "[ left ACTIVE, ACTIVE_DIR left | through | through ]");
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/test/gurka/test_instructions_internal_intersection.cc
+++ b/test/gurka/test_instructions_internal_intersection.cc
@@ -102,7 +102,7 @@ TEST_F(InstructionsInternalIntersection, DriveNorth_BrokenLandParkway_TurnLeft_P
   auto prev_edge = etl.GetPrevEdge(maneuver.begin_path_index());
   ASSERT_TRUE(prev_edge);
   EXPECT_EQ(prev_edge->turn_lanes_size(), 3);
-  EXPECT_EQ(prev_edge->TurnLanesToString(), "[ left ACTIVE, ACTIVE_DIR left | through | through ]");
+  EXPECT_EQ(prev_edge->TurnLanesToString(), "[ *left* ACTIVE | through | through ]");
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/test/gurka/test_turn_lanes.cc
+++ b/test/gurka/test_turn_lanes.cc
@@ -57,7 +57,8 @@ TEST(Standalone, TurnLanes) {
 
   ASSERT_TRUE(prev_edge);
   EXPECT_EQ(prev_edge->turn_lanes_size(), 3);
-  EXPECT_EQ(prev_edge->TurnLanesToString(), "[ left | through | through;right ACTIVE ]");
+  EXPECT_EQ(prev_edge->TurnLanesToString(),
+            "[ left | through | through;right ACTIVE, ACTIVE_DIR right ]");
 }
 
 // Split lane example - 5-way intersection
@@ -100,17 +101,23 @@ TEST(Standalone, TurnLanesSplitLane) {
 
   // A -> C - takes the leftmost left lane
   result = gurka::route(map, "A", "C", "auto");
-  validate_turn_lanes(result, {
-                                  {3, "[ left ACTIVE | left;through | through;right ]"},
-                                  {0, ""},
-                              });
+  validate_turn_lanes(
+      result,
+      {
+          {3,
+           "[ left ACTIVE, ACTIVE_DIR left | left;through VALID, ACTIVE_DIR left | through;right ]"},
+          {0, ""},
+      });
 
   // A -> E - takes the leftmost through lane
   result = gurka::route(map, "A", "E", "auto");
-  validate_turn_lanes(result, {
-                                  {3, "[ left | left;through ACTIVE | through;right ]"},
-                                  {0, ""}, // TODO lanes are tossed when all are through
-                              });
+  validate_turn_lanes(
+      result,
+      {
+          {3,
+           "[ left | left;through ACTIVE, ACTIVE_DIR through | through;right VALID, ACTIVE_DIR through ]"},
+          {0, ""}, // TODO lanes are tossed when all are through
+      });
 
   // A -> G - takes the rightmost through lane
   result = gurka::route(map, "A", "G", "auto");
@@ -118,17 +125,19 @@ TEST(Standalone, TurnLanesSplitLane) {
   gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
                                                 DirectionsLeg_Maneuver_Type_kSlightRight,
                                                 DirectionsLeg_Maneuver_Type_kDestination});
-  validate_turn_lanes(result, {
-                                  {3, "[ left | left;through | through;right ACTIVE ]"},
-                                  {0, ""}, // TODO lanes are tossed when all are through
-                              });
+  validate_turn_lanes(result,
+                      {
+                          {3, "[ left | left;through | through;right ACTIVE, ACTIVE_DIR right ]"},
+                          {0, ""}, // TODO lanes are tossed when all are through
+                      });
 
   // A -> H - takes the right lane
   result = gurka::route(map, "A", "H", "auto");
-  validate_turn_lanes(result, {
-                                  {3, "[ left | left;through | through;right ACTIVE ]"},
-                                  {0, ""},
-                              });
+  validate_turn_lanes(result,
+                      {
+                          {3, "[ left | left;through | through;right ACTIVE, ACTIVE_DIR right ]"},
+                          {0, ""},
+                      });
 }
 
 // Shared turn lane example
@@ -164,29 +173,33 @@ TEST(Standalone, TurnLanesSharedTurnLane) {
 
   // A -> G  - only through lanes should be active throughout
   auto result = gurka::route(map, "A", "G", "auto");
-  validate_turn_lanes(result, {
-                                  {3, "[ through ACTIVE | through | right ]"},
-                                  {3, "[ through ACTIVE | through | right ]"},
-                                  {3, "[ through ACTIVE | through | right ]"},
-                                  {0, ""},
-                              });
+  validate_turn_lanes(
+      result,
+      {
+          {3, "[ through ACTIVE, ACTIVE_DIR through | through VALID, ACTIVE_DIR through | right ]"},
+          {3, "[ through ACTIVE, ACTIVE_DIR through | through VALID, ACTIVE_DIR through | right ]"},
+          {3, "[ through ACTIVE, ACTIVE_DIR through | through VALID, ACTIVE_DIR through | right ]"},
+          {0, ""},
+      });
 
   // A -> C - right lane should always be active
   result = gurka::route(map, "A", "C", "auto");
   validate_turn_lanes(result, {
-                                  {3, "[ through | through | right ACTIVE ]"},
+                                  {3, "[ through | through | right ACTIVE, ACTIVE_DIR right ]"},
                                   {0, ""},
                               });
 
   // A -> F - only right lane after B should be active, before that rightmost right lane should be
   // active
   result = gurka::route(map, "A", "F", "auto");
-  validate_turn_lanes(result, {
-                                  {3, "[ through | through ACTIVE | right ]"},
-                                  {3, "[ through | through | right ACTIVE ]"},
-                                  {3, "[ through | through | right ACTIVE ]"},
-                                  {0, ""},
-                              });
+  validate_turn_lanes(
+      result,
+      {
+          {3, "[ through VALID, ACTIVE_DIR through | through ACTIVE, ACTIVE_DIR through | right ]"},
+          {3, "[ through | through | right ACTIVE, ACTIVE_DIR right ]"},
+          {3, "[ through | through | right ACTIVE, ACTIVE_DIR right ]"},
+          {0, ""},
+      });
 }
 
 // Multiple turn lanes with short arrival
@@ -248,53 +261,181 @@ TEST(Standalone, TurnLanesMultiLaneShort) {
   gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
                                                 DirectionsLeg_Maneuver_Type_kLeft,
                                                 DirectionsLeg_Maneuver_Type_kDestination});
-  validate_turn_lanes(result, {
-                                  {5, "[ left ACTIVE | left | through | right | right ]"},
-                                  {5, "[ left ACTIVE | left | through | right | right ]"},
-                                  {0, ""},
-                              });
+  validate_turn_lanes(
+      result,
+      {
+          {5,
+           "[ left ACTIVE, ACTIVE_DIR left | left VALID, ACTIVE_DIR left | through | right | right ]"},
+          {5,
+           "[ left ACTIVE, ACTIVE_DIR left | left VALID, ACTIVE_DIR left | through | right | right ]"},
+          {0, ""},
+      });
 
   // A -> 3 - takes rightmost right lane
   result = gurka::route(map, "A", "3", "auto");
   gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
                                                 DirectionsLeg_Maneuver_Type_kRight,
                                                 DirectionsLeg_Maneuver_Type_kDestinationRight});
-  validate_turn_lanes(result, {
-                                  {5, "[ left | left | through | right | right ACTIVE ]"},
-                                  {5, "[ left | left | through | right | right ACTIVE ]"},
-                                  {0, ""},
-                              });
+  validate_turn_lanes(
+      result,
+      {
+          {5,
+           "[ left | left | through | right VALID, ACTIVE_DIR right | right ACTIVE, ACTIVE_DIR right ]"},
+          {5,
+           "[ left | left | through | right VALID, ACTIVE_DIR right | right ACTIVE, ACTIVE_DIR right ]"},
+          {0, ""},
+      });
 
   // A -> 4 - takes leftmost right lane
   result = gurka::route(map, "A", "4", "auto");
   gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
                                                 DirectionsLeg_Maneuver_Type_kRight,
                                                 DirectionsLeg_Maneuver_Type_kDestinationLeft});
-  validate_turn_lanes(result, {
-                                  {5, "[ left | left | through | right ACTIVE | right ]"},
-                                  {5, "[ left | left | through | right ACTIVE | right ]"},
-                                  {0, ""},
-                              });
+  validate_turn_lanes(
+      result,
+      {
+          {5,
+           "[ left | left | through | right ACTIVE, ACTIVE_DIR right | right VALID, ACTIVE_DIR right ]"},
+          {5,
+           "[ left | left | through | right ACTIVE, ACTIVE_DIR right | right VALID, ACTIVE_DIR right ]"},
+          {0, ""},
+      });
 
   // A -> F - takes leftmost right lane (left side driving)
   result = gurka::route(map, "A", "F", "auto");
   gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
                                                 DirectionsLeg_Maneuver_Type_kRight,
                                                 DirectionsLeg_Maneuver_Type_kDestination});
-  validate_turn_lanes(result, {
-                                  {5, "[ left | left | through | right ACTIVE | right ]"},
-                                  {5, "[ left | left | through | right ACTIVE | right ]"},
-                                  {0, ""},
-                              });
+  validate_turn_lanes(
+      result,
+      {
+          {5,
+           "[ left | left | through | right ACTIVE, ACTIVE_DIR right | right VALID, ACTIVE_DIR right ]"},
+          {5,
+           "[ left | left | through | right ACTIVE, ACTIVE_DIR right | right VALID, ACTIVE_DIR right ]"},
+          {0, ""},
+      });
 
   // A -> G - takes both right lanes as destination is far away from previous transition
   result = gurka::route(map, "A", "G", "auto");
   gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
                                                 DirectionsLeg_Maneuver_Type_kRight,
                                                 DirectionsLeg_Maneuver_Type_kDestination});
-  validate_turn_lanes(result, {
-                                  {5, "[ left | left | through | right ACTIVE | right ACTIVE ]"},
-                                  {5, "[ left | left | through | right ACTIVE | right ACTIVE ]"},
-                                  {0, ""},
-                              });
+  validate_turn_lanes(
+      result,
+      {
+          {5,
+           "[ left | left | through | right ACTIVE, ACTIVE_DIR right | right ACTIVE, ACTIVE_DIR right ]"},
+          {5,
+           "[ left | left | through | right ACTIVE, ACTIVE_DIR right | right ACTIVE, ACTIVE_DIR right ]"},
+          {0, ""},
+      });
+}
+
+TEST(Standalone, TurnLanesSerializedResponse) {
+  const std::string ascii_map = R"(
+        C
+        |
+    A---B
+        |
+        D--E
+        |
+        F
+  )";
+
+  const gurka::ways ways =
+      {{"AB", {{"highway", "trunk"}, {"lanes", "3"}, {"turn:lanes", "left|right|right"}}},
+       {"BC", {{"highway", "primary"}}},
+       {"BD", {{"highway", "primary"}, {"lanes", "3"}, {"turn:lanes", "left|left;through|through"}}},
+       {"DE", {{"highway", "primary"}}},
+       {"DF", {{"highway", "primary"}, {"lanes", "2"}, {"turn:lanes", "through|through"}}}};
+
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, 10);
+  auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_turn_lanes_5");
+
+  auto verify_lane_schema = [](const rapidjson::Value& lanes) -> void {
+    // Verify common lane attributes:
+    // - has valid & active booleans
+    // - has a non-empty indications array
+    for (const auto& lane : lanes.GetArray()) {
+      ASSERT_TRUE(lane.HasMember("valid"));
+      EXPECT_TRUE(lane["valid"].IsBool());
+      ASSERT_TRUE(lane.HasMember("active"));
+      EXPECT_TRUE(lane["active"].IsBool());
+      ASSERT_TRUE(lane.HasMember("indications"));
+      ASSERT_TRUE(lane["indications"].IsArray());
+      ASSERT_GT(lane["indications"].Size(), 0);
+    }
+  };
+
+  // A->E : Both right lanes should be valid and left-most right lane should
+  // be active. For following step, both left lanes should be valid and the
+  // left-most left lane should be active.
+  auto result = gurka::route(map, "A", "E", "auto");
+  rapidjson::Document directions = gurka::convert_to_json(result, valhalla::Options_Format_osrm);
+
+  // Assert expected number of routes, legs, steps
+  ASSERT_EQ(directions["routes"].Size(), 1);
+  ASSERT_EQ(directions["routes"][0]["legs"].Size(), 1);
+  ASSERT_EQ(directions["routes"][0]["legs"][0]["steps"].Size(), 4);
+  const rapidjson::Value& steps = directions["routes"][0]["legs"][0]["steps"];
+
+  {
+    // Validate lane object of second step
+    const rapidjson::Value& step1_int0 = steps[1]["intersections"][0];
+    ASSERT_TRUE(step1_int0.HasMember("lanes"));
+    ASSERT_EQ(step1_int0["lanes"].Size(), 3);
+
+    verify_lane_schema(step1_int0["lanes"]);
+    // lane 0 - active: false, valid: false
+    EXPECT_FALSE(step1_int0["lanes"][0]["active"].GetBool());
+    EXPECT_FALSE(step1_int0["lanes"][0]["valid"].GetBool());
+    ASSERT_EQ(step1_int0["lanes"][0]["indications"].Size(), 1);
+    EXPECT_EQ(step1_int0["lanes"][0]["indications"][0].GetString(), std::string("left"));
+    EXPECT_FALSE(step1_int0["lanes"][0].HasMember("active_indication"));
+    // lane 1 - active: true, valid: true, active_ind: right
+    EXPECT_TRUE(step1_int0["lanes"][1]["active"].GetBool());
+    EXPECT_TRUE(step1_int0["lanes"][1]["valid"].GetBool());
+    ASSERT_EQ(step1_int0["lanes"][1]["indications"].Size(), 1);
+    EXPECT_EQ(step1_int0["lanes"][1]["indications"][0].GetString(), std::string("right"));
+    ASSERT_TRUE(step1_int0["lanes"][1].HasMember("active_indication"));
+    EXPECT_EQ(step1_int0["lanes"][1]["active_indication"].GetString(), std::string("right"));
+    // lane 2 - active: false, valid: true, active_ind: right
+    EXPECT_FALSE(step1_int0["lanes"][2]["active"].GetBool());
+    EXPECT_TRUE(step1_int0["lanes"][2]["valid"].GetBool());
+    ASSERT_EQ(step1_int0["lanes"][2]["indications"].Size(), 1);
+    EXPECT_EQ(step1_int0["lanes"][2]["indications"][0].GetString(), std::string("right"));
+    ASSERT_TRUE(step1_int0["lanes"][2].HasMember("active_indication"));
+    EXPECT_EQ(step1_int0["lanes"][2]["active_indication"].GetString(), std::string("right"));
+  }
+
+  {
+    // Validate lane object of third step
+    const rapidjson::Value& step2_int0 = steps[2]["intersections"][0];
+    ASSERT_TRUE(step2_int0.HasMember("lanes"));
+    ASSERT_EQ(step2_int0["lanes"].Size(), 3);
+
+    verify_lane_schema(step2_int0["lanes"]);
+    // lane 0 - active: true, valid: true, active_ind: left
+    EXPECT_TRUE(step2_int0["lanes"][0]["active"].GetBool());
+    EXPECT_TRUE(step2_int0["lanes"][0]["valid"].GetBool());
+    ASSERT_EQ(step2_int0["lanes"][0]["indications"].Size(), 1);
+    EXPECT_EQ(step2_int0["lanes"][0]["indications"][0].GetString(), std::string("left"));
+    ASSERT_TRUE(step2_int0["lanes"][0].HasMember("active_indication"));
+    EXPECT_EQ(step2_int0["lanes"][0]["active_indication"].GetString(), std::string("left"));
+    // lane 1 - active: false, valid: true, active_ind: left
+    EXPECT_FALSE(step2_int0["lanes"][1]["active"].GetBool());
+    EXPECT_TRUE(step2_int0["lanes"][1]["valid"].GetBool());
+    ASSERT_EQ(step2_int0["lanes"][1]["indications"].Size(), 2);
+    EXPECT_EQ(step2_int0["lanes"][1]["indications"][0].GetString(), std::string("left"));
+    EXPECT_EQ(step2_int0["lanes"][1]["indications"][1].GetString(), std::string("straight"));
+    ASSERT_TRUE(step2_int0["lanes"][1].HasMember("active_indication"));
+    EXPECT_EQ(step2_int0["lanes"][1]["active_indication"].GetString(), std::string("left"));
+    // lane 2 - active: false, valid: false
+    EXPECT_FALSE(step2_int0["lanes"][2]["active"].GetBool());
+    EXPECT_FALSE(step2_int0["lanes"][2]["valid"].GetBool());
+    ASSERT_EQ(step2_int0["lanes"][2]["indications"].Size(), 1);
+    EXPECT_EQ(step2_int0["lanes"][2]["indications"][0].GetString(), std::string("straight"));
+    ASSERT_FALSE(step2_int0["lanes"][2].HasMember("active_indication"));
+  }
 }

--- a/test/gurka/test_turn_lanes.cc
+++ b/test/gurka/test_turn_lanes.cc
@@ -57,8 +57,7 @@ TEST(Standalone, TurnLanes) {
 
   ASSERT_TRUE(prev_edge);
   EXPECT_EQ(prev_edge->turn_lanes_size(), 3);
-  EXPECT_EQ(prev_edge->TurnLanesToString(),
-            "[ left | through | through;right ACTIVE, ACTIVE_DIR right ]");
+  EXPECT_EQ(prev_edge->TurnLanesToString(), "[ left | through | through;*right* ACTIVE ]");
 }
 
 // Split lane example - 5-way intersection
@@ -101,23 +100,17 @@ TEST(Standalone, TurnLanesSplitLane) {
 
   // A -> C - takes the leftmost left lane
   result = gurka::route(map, "A", "C", "auto");
-  validate_turn_lanes(
-      result,
-      {
-          {3,
-           "[ left ACTIVE, ACTIVE_DIR left | left;through VALID, ACTIVE_DIR left | through;right ]"},
-          {0, ""},
-      });
+  validate_turn_lanes(result, {
+                                  {3, "[ *left* ACTIVE | *left*;through VALID | through;right ]"},
+                                  {0, ""},
+                              });
 
   // A -> E - takes the leftmost through lane
   result = gurka::route(map, "A", "E", "auto");
-  validate_turn_lanes(
-      result,
-      {
-          {3,
-           "[ left | left;through ACTIVE, ACTIVE_DIR through | through;right VALID, ACTIVE_DIR through ]"},
-          {0, ""}, // TODO lanes are tossed when all are through
-      });
+  validate_turn_lanes(result, {
+                                  {3, "[ left | left;*through* ACTIVE | *through*;right VALID ]"},
+                                  {0, ""}, // TODO lanes are tossed when all are through
+                              });
 
   // A -> G - takes the rightmost through lane
   result = gurka::route(map, "A", "G", "auto");
@@ -125,19 +118,17 @@ TEST(Standalone, TurnLanesSplitLane) {
   gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
                                                 DirectionsLeg_Maneuver_Type_kSlightRight,
                                                 DirectionsLeg_Maneuver_Type_kDestination});
-  validate_turn_lanes(result,
-                      {
-                          {3, "[ left | left;through | through;right ACTIVE, ACTIVE_DIR right ]"},
-                          {0, ""}, // TODO lanes are tossed when all are through
-                      });
+  validate_turn_lanes(result, {
+                                  {3, "[ left | left;through | through;*right* ACTIVE ]"},
+                                  {0, ""}, // TODO lanes are tossed when all are through
+                              });
 
   // A -> H - takes the right lane
   result = gurka::route(map, "A", "H", "auto");
-  validate_turn_lanes(result,
-                      {
-                          {3, "[ left | left;through | through;right ACTIVE, ACTIVE_DIR right ]"},
-                          {0, ""},
-                      });
+  validate_turn_lanes(result, {
+                                  {3, "[ left | left;through | through;*right* ACTIVE ]"},
+                                  {0, ""},
+                              });
 }
 
 // Shared turn lane example
@@ -173,33 +164,29 @@ TEST(Standalone, TurnLanesSharedTurnLane) {
 
   // A -> G  - only through lanes should be active throughout
   auto result = gurka::route(map, "A", "G", "auto");
-  validate_turn_lanes(
-      result,
-      {
-          {3, "[ through ACTIVE, ACTIVE_DIR through | through VALID, ACTIVE_DIR through | right ]"},
-          {3, "[ through ACTIVE, ACTIVE_DIR through | through VALID, ACTIVE_DIR through | right ]"},
-          {3, "[ through ACTIVE, ACTIVE_DIR through | through VALID, ACTIVE_DIR through | right ]"},
-          {0, ""},
-      });
+  validate_turn_lanes(result, {
+                                  {3, "[ *through* ACTIVE | *through* VALID | right ]"},
+                                  {3, "[ *through* ACTIVE | *through* VALID | right ]"},
+                                  {3, "[ *through* ACTIVE | *through* VALID | right ]"},
+                                  {0, ""},
+                              });
 
   // A -> C - right lane should always be active
   result = gurka::route(map, "A", "C", "auto");
   validate_turn_lanes(result, {
-                                  {3, "[ through | through | right ACTIVE, ACTIVE_DIR right ]"},
+                                  {3, "[ through | through | *right* ACTIVE ]"},
                                   {0, ""},
                               });
 
   // A -> F - only right lane after B should be active, before that rightmost right lane should be
   // active
   result = gurka::route(map, "A", "F", "auto");
-  validate_turn_lanes(
-      result,
-      {
-          {3, "[ through VALID, ACTIVE_DIR through | through ACTIVE, ACTIVE_DIR through | right ]"},
-          {3, "[ through | through | right ACTIVE, ACTIVE_DIR right ]"},
-          {3, "[ through | through | right ACTIVE, ACTIVE_DIR right ]"},
-          {0, ""},
-      });
+  validate_turn_lanes(result, {
+                                  {3, "[ *through* VALID | *through* ACTIVE | right ]"},
+                                  {3, "[ through | through | *right* ACTIVE ]"},
+                                  {3, "[ through | through | *right* ACTIVE ]"},
+                                  {0, ""},
+                              });
 }
 
 // Multiple turn lanes with short arrival
@@ -261,75 +248,55 @@ TEST(Standalone, TurnLanesMultiLaneShort) {
   gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
                                                 DirectionsLeg_Maneuver_Type_kLeft,
                                                 DirectionsLeg_Maneuver_Type_kDestination});
-  validate_turn_lanes(
-      result,
-      {
-          {5,
-           "[ left ACTIVE, ACTIVE_DIR left | left VALID, ACTIVE_DIR left | through | right | right ]"},
-          {5,
-           "[ left ACTIVE, ACTIVE_DIR left | left VALID, ACTIVE_DIR left | through | right | right ]"},
-          {0, ""},
-      });
+  validate_turn_lanes(result, {
+                                  {5, "[ *left* ACTIVE | *left* VALID | through | right | right ]"},
+                                  {5, "[ *left* ACTIVE | *left* VALID | through | right | right ]"},
+                                  {0, ""},
+                              });
 
   // A -> 3 - takes rightmost right lane
   result = gurka::route(map, "A", "3", "auto");
   gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
                                                 DirectionsLeg_Maneuver_Type_kRight,
                                                 DirectionsLeg_Maneuver_Type_kDestinationRight});
-  validate_turn_lanes(
-      result,
-      {
-          {5,
-           "[ left | left | through | right VALID, ACTIVE_DIR right | right ACTIVE, ACTIVE_DIR right ]"},
-          {5,
-           "[ left | left | through | right VALID, ACTIVE_DIR right | right ACTIVE, ACTIVE_DIR right ]"},
-          {0, ""},
-      });
+  validate_turn_lanes(result, {
+                                  {5, "[ left | left | through | *right* VALID | *right* ACTIVE ]"},
+                                  {5, "[ left | left | through | *right* VALID | *right* ACTIVE ]"},
+                                  {0, ""},
+                              });
 
   // A -> 4 - takes leftmost right lane
   result = gurka::route(map, "A", "4", "auto");
   gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
                                                 DirectionsLeg_Maneuver_Type_kRight,
                                                 DirectionsLeg_Maneuver_Type_kDestinationLeft});
-  validate_turn_lanes(
-      result,
-      {
-          {5,
-           "[ left | left | through | right ACTIVE, ACTIVE_DIR right | right VALID, ACTIVE_DIR right ]"},
-          {5,
-           "[ left | left | through | right ACTIVE, ACTIVE_DIR right | right VALID, ACTIVE_DIR right ]"},
-          {0, ""},
-      });
+  validate_turn_lanes(result, {
+                                  {5, "[ left | left | through | *right* ACTIVE | *right* VALID ]"},
+                                  {5, "[ left | left | through | *right* ACTIVE | *right* VALID ]"},
+                                  {0, ""},
+                              });
 
   // A -> F - takes leftmost right lane (left side driving)
   result = gurka::route(map, "A", "F", "auto");
   gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
                                                 DirectionsLeg_Maneuver_Type_kRight,
                                                 DirectionsLeg_Maneuver_Type_kDestination});
-  validate_turn_lanes(
-      result,
-      {
-          {5,
-           "[ left | left | through | right ACTIVE, ACTIVE_DIR right | right VALID, ACTIVE_DIR right ]"},
-          {5,
-           "[ left | left | through | right ACTIVE, ACTIVE_DIR right | right VALID, ACTIVE_DIR right ]"},
-          {0, ""},
-      });
+  validate_turn_lanes(result, {
+                                  {5, "[ left | left | through | *right* ACTIVE | *right* VALID ]"},
+                                  {5, "[ left | left | through | *right* ACTIVE | *right* VALID ]"},
+                                  {0, ""},
+                              });
 
   // A -> G - takes both right lanes as destination is far away from previous transition
   result = gurka::route(map, "A", "G", "auto");
   gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
                                                 DirectionsLeg_Maneuver_Type_kRight,
                                                 DirectionsLeg_Maneuver_Type_kDestination});
-  validate_turn_lanes(
-      result,
-      {
-          {5,
-           "[ left | left | through | right ACTIVE, ACTIVE_DIR right | right ACTIVE, ACTIVE_DIR right ]"},
-          {5,
-           "[ left | left | through | right ACTIVE, ACTIVE_DIR right | right ACTIVE, ACTIVE_DIR right ]"},
-          {0, ""},
-      });
+  validate_turn_lanes(result, {
+                                  {5, "[ left | left | through | *right* ACTIVE | *right* ACTIVE ]"},
+                                  {5, "[ left | left | through | *right* ACTIVE | *right* ACTIVE ]"},
+                                  {0, ""},
+                              });
 }
 
 TEST(Standalone, TurnLanesSerializedResponse) {

--- a/test/turnlanes.cc
+++ b/test/turnlanes.cc
@@ -127,52 +127,54 @@ TEST(Turnlanes, validate_turn_lanes) {
   // Test right active
   test_turn_lanes({VALHALLA_SOURCE_DIR "test/pinpoints/turn_lanes/right_active_pinpoint.pbf"},
                   expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
-                  "[ left | through | through;right ACTIVE ]");
+                  "[ left | through | through;right ACTIVE, ACTIVE_DIR right ]");
 
   // Test left active
   test_turn_lanes({VALHALLA_SOURCE_DIR "test/pinpoints/turn_lanes/left_active_pinpoint.pbf"},
                   expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
-                  "[ left ACTIVE | through | through;right ]");
+                  "[ left ACTIVE, ACTIVE_DIR left | through | through;right ]");
 
   // Test right most slight left active
-  test_turn_lanes({VALHALLA_SOURCE_DIR
-                   "test/pinpoints/turn_lanes/right_most_slight_left_active_pinpoint.pbf"},
-                  expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
-                  "[ slight_left | slight_left ACTIVE | slight_right | right ]");
+  test_turn_lanes(
+      {VALHALLA_SOURCE_DIR "test/pinpoints/turn_lanes/right_most_slight_left_active_pinpoint.pbf"},
+      expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
+      "[ slight_left VALID, ACTIVE_DIR slight_left | slight_left ACTIVE, ACTIVE_DIR slight_left | slight_right | right ]");
 
   // Test slight right active
-  test_turn_lanes({VALHALLA_SOURCE_DIR "test/pinpoints/turn_lanes/slight_right_active_pinpoint.pbf"},
-                  expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
-                  "[ slight_left | slight_left | slight_right ACTIVE | right ]");
+  test_turn_lanes(
+      {VALHALLA_SOURCE_DIR "test/pinpoints/turn_lanes/slight_right_active_pinpoint.pbf"},
+      expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
+      "[ slight_left | slight_left | slight_right ACTIVE, ACTIVE_DIR slight_right | right ]");
 
   // Test left most left u-turn active
-  test_turn_lanes({VALHALLA_SOURCE_DIR
-                   "test/pinpoints/turn_lanes/left_most_left_uturn_active_pinpoint.pbf"},
-                  expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
-                  "[ left ACTIVE | left | left | through | through;right ]");
+  test_turn_lanes(
+      {VALHALLA_SOURCE_DIR "test/pinpoints/turn_lanes/left_most_left_uturn_active_pinpoint.pbf"},
+      expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
+      "[ left ACTIVE, ACTIVE_DIR left | left VALID, ACTIVE_DIR left | left VALID, ACTIVE_DIR left | through | through;right ]");
 
   // Test left reverse active
   test_turn_lanes({VALHALLA_SOURCE_DIR "test/pinpoints/turn_lanes/left_reverse_active_pinpoint.pbf"},
                   expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
-                  "[ reverse ACTIVE | through | through | right ]");
+                  "[ reverse ACTIVE, ACTIVE_DIR reverse | through | through | right ]");
 
   expected_maneuvers_size = 4;
   // Test right most left active
-  test_turn_lanes({VALHALLA_SOURCE_DIR
-                   "test/pinpoints/turn_lanes/right_most_left_active_pinpoint.pbf"},
-                  expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
-                  "[ left | left;through ACTIVE | through;right ]");
+  test_turn_lanes(
+      {VALHALLA_SOURCE_DIR "test/pinpoints/turn_lanes/right_most_left_active_pinpoint.pbf"},
+      expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
+      "[ left VALID, ACTIVE_DIR left | left;through ACTIVE, ACTIVE_DIR left | through;right ]");
 
   // Test both left active
-  test_turn_lanes({VALHALLA_SOURCE_DIR "test/pinpoints/turn_lanes/both_left_active_pinpoint.pbf"},
-                  expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
-                  "[ left ACTIVE | left;through ACTIVE | through;right ]");
+  test_turn_lanes(
+      {VALHALLA_SOURCE_DIR "test/pinpoints/turn_lanes/both_left_active_pinpoint.pbf"},
+      expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
+      "[ left ACTIVE, ACTIVE_DIR left | left;through ACTIVE, ACTIVE_DIR left | through;right ]");
 
   // Test left most left active
-  test_turn_lanes({VALHALLA_SOURCE_DIR
-                   "test/pinpoints/turn_lanes/left_most_left_active_pinpoint.pbf"},
-                  expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
-                  "[ left ACTIVE | left;through | through;right ]");
+  test_turn_lanes(
+      {VALHALLA_SOURCE_DIR "test/pinpoints/turn_lanes/left_most_left_active_pinpoint.pbf"},
+      expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
+      "[ left ACTIVE, ACTIVE_DIR left | left;through VALID, ACTIVE_DIR left | through;right ]");
 }
 
 } // namespace

--- a/test/turnlanes.cc
+++ b/test/turnlanes.cc
@@ -127,54 +127,52 @@ TEST(Turnlanes, validate_turn_lanes) {
   // Test right active
   test_turn_lanes({VALHALLA_SOURCE_DIR "test/pinpoints/turn_lanes/right_active_pinpoint.pbf"},
                   expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
-                  "[ left | through | through;right ACTIVE, ACTIVE_DIR right ]");
+                  "[ left | through | through;*right* ACTIVE ]");
 
   // Test left active
   test_turn_lanes({VALHALLA_SOURCE_DIR "test/pinpoints/turn_lanes/left_active_pinpoint.pbf"},
                   expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
-                  "[ left ACTIVE, ACTIVE_DIR left | through | through;right ]");
+                  "[ *left* ACTIVE | through | through;right ]");
 
   // Test right most slight left active
-  test_turn_lanes(
-      {VALHALLA_SOURCE_DIR "test/pinpoints/turn_lanes/right_most_slight_left_active_pinpoint.pbf"},
-      expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
-      "[ slight_left VALID, ACTIVE_DIR slight_left | slight_left ACTIVE, ACTIVE_DIR slight_left | slight_right | right ]");
+  test_turn_lanes({VALHALLA_SOURCE_DIR
+                   "test/pinpoints/turn_lanes/right_most_slight_left_active_pinpoint.pbf"},
+                  expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
+                  "[ *slight_left* VALID | *slight_left* ACTIVE | slight_right | right ]");
 
   // Test slight right active
-  test_turn_lanes(
-      {VALHALLA_SOURCE_DIR "test/pinpoints/turn_lanes/slight_right_active_pinpoint.pbf"},
-      expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
-      "[ slight_left | slight_left | slight_right ACTIVE, ACTIVE_DIR slight_right | right ]");
+  test_turn_lanes({VALHALLA_SOURCE_DIR "test/pinpoints/turn_lanes/slight_right_active_pinpoint.pbf"},
+                  expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
+                  "[ slight_left | slight_left | *slight_right* ACTIVE | right ]");
 
   // Test left most left u-turn active
-  test_turn_lanes(
-      {VALHALLA_SOURCE_DIR "test/pinpoints/turn_lanes/left_most_left_uturn_active_pinpoint.pbf"},
-      expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
-      "[ left ACTIVE, ACTIVE_DIR left | left VALID, ACTIVE_DIR left | left VALID, ACTIVE_DIR left | through | through;right ]");
+  test_turn_lanes({VALHALLA_SOURCE_DIR
+                   "test/pinpoints/turn_lanes/left_most_left_uturn_active_pinpoint.pbf"},
+                  expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
+                  "[ *left* ACTIVE | *left* VALID | *left* VALID | through | through;right ]");
 
   // Test left reverse active
   test_turn_lanes({VALHALLA_SOURCE_DIR "test/pinpoints/turn_lanes/left_reverse_active_pinpoint.pbf"},
                   expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
-                  "[ reverse ACTIVE, ACTIVE_DIR reverse | through | through | right ]");
+                  "[ *reverse* ACTIVE | through | through | right ]");
 
   expected_maneuvers_size = 4;
   // Test right most left active
-  test_turn_lanes(
-      {VALHALLA_SOURCE_DIR "test/pinpoints/turn_lanes/right_most_left_active_pinpoint.pbf"},
-      expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
-      "[ left VALID, ACTIVE_DIR left | left;through ACTIVE, ACTIVE_DIR left | through;right ]");
+  test_turn_lanes({VALHALLA_SOURCE_DIR
+                   "test/pinpoints/turn_lanes/right_most_left_active_pinpoint.pbf"},
+                  expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
+                  "[ *left* VALID | *left*;through ACTIVE | through;right ]");
 
   // Test both left active
-  test_turn_lanes(
-      {VALHALLA_SOURCE_DIR "test/pinpoints/turn_lanes/both_left_active_pinpoint.pbf"},
-      expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
-      "[ left ACTIVE, ACTIVE_DIR left | left;through ACTIVE, ACTIVE_DIR left | through;right ]");
+  test_turn_lanes({VALHALLA_SOURCE_DIR "test/pinpoints/turn_lanes/both_left_active_pinpoint.pbf"},
+                  expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
+                  "[ *left* ACTIVE | *left*;through ACTIVE | through;right ]");
 
   // Test left most left active
-  test_turn_lanes(
-      {VALHALLA_SOURCE_DIR "test/pinpoints/turn_lanes/left_most_left_active_pinpoint.pbf"},
-      expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
-      "[ left ACTIVE, ACTIVE_DIR left | left;through VALID, ACTIVE_DIR left | through;right ]");
+  test_turn_lanes({VALHALLA_SOURCE_DIR
+                   "test/pinpoints/turn_lanes/left_most_left_active_pinpoint.pbf"},
+                  expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
+                  "[ *left* ACTIVE | *left*;through VALID | through;right ]");
 }
 
 } // namespace

--- a/test/turnlanes.cc
+++ b/test/turnlanes.cc
@@ -149,7 +149,7 @@ TEST(Turnlanes, validate_turn_lanes) {
   test_turn_lanes({VALHALLA_SOURCE_DIR
                    "test/pinpoints/turn_lanes/left_most_left_uturn_active_pinpoint.pbf"},
                   expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
-                  "[ *left* ACTIVE | *left* VALID | *left* VALID | through | through;right ]");
+                  "[ *left* ACTIVE | left | left | through | through;right ]");
 
   // Test left reverse active
   test_turn_lanes({VALHALLA_SOURCE_DIR "test/pinpoints/turn_lanes/left_reverse_active_pinpoint.pbf"},

--- a/valhalla/odin/enhancedtrippath.h
+++ b/valhalla/odin/enhancedtrippath.h
@@ -422,8 +422,10 @@ public:
                              const DirectionsLeg_Maneuver_Type& curr_maneuver_type,
                              const DirectionsLeg_Maneuver_Type& next_maneuver_type);
   uint16_t ActivateTurnLanesFromLeft(uint16_t turn_lane_direction,
+                                     const DirectionsLeg_Maneuver_Type& curr_maneuver_type,
                                      uint16_t activated_max = std::numeric_limits<uint16_t>::max());
   uint16_t ActivateTurnLanesFromRight(uint16_t turn_lane_direction,
+                                      const DirectionsLeg_Maneuver_Type& curr_maneuver_type,
                                       uint16_t activated_max = std::numeric_limits<uint16_t>::max());
 
   std::string ToString() const;

--- a/valhalla/odin/maneuversbuilder.h
+++ b/valhalla/odin/maneuversbuilder.h
@@ -217,7 +217,7 @@ protected:
    * @param maneuver The maneuver at the intersection.
    */
   uint16_t GetExpectedTurnLaneDirection(std::unique_ptr<EnhancedTripLeg_Edge>& turn_lane_edge,
-                                        Maneuver& maneuver) const;
+                                        const Maneuver& maneuver) const;
 
   /**
    * Process the turn lanes at the maneuver point as well as within the maneuver.


### PR DESCRIPTION
The turn lane object (intersection.lanes) within a step is enhanced with
new attributes:
* "active": Set to true for lanes which are most appropriate to be in,
considering the current and next maneuver. false otherwise.
* "active_indication": An optional attribute containing the active lane's
arrow indication in the direction of the maneuver. Eg: if active lane has
"indications: [ left, straight ]" and we're turning left from this lane,
then "active_indication" will be "left".

The existing attribute "valid", will be set to true for lanes which can
be taken for completing the maneuver, but might not be the best lane to
be in, considering the next maneuver.