### PR TITLE
fix reach counting of transition nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@
    * FIXED: Remove unnecessary maneuvers to continue straight [#2647](https://github.com/valhalla/valhalla/pull/2647)
    * FIXED: Linear reference support in route/mapmatch apis (FOW, FRC, bearing, and number of references) [#2645](https://github.com/valhalla/valhalla/pull/2645)
    * FIXED: Ambiguous local to global (with timezone information) date time conversions now all choose to use the later time instead of throwing unhandled exceptions [#2665](https://github.com/valhalla/valhalla/pull/2665)
+   * FIXED: Overestimated reach caused be reenquing transition nodes without checking that they had been already expanded [#2670](https://github.com/valhalla/valhalla/pull/2670)
 
 * **Enhancement**
    * ADDED: Add ability to provide custom implementation for candidate collection in CandidateQuery. [#2328](https://github.com/valhalla/valhalla/pull/2328)

--- a/src/loki/reach.cc
+++ b/src/loki/reach.cc
@@ -29,10 +29,15 @@ void Reach::enqueue(const baldr::GraphId& node_id,
   // otherwise we enqueue it
   queue_.insert(node_id);
   // and we enqueue it on the other levels
-  for (const auto& transition : tile->GetNodeTransitions(node))
+  for (const auto& transition : tile->GetNodeTransitions(node)) {
+    // skip nodes which are done already
+    if (done_.find(transition.endnode()) != done_.cend())
+      continue;
+    // otherwise we enqueue it
     queue_.insert(transition.endnode());
-  // and we remember how many duplicates we enqueued
-  transitions_ += node->transition_count();
+    // and we remember how many duplicates we enqueued
+    ++transitions_;
+  }
 }
 
 directed_reach Reach::operator()(const DirectedEdge* edge,

--- a/src/loki/reach.cc
+++ b/src/loki/reach.cc
@@ -193,11 +193,11 @@ directed_reach Reach::exact(const valhalla::baldr::DirectedEdge* edge,
 }
 
 // callback fired when a node is expanded from, the node will be the end node of the previous label
-void Reach::ExpandingNode(baldr::GraphReader& graphreader,
+void Reach::ExpandingNode(baldr::GraphReader&,
                           const baldr::GraphTile* tile,
                           const baldr::NodeInfo* node,
-                          const sif::EdgeLabel& current,
-                          const sif::EdgeLabel* previous) {
+                          const sif::EdgeLabel&,
+                          const sif::EdgeLabel*) {
   // compute the nodes id
   GraphId node_id = tile->header()->graphid();
   node_id.set_id(node - tile->node(0));
@@ -211,9 +211,8 @@ void Reach::ExpandingNode(baldr::GraphReader& graphreader,
 }
 
 // when the main loop is looking to continue expanding we tell it to terminate here
-thor::ExpansionRecommendation Reach::ShouldExpand(baldr::GraphReader& graphreader,
-                                                  const sif::EdgeLabel& pred,
-                                                  const thor::InfoRoutingType route_type) {
+thor::ExpansionRecommendation
+Reach::ShouldExpand(baldr::GraphReader&, const sif::EdgeLabel&, const thor::InfoRoutingType) {
   if ((done_.size() - transitions_) < max_reach_)
     return thor::ExpansionRecommendation::continue_expansion;
   return thor::ExpansionRecommendation::prune_expansion;

--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -89,8 +89,7 @@ PathLocation::SideOfStreet flip_side(const PathLocation::SideOfStreet side) {
   return side;
 }
 
-std::function<std::tuple<int32_t, unsigned short, float>()> make_binner(const PointLL& p,
-                                                                        const GraphReader& reader) {
+std::function<std::tuple<int32_t, unsigned short, float>()> make_binner(const PointLL& p) {
   const auto& tiles = TileHierarchy::levels().rbegin()->second.tiles;
   return tiles.ClosestFirst(p);
 }
@@ -164,7 +163,7 @@ struct candidate_t {
 // is found.
 struct projector_wrapper {
   projector_wrapper(const Location& location, GraphReader& reader)
-      : binner(make_binner(location.latlng_, reader)), location(location),
+      : binner(make_binner(location.latlng_)), location(location),
         sq_radius(square(double(location.radius_))), project(location.latlng_) {
     // TODO: something more empirical based on radius
     unreachable.reserve(64);

--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -585,6 +585,7 @@ struct bin_handler_t {
               opp_reach.inbound >= p_itr->location.min_inbound_reach_) {
             tile = opp_tile;
             edge = opp_edge;
+            edge_id = opp_edgeid;
             reach = opp_reach;
             reachable = true;
           }

--- a/test/reach.cc
+++ b/test/reach.cc
@@ -1,3 +1,4 @@
+#include "gurka/gurka.h"
 #include "test.h"
 
 #include "baldr/graphreader.h"
@@ -116,6 +117,47 @@ TEST(Reach, check_all_reach) {
                  std::to_string(edge_id.value) + " " + shape_str;
     }
   }
+}
+
+TEST(Reach, transition_misscount) {
+  const std::string ascii_map = R"(
+      b--c--d
+      |  |  |
+      |  |  |
+      a--f--e
+      |  |  |
+      |  |  |
+      g--h--i
+    )";
+
+  const gurka::ways ways = {
+      {"abcdefaghie", {{"highway", "residential"}}},
+      {"cfh", {{"highway", "tertiary"}}},
+  };
+
+  // build the graph
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100);
+  auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/wrong_reach");
+
+  // get an auto costing
+  sif::CostFactory factory;
+  auto costing = factory.Create(valhalla::auto_);
+
+  // find the problem edge
+  baldr::GraphReader reader(map.config.get_child("mjolnir"));
+  auto edge = gurka::findEdgeByNodes(reader, map.nodes, "a", "f");
+
+  // check its reach
+  loki::Reach reach_checker;
+  auto reach = reach_checker(std::get<1>(edge), std::get<0>(edge), 50, reader, costing);
+
+  // all edges should have the same in/outbound reach
+  EXPECT_EQ(reach.inbound, reach.outbound);
+
+  // they all should be 7. there are only 5 obvious graph nodes above but we insert 2 more
+  // at d and g because the path the way makes loops back on itself
+  EXPECT_EQ(reach.inbound, 7);
+  EXPECT_EQ(reach.outbound, 7);
 }
 
 } // namespace


### PR DESCRIPTION
There were two amateur level bugs (very likely my own) in loki.

1. when edge in spatial bin is filtered but opposing edge is not, we flip to creating a search candidate out of the opposing edge. we forgot to flip the edge_id to match the opposing edge. its unclear what impact this has had in the past (wrong edge with wrong id sent to the finalize method in loki::search). its possible there is no effect as the finalize method looks up both directions of an edge when making the final result. i'll review the code and run RAD
2. the major bug here.. in the naive reach calculation, it is possible expand from the same node multiple times so long as it was evaluated as a transition node. the code that enqueued those nodes didnt check if the node had alraedy been expanded. so you could visit the node and then if another edge saw the node from a transition it would get enqueued again. with the right graph and some bad luck this can make edges look reachable when they are not