### PR TITLE
Add annotations to osrm response including speed limits, unit and sign conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,7 @@
    * ADDED: Linear reference support to locate api [#2645](https://github.com/valhalla/valhalla/pull/2645)
    * ADDED: Implemented OSRM-like turn duration calculation for car. Uses it now in auto costing. [#2651](https://github.com/valhalla/valhalla/pull/2651)
    * ADDED: Enhanced turn lane information in guidance [#2653](https://github.com/valhalla/valhalla/pull/2653)
+   * ADDED: Add annotations to osrm response including speed limits, unit and sign conventions [#2668](https://github.com/valhalla/valhalla/pull/2668)
 
 ## Release Date: 2019-11-21 Valhalla 3.0.9
 * **Bug Fix**

--- a/proto/trip.proto
+++ b/proto/trip.proto
@@ -303,6 +303,8 @@ message TripLeg {
     repeated uint32 time = 1 [packed=true]; // milliseconds
     repeated uint32 length = 2 [packed=true]; // decimeters
     repeated uint32 speed = 3 [packed=true]; // decimeters per sec
+    // 4 is reserved
+    repeated uint32 speed_limit = 5 [packed=true]; // speed limit in kph
   }
 
   // we encapsulate the real incident object here so we can add information

--- a/src/thor/attributes_controller.cc
+++ b/src/thor/attributes_controller.cc
@@ -128,7 +128,9 @@ const std::unordered_map<std::string, bool> AttributesController::kDefaultAttrib
     // Per-shape attributes
     {kShapeAttributesTime, false},
     {kShapeAttributesLength, false},
-    {kShapeAttributesSpeed, false}};
+    {kShapeAttributesSpeed, false},
+    {kShapeAttributesSpeedLimit, false},
+};
 
 AttributesController::AttributesController() {
   attributes = kDefaultAttributes;

--- a/src/thor/triplegbuilder.cc
+++ b/src/thor/triplegbuilder.cc
@@ -423,7 +423,6 @@ TripLeg_Edge* AddTripEdge(const AttributesController& controller,
                           const bool drive_on_right,
                           TripLeg_Node* trip_node,
                           const GraphTile* graphtile,
-                          GraphReader& graphreader,
                           const uint32_t second_of_week,
                           const uint32_t start_node_idx,
                           const bool has_junction_name,
@@ -1179,8 +1178,8 @@ void TripLegBuilder::Build(
     TripLeg_Edge* trip_edge =
         AddTripEdge(controller, edge, edge_itr->trip_id, multimodal_builder.block_id, mode,
                     travel_type, costing, directededge, node->drive_on_right(), trip_node, graphtile,
-                    graphreader, time_info.second_of_week, startnode.id(), node->named_intersection(),
-                    start_tile, edge_itr->restriction_index);
+                    time_info.second_of_week, startnode.id(), node->named_intersection(), start_tile,
+                    edge_itr->restriction_index);
 
     // some information regarding shape/length trimming
     auto is_first_edge = edge_itr == path_begin;

--- a/src/thor/triplegbuilder.cc
+++ b/src/thor/triplegbuilder.cc
@@ -241,6 +241,7 @@ void SetShapeAttributes(const AttributesController& controller,
   }
 
   // Find the first cut to the right of where we start on this edge
+  auto edgeinfo = tile->edgeinfo(edge->edgeinfo_offset());
   double distance_total_pct = src_pct;
   auto cut_itr = std::find_if(cuts.cbegin(), cuts.cend(),
                               [distance_total_pct](const decltype(cuts)::value_type& s) {
@@ -283,6 +284,11 @@ void SetShapeAttributes(const AttributesController& controller,
     if (controller.attributes.at(kShapeAttributesSpeed)) {
       // convert speed to decimeters per sec and then round to an integer
       leg.mutable_shape_attributes()->add_speed((distance * kDecimeterPerMeter / time) + 0.5);
+    }
+
+    // Set the maxspeed if requested
+    if (controller.attributes.at(kShapeAttributesSpeedLimit)) {
+      leg.mutable_shape_attributes()->add_speed_limit(edgeinfo.speed_limit());
     }
 
     // Set the incidents if we just cut or we are at the end

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -33,6 +33,10 @@ using namespace std;
 namespace {
 const std::string kSignElementDelimiter = ", ";
 const std::string kDestinationsDelimiter = ": ";
+const std::string kSpeedLimitSignVienna = "vienna";
+const std::string kSpeedLimitSignMutcd = "mutcd";
+const std::string kSpeedLimitUnitsKph = "km/h";
+const std::string kSpeedLimitUnitsMph = "mph";
 
 constexpr std::size_t MAX_USED_SEGMENTS = 2;
 struct NamedSegment {
@@ -179,6 +183,35 @@ std::unordered_map<std::string, std::string> iso2_to_iso3 =
      {"UY", "URY"}, {"UZ", "UZB"}, {"VA", "VAT"}, {"VC", "VCT"}, {"VE", "VEN"}, {"VG", "VGB"},
      {"VI", "VIR"}, {"VN", "VNM"}, {"VU", "VUT"}, {"WF", "WLF"}, {"WS", "WSM"}, {"YE", "YEM"},
      {"YT", "MYT"}, {"ZA", "ZAF"}, {"ZM", "ZMB"}, {"ZW", "ZWE"}, {"CS", "SCG"}, {"AN", "ANT"}};
+
+std::unordered_map<std::string, std::pair<std::string, std::string>> speed_limit_info = {
+    {"AG", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
+    {"AS", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
+    {"BS", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
+    {"BZ", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
+    {"CA", {kSpeedLimitSignMutcd, kSpeedLimitUnitsKph}},
+    {"DM", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
+    {"FK", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
+    {"GB", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
+    {"GD", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
+    {"GG", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
+    {"GU", {kSpeedLimitSignMutcd, kSpeedLimitUnitsMph}},
+    {"IM", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
+    {"JE", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
+    {"KN", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
+    {"KY", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
+    {"LC", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
+    {"LR", {kSpeedLimitSignMutcd, kSpeedLimitUnitsKph}},
+    {"MP", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
+    {"PR", {kSpeedLimitSignMutcd, kSpeedLimitUnitsMph}},
+    {"SH", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
+    {"TC", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
+    {"US", {kSpeedLimitSignMutcd, kSpeedLimitUnitsMph}},
+    {"VC", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
+    {"VG", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
+    {"VI", {kSpeedLimitSignMutcd, kSpeedLimitUnitsMph}},
+    {"WS", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
+};
 
 namespace osrm_serializers {
 /*
@@ -334,6 +367,57 @@ void route_geometry(json::MapPtr& route,
     int precision = options.shape_format() == polyline6 ? 1e6 : 1e5;
     route->emplace("geometry", midgard::encode(shape, precision));
   }
+}
+
+json::MapPtr serialize_annotations(const valhalla::TripLeg& trip_leg) {
+  auto attributes_map = json::map({});
+
+  if (trip_leg.shape_attributes().time_size() > 0) {
+    auto duration_array = json::array({});
+    for (const auto& time : trip_leg.shape_attributes().time()) {
+      // milliseconds (ms) to seconds (sec)
+      duration_array->push_back(json::fp_t{time * kSecPerMillisecond, 3});
+    }
+    attributes_map->emplace("duration", duration_array);
+  }
+
+  if (trip_leg.shape_attributes().length_size() > 0) {
+    auto distance_array = json::array({});
+    for (const auto& length : trip_leg.shape_attributes().length()) {
+      // decimeters (dm) to meters (m)
+      distance_array->push_back(json::fp_t{length * kMeterPerDecimeter, 1});
+    }
+    attributes_map->emplace("distance", distance_array);
+  }
+
+  if (trip_leg.shape_attributes().speed_size() > 0) {
+    auto speeds_array = json::array({});
+    for (const auto& speed : trip_leg.shape_attributes().speed()) {
+      // dm/s to m/s
+      speeds_array->push_back(json::fp_t{speed * kMeterPerDecimeter, 1});
+    }
+    attributes_map->emplace("speed", speeds_array);
+  }
+
+  if (trip_leg.shape_attributes().speed_limit_size() > 0) {
+    auto speed_limits_array = json::array({});
+    for (const auto& speed_limit : trip_leg.shape_attributes().speed_limit()) {
+      auto speed_limit_annotation = json::map({});
+      if (speed_limit == kUnlimitedSpeedLimit) {
+        speed_limit_annotation->emplace("none", true);
+      } else if (speed_limit > 0) {
+        // TODO support mph?
+        speed_limit_annotation->emplace("unit", kSpeedLimitUnitsKph);
+        speed_limit_annotation->emplace("speed", static_cast<uint64_t>(speed_limit));
+      } else {
+        speed_limit_annotation->emplace("unknown", true);
+      }
+      speed_limits_array->push_back(speed_limit_annotation);
+    }
+    attributes_map->emplace("maxspeed", speed_limits_array);
+  }
+
+  return attributes_map;
 }
 
 // Serialize waypoints for optimized route. Note that OSRM retains the
@@ -1376,6 +1460,22 @@ json::ArrayPtr serialize_legs(const google::protobuf::RepeatedPtrField<valhalla:
         step->emplace("ref", ref);
       }
 
+      // Check if speed limits were requested
+      if (path_leg.shape_attributes().speed_limit_size() > 0) {
+        // Lookup speed limit info for this country
+        auto country_code = etp.GetCountryCode(maneuver.begin_path_index());
+        auto country = speed_limit_info.find(country_code);
+        if (country != speed_limit_info.end()) {
+          // Some countries have different speed limit sign types and speed units
+          step->emplace("speedLimitSign", country->second.first);
+          step->emplace("speedLimitUnit", country->second.second);
+        } else {
+          // Otherwise use the defaults (vienna convention style and km/h)
+          step->emplace("speedLimitSign", std::string(kSpeedLimitSignVienna));
+          step->emplace("speedLimitUnit", std::string(kSpeedLimitUnitsKph));
+        }
+      }
+
       rotary = ((maneuver.type() == DirectionsLeg_Maneuver_Type_kRoundaboutEnter) &&
                 (maneuver.street_name_size() > 0));
       if (rotary) {
@@ -1493,6 +1593,11 @@ json::ArrayPtr serialize_legs(const google::protobuf::RepeatedPtrField<valhalla:
 
     // Add steps to the leg
     output_leg->emplace("steps", steps);
+
+    // Add shape_attributes, if requested
+    if (path_leg.has_shape_attributes()) {
+      output_leg->emplace("annotation", serialize_annotations(path_leg));
+    }
 
     // Add incidents to the leg
     serializeIncidents(path_leg.incidents(), *output_leg);
@@ -1768,6 +1873,77 @@ TEST(RouteSerializerOsrm, testserializeIncidentsNothingToAdd) {
   rapidjson::Document expected_json;
   {
     expected_json.Parse("{}");
+    ASSERT_TRUE(expected_json.IsObject());
+  }
+
+  assert_json_equality(serialized_to_json, expected_json);
+}
+
+TEST(RouteSerializerOsrm, testserializeAnnotationsEmpty) {
+  rapidjson::Document serialized_to_json;
+  {
+    auto leg = TripLeg();
+    json::MapPtr annotations = serialize_annotations(leg);
+
+    std::stringstream ss;
+    ss << *annotations;
+    serialized_to_json.Parse(ss.str().c_str());
+    std::cout << *annotations << std::endl;
+  }
+  rapidjson::Document expected_json;
+  { expected_json.Parse(R"({})"); }
+
+  assert_json_equality(serialized_to_json, expected_json);
+}
+
+TEST(RouteSerializerOsrm, testserializeAnnotations) {
+  rapidjson::Document serialized_to_json;
+  {
+    auto leg = TripLeg();
+    leg.mutable_shape_attributes()->add_time(1);
+    leg.mutable_shape_attributes()->add_length(2);
+    leg.mutable_shape_attributes()->add_speed(3);
+    auto annotations = serialize_annotations(leg);
+
+    std::stringstream ss;
+    ss << *annotations;
+    serialized_to_json.Parse(ss.str().c_str());
+  }
+  rapidjson::Document expected_json;
+  {
+    expected_json.Parse(R"({
+      "duration": [0.001],
+      "distance": [0.2],
+      "speed": [0.3]
+    })");
+    ASSERT_TRUE(expected_json.IsObject());
+  }
+
+  assert_json_equality(serialized_to_json, expected_json);
+}
+
+TEST(RouteSerializerOsrm, testserializeAnnotationsSpeedLimits) {
+  rapidjson::Document serialized_to_json;
+  {
+    auto leg = TripLeg();
+    leg.mutable_shape_attributes()->add_speed_limit(30);
+    leg.mutable_shape_attributes()->add_speed_limit(255);
+    leg.mutable_shape_attributes()->add_speed_limit(0);
+    auto annotations = serialize_annotations(leg);
+
+    std::stringstream ss;
+    ss << *annotations;
+    serialized_to_json.Parse(ss.str().c_str());
+  }
+  rapidjson::Document expected_json;
+  {
+    expected_json.Parse(R"({
+      "maxspeed": [
+        { "speed": 30, "unit": "km/h" },
+        { "none": true },
+        { "unknown": true }
+      ]
+    })");
     ASSERT_TRUE(expected_json.IsObject());
   }
 

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -189,6 +189,7 @@ std::unordered_map<std::string, std::string> iso2_to_iso3 =
 // use MUTCD and/or mph conventions.
 std::unordered_map<std::string, std::pair<std::string, std::string>> speed_limit_info = {
     {"AG", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
+    {"AI", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
     {"AS", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
     {"BS", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
     {"BZ", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
@@ -198,6 +199,7 @@ std::unordered_map<std::string, std::pair<std::string, std::string>> speed_limit
     {"GB", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
     {"GD", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
     {"GG", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
+    {"GS", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
     {"GU", {kSpeedLimitSignMutcd, kSpeedLimitUnitsMph}},
     {"IM", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
     {"JE", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
@@ -206,6 +208,7 @@ std::unordered_map<std::string, std::pair<std::string, std::string>> speed_limit
     {"LC", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
     {"LR", {kSpeedLimitSignMutcd, kSpeedLimitUnitsKph}},
     {"MP", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
+    {"MS", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
     {"PR", {kSpeedLimitSignMutcd, kSpeedLimitUnitsMph}},
     {"SH", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
     {"TC", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -184,6 +184,9 @@ std::unordered_map<std::string, std::string> iso2_to_iso3 =
      {"VI", "VIR"}, {"VN", "VNM"}, {"VU", "VUT"}, {"WF", "WLF"}, {"WS", "WSM"}, {"YE", "YEM"},
      {"YT", "MYT"}, {"ZA", "ZAF"}, {"ZM", "ZMB"}, {"ZW", "ZWE"}, {"CS", "SCG"}, {"AN", "ANT"}};
 
+// Sign style and unit conventions for speed limit signs by country.
+// Most countries use Vienna style and km/h, but the countries below
+// use MUTCD and/or mph conventions.
 std::unordered_map<std::string, std::pair<std::string, std::string>> speed_limit_info = {
     {"AG", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
     {"AS", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
@@ -1471,8 +1474,8 @@ json::ArrayPtr serialize_legs(const google::protobuf::RepeatedPtrField<valhalla:
           step->emplace("speedLimitUnit", country->second.second);
         } else {
           // Otherwise use the defaults (vienna convention style and km/h)
-          step->emplace("speedLimitSign", std::string(kSpeedLimitSignVienna));
-          step->emplace("speedLimitUnit", std::string(kSpeedLimitUnitsKph));
+          step->emplace("speedLimitSign", kSpeedLimitSignVienna);
+          step->emplace("speedLimitUnit", kSpeedLimitUnitsKph);
         }
       }
 

--- a/test/gurka/test_maxspeed.cc
+++ b/test/gurka/test_maxspeed.cc
@@ -46,6 +46,7 @@ TEST(Standalone, Maxspeed) {
   // ]
   auto d = gurka::convert_to_json(result, valhalla::Options_Format_osrm);
   EXPECT_EQ(d["routes"][0]["legs"][0]["annotation"]["maxspeed"].Size(), 6);
+  EXPECT_EQ(d["routes"][0]["legs"][0]["steps"].Size(), 3);
 
   EXPECT_EQ(d["routes"][0]["legs"][0]["annotation"]["maxspeed"][0]["speed"].GetInt(), 50);
   EXPECT_STREQ(d["routes"][0]["legs"][0]["annotation"]["maxspeed"][0]["unit"].GetString(), "km/h");
@@ -56,4 +57,11 @@ TEST(Standalone, Maxspeed) {
   EXPECT_EQ(d["routes"][0]["legs"][0]["annotation"]["maxspeed"][4]["none"].GetBool(), true);
   EXPECT_EQ(d["routes"][0]["legs"][0]["annotation"]["maxspeed"][5]["speed"].GetInt(), 40);
   EXPECT_STREQ(d["routes"][0]["legs"][0]["annotation"]["maxspeed"][5]["unit"].GetString(), "km/h");
+
+  EXPECT_STREQ(d["routes"][0]["legs"][0]["steps"][0]["speedLimitSign"].GetString(), "vienna");
+  EXPECT_STREQ(d["routes"][0]["legs"][0]["steps"][0]["speedLimitUnit"].GetString(), "km/h");
+  EXPECT_STREQ(d["routes"][0]["legs"][0]["steps"][1]["speedLimitSign"].GetString(), "vienna");
+  EXPECT_STREQ(d["routes"][0]["legs"][0]["steps"][1]["speedLimitUnit"].GetString(), "km/h");
+  EXPECT_STREQ(d["routes"][0]["legs"][0]["steps"][2]["speedLimitSign"].GetString(), "vienna");
+  EXPECT_STREQ(d["routes"][0]["legs"][0]["steps"][2]["speedLimitUnit"].GetString(), "km/h");
 }

--- a/test/gurka/test_maxspeed.cc
+++ b/test/gurka/test_maxspeed.cc
@@ -20,7 +20,9 @@ TEST(Standalone, Maxspeed) {
   };
   const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100);
   auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_maxspeed");
-  auto result = gurka::route(map, "A", "G", "auto");
+  auto result = gurka::route(map, "A", "G", "auto",
+                             {{"/filters/action", "include"},
+                              {"/filters/attributes/0", "shape_attributes.speed_limit"}});
 
   ASSERT_EQ(result.trip().routes(0).legs_size(), 1);
   auto leg = result.trip().routes(0).legs(0);
@@ -31,4 +33,27 @@ TEST(Standalone, Maxspeed) {
   EXPECT_EQ(leg.node(3).edge().speed_limit(), 0);   // DE
   EXPECT_EQ(leg.node(4).edge().speed_limit(), 255); // EF
   EXPECT_EQ(leg.node(5).edge().speed_limit(), 40);  // FG
+
+  // Test osrm output
+  //
+  // "maxspeed": [
+  //  {"speed":50,"unit":"km\/h"},
+  //  {"speed":97,"unit":"km\/h"},
+  //  {"unknown":true},
+  //  {"unknown":true},
+  //  {"none":true},
+  //  {"speed":40,"unit":"km\/h"}
+  // ]
+  auto d = gurka::convert_to_json(result, valhalla::Options_Format_osrm);
+  EXPECT_EQ(d["routes"][0]["legs"][0]["annotation"]["maxspeed"].Size(), 6);
+
+  EXPECT_EQ(d["routes"][0]["legs"][0]["annotation"]["maxspeed"][0]["speed"].GetInt(), 50);
+  EXPECT_STREQ(d["routes"][0]["legs"][0]["annotation"]["maxspeed"][0]["unit"].GetString(), "km/h");
+  EXPECT_EQ(d["routes"][0]["legs"][0]["annotation"]["maxspeed"][1]["speed"].GetInt(), 97);
+  EXPECT_STREQ(d["routes"][0]["legs"][0]["annotation"]["maxspeed"][1]["unit"].GetString(), "km/h");
+  EXPECT_EQ(d["routes"][0]["legs"][0]["annotation"]["maxspeed"][2]["unknown"].GetBool(), true);
+  EXPECT_EQ(d["routes"][0]["legs"][0]["annotation"]["maxspeed"][3]["unknown"].GetBool(), true);
+  EXPECT_EQ(d["routes"][0]["legs"][0]["annotation"]["maxspeed"][4]["none"].GetBool(), true);
+  EXPECT_EQ(d["routes"][0]["legs"][0]["annotation"]["maxspeed"][5]["speed"].GetInt(), 40);
+  EXPECT_STREQ(d["routes"][0]["legs"][0]["annotation"]["maxspeed"][5]["unit"].GetString(), "km/h");
 }

--- a/valhalla/thor/attributes_controller.h
+++ b/valhalla/thor/attributes_controller.h
@@ -134,6 +134,7 @@ const std::string kRawScore = "raw_score";
 const std::string kShapeAttributesTime = "shape_attributes.time";
 const std::string kShapeAttributesLength = "shape_attributes.length";
 const std::string kShapeAttributesSpeed = "shape_attributes.speed";
+const std::string kShapeAttributesSpeedLimit = "shape_attributes.speed_limit";
 
 // Categories
 const std::string kNodeCategory = "node.";


### PR DESCRIPTION
# Issue

Adds speed limiit (a.k.a maxspeed) annotations to the osrm response when requested. Also includes speedLimitUnit and speedLimitSign properties on the step to denote the commonly used sign style ([Vienna Convention](https://en.wikipedia.org/wiki/Vienna_Convention_on_Road_Signs_and_Signals) or [MUTCD](https://en.wikipedia.org/wiki/Manual_on_Uniform_Traffic_Control_Devices)) and display unit (km/h or mph) in each country/region.

This PR also adds distance, duration, and speed annotations to the response -- these shape attributes were already on the tripleg, this PR just serializes them for consistency with speed limits.

## Tasklist

 - [X] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
