### PR TITLE
Update elapsed_cost.cost properly when collapsing non-break via/through locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@
    * FIXED: Missing fork or bear instruction [#2683](https://github.com/valhalla/valhalla/pull/2683)
    * FIXED: Eliminate null pointer dereference in GraphReader::AreEdgesConnected [#2695](https://github.com/valhalla/valhalla/issues/2695)
    * FIXED: Fix polyline simplification float/double comparison [#2698](https://github.com/valhalla/valhalla/issues/2698)
+   * FIXED: Weights were sometimes negative due to incorrect updates to elapsed_cost [#2702](https://github.com/valhalla/valhalla/pull/2702)
 
 * **Enhancement**
    * ADDED: Add ability to provide custom implementation for candidate collection in CandidateQuery. [#2328](https://github.com/valhalla/valhalla/pull/2328)

--- a/src/thor/route_action.cc
+++ b/src/thor/route_action.cc
@@ -404,9 +404,9 @@ void thor_worker_t::path_arrive_by(Api& api, const std::string& costing) {
 
       // Merge through legs by updating the time and splicing the lists
       if (!temp_path.empty()) {
-        auto offset = path.back().elapsed_cost.secs;
+        auto offset = path.back().elapsed_cost;
         std::for_each(temp_path.begin(), temp_path.end(),
-                      [offset](PathInfo& i) { i.elapsed_cost.secs += offset; });
+                      [offset](PathInfo& i) { i.elapsed_cost += offset; });
         // Connects via the same edge so we only need it once
         if (path.back().edgeid == temp_path.front().edgeid) {
           path.pop_back();
@@ -507,9 +507,9 @@ void thor_worker_t::path_depart_at(Api& api, const std::string& costing) {
 
       // Merge through legs by updating the time and splicing the lists
       if (!path.empty()) {
-        auto offset = path.back().elapsed_cost.secs;
+        auto offset = path.back().elapsed_cost;
         std::for_each(temp_path.begin(), temp_path.end(),
-                      [offset](PathInfo& i) { i.elapsed_cost.secs += offset; });
+                      [offset](PathInfo& i) { i.elapsed_cost += offset; });
         // Connects via the same edge so we only need it once
         if (path.back().edgeid == temp_path.front().edgeid) {
           path.pop_back();

--- a/test/gurka/test_route.cc
+++ b/test/gurka/test_route.cc
@@ -403,3 +403,26 @@ TEST_F(AlgorithmTest, Bidir) {
     EXPECT_EQ(speed_from_edge(api), current);
   }
 }
+
+/*************************************************************/
+TEST(Standalone, LegWeightRegression) {
+
+  const std::string ascii_map = R"(A-1---B----------C-3-----D
+                                          \        /
+                                           E----2-F)";
+
+  const gurka::ways ways = {{"ABCD", {{"highway", "motorway"}}},
+                            {"BE", {{"highway", "motorway_link"}}},
+                            {"FC", {{"highway", "motorway_link"}}},
+                            {"EF", {{"highway", "service"}}}};
+
+  const double gridsize = 30;
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, gridsize);
+  auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/leg_weights");
+  auto result = gurka::route(map, {"1", "E", "3"}, "auto", {{"/locations/1/type", "via"}});
+
+  auto doc = gurka::convert_to_json(result, valhalla::Options_Format_osrm);
+
+  // "weight" was negative due to failing to properly update elapsed_cost.cost
+  EXPECT_GT(doc["routes"][0]["legs"][0]["steps"][2]["weight"].GetDouble(), 0);
+}


### PR DESCRIPTION
# Issue

When using `type: via` or `type: through` (silent waypoints), the `weight` value on some steps was incorrect, and sometimes negative, due to failing to properly update the `elapsed_cost.cost` field.

## Tasklist

 - [x] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [x] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
