### PR TITLE
we should stop expanding if we hit our reach target

### DIFF
--- a/src/loki/reach.cc
+++ b/src/loki/reach.cc
@@ -215,7 +215,7 @@ thor::ExpansionRecommendation
 Reach::ShouldExpand(baldr::GraphReader&, const sif::EdgeLabel&, const thor::InfoRoutingType) {
   if ((done_.size() - transitions_) < max_reach_)
     return thor::ExpansionRecommendation::continue_expansion;
-  return thor::ExpansionRecommendation::prune_expansion;
+  return thor::ExpansionRecommendation::stop_expansion;
 }
 
 // tell the expansion how many labels to expect and how many buckets to use


### PR DESCRIPTION
it seems to me like we should tell dijkstras to stop instead of prune when we hit our reach target. to me the current code seem to suggest that instead of doing that, we make sure to first pop off and settle all of the outstanding labels in the label set, which is a huge waste of time!

this is only for exact reach which doesnt happen that often but when it does this should be more performant so long as i'm correct :wink: 