### PR TITLE
Fix C++17 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
    * FIXED: Linear reference support in route/mapmatch apis (FOW, FRC, bearing, and number of references) [#2645](https://github.com/valhalla/valhalla/pull/2645)
    * FIXED: Ambiguous local to global (with timezone information) date time conversions now all choose to use the later time instead of throwing unhandled exceptions [#2665](https://github.com/valhalla/valhalla/pull/2665)
    * FIXED: Overestimated reach caused be reenquing transition nodes without checking that they had been already expanded [#2670](https://github.com/valhalla/valhalla/pull/2670)
+   * FIXED: Build with C++17 standard. Deprecated function calls are substituted with new ones. [#2669](https://github.com/valhalla/valhalla/pull/2669)
 
 * **Enhancement**
    * ADDED: Add ability to provide custom implementation for candidate collection in CandidateQuery. [#2328](https://github.com/valhalla/valhalla/pull/2328)

--- a/src/mjolnir/elevationbuilder.cc
+++ b/src/mjolnir/elevationbuilder.cc
@@ -41,7 +41,7 @@ void add_elevation(const boost::property_tree::ptree& pt,
                    std::deque<GraphId>& tilequeue,
                    std::mutex& lock,
                    const std::unique_ptr<const valhalla::skadi::sample>& sample,
-                   std::promise<uint32_t>& result) {
+                   std::promise<uint32_t>& /*result*/) {
   // Local Graphreader
   GraphReader graphreader(pt.get_child("mjolnir"));
 

--- a/src/mjolnir/elevationbuilder.cc
+++ b/src/mjolnir/elevationbuilder.cc
@@ -189,7 +189,8 @@ void ElevationBuilder::Build(const boost::property_tree::ptree& pt) {
   for (const auto& id : tileset) {
     tilequeue.emplace_back(id);
   }
-  std::random_shuffle(tilequeue.begin(), tilequeue.end());
+  std::random_device rd;
+  std::shuffle(tilequeue.begin(), tilequeue.end(), std::mt19937(rd()));
 
   // An mutex we can use to do the synchronization
   std::mutex lock;

--- a/src/mjolnir/graphenhancer.cc
+++ b/src/mjolnir/graphenhancer.cc
@@ -666,7 +666,6 @@ bool IsNotThruEdge(GraphReader& reader,
 bool IsIntersectionInternal(const GraphTile* start_tile,
                             GraphReader& reader,
                             std::mutex& lock,
-                            const GraphId& startnode,
                             const NodeInfo& startnodeinfo,
                             const DirectedEdge& directededge,
                             const uint32_t idx) {
@@ -885,8 +884,7 @@ bool IsNextEdgeInternalImpl(const DirectedEdge directededge,
       if (!infer_internal_intersections)
         return diredge->internal();
       else
-        return IsIntersectionInternal(&end_node_tile, reader, lock, directededge.endnode(),
-                                      end_node_info, *diredge, i);
+        return IsIntersectionInternal(&end_node_tile, reader, lock, end_node_info, *diredge, i);
     }
   }
   return false;
@@ -1765,8 +1763,7 @@ void enhance(const boost::property_tree::ptree& pt,
         // Test if an internal intersection edge. Must do this after setting
         // opposing edge index
         if (infer_internal_intersections &&
-            IsIntersectionInternal(&tilebuilder, reader, lock, startnode, nodeinfo, directededge,
-                                   j)) {
+            IsIntersectionInternal(&tilebuilder, reader, lock, nodeinfo, directededge, j)) {
           directededge.set_internal(true);
         }
 

--- a/src/mjolnir/graphenhancer.cc
+++ b/src/mjolnir/graphenhancer.cc
@@ -1891,7 +1891,8 @@ void GraphEnhancer::Enhance(const boost::property_tree::ptree& pt,
   for (const auto& tile_id : local_tiles) {
     tempqueue.emplace_back(tile_id);
   }
-  std::random_shuffle(tempqueue.begin(), tempqueue.end());
+  std::random_device rd;
+  std::shuffle(tempqueue.begin(), tempqueue.end(), std::mt19937(rd()));
   std::queue<GraphId> tilequeue(tempqueue);
 
   // An atomic object we can use to do the synchronization

--- a/src/mjolnir/restrictionbuilder.cc
+++ b/src/mjolnir/restrictionbuilder.cc
@@ -621,7 +621,8 @@ void RestrictionBuilder::Build(const boost::property_tree::ptree& pt,
     for (const auto& tile_id : level_tiles) {
       tempqueue.emplace_back(tile_id);
     }
-    std::random_shuffle(tempqueue.begin(), tempqueue.end());
+    std::random_device rd;
+    std::shuffle(tempqueue.begin(), tempqueue.end(), std::mt19937(rd()));
     std::queue<GraphId> tilequeue(tempqueue);
 
     // An atomic object we can use to do the synchronization

--- a/src/mjolnir/timeparsing.cc
+++ b/src/mjolnir/timeparsing.cc
@@ -20,7 +20,8 @@ namespace mjolnir {
 
 std::vector<std::string> GetTokens(const std::string& tag_value, char delim) {
   std::vector<std::string> tokens;
-  boost::algorithm::split(tokens, tag_value, std::bind1st(std::equal_to<char>(), delim),
+  boost::algorithm::split(tokens, tag_value,
+                          std::bind(std::equal_to<char>(), delim, std::placeholders::_1),
                           boost::algorithm::token_compress_on);
   return tokens;
 }

--- a/src/mjolnir/util.cc
+++ b/src/mjolnir/util.cc
@@ -52,7 +52,8 @@ namespace mjolnir {
  */
 std::vector<std::string> GetTagTokens(const std::string& tag_value, char delim) {
   std::vector<std::string> tokens;
-  boost::algorithm::split(tokens, tag_value, std::bind1st(std::equal_to<char>(), delim),
+  boost::algorithm::split(tokens, tag_value,
+                          std::bind(std::equal_to<char>(), delim, std::placeholders::_1),
                           boost::algorithm::token_compress_off);
   return tokens;
 }

--- a/src/mjolnir/valhalla_add_predicted_traffic.cc
+++ b/src/mjolnir/valhalla_add_predicted_traffic.cc
@@ -329,7 +329,8 @@ int main(int argc, char** argv) {
   }
   std::vector<std::pair<GraphId, std::vector<std::string>>> traffic_tiles(files_per_tile.begin(),
                                                                           files_per_tile.end());
-  std::random_shuffle(traffic_tiles.begin(), traffic_tiles.end());
+  std::random_device rd;
+  std::shuffle(traffic_tiles.begin(), traffic_tiles.end(), std::mt19937(rd()));
 
   // Read the config file
   boost::property_tree::ptree pt;

--- a/src/mjolnir/valhalla_build_statistics.cc
+++ b/src/mjolnir/valhalla_build_statistics.cc
@@ -536,7 +536,8 @@ void BuildStatistics(const boost::property_tree::ptree& pt) {
       }
     }
   }
-  std::random_shuffle(tilequeue.begin(), tilequeue.end());
+  std::random_device rd;
+  std::shuffle(tilequeue.begin(), tilequeue.end(), std::mt19937(rd()));
 
   // A mutex we can use to do the synchronization
   std::mutex lock;

--- a/src/mjolnir/valhalla_build_statistics.cc
+++ b/src/mjolnir/valhalla_build_statistics.cc
@@ -49,8 +49,6 @@ struct HGVRestrictionTypes {
 
 bool IsLoopTerminal(const GraphTile& tile,
                     GraphReader& reader,
-                    const GraphId& startnode,
-                    const NodeInfo& startnodeinfo,
                     const DirectedEdge& directededge,
                     statistics::RouletteData& rd) {
   // Get correct tile to work with
@@ -202,10 +200,7 @@ bool IsLoop(GraphReader& reader,
 }
 
 bool IsUnroutableNode(const GraphTile& tile,
-                      GraphReader& reader,
-                      const GraphId& startnode,
                       const NodeInfo& startnodeinfo,
-                      const DirectedEdge& directededge,
                       statistics::RouletteData& rd) {
 
   const DirectedEdge* diredge = tile.directededge(startnodeinfo.edge_index());
@@ -235,8 +230,7 @@ bool IsUnroutableNode(const GraphTile& tile,
   return false;
 }
 
-void checkExitInfo(const GraphTile& tile,
-                   GraphReader& reader,
+void checkExitInfo(GraphReader& reader,
                    const GraphId& startnode,
                    const NodeInfo& startnodeinfo,
                    const DirectedEdge& directededge,
@@ -292,8 +286,7 @@ void AddStatistics(statistics& stats,
                    const GraphTile& tile,
                    GraphReader& graph_reader,
                    GraphId& node,
-                   const NodeInfo& nodeinfo,
-                   uint32_t idx) {
+                   const NodeInfo& nodeinfo) {
 
   auto rclass = directededge.classification();
   float edge_length = (tileid == directededge.endnode().tileid()) ? directededge.length() * 0.5f
@@ -331,15 +324,14 @@ void AddStatistics(statistics& stats,
 
   // Check for exit signage if it is a highway link
   if (directededge.link() && (rclass == RoadClass::kMotorway || rclass == RoadClass::kTrunk)) {
-    checkExitInfo(tile, graph_reader, node, nodeinfo, directededge, stats);
+    checkExitInfo(graph_reader, node, nodeinfo, directededge, stats);
   }
 
   // Add all other statistics
   // Only consider edge if edge is good and it's not a link
   if (!directededge.link()) {
     edge_length *= 0.5f;
-    bool found =
-        IsUnroutableNode(tile, graph_reader, node, nodeinfo, directededge, stats.roulette_data);
+    bool found = IsUnroutableNode(tile, nodeinfo, stats.roulette_data);
     if (!found) {
       // IsLoop(graph_reader,directededge,node,stats.roulette_data);
     }
@@ -478,7 +470,7 @@ void build(const boost::property_tree::ptree& pt,
         // Statistics
         if (valid_length) {
           AddStatistics(stats, *directededge, tileid, begin_node_iso, hgv, *tile, graph_reader, node,
-                        *nodeinfo, j);
+                        *nodeinfo);
         }
       }
     }

--- a/src/thor/optimizer.cc
+++ b/src/thor/optimizer.cc
@@ -106,7 +106,8 @@ void Optimizer::CreateRandomTour() {
   for (uint32_t i = 1; i < count_ - 1; i++) {
     tour_.push_back(i);
   }
-  std::random_shuffle(tour_.begin(), tour_.end());
+  std::random_device rd;
+  std::shuffle(tour_.begin(), tour_.end(), std::mt19937(rd()));
   tour_.insert(tour_.begin(), 0);
   tour_.push_back(count_ - 1);
 }


### PR DESCRIPTION
Change deprecated std::random_shuffle calls to std::shuffle, use
std::bind instead of deprecated std::bind1st

# Issue

#2669

## Tasklist

 - [x] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

Valhalla wasn't compile for C++17 because of usage of deprecated functions. This PR fixes it.
