### PR TITLE
breakfix for internals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@
    * FIXED: Weights were sometimes negative due to incorrect updates to elapsed_cost [#2702](https://github.com/valhalla/valhalla/pull/2702)
    * FIXED: Fix bidirectional route failures at deadends [#2705](https://github.com/valhalla/valhalla/pull/2705)
    * FIXED: Updated logic to call out a non-obvious turn [#2708](https://github.com/valhalla/valhalla/pull/2708)
+   * FIXED: If infer_internal_intersections is true then allow internals that are also ramps or TCs. Without this we produce an extra continue manuever.  [#2710](https://github.com/valhalla/valhalla/pull/2710)
 
 * **Enhancement**
    * ADDED: Add ability to provide custom implementation for candidate collection in CandidateQuery. [#2328](https://github.com/valhalla/valhalla/pull/2328)

--- a/src/mjolnir/graphenhancer.cc
+++ b/src/mjolnir/graphenhancer.cc
@@ -1749,8 +1749,7 @@ void enhance(const boost::property_tree::ptree& pt,
         // opposing edge index
         if (infer_internal_intersections &&
             IsIntersectionInternal(&tilebuilder, reader, lock, nodeinfo, directededge, j)) {
-          if (directededge.use() != Use::kRamp && directededge.use() != Use::kTurnChannel)
-            directededge.set_internal(true);
+          directededge.set_internal(true);
         }
 
         if (directededge.internal()) {

--- a/test/gurka/test_ramps_tc.cc
+++ b/test/gurka/test_ramps_tc.cc
@@ -7,177 +7,165 @@
 #endif
 
 using namespace valhalla;
+TEST(RampsTCs, test_tc_no_infer) {
 
-class RampsTCs : public ::testing::Test {
-protected:
-  static gurka::map map;
+  constexpr double gridsize_metres = 100;
 
-  static void SetUpTestSuite() {
-    constexpr double gridsize_metres = 100;
+  const std::string ascii_map = R"(
+            E D
+            | |
+            Q P
+           /| |\
+          / | | \
+      L--R--F-C--O--K
+            | |
+      I-----G-B--N--J
+            | | /
+            | |/
+            | M
+            | |
+            H A
+)";
 
-    const std::string ascii_map = R"(
-              E D
-              | |
-              Q P
-             /| |\
-            / | | \
-        L--R--F-C--O--K
-              | |
-        I-----G-B--N--J
-              | | /
-              | |/
-              | M
-              | |
-              H A
-  )";
+  const gurka::ways ways = {{"AM",
+                             {{"highway", "primary"},
+                              {"oneway", "yes"},
+                              {"lanes", "5"},
+                              {"turn:lanes", "through|through|right"}}},
+                            {"MB",
+                             {{"highway", "primary"},
+                              {"oneway", "yes"},
+                              {"lanes", "5"},
+                              {"internal_intersection", "true"},
+                              {"turn:lanes", "left|through|through"}}},
+                            {"MN",
+                             {{"highway", "primary_link"},
+                              {"oneway", "yes"},
+                              {"internal_intersection", "true"},
+                              {"turn_channel", "true"}}},
+                            {"OP",
+                             {{"highway", "primary"},
+                              {"oneway", "yes"},
+                              {"internal_intersection", "true"},
+                              {"turn_channel", "true"}}},
+                            {"QR",
+                             {{"highway", "primary_link"},
+                              {"oneway", "yes"},
+                              {"internal_intersection", "false"},
+                              {"turn_channel", "false"}}},
+                            {"EQ",
+                             {{"highway", "primary"},
+                              {"oneway", "yes"},
+                              {"lanes", "4"},
+                              {"turn:lanes", "reverse|left|through|right"}}},
+                            {"QF",
+                             {{"highway", "primary"},
+                              {"oneway", "yes"},
+                              {"lanes", "4"},
+                              {"turn:lanes", "reverse|left|through|right"}}},
+                            {"BC",
+                             {
+                                 {"highway", "primary"},
+                                 {"oneway", "yes"},
+                                 {"internal_intersection", "true"},
+                             }},
+                            {"CP",
+                             {
+                                 {"highway", "primary"},
+                                 {"oneway", "yes"},
+                             }},
+                            {"PD",
+                             {
+                                 {"highway", "primary"},
+                                 {"oneway", "yes"},
+                             }},
+                            {"FG",
+                             {
+                                 {"highway", "primary"},
+                                 {"oneway", "yes"},
+                                 {"internal_intersection", "true"},
+                             }},
+                            {"GH",
+                             {
+                                 {"highway", "primary"},
+                                 {"oneway", "yes"},
+                             }},
+                            {"IG",
+                             {
+                                 {"highway", "primary"},
+                                 {"oneway", "yes"},
+                             }},
+                            {"GB",
+                             {
+                                 {"highway", "primary"},
+                                 {"oneway", "yes"},
+                                 {"internal_intersection", "true"},
+                             }},
+                            {"BN",
+                             {
+                                 {"highway", "primary"},
+                                 {"oneway", "yes"},
+                                 {"internal_intersection", "true"},
+                             }},
+                            {"NJ",
+                             {
+                                 {"highway", "primary"},
+                                 {"oneway", "yes"},
+                             }},
+                            {"KO",
+                             {
+                                 {"highway", "primary"},
+                                 {"oneway", "yes"},
+                             }},
+                            {"OC",
+                             {
+                                 {"highway", "primary"},
+                                 {"oneway", "yes"},
+                             }},
+                            {"CF",
+                             {
+                                 {"highway", "primary"},
+                                 {"oneway", "yes"},
+                                 {"internal_intersection", "true"},
+                             }},
+                            {"FR",
+                             {
+                                 {"highway", "primary"},
+                                 {"oneway", "yes"},
+                             }},
+                            {"RL",
+                             {
+                                 {"highway", "primary"},
+                                 {"oneway", "yes"},
+                             }}};
 
-    const gurka::ways ways = {{"AM",
-                               {{"highway", "primary"},
-                                {"oneway", "yes"},
-                                {"lanes", "5"},
-                                {"turn:lanes", "through|through|right"}}},
-                              {"MB",
-                               {{"highway", "primary"},
-                                {"oneway", "yes"},
-                                {"lanes", "5"},
-                                {"internal_intersection", "true"},
-                                {"turn:lanes", "left|through|through"}}},
-                              {"MN",
-                               {{"highway", "primary_link"},
-                                {"oneway", "yes"},
-                                {"internal_intersection", "true"},
-                                {"turn_channel", "true"}}},
-                              {"OP",
-                               {{"highway", "primary"},
-                                {"oneway", "yes"},
-                                {"internal_intersection", "true"},
-                                {"turn_channel", "true"}}},
-                              {"QR",
-                               {{"highway", "primary_link"},
-                                {"oneway", "yes"},
-                                {"internal_intersection", "false"},
-                                {"turn_channel", "false"}}},
-                              {"EQ",
-                               {{"highway", "primary"},
-                                {"oneway", "yes"},
-                                {"lanes", "4"},
-                                {"turn:lanes", "reverse|left|through|right"}}},
-                              {"QF",
-                               {{"highway", "primary"},
-                                {"oneway", "yes"},
-                                {"lanes", "4"},
-                                {"turn:lanes", "reverse|left|through|right"}}},
-                              {"BC",
-                               {
-                                   {"highway", "primary"},
-                                   {"oneway", "yes"},
-                                   {"internal_intersection", "true"},
-                               }},
-                              {"CP",
-                               {
-                                   {"highway", "primary"},
-                                   {"oneway", "yes"},
-                               }},
-                              {"PD",
-                               {
-                                   {"highway", "primary"},
-                                   {"oneway", "yes"},
-                               }},
-                              {"FG",
-                               {
-                                   {"highway", "primary"},
-                                   {"oneway", "yes"},
-                                   {"internal_intersection", "true"},
-                               }},
-                              {"GH",
-                               {
-                                   {"highway", "primary"},
-                                   {"oneway", "yes"},
-                               }},
-                              {"IG",
-                               {
-                                   {"highway", "primary"},
-                                   {"oneway", "yes"},
-                               }},
-                              {"GB",
-                               {
-                                   {"highway", "primary"},
-                                   {"oneway", "yes"},
-                                   {"internal_intersection", "true"},
-                               }},
-                              {"BN",
-                               {
-                                   {"highway", "primary"},
-                                   {"oneway", "yes"},
-                                   {"internal_intersection", "true"},
-                               }},
-                              {"NJ",
-                               {
-                                   {"highway", "primary"},
-                                   {"oneway", "yes"},
-                               }},
-                              {"KO",
-                               {
-                                   {"highway", "primary"},
-                                   {"oneway", "yes"},
-                               }},
-                              {"OC",
-                               {
-                                   {"highway", "primary"},
-                                   {"oneway", "yes"},
-                               }},
-                              {"CF",
-                               {
-                                   {"highway", "primary"},
-                                   {"oneway", "yes"},
-                                   {"internal_intersection", "true"},
-                               }},
-                              {"FR",
-                               {
-                                   {"highway", "primary"},
-                                   {"oneway", "yes"},
-                               }},
-                              {"RL",
-                               {
-                                   {"highway", "primary"},
-                                   {"oneway", "yes"},
-                               }}};
+  const gurka::relations relations = {
+      {{
+           {gurka::way_member, "MB", "from"},
+           {gurka::way_member, "BN", "to"},
+           {gurka::node_member, "B", "via"},
+       },
+       {
+           {"type", "restriction"},
+           {"restriction", "no_right_turn"},
+       }},
+      {{
+           {gurka::way_member, "BC", "from"},
+           {gurka::way_member, "CF", "to"},
+           {gurka::node_member, "C", "via"},
+       },
+       {
+           {"type", "restriction"},
+           {"restriction", "no_left_turn"},
+       }},
+  };
 
-    const gurka::relations relations = {
-        {{
-             {gurka::way_member, "MB", "from"},
-             {gurka::way_member, "BN", "to"},
-             {gurka::node_member, "B", "via"},
-         },
-         {
-             {"type", "restriction"},
-             {"restriction", "no_right_turn"},
-         }},
-        {{
-             {gurka::way_member, "BC", "from"},
-             {gurka::way_member, "CF", "to"},
-             {gurka::node_member, "C", "via"},
-         },
-         {
-             {"type", "restriction"},
-             {"restriction", "no_left_turn"},
-         }},
-    };
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, gridsize_metres);
+  auto map = gurka::buildtiles(layout, ways, {}, relations, "test/data/gurka_ramps_tc_no_infer",
+                               {{"mjolnir.data_processing.infer_internal_intersections", "false"},
+                                {"mjolnir.data_processing.infer_turn_channels", "false"},
+                                {"mjolnir.reclassify_links", "false"}});
 
-    const auto layout = gurka::detail::map_to_coordinates(ascii_map, gridsize_metres);
-    map = gurka::buildtiles(layout, ways, {}, relations, "test/data/gurka_ramps_tc",
-                            {{"mjolnir.data_processing.infer_internal_intersections", "false"},
-                             {"mjolnir.data_processing.infer_turn_channels", "false"},
-                             {"mjolnir.reclassify_links", "false"}});
-  }
-};
-gurka::map RampsTCs::map = {};
-Api api;
-rapidjson::Document d;
-
-/*************************************************************/
-
-TEST_F(RampsTCs, test_tc_use) {
   auto result = gurka::route(map, "A", "J", "auto");
   ASSERT_EQ(result.trip().routes(0).legs_size(), 1);
   auto leg = result.trip().routes(0).legs(0);
@@ -205,4 +193,89 @@ TEST_F(RampsTCs, test_tc_use) {
   gurka::assert::raw::expect_path(result, {"AM", "MB", "BC", "CP", "PD"});
   EXPECT_EQ(leg.node(1).edge().use(), valhalla::TripLeg_Use::TripLeg_Use_kRoadUse);
   EXPECT_EQ(leg.node(1).edge().internal_intersection(), 1);
+}
+
+TEST(RampsTCs, test_tc_infer) {
+
+  constexpr double gridsize_metres = 10;
+
+  const std::string ascii_map = R"(
+
+      A---B-------------------------------C------D
+           \                             /
+            \            F J            /
+             \           | |           /
+              \          | |          /
+               \         | |         /
+                \        | |        /
+                 --E-----G-K-----N--
+                    \    | |    /
+                     \   | |   /
+                      \  | |  /
+                       \ | | /
+                         H L
+                         | |
+                         | |
+                         | |
+                         I M
+
+
+)";
+
+  const gurka::ways ways = {
+      {"AB", {{"highway", "motorway"}, {"oneway", "yes"}}},
+      {"BC", {{"highway", "motorway"}, {"oneway", "yes"}}},
+      {"CD", {{"highway", "motorway"}, {"oneway", "yes"}}},
+
+      {"BE", {{"highway", "motorway_link"}, {"oneway", "yes"}}},
+      {"EG", {{"highway", "motorway_link"}, {"oneway", "yes"}}},
+      {"EH", {{"highway", "motorway_link"}, {"oneway", "yes"}}},
+      {"GK", {{"highway", "motorway_link"}, {"oneway", "yes"}}},
+      {"FG", {{"highway", "primary"}, {"oneway", "yes"}}},
+      {"GH", {{"highway", "primary"}, {"oneway", "yes"}}},
+      {"HI", {{"highway", "primary"}, {"oneway", "yes"}}},
+      {"ML", {{"highway", "primary"}, {"oneway", "yes"}}},
+      {"LK", {{"highway", "primary"}, {"oneway", "yes"}}},
+      {"KJ", {{"highway", "primary"}, {"oneway", "yes"}}},
+      {"KN", {{"highway", "motorway_link"}, {"oneway", "yes"}}},
+      {"LN", {{"highway", "motorway_link"}, {"oneway", "yes"}}},
+      {"NC", {{"highway", "motorway_link"}, {"oneway", "yes"}}},
+  };
+
+  const gurka::nodes nodes = {{"B", {{"highway", "motorway_junction"}, {"ref", "4"}}}};
+
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, gridsize_metres);
+  auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_ramps_tc_infer",
+                               {{"mjolnir.data_processing.infer_internal_intersections", "true"},
+                                {"mjolnir.data_processing.infer_turn_channels", "true"},
+                                {"mjolnir.reclassify_links", "true"}});
+
+  auto result = gurka::route(map, "A", "J", "auto");
+  ASSERT_EQ(result.trip().routes(0).legs_size(), 1);
+  auto leg = result.trip().routes(0).legs(0);
+  gurka::assert::raw::expect_path(result, {"AB", "BE", "EG", "GK", "KJ"});
+
+  EXPECT_EQ(leg.node(0).edge().use(), valhalla::TripLeg_Use::TripLeg_Use_kRoadUse);
+  EXPECT_EQ(leg.node(0).edge().internal_intersection(), 0);
+
+  EXPECT_EQ(leg.node(1).edge().use(), valhalla::TripLeg_Use::TripLeg_Use_kRampUse);
+  EXPECT_EQ(leg.node(1).edge().internal_intersection(), 0);
+
+  EXPECT_EQ(leg.node(2).edge().use(), valhalla::TripLeg_Use::TripLeg_Use_kRampUse);
+  EXPECT_EQ(leg.node(2).edge().internal_intersection(), 0);
+
+  EXPECT_EQ(leg.node(3).edge().use(), valhalla::TripLeg_Use::TripLeg_Use_kTurnChannelUse);
+  EXPECT_EQ(leg.node(3).edge().internal_intersection(), 1);
+
+  EXPECT_EQ(leg.node(4).edge().use(), valhalla::TripLeg_Use::TripLeg_Use_kRoadUse);
+  EXPECT_EQ(leg.node(4).edge().internal_intersection(), 0);
+
+  gurka::assert::raw::expect_maneuver_begin_path_indexes(result, {0, 1, 2, 4, 5});
+
+  int maneuver_index = 3;
+
+  // Verify that we are marking the internal edge.  If not, there will be a continue instruction
+  gurka::assert::raw::expect_instructions_at_maneuver_index(
+      result, maneuver_index, "Turn left onto KJ.", "Turn left onto KJ.",
+      "Turn left onto KJ. Then You will arrive at your destination.", "Continue for 50 meters.");
 }


### PR DESCRIPTION
# Issue
If infer_internal_intersections is true then allow internals that are also ramps or TCs.  Without this we produce an extra continue manuever.

## Before
![Screenshot from 2020-12-04 13-02-40](https://user-images.githubusercontent.com/2676277/101198236-23fcce80-3631-11eb-950c-d2ca4a14e0d3.png)

## After
![Screenshot from 2020-12-04 13-02-25](https://user-images.githubusercontent.com/2676277/101198245-27905580-3631-11eb-9c6e-61928cd0e71f.png)

## Tasklist

 - [x] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
