### PR TITLE
Improve German post_transition_verbal instruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@
    * FIXED: Ambiguous local to global (with timezone information) date time conversions now all choose to use the later time instead of throwing unhandled exceptions [#2665](https://github.com/valhalla/valhalla/pull/2665)
    * FIXED: Overestimated reach caused be reenquing transition nodes without checking that they had been already expanded [#2670](https://github.com/valhalla/valhalla/pull/2670)
    * FIXED: Build with C++17 standard. Deprecated function calls are substituted with new ones. [#2669](https://github.com/valhalla/valhalla/pull/2669)
+   * FIXED: Improve German post_transition_verbal instruction [#2677](https://github.com/valhalla/valhalla/pull/2677)
 
 * **Enhancement**
    * ADDED: Add ability to provide custom implementation for candidate collection in CandidateQuery. [#2328](https://github.com/valhalla/valhalla/pull/2328)
@@ -189,7 +190,7 @@
    * ADDED: Enhanced turn lane information in guidance [#2653](https://github.com/valhalla/valhalla/pull/2653)
    * ADDED: Add annotations to osrm response including speed limits, unit and sign conventions [#2668](https://github.com/valhalla/valhalla/pull/2668)
    * ADDED: Added functions for predicted speeds encoding-decoding [#2674](https://github.com/valhalla/valhalla/pull/2674)
-   
+
 ## Release Date: 2019-11-21 Valhalla 3.0.9
 * **Bug Fix**
    * FIXED: Changed reachability computation to consider both directions of travel wrt candidate edges [#1965](https://github.com/valhalla/valhalla/pull/1965)

--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -1139,7 +1139,7 @@
     },
     "post_transition_verbal": {
       "phrases": {
-        "0": "<LENGTH> weiter.",
+        "0": "<LENGTH> weiter der Route folgen.",
         "1": "<LENGTH> weiter auf <STREET_NAMES>."
       },
       "empty_street_name_labels": [

--- a/test/narrativebuilder.cc
+++ b/test/narrativebuilder.cc
@@ -4234,7 +4234,8 @@ TEST(NarrativeBuilder, TestBuildTurnInstructions_1_miles_de_DE) {
   PopulateTurnManeuverList_1(expected_maneuvers, country_code, state_code);
   SetExpectedManeuverInstructions(expected_maneuvers, "Links auf Middletown Road abbiegen.",
                                   "Links auf Middletown Road abbiegen.",
-                                  "Links auf Middletown Road abbiegen.", "eine Meile weiter.");
+                                  "Links auf Middletown Road abbiegen.",
+                                  "eine Meile weiter der Route folgen.");
 
   TryBuild(options, maneuvers, expected_maneuvers);
 }

--- a/test/narrativebuilder.cc
+++ b/test/narrativebuilder.cc
@@ -245,7 +245,6 @@ TransitPlatformInfo GetTransitPlatformInfo(TransitPlatformInfo_Type type,
                                            const std::string& name,
                                            const std::string& arrival_date_time,
                                            const std::string& departure_date_time,
-                                           bool is_parent_stop,
                                            bool assumed_schedule,
                                            float lat,
                                            float lng) {
@@ -2248,7 +2247,7 @@ void PopulateTransitConnectionStartManeuverList_1(std::list<Maneuver>& maneuvers
   maneuver.set_transit_connection_platform_info(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation,
                              "s-9q8yyv42k3-caltrain~sanfranciscostation",
-                             "CALTRAIN - SAN FRANCISCO STATION", "", "2016-03-29T08:57-04:00", 0, 1,
+                             "CALTRAIN - SAN FRANCISCO STATION", "", "2016-03-29T08:57-04:00", 1,
                              0.0f, 0.0f));
 }
 
@@ -2264,7 +2263,7 @@ void PopulateTransitConnectionStartManeuverList_2(std::list<Maneuver>& maneuvers
                    0, 0, 0, 0, 0, 0, {}, {}, {}, {}, 0, 0, 0, 0, 1, 0, "", "", "", 0, 0, 0, 0, 25, 0);
   maneuver.set_transit_connection_platform_info(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsq8pqg-8st~nyu<r21n",
-                             "8 St - NYU", "", "2016-03-29T08:02-04:00", 0, 0, 0.0f, 0.0f));
+                             "8 St - NYU", "", "2016-03-29T08:02-04:00", 0, 0.0f, 0.0f));
 }
 
 void PopulateTransitConnectionTransferManeuverList_0(std::list<Maneuver>& maneuvers,
@@ -2294,7 +2293,7 @@ void PopulateTransitConnectionTransferManeuverList_1(std::list<Maneuver>& maneuv
   maneuver.set_transit_connection_platform_info(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation,
                              "s-9q8yyv42k3-caltrain~sanfranciscostation",
-                             "CALTRAIN - SAN FRANCISCO STATION", "", "2016-03-29T08:57-04:00", 0, 1,
+                             "CALTRAIN - SAN FRANCISCO STATION", "", "2016-03-29T08:57-04:00", 1,
                              0.0f, 0.0f));
 }
 
@@ -2311,7 +2310,7 @@ void PopulateTransitConnectionTransferManeuverList_2(std::list<Maneuver>& maneuv
                    0);
   maneuver.set_transit_connection_platform_info(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsq8pqg-8st~nyu<r21s",
-                             "8 St - NYU", "2016-03-29T08:19-04:00", "", 0, 0, 0.0f, 0.0f));
+                             "8 St - NYU", "2016-03-29T08:19-04:00", "", 0, 0.0f, 0.0f));
 }
 
 void PopulateTransitConnectionDestinationManeuverList_0(std::list<Maneuver>& maneuvers,
@@ -2342,7 +2341,7 @@ void PopulateTransitConnectionDestinationManeuverList_1(std::list<Maneuver>& man
   maneuver.set_transit_connection_platform_info(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation,
                              "s-9q8yyv42k3-caltrain~sanfranciscostation",
-                             "CALTRAIN - SAN FRANCISCO STATION", "", "2016-03-29T08:57-04:00", 0, 1,
+                             "CALTRAIN - SAN FRANCISCO STATION", "", "2016-03-29T08:57-04:00", 1,
                              0.0f, 0.0f));
 }
 
@@ -2359,7 +2358,7 @@ void PopulateTransitConnectionDestinationManeuverList_2(std::list<Maneuver>& man
                    0);
   maneuver.set_transit_connection_platform_info(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsq8pqg-8st~nyu<r21s",
-                             "8 St - NYU", "2016-03-29T08:19-04:00", "", 0, 0, 0.0f, 0.0f));
+                             "8 St - NYU", "2016-03-29T08:19-04:00", "", 0, 0.0f, 0.0f));
 }
 
 void PopulateTransitManeuverList_0_train(std::list<Maneuver>& maneuvers,
@@ -2381,20 +2380,20 @@ void PopulateTransitManeuverList_0_train(std::list<Maneuver>& maneuvers,
   // Insert the transit stops in reverse order (end to begin of line)
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5ru65x7v-34st~heraldsq<r17n",
-                             "34 St - Herald Sq", "2016-03-29T08:08-04:00", "", 0, 1, 0.0f, 0.0f)));
+                             "34 St - Herald Sq", "2016-03-29T08:08-04:00", "", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5ru37pdw-28st<r18n", "28 St",
-                             "2016-03-29T08:07-04:00", "2016-03-29T08:07-04:00", 0, 1, 0.0f, 0.0f)));
+                             "2016-03-29T08:07-04:00", "2016-03-29T08:07-04:00", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5ru2dx73-23st<r19n", "23 St",
-                             "2016-03-29T08:06-04:00", "2016-03-29T08:06-04:00", 0, 1, 0.0f, 0.0f)));
+                             "2016-03-29T08:06-04:00", "2016-03-29T08:06-04:00", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsr9wyg-14st~unionsq<r20n",
                              "14 St - Union Sq", "2016-03-29T08:04-04:00", "2016-03-29T08:04-04:00",
-                             0, 1, 0.0f, 0.0f)));
-  maneuver.InsertTransitStop(std::move(
-      GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsq8pqg-8st~nyu<r21n",
-                             "8 St - NYU", "", "2016-03-29T08:02-04:00", 0, 1, 0.0f, 0.0f)));
+                             1, 0.0f, 0.0f)));
+  maneuver.InsertTransitStop(
+      std::move(GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsq8pqg-8st~nyu<r21n",
+                                       "8 St - NYU", "", "2016-03-29T08:02-04:00", 1, 0.0f, 0.0f)));
 
   maneuver.set_transit_type(TripLeg_TransitType_kRail);
 }
@@ -2419,20 +2418,20 @@ void PopulateTransitManeuverList_0(std::list<Maneuver>& maneuvers,
   // Insert the transit stops in reverse order (end to begin of line)
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5ru65x7v-34st~heraldsq<r17n",
-                             "34 St - Herald Sq", "2016-03-29T08:08-04:00", "", 0, 1, 0.0f, 0.0f)));
+                             "34 St - Herald Sq", "2016-03-29T08:08-04:00", "", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5ru37pdw-28st<r18n", "28 St",
-                             "2016-03-29T08:07-04:00", "2016-03-29T08:07-04:00", 0, 1, 0.0f, 0.0f)));
+                             "2016-03-29T08:07-04:00", "2016-03-29T08:07-04:00", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5ru2dx73-23st<r19n", "23 St",
-                             "2016-03-29T08:06-04:00", "2016-03-29T08:06-04:00", 0, 1, 0.0f, 0.0f)));
+                             "2016-03-29T08:06-04:00", "2016-03-29T08:06-04:00", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsr9wyg-14st~unionsq<r20n",
                              "14 St - Union Sq", "2016-03-29T08:04-04:00", "2016-03-29T08:04-04:00",
-                             0, 1, 0.0f, 0.0f)));
-  maneuver.InsertTransitStop(std::move(
-      GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsq8pqg-8st~nyu<r21n",
-                             "8 St - NYU", "", "2016-03-29T08:02-04:00", 0, 1, 0.0f, 0.0f)));
+                             1, 0.0f, 0.0f)));
+  maneuver.InsertTransitStop(
+      std::move(GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsq8pqg-8st~nyu<r21n",
+                                       "8 St - NYU", "", "2016-03-29T08:02-04:00", 1, 0.0f, 0.0f)));
 }
 
 void PopulateTransitManeuverList_1_cable_car(std::list<Maneuver>& maneuvers,
@@ -2450,37 +2449,36 @@ void PopulateTransitManeuverList_1_cable_car(std::list<Maneuver>& maneuvers,
                       "San Francisco Municipal Transportation Agency", "http://www.sfmta.com/");
 
   // Insert the transit stops in reverse order (end to begin of line)
-  maneuver.InsertTransitStop(
-      std::move(GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation,
-                                       "s-9q8zn2c3gg-hydest~vallejost", "Hyde St & Vallejo St",
-                                       "2016-05-17T08:06-04:00", "", 0, 1, 0.0f, 0.0f)));
+  maneuver.InsertTransitStop(std::move(
+      GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-9q8zn2c3gg-hydest~vallejost",
+                             "Hyde St & Vallejo St", "2016-05-17T08:06-04:00", "", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-9q8zn2cpr9-hydest~greenst",
                              "Hyde St & Green St", "2016-05-17T08:06-04:00", "2016-05-17T08:06-04:00",
-                             0, 1, 0.0f, 0.0f)));
+                             1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-9q8zn31h5q-hydest~unionst",
                              "Hyde St & Union St", "2016-05-17T08:06-04:00", "2016-05-17T08:06-04:00",
-                             0, 1, 0.0f, 0.0f)));
+                             1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-9q8zn32fnv-hydest~filbertst",
                              "Hyde St & Filbert St", "2016-05-17T08:05-04:00",
-                             "2016-05-17T08:05-04:00", 0, 1, 0.0f, 0.0f)));
+                             "2016-05-17T08:05-04:00", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-9q8zn32yg5-hydest~greenwichst",
                              "Hyde St & Greenwich St", "2016-05-17T08:05-04:00",
-                             "2016-05-17T08:05-04:00", 0, 1, 0.0f, 0.0f)));
+                             "2016-05-17T08:05-04:00", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-9q8zn38ez1-hydest~lombardst",
                              "Hyde St & Lombard St", "2016-05-17T08:04-04:00",
-                             "2016-05-17T08:04-04:00", 0, 1, 0.0f, 0.0f)));
+                             "2016-05-17T08:04-04:00", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-9q8zn3b9cv-hydest~chestnutst",
                              "Hyde St & Chestnut St", "2016-05-17T08:04-04:00",
-                             "2016-05-17T08:04-04:00", 0, 1, 0.0f, 0.0f)));
+                             "2016-05-17T08:04-04:00", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-9q8zn60kc1-hydest~bayst",
-                             "Hyde St & Bay St", "", "2016-05-17T08:03-04:00", 0, 1, 0.0f, 0.0f)));
+                             "Hyde St & Bay St", "", "2016-05-17T08:03-04:00", 1, 0.0f, 0.0f)));
 
   maneuver.set_transit_type(TripLeg_TransitType_kCableCar);
 }
@@ -2507,11 +2505,11 @@ void PopulateTransitManeuverList_1_stop_count_1(std::list<Maneuver>& maneuvers,
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation,
                              "s-dr5rkw4r8c-atlanticav~barclaysctr<r31n", "Atlantic Av - Barclays Ctr",
-                             "2016-05-17T08:08-04:00", "", 0, 0, 0.0f, 0.0f)));
+                             "2016-05-17T08:08-04:00", "", 0, 0.0f, 0.0f)));
 
   maneuver.InsertTransitStop(
       std::move(GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rkmp4s9-unionst<r32n",
-                                       "Union St", "", "2016-05-17T08:06-04:00", 0, 0, 0.0f, 0.0f)));
+                                       "Union St", "", "2016-05-17T08:06-04:00", 0, 0.0f, 0.0f)));
 }
 
 void PopulateTransitManeuverList_1_stop_count_2(std::list<Maneuver>& maneuvers,
@@ -2535,15 +2533,15 @@ void PopulateTransitManeuverList_1_stop_count_2(std::list<Maneuver>& maneuvers,
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsr9wyg-14st~unionsq<r20s",
                              "14 St - Union Sq", "2016-05-17T08:08-04:00", "2016-05-17T08:11-04:00",
-                             0, 0, 0.0f, 0.0f)));
+                             0, 0.0f, 0.0f)));
 
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5ru2dx73-23st<r19s", "23 St",
-                             "2016-05-17T08:07-04:00", "2016-05-17T08:07-04:00", 0, 0, 0.0f, 0.0f)));
+                             "2016-05-17T08:07-04:00", "2016-05-17T08:07-04:00", 0, 0.0f, 0.0f)));
 
   maneuver.InsertTransitStop(
       std::move(GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5ru37pdw-28st<r18s",
-                                       "28 St", "", "2016-05-17T08:05-04:00", 0, 0, 0.0f, 0.0f)));
+                                       "28 St", "", "2016-05-17T08:05-04:00", 0, 0.0f, 0.0f)));
 }
 
 void PopulateTransitManeuverList_1_stop_count_4(std::list<Maneuver>& maneuvers,
@@ -2566,20 +2564,20 @@ void PopulateTransitManeuverList_1_stop_count_4(std::list<Maneuver>& maneuvers,
   // Insert the transit stops in reverse order (end to begin of line)
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5ru65x7v-34st~heraldsq<r17n",
-                             "34 St - Herald Sq", "2016-03-29T08:08-04:00", "", 0, 1, 0.0f, 0.0f)));
+                             "34 St - Herald Sq", "2016-03-29T08:08-04:00", "", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5ru37pdw-28st<r18n", "28 St",
-                             "2016-03-29T08:07-04:00", "2016-03-29T08:07-04:00", 0, 1, 0.0f, 0.0f)));
+                             "2016-03-29T08:07-04:00", "2016-03-29T08:07-04:00", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5ru2dx73-23st<r19n", "23 St",
-                             "2016-03-29T08:06-04:00", "2016-03-29T08:06-04:00", 0, 1, 0.0f, 0.0f)));
+                             "2016-03-29T08:06-04:00", "2016-03-29T08:06-04:00", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsr9wyg-14st~unionsq<r20n",
                              "14 St - Union Sq", "2016-03-29T08:04-04:00", "2016-03-29T08:04-04:00",
-                             0, 1, 0.0f, 0.0f)));
-  maneuver.InsertTransitStop(std::move(
-      GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsq8pqg-8st~nyu<r21n",
-                             "8 St - NYU", "", "2016-03-29T08:02-04:00", 0, 1, 0.0f, 0.0f)));
+                             1, 0.0f, 0.0f)));
+  maneuver.InsertTransitStop(
+      std::move(GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsq8pqg-8st~nyu<r21n",
+                                       "8 St - NYU", "", "2016-03-29T08:02-04:00", 1, 0.0f, 0.0f)));
 }
 
 void PopulateTransitManeuverList_1_stop_count_8(std::list<Maneuver>& maneuvers,
@@ -2603,44 +2601,44 @@ void PopulateTransitManeuverList_1_stop_count_8(std::list<Maneuver>& maneuvers,
   // Insert the transit stops in reverse order (end to begin of line)
   maneuver.InsertTransitStop(
       std::move(GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5ru3006q-23st<d18n",
-                                       "23 St", "2016-05-17T08:32-04:00", "", 0, 0, 0.0f, 0.0f)));
+                                       "23 St", "2016-05-17T08:32-04:00", "", 0, 0.0f, 0.0f)));
 
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5ru0jt7k-14st<d19n", "14 St",
-                             "2016-05-17T08:30-04:00", "2016-05-17T08:30-04:00", 0, 0, 0.0f, 0.0f)));
+                             "2016-05-17T08:30-04:00", "2016-05-17T08:30-04:00", 0, 0.0f, 0.0f)));
 
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsp47p6-w4st<d20n", "W 4 St",
-                             "2016-05-17T08:29-04:00", "2016-05-17T08:29-04:00", 0, 0, 0.0f, 0.0f)));
+                             "2016-05-17T08:29-04:00", "2016-05-17T08:29-04:00", 0, 0.0f, 0.0f)));
 
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation,
                              "s-dr5rsjvd53-broadway~lafayettest<d21n", "Broadway-Lafayette St",
-                             "2016-05-17T08:26-04:00", "2016-05-17T08:26-04:00", 0, 0, 0.0f, 0.0f)));
+                             "2016-05-17T08:26-04:00", "2016-05-17T08:26-04:00", 0, 0.0f, 0.0f)));
 
   maneuver.InsertTransitStop(
       std::move(GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rskecru-essexst<m18n",
                                        "Essex St", "2016-05-17T08:23-04:00", "2016-05-17T08:23-04:00",
-                                       0, 0, 0.0f, 0.0f)));
+                                       0, 0.0f, 0.0f)));
 
   maneuver.InsertTransitStop(
       std::move(GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rt49x7k-marcyav<m16n",
                                        "Marcy Av", "2016-05-17T08:16-04:00", "2016-05-17T08:16-04:00",
-                                       0, 0, 0.0f, 0.0f)));
+                                       0, 0.0f, 0.0f)));
 
   maneuver.InsertTransitStop(
       std::move(GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rt4ky8n-hewesst<m14n",
                                        "Hewes St", "2016-05-17T08:15-04:00", "2016-05-17T08:15-04:00",
-                                       0, 0, 0.0f, 0.0f)));
+                                       0, 0.0f, 0.0f)));
 
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rt3cjhx-lorimerst<m13n",
-                             "Lorimer St", "2016-05-17T08:13-04:00", "2016-05-17T08:13-04:00", 0, 0,
+                             "Lorimer St", "2016-05-17T08:13-04:00", "2016-05-17T08:13-04:00", 0,
                              0.0f, 0.0f)));
 
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rt3m8ny-flushingav<m12n",
-                             "Flushing Av", "", "2016-05-17T08:11-04:00", 0, 0, 0.0f, 0.0f)));
+                             "Flushing Av", "", "2016-05-17T08:11-04:00", 0, 0.0f, 0.0f)));
 }
 
 void PopulateTransitTransferManeuverList_0_no_name(std::list<Maneuver>& maneuvers,
@@ -2662,20 +2660,20 @@ void PopulateTransitTransferManeuverList_0_no_name(std::list<Maneuver>& maneuver
   // Insert the transit stops in reverse order (end to begin of line)
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5ru65x7v-34st~heraldsq<r17n",
-                             "34 St - Herald Sq", "2016-03-29T08:08-04:00", "", 0, 1, 0.0f, 0.0f)));
+                             "34 St - Herald Sq", "2016-03-29T08:08-04:00", "", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5ru37pdw-28st<r18n", "28 St",
-                             "2016-03-29T08:07-04:00", "2016-03-29T08:07-04:00", 0, 1, 0.0f, 0.0f)));
+                             "2016-03-29T08:07-04:00", "2016-03-29T08:07-04:00", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5ru2dx73-23st<r19n", "23 St",
-                             "2016-03-29T08:06-04:00", "2016-03-29T08:06-04:00", 0, 1, 0.0f, 0.0f)));
+                             "2016-03-29T08:06-04:00", "2016-03-29T08:06-04:00", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsr9wyg-14st~unionsq<r20n",
                              "14 St - Union Sq", "2016-03-29T08:04-04:00", "2016-03-29T08:04-04:00",
-                             0, 1, 0.0f, 0.0f)));
-  maneuver.InsertTransitStop(std::move(
-      GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsq8pqg-8st~nyu<r21n",
-                             "8 St - NYU", "", "2016-03-29T08:02-04:00", 0, 1, 0.0f, 0.0f)));
+                             1, 0.0f, 0.0f)));
+  maneuver.InsertTransitStop(
+      std::move(GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsq8pqg-8st~nyu<r21n",
+                                       "8 St - NYU", "", "2016-03-29T08:02-04:00", 1, 0.0f, 0.0f)));
 }
 
 void PopulateTransitTransferManeuverList_0(std::list<Maneuver>& maneuvers,
@@ -2698,20 +2696,20 @@ void PopulateTransitTransferManeuverList_0(std::list<Maneuver>& maneuvers,
   // Insert the transit stops in reverse order (end to begin of line)
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5ru65x7v-34st~heraldsq<r17n",
-                             "34 St - Herald Sq", "2016-03-29T08:08-04:00", "", 0, 1, 0.0f, 0.0f)));
+                             "34 St - Herald Sq", "2016-03-29T08:08-04:00", "", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5ru37pdw-28st<r18n", "28 St",
-                             "2016-03-29T08:07-04:00", "2016-03-29T08:07-04:00", 0, 1, 0.0f, 0.0f)));
+                             "2016-03-29T08:07-04:00", "2016-03-29T08:07-04:00", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5ru2dx73-23st<r19n", "23 St",
-                             "2016-03-29T08:06-04:00", "2016-03-29T08:06-04:00", 0, 1, 0.0f, 0.0f)));
+                             "2016-03-29T08:06-04:00", "2016-03-29T08:06-04:00", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsr9wyg-14st~unionsq<r20n",
                              "14 St - Union Sq", "2016-03-29T08:04-04:00", "2016-03-29T08:04-04:00",
-                             0, 1, 0.0f, 0.0f)));
-  maneuver.InsertTransitStop(std::move(
-      GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsq8pqg-8st~nyu<r21n",
-                             "8 St - NYU", "", "2016-03-29T08:02-04:00", 0, 1, 0.0f, 0.0f)));
+                             1, 0.0f, 0.0f)));
+  maneuver.InsertTransitStop(
+      std::move(GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsq8pqg-8st~nyu<r21n",
+                                       "8 St - NYU", "", "2016-03-29T08:02-04:00", 1, 0.0f, 0.0f)));
 }
 
 void PopulateTransitTransferManeuverList_1(std::list<Maneuver>& maneuvers,
@@ -2734,20 +2732,20 @@ void PopulateTransitTransferManeuverList_1(std::list<Maneuver>& maneuvers,
   // Insert the transit stops in reverse order (end to begin of line)
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5ru65x7v-34st~heraldsq<r17n",
-                             "34 St - Herald Sq", "2016-03-29T08:08-04:00", "", 0, 1, 0.0f, 0.0f)));
+                             "34 St - Herald Sq", "2016-03-29T08:08-04:00", "", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5ru37pdw-28st<r18n", "28 St",
-                             "2016-03-29T08:07", "2016-03-29T08:07-04:00", 0, 1, 0.0f, 0.0f)));
+                             "2016-03-29T08:07", "2016-03-29T08:07-04:00", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5ru2dx73-23st<r19n", "23 St",
-                             "2016-03-29T08:06-04:00", "2016-03-29T08:06-04:00", 0, 1, 0.0f, 0.0f)));
+                             "2016-03-29T08:06-04:00", "2016-03-29T08:06-04:00", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsr9wyg-14st~unionsq<r20n",
                              "14 St - Union Sq", "2016-03-29T08:04-04:00", "2016-03-29T08:04-04:00",
-                             0, 1, 0.0f, 0.0f)));
-  maneuver.InsertTransitStop(std::move(
-      GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsq8pqg-8st~nyu<r21n",
-                             "8 St - NYU", "", "2016-03-29T08:02-04:00", 0, 1, 0.0f, 0.0f)));
+                             1, 0.0f, 0.0f)));
+  maneuver.InsertTransitStop(
+      std::move(GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsq8pqg-8st~nyu<r21n",
+                                       "8 St - NYU", "", "2016-03-29T08:02-04:00", 1, 0.0f, 0.0f)));
 }
 
 void PopulateTransitRemainOnManeuverList_0_no_name(std::list<Maneuver>& maneuvers,
@@ -2769,20 +2767,20 @@ void PopulateTransitRemainOnManeuverList_0_no_name(std::list<Maneuver>& maneuver
   // Insert the transit stops in reverse order (end to begin of line)
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5ru65x7v-34st~heraldsq<r17n",
-                             "34 St - Herald Sq", "2016-03-29T08:08-04:00", "", 0, 1, 0.0f, 0.0f)));
+                             "34 St - Herald Sq", "2016-03-29T08:08-04:00", "", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5ru37pdw-28st<r18n", "28 St",
-                             "2016-03-29T08:07-04:00", "2016-03-29T08:07-04:00", 0, 1, 0.0f, 0.0f)));
+                             "2016-03-29T08:07-04:00", "2016-03-29T08:07-04:00", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5ru2dx73-23st<r19n", "23 St",
-                             "2016-03-29T08:06-04:00", "2016-03-29T08:06-04:00", 0, 1, 0.0f, 0.0f)));
+                             "2016-03-29T08:06-04:00", "2016-03-29T08:06-04:00", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsr9wyg-14st~unionsq<r20n",
                              "14 St - Union Sq", "2016-03-29T08:04-04:00", "2016-03-29T08:04-04:00",
-                             0, 1, 0.0f, 0.0f)));
-  maneuver.InsertTransitStop(std::move(
-      GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsq8pqg-8st~nyu<r21n",
-                             "8 St - NYU", "", "2016-03-29T08:02-04:00", 0, 1, 0.0f, 0.0f)));
+                             1, 0.0f, 0.0f)));
+  maneuver.InsertTransitStop(
+      std::move(GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsq8pqg-8st~nyu<r21n",
+                                       "8 St - NYU", "", "2016-03-29T08:02-04:00", 1, 0.0f, 0.0f)));
 }
 
 void PopulateTransitRemainOnManeuverList_0(std::list<Maneuver>& maneuvers,
@@ -2805,20 +2803,20 @@ void PopulateTransitRemainOnManeuverList_0(std::list<Maneuver>& maneuvers,
   // Insert the transit stops in reverse order (end to begin of line)
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5ru65x7v-34st~heraldsq<r17n",
-                             "34 St - Herald Sq", "2016-03-29T08:08-04:00", "", 0, 1, 0.0f, 0.0f)));
+                             "34 St - Herald Sq", "2016-03-29T08:08-04:00", "", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5ru37pdw-28st<r18n", "28 St",
-                             "2016-03-29T08:07-04:00", "2016-03-29T08:07-04:00", 0, 1, 0.0f, 0.0f)));
+                             "2016-03-29T08:07-04:00", "2016-03-29T08:07-04:00", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5ru2dx73-23st<r19n", "23 St",
-                             "2016-03-29T08:06-04:00", "2016-03-29T08:06-04:00", 0, 1, 0.0f, 0.0f)));
+                             "2016-03-29T08:06-04:00", "2016-03-29T08:06-04:00", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsr9wyg-14st~unionsq<r20n",
                              "14 St - Union Sq", "2016-03-29T08:04-04:00", "2016-03-29T08:04-04:00",
-                             0, 1, 0.0f, 0.0f)));
-  maneuver.InsertTransitStop(std::move(
-      GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsq8pqg-8st~nyu<r21n",
-                             "8 St - NYU", "", "2016-03-29T08:02-04:00", 0, 1, 0.0f, 0.0f)));
+                             1, 0.0f, 0.0f)));
+  maneuver.InsertTransitStop(
+      std::move(GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsq8pqg-8st~nyu<r21n",
+                                       "8 St - NYU", "", "2016-03-29T08:02-04:00", 1, 0.0f, 0.0f)));
 }
 
 void PopulateTransitRemainOnManeuverList_1(std::list<Maneuver>& maneuvers,
@@ -2841,20 +2839,20 @@ void PopulateTransitRemainOnManeuverList_1(std::list<Maneuver>& maneuvers,
   // Insert the transit stops in reverse order (end to begin of line)
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5ru65x7v-34st~heraldsq<r17n",
-                             "34 St - Herald Sq", "2016-03-29T08:08-04:00", "", 0, 1, 0.0f, 0.0f)));
+                             "34 St - Herald Sq", "2016-03-29T08:08-04:00", "", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5ru37pdw-28st<r18n", "28 St",
-                             "2016-03-29T08:07-04:00", "2016-03-29T08:07-04:00", 0, 1, 0.0f, 0.0f)));
+                             "2016-03-29T08:07-04:00", "2016-03-29T08:07-04:00", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5ru2dx73-23st<r19n", "23 St",
-                             "2016-03-29T08:06-04:00", "2016-03-29T08:06-04:00", 0, 1, 0.0f, 0.0f)));
+                             "2016-03-29T08:06-04:00", "2016-03-29T08:06-04:00", 1, 0.0f, 0.0f)));
   maneuver.InsertTransitStop(std::move(
       GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsr9wyg-14st~unionsq<r20n",
                              "14 St - Union Sq", "2016-03-29T08:04-04:00", "2016-03-29T08:04-04:00",
-                             0, 1, 0.0f, 0.0f)));
-  maneuver.InsertTransitStop(std::move(
-      GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsq8pqg-8st~nyu<r21n",
-                             "8 St - NYU", "", "2016-03-29T08:02-04:00", 0, 1, 0.0f, 0.0f)));
+                             1, 0.0f, 0.0f)));
+  maneuver.InsertTransitStop(
+      std::move(GetTransitPlatformInfo(TransitPlatformInfo_Type_kStation, "s-dr5rsq8pqg-8st~nyu<r21n",
+                                       "8 St - NYU", "", "2016-03-29T08:02-04:00", 1, 0.0f, 0.0f)));
 }
 
 void PopulatePostTransitConnectionDestinationManeuverList_0(std::list<Maneuver>& maneuvers,


### PR DESCRIPTION
# Issue

Improves the post verbal instruction in German. Feedback was that the previous version was too terse and sounds incorrect without a verb in the phrase. 

1,5 Kilometer weiter. => 1,5 Kilometer weiter der Route folgen.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
