### PR TITLE
Ambiguous Local Time when Within DST Change Hour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@
    * FIXED: Fix all compiler warnings in sif and set to -Werror [#2642](https://github.com/valhalla/valhalla/pull/2642)
    * FIXED: Remove unnecessary maneuvers to continue straight [#2647](https://github.com/valhalla/valhalla/pull/2647)
    * FIXED: Linear reference support in route/mapmatch apis (FOW, FRC, bearing, and number of references) [#2645](https://github.com/valhalla/valhalla/pull/2645)
+   * FIXED: Ambiguous local to global (with timezone information) date time conversions now all choose to use the later time instead of throwing unhandled exceptions [#2665](https://github.com/valhalla/valhalla/pull/2665)
 
 * **Enhancement**
    * ADDED: Add ability to provide custom implementation for candidate collection in CandidateQuery. [#2328](https://github.com/valhalla/valhalla/pull/2328)

--- a/src/baldr/datetime.cc
+++ b/src/baldr/datetime.cc
@@ -469,9 +469,11 @@ bool is_conditional_active(const bool type,
     }
 
     // Time does not matter here; we are only dealing with dates.
-    auto b_in_local_time = date::make_zoned(time_zone, date::local_days(begin_date));
-    auto local_dt = date::make_zoned(time_zone, date::local_days(d));
-    auto e_in_local_time = date::make_zoned(time_zone, date::local_days(end_date));
+    auto b_in_local_time =
+        date::make_zoned(time_zone, date::local_days(begin_date), date::choose::latest);
+    auto local_dt = date::make_zoned(time_zone, date::local_days(d), date::choose::latest);
+    auto e_in_local_time =
+        date::make_zoned(time_zone, date::local_days(end_date), date::choose::latest);
 
     if (edge_case) {
 
@@ -482,11 +484,13 @@ bool is_conditional_active(const bool type,
       // end date = Jan 02, 2021
       date::year_month_day new_ed =
           date::year_month_day(date::year(b_year), date::month(12), date::day(31));
-      auto new_e_in_local_time = date::make_zoned(time_zone, date::local_days(new_ed));
+      auto new_e_in_local_time =
+          date::make_zoned(time_zone, date::local_days(new_ed), date::choose::latest);
 
       date::year_month_day new_bd =
           date::year_month_day(date::year(b_year), date::month(1), date::day(1));
-      auto new_b_in_local_time = date::make_zoned(time_zone, date::local_days(new_bd));
+      auto new_b_in_local_time =
+          date::make_zoned(time_zone, date::local_days(new_bd), date::choose::latest);
 
       // we need to check Jan 04, 2021 to Dec 31, 2021 and Jan 01, 2021 to Jan 02, 2021
       dt_in_range = (((b_in_local_time.get_local_time() <= local_dt.get_local_time() &&

--- a/src/mjolnir/servicedays.cc
+++ b/src/mjolnir/servicedays.cc
@@ -31,7 +31,7 @@ std::string get_testing_date_time() {
   }
 
   std::ostringstream iso_date_time;
-  const auto d = date::make_zoned(tz, tp);
+  const auto d = date::make_zoned(tz, tp, date::choose::latest);
   iso_date_time << date::format("%FT%R", d);
   return iso_date_time.str();
 }

--- a/test/datetime.cc
+++ b/test/datetime.cc
@@ -350,20 +350,6 @@ TEST(DateTime, TestDST) {
   TryTestDST(1478417468, 1478419500, "2016-11-06T02:31-05:00", "2016-11-06T03:05-05:00");
 }
 
-TEST(DateTime, TestAmbiguousDST) {
-  // BST and GMT ambiguity near day light savings time
-  size_t tz_idx = DateTime::get_tz_db().to_index("Europe/London");
-  const date::time_zone* tz = DateTime::get_tz_db().from_index(tz_idx);
-
-  // parse this into local epoch seconds
-  date::local_seconds parsed_date;
-  EXPECT_NO_THROW(parsed_date = DateTime::get_formatted_date("2020-10-25T01:57", true));
-
-  // account for the timezone where we have the local time in epoch seconds
-  EXPECT_NO_THROW(date::make_zoned(tz, parsed_date, date::choose::latest))
-      << " could not apply timezone to local time";
-}
-
 TEST(DateTime, TestIsRestricted) {
 
   TimeDomain td = TimeDomain(23622321788); // Mo-Fr 06:00-11:00

--- a/test/datetime.cc
+++ b/test/datetime.cc
@@ -357,10 +357,11 @@ TEST(DateTime, TestAmbiguousDST) {
 
   // parse this into local epoch seconds
   date::local_seconds parsed_date;
-  ASSERT_NO_THROW(parsed_date = DateTime::get_formatted_date("2020-10-25T01:57", true));
+  EXPECT_NO_THROW(parsed_date = DateTime::get_formatted_date("2020-10-25T01:57", true));
 
   // account for the timezone where we have the local time in epoch seconds
-  ASSERT_NO_THROW(date::make_zoned(tz, parsed_date));
+  EXPECT_NO_THROW(date::make_zoned(tz, parsed_date, date::choose::latest))
+      << " could not apply timezone to local time";
 }
 
 TEST(DateTime, TestIsRestricted) {

--- a/test/datetime.cc
+++ b/test/datetime.cc
@@ -350,6 +350,19 @@ TEST(DateTime, TestDST) {
   TryTestDST(1478417468, 1478419500, "2016-11-06T02:31-05:00", "2016-11-06T03:05-05:00");
 }
 
+TEST(DateTime, TestAmbiguousDST) {
+  // BST and GMT ambiguity near day light savings time
+  size_t tz_idx = DateTime::get_tz_db().to_index("Europe/London");
+  const date::time_zone* tz = DateTime::get_tz_db().from_index(tz_idx);
+
+  // parse this into local epoch seconds
+  date::local_seconds parsed_date;
+  ASSERT_NO_THROW(parsed_date = DateTime::get_formatted_date("2020-10-25T01:57", true));
+
+  // account for the timezone where we have the local time in epoch seconds
+  ASSERT_NO_THROW(date::make_zoned(tz, parsed_date));
+}
+
 TEST(DateTime, TestIsRestricted) {
 
   TimeDomain td = TimeDomain(23622321788); // Mo-Fr 06:00-11:00

--- a/test/gurka/test_time_tracking.cc
+++ b/test/gurka/test_time_tracking.cc
@@ -266,3 +266,11 @@ TEST(TimeTracking, routes) {
   ASSERT_TRUE(std::equal(times.begin(), times.end(), expected.begin(), expected.end(),
                          [](double a, double b) { return std::abs(a - b) < .0001; }));
 }
+
+TEST(TimeTracking, dst) {
+  // BST and GMT ambiguity where we gain an hour due to DST
+  std::string date_time = "2020-10-25T01:57";
+  int tz_idx = dt::get_tz_db().to_index("Europe/London");
+  EXPECT_NO_THROW(baldr::TimeInfo::make(date_time, tz_idx))
+      << " could not apply timezone to local time";
+}

--- a/valhalla/baldr/time_info.h
+++ b/valhalla/baldr/time_info.h
@@ -134,7 +134,7 @@ struct TimeInfo {
       LOG_ERROR("Could not parse provided date_time: " + date_time);
       return {false, 0, 0, kConstrainedFlowSecondOfDay, 0, false, nullptr};
     }
-    const auto then_date = date::make_zoned(tz, parsed_date);
+    const auto then_date = date::make_zoned(tz, parsed_date, date::choose::latest);
     uint64_t local_time = date::to_utc_time(then_date.get_sys_time()).time_since_epoch().count();
 
     // What second of the week is this (for historical traffic lookup)


### PR DESCRIPTION
If you select a local time that is within the DST change window and then apply a timezone to it it seems that the datetime library notices that it has two options for interpreting the time, either you meant the time BEFORE or AFTER the DST change and it doesnt know which. We might try asking Howard Hinnant if he can suggest a work around or a way of telling the library to choose between the two. As a last resort we can catch such an exception, move the time an hour and move it back after the transformation.

EDIT: Howard Hinnant already provided a solution for this which is to actually allow you to tell the library to choose which option you want :smile: so i'll update the PR with that and set this for review