### PR TITLE
Fix valhalla build statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@
    * FIXED: Weights were sometimes negative due to incorrect updates to elapsed_cost [#2702](https://github.com/valhalla/valhalla/pull/2702)
    * FIXED: Fix bidirectional route failures at deadends [#2705](https://github.com/valhalla/valhalla/pull/2705)
    * FIXED: Updated logic to call out a non-obvious turn [#2708](https://github.com/valhalla/valhalla/pull/2708)
+   * FIXED: valhalla_build_statistics multithreaded mode fixed [#2707](https://github.com/valhalla/valhalla/pull/2707)
 
 * **Enhancement**
    * ADDED: Add ability to provide custom implementation for candidate collection in CandidateQuery. [#2328](https://github.com/valhalla/valhalla/pull/2328)

--- a/src/mjolnir/statistics.cc
+++ b/src/mjolnir/statistics.cc
@@ -45,6 +45,16 @@ template <class T> T merge_counts(T& a, T b) {
   }
   return tmp;
 }
+
+// merge two hashes by key and merge underlying hash buckets
+template <class T> T deep_merge_counts(T& a, T const& b) {
+  T tmp(a);
+  for (auto it = b.begin(); it != b.end(); it++) {
+    tmp[it->first] = merge_counts(tmp[it->first], it->second);
+  }
+  return tmp;
+}
+
 } // namespace
 
 namespace valhalla {
@@ -415,18 +425,18 @@ void statistics::add(const statistics& stats) {
   tile_axle_load = merge(tile_axle_load, stats.get_tile_axle_load());
 
   // Combine country statistics
-  country_lengths = merge(country_lengths, stats.get_country_lengths());
-  country_one_way = merge(country_one_way, stats.get_country_one_way());
-  country_speed_info = merge(country_speed_info, stats.get_country_speed_info());
-  country_int_edges = merge(country_int_edges, stats.get_country_int_edges());
-  country_named = merge(country_named, stats.get_country_named());
-  country_hazmat = merge(country_hazmat, stats.get_country_hazmat());
-  country_truck_route = merge(country_truck_route, stats.get_country_truck_route());
-  country_height = merge(country_height, stats.get_country_height());
-  country_width = merge(country_width, stats.get_country_width());
-  country_length = merge(country_length, stats.get_country_length());
-  country_weight = merge(country_weight, stats.get_country_weight());
-  country_axle_load = merge(country_axle_load, stats.get_country_axle_load());
+  country_lengths = deep_merge_counts(country_lengths, stats.get_country_lengths());
+  country_one_way = deep_merge_counts(country_one_way, stats.get_country_one_way());
+  country_speed_info = deep_merge_counts(country_speed_info, stats.get_country_speed_info());
+  country_int_edges = deep_merge_counts(country_int_edges, stats.get_country_int_edges());
+  country_named = deep_merge_counts(country_named, stats.get_country_named());
+  country_hazmat = deep_merge_counts(country_hazmat, stats.get_country_hazmat());
+  country_truck_route = deep_merge_counts(country_truck_route, stats.get_country_truck_route());
+  country_height = deep_merge_counts(country_height, stats.get_country_height());
+  country_width = deep_merge_counts(country_width, stats.get_country_width());
+  country_length = deep_merge_counts(country_length, stats.get_country_length());
+  country_weight = deep_merge_counts(country_weight, stats.get_country_weight());
+  country_axle_load = deep_merge_counts(country_axle_load, stats.get_country_axle_load());
 
   // Combine exit statistics
   tile_exit_signs = merge_counts(tile_exit_signs, stats.get_tile_exit_info());

--- a/src/mjolnir/statistics.cc
+++ b/src/mjolnir/statistics.cc
@@ -60,16 +60,6 @@ template <class T> T deep_merge_counts(T& a, T const& b) {
 namespace valhalla {
 namespace mjolnir {
 
-statistics::statistics()
-    : tile_lengths(), country_lengths(), tile_int_edges(), country_int_edges(), tile_one_way(),
-      country_one_way(), tile_speed_info(), country_speed_info(), tile_named(), country_named(),
-      tile_truck_route(), country_truck_route(), tile_hazmat(), country_hazmat(), tile_height(),
-      country_height(), tile_width(), country_width(), tile_length(), country_length(), tile_weight(),
-      country_weight(), tile_axle_load(), country_axle_load(), tile_exit_signs(), tile_fork_signs(),
-      ctry_exit_signs(), ctry_fork_signs(), tile_exit_count(), tile_fork_count(), ctry_exit_count(),
-      ctry_fork_count(), tile_areas(), tile_geometries(), iso_codes(), tile_ids() {
-}
-
 void statistics::add_tile_road(const uint64_t& tile_id, const RoadClass& rclass, const float length) {
   tile_ids.insert(tile_id);
   tile_lengths[tile_id][rclass] += length;
@@ -479,7 +469,7 @@ void statistics::RouletteData::Add(const RouletteData& rd) {
   unroutable_nodes = merge(unroutable_nodes, rd.unroutable_nodes);
 }
 
-void statistics::RouletteData::GenerateTasks(const boost::property_tree::ptree& pt) const {
+void statistics::RouletteData::GenerateTasks(const boost::property_tree::ptree& /*pt*/) const {
   // build a task list for each collected wayid
   json::ArrayPtr tasks = json::array({});
   for (auto& id : way_IDs) {

--- a/src/mjolnir/statistics.h
+++ b/src/mjolnir/statistics.h
@@ -123,8 +123,6 @@ public:
     void GenerateTasks(const boost::property_tree::ptree& pt) const;
   } roulette_data;
 
-  statistics();
-
   void add_tile_road(const uint64_t& tile_id, const RoadClass& rclass, const float length);
   void add_country_road(const std::string& ctry_code, const RoadClass& rclass, const float length);
 


### PR DESCRIPTION
valhalla_build_statistics currently do not reproduces results in multithreaded  mode
It seems, we need to merge underlying hashes.
With this patch country_data reproduces and equals singlethreaded results


