### PR TITLE
Fix polyline simplification float/double comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@
    * FIXED: Check that speeds are equal for the edges going in the same direction while buildig shortcuts [#2691](https://github.com/valhalla/valhalla/pull/2691)
    * FIXED: Missing fork or bear instruction [#2683](https://github.com/valhalla/valhalla/pull/2683)
    * FIXED: Eliminate null pointer dereference in GraphReader::AreEdgesConnected [#2695](https://github.com/valhalla/valhalla/issues/2695)
+   * FIXED: Fix polyline simplification float/double comparison [#2698](https://github.com/valhalla/valhalla/issues/2698)
 
 * **Enhancement**
    * ADDED: Add ability to provide custom implementation for candidate collection in CandidateQuery. [#2328](https://github.com/valhalla/valhalla/pull/2328)

--- a/src/midgard/polyline2.cc
+++ b/src/midgard/polyline2.cc
@@ -64,7 +64,7 @@ void Polyline2<coord_t>::Generalize(container_t& polyline,
   peucker = [&peucker, &polyline, epsilon, &indices](typename container_t::iterator start, size_t s,
                                                      typename container_t::iterator end, size_t e) {
     // find the point furthest from the line
-    float dmax = std::numeric_limits<typename coord_t::value_type>::lowest();
+    double dmax = std::numeric_limits<typename coord_t::value_type>::lowest();
     typename container_t::iterator itr;
     LineSegment2<coord_t> l{*start, *end};
     size_t j = e - 1, k;

--- a/src/midgard/polyline2.cc
+++ b/src/midgard/polyline2.cc
@@ -64,7 +64,7 @@ void Polyline2<coord_t>::Generalize(container_t& polyline,
   peucker = [&peucker, &polyline, epsilon, &indices](typename container_t::iterator start, size_t s,
                                                      typename container_t::iterator end, size_t e) {
     // find the point furthest from the line
-    coord_t::value_type dmax = std::numeric_limits<typename coord_t::value_type>::lowest();
+    typename coord_t::value_type dmax = std::numeric_limits<typename coord_t::value_type>::lowest();
     typename container_t::iterator itr;
     LineSegment2<coord_t> l{*start, *end};
     size_t j = e - 1, k;

--- a/src/midgard/polyline2.cc
+++ b/src/midgard/polyline2.cc
@@ -64,7 +64,7 @@ void Polyline2<coord_t>::Generalize(container_t& polyline,
   peucker = [&peucker, &polyline, epsilon, &indices](typename container_t::iterator start, size_t s,
                                                      typename container_t::iterator end, size_t e) {
     // find the point furthest from the line
-    double dmax = std::numeric_limits<typename coord_t::value_type>::lowest();
+    coord_t::value_type dmax = std::numeric_limits<typename coord_t::value_type>::lowest();
     typename container_t::iterator itr;
     LineSegment2<coord_t> l{*start, *end};
     size_t j = e - 1, k;

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -76,7 +76,7 @@ const constexpr double DEGREE_TO_RAD = 0.017453292519943295769236907684886;
 const constexpr double RAD_TO_DEGREE = 1. / DEGREE_TO_RAD;
 const constexpr double EPSG3857_MAX_LATITUDE = 85.051128779806592378; // 90(4*atan(exp(pi))/pi-1)
 
-const constexpr float DOUGLAS_PEUCKER_THRESHOLDS[19] = {
+const constexpr double DOUGLAS_PEUCKER_THRESHOLDS[19] = {
     703125.0, // z0
     351562.5, // z1
     175781.2, // z2

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -76,7 +76,7 @@ const constexpr double DEGREE_TO_RAD = 0.017453292519943295769236907684886;
 const constexpr double RAD_TO_DEGREE = 1. / DEGREE_TO_RAD;
 const constexpr double EPSG3857_MAX_LATITUDE = 85.051128779806592378; // 90(4*atan(exp(pi))/pi-1)
 
-const constexpr double DOUGLAS_PEUCKER_THRESHOLDS[19] = {
+const constexpr PointLL::first_type DOUGLAS_PEUCKER_THRESHOLDS[19] = {
     703125.0, // z0
     351562.5, // z1
     175781.2, // z2

--- a/test/gurka/test_osrm_serializer.cc
+++ b/test/gurka/test_osrm_serializer.cc
@@ -25,7 +25,7 @@ TEST(Standalone, OsrmSerializerShape) {
   auto route_geometry = json["routes"][0]["geometry"]["coordinates"].GetArray();
   EXPECT_EQ(route_geometry.Size(), 4);
 
-  // Test that shape is simplified (B-C-D should simplify out C)
+  // Test that shape is simplified (should simplify out C but not B)
   result =
       gurka::route(map, {"A", "D"}, "auto", {{"/generalize", "0"}, {"/shape_format", "geojson"}});
   json = gurka::convert_to_json(result, Options::Format::Options_Format_osrm);

--- a/test/gurka/test_osrm_serializer.cc
+++ b/test/gurka/test_osrm_serializer.cc
@@ -1,0 +1,34 @@
+#include "gurka.h"
+#include <gtest/gtest.h>
+
+using namespace valhalla;
+
+TEST(Standalone, OsrmSerializerShape) {
+  const std::string ascii_map = R"(
+    B---C---D
+    |
+    A
+  )";
+
+  const gurka::ways ways = {
+      {"AB", {{"highway", "primary"}}},
+      {"BC", {{"highway", "primary"}}},
+      {"CD", {{"highway", "primary"}}},
+  };
+
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, 10, {40.7351162, -73.985719});
+  auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/osrm_serializer_shape");
+
+  // Test that full shape is returned by default
+  auto result = gurka::route(map, {"A", "D"}, "auto", {{"/shape_format", "geojson"}});
+  auto json = gurka::convert_to_json(result, Options::Format::Options_Format_osrm);
+  auto route_geometry = json["routes"][0]["geometry"]["coordinates"].GetArray();
+  EXPECT_EQ(route_geometry.Size(), 4);
+
+  // Test that shape is simplified (A-B-C should simplify out B)
+  result =
+      gurka::route(map, {"A", "D"}, "auto", {{"/generalize", "0"}, {"/shape_format", "geojson"}});
+  json = gurka::convert_to_json(result, Options::Format::Options_Format_osrm);
+  route_geometry = json["routes"][0]["geometry"]["coordinates"].GetArray();
+  EXPECT_EQ(route_geometry.Size(), 3);
+}

--- a/test/gurka/test_osrm_serializer.cc
+++ b/test/gurka/test_osrm_serializer.cc
@@ -25,7 +25,7 @@ TEST(Standalone, OsrmSerializerShape) {
   auto route_geometry = json["routes"][0]["geometry"]["coordinates"].GetArray();
   EXPECT_EQ(route_geometry.Size(), 4);
 
-  // Test that shape is simplified (A-B-C should simplify out B)
+  // Test that shape is simplified (B-C-D should simplify out C)
   result =
       gurka::route(map, {"A", "D"}, "auto", {{"/generalize", "0"}, {"/shape_format", "geojson"}});
   json = gurka::convert_to_json(result, Options::Format::Options_Format_osrm);

--- a/test/gurka/test_osrm_serializer.cc
+++ b/test/gurka/test_osrm_serializer.cc
@@ -22,13 +22,11 @@ TEST(Standalone, OsrmSerializerShape) {
   // Test that full shape is returned by default
   auto result = gurka::route(map, {"A", "D"}, "auto", {{"/shape_format", "geojson"}});
   auto json = gurka::convert_to_json(result, Options::Format::Options_Format_osrm);
-  auto route_geometry = json["routes"][0]["geometry"]["coordinates"].GetArray();
-  EXPECT_EQ(route_geometry.Size(), 4);
+  EXPECT_EQ(json["routes"][0]["geometry"]["coordinates"].GetArray().Size(), 4);
 
   // Test that shape is simplified (should simplify out C but not B)
   result =
       gurka::route(map, {"A", "D"}, "auto", {{"/generalize", "0"}, {"/shape_format", "geojson"}});
   json = gurka::convert_to_json(result, Options::Format::Options_Format_osrm);
-  route_geometry = json["routes"][0]["geometry"]["coordinates"].GetArray();
-  EXPECT_EQ(route_geometry.Size(), 3);
+  EXPECT_EQ(json["routes"][0]["geometry"]["coordinates"].GetArray().Size(), 3);
 }


### PR DESCRIPTION
# Issue

#2693 updated coordinates to use double precision. In [polyline simplification code we were relying on a `>=` equality to compare distances](https://github.com/valhalla/valhalla/blob/master/src/midgard/polyline2.cc#L92), which tends to fail when one side of the comparison is float and the other is double. 

The result was we were almost always simplifying the entire polyline to 2 points, because the first iteration of the simplifier sets `dmax = epsilon`. The gurka test here captures that failure mode.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
