### PR TITLE
Moving guidance view conversion logic

### DIFF
--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -218,22 +218,6 @@ std::unordered_map<std::string, std::pair<std::string, std::string>> speed_limit
     {"WS", {kSpeedLimitSignVienna, kSpeedLimitUnitsMph}},
 };
 
-const std::unordered_map<int, std::string>
-    guidanceview_type_string{{static_cast<int>(DirectionsLeg_GuidanceView_Type_kJunction), "jct"},
-                             {static_cast<int>(DirectionsLeg_GuidanceView_Type_kSapa), "sapa"},
-                             {static_cast<int>(DirectionsLeg_GuidanceView_Type_kTollbranch),
-                              "tollbranch"},
-                             {static_cast<int>(DirectionsLeg_GuidanceView_Type_kAftertoll),
-                              "aftertoll"},
-                             {static_cast<int>(DirectionsLeg_GuidanceView_Type_kEnt), "ent"},
-                             {static_cast<int>(DirectionsLeg_GuidanceView_Type_kExit), "exit"},
-                             {static_cast<int>(DirectionsLeg_GuidanceView_Type_kCityreal),
-                              "cityreal"},
-                             {static_cast<int>(DirectionsLeg_GuidanceView_Type_kDirectionboard),
-                              "directionboard"},
-                             {static_cast<int>(DirectionsLeg_GuidanceView_Type_kSignboard),
-                              "signboard"}};
-
 namespace osrm_serializers {
 /*
 OSRM output is described in: http://project-osrm.org/docs/v5.5.1/api/

--- a/valhalla/proto_conversions.h
+++ b/valhalla/proto_conversions.h
@@ -226,4 +226,20 @@ bool DirectionsType_Enum_Parse(const std::string& dtype, DirectionsType* t);
 bool PreferredSide_Enum_Parse(const std::string& pside, valhalla::Location::PreferredSide* p);
 bool RoadClass_Enum_Parse(const std::string& rc_name, valhalla::RoadClass* rc);
 
+const std::unordered_map<int, std::string>
+    guidanceview_type_string{{static_cast<int>(DirectionsLeg_GuidanceView_Type_kJunction), "jct"},
+                             {static_cast<int>(DirectionsLeg_GuidanceView_Type_kSapa), "sapa"},
+                             {static_cast<int>(DirectionsLeg_GuidanceView_Type_kTollbranch),
+                              "tollbranch"},
+                             {static_cast<int>(DirectionsLeg_GuidanceView_Type_kAftertoll),
+                              "aftertoll"},
+                             {static_cast<int>(DirectionsLeg_GuidanceView_Type_kEnt), "ent"},
+                             {static_cast<int>(DirectionsLeg_GuidanceView_Type_kExit), "exit"},
+                             {static_cast<int>(DirectionsLeg_GuidanceView_Type_kCityreal),
+                              "cityreal"},
+                             {static_cast<int>(DirectionsLeg_GuidanceView_Type_kDirectionboard),
+                              "directionboard"},
+                             {static_cast<int>(DirectionsLeg_GuidanceView_Type_kSignboard),
+                              "signboard"}};
+
 } // namespace valhalla


### PR DESCRIPTION
# Issue

Moved enum to string conversion for guidance views to proto_conversions

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Generally use squash merge to rebase and clean comments before merging
 - [ ] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
