### PR TITLE
Add option to use thread-safe GraphTile's reference counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,6 +230,8 @@
    * CHANGED: Change generic service roads to a new Use=kServiceRoad. This is for highway=service without other service=* tags (such as driveway, alley, parking aisle).
    * ADDED: Add support for ignoring live traffic closures for waypoints [#2685](https://github.com/valhalla/valhalla/pull/2685)
    * CHANGED: Reducing the number of uturns by increasing the cost to for them to 9.5f. Note: Did not increase the cost for motorcycles or motorscooters. [#2770](https://github.com/valhalla/valhalla/pull/2770)
+   * ADDED: Add option to use thread-safe GraphTile's reference counter. [#2772](https://github.com/valhalla/valhalla/pull/2772)
+
 
 ## Release Date: 2019-11-21 Valhalla 3.0.9
 * **Bug Fix**

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,8 @@ option(ENABLE_UNDEFINED_SANITIZER "Use UB sanitizer for Debug build" OFF)
 option(ENABLE_TESTS "Enable Valhalla tests" ON)
 option(ENABLE_WERROR "Convert compiler warnings to errors. Requires ENABLE_COMPILER_WARNINGS=ON to take effect" OFF)
 option(ENABLE_BENCHMARKS "Enable microbenchmarking" ON)
+option(ENABLE_THREAD_SAFE_TILE_REF_COUNT "If ON tiles reference counters are thread safe" OFF)
+
 set(LOGGING_LEVEL "" CACHE STRING "Logging level, default is INFO")
 set_property(CACHE LOGGING_LEVEL PROPERTY STRINGS "NONE;ALL;ERROR;WARN;INFO;DEBUG;TRACE")
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
@@ -226,6 +228,10 @@ elseif(NOT Boost_FOUND)
   find_package(Boost 1.51 REQUIRED)
 endif()
 add_definitions(-DBOOST_NO_CXX11_SCOPED_ENUMS)
+
+if (ENABLE_THREAD_SAFE_TILE_REF_COUNT)
+ add_definitions(-DENABLE_THREAD_SAFE_TILE_REF_COUNT)
+endif ()
 
 ## libvalhalla
 add_subdirectory(src)

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -42,11 +42,17 @@ namespace baldr {
 const std::string SUFFIX_NON_COMPRESSED = ".gph";
 const std::string SUFFIX_COMPRESSED = ".gph.gz";
 
+#ifdef ENABLE_THREAD_SAFE_TILE_REF_COUNT
+using GraphTileRefCounter = boost::thread_safe_counter;
+#else
+using GraphTileRefCounter = boost::thread_unsafe_counter;
+#endif // ENABLE_THREAD_SAFE_TILE_REF_COUNT
+
 class tile_getter_t;
 /**
  * Graph information for a tile within the Tiled Hierarchical Graph.
  */
-class GraphTile : public boost::intrusive_ref_counter<GraphTile, boost::thread_unsafe_counter> {
+class GraphTile : public boost::intrusive_ref_counter<GraphTile, GraphTileRefCounter> {
 public:
   static const constexpr char* kTilePathPattern = "{tilePath}";
 


### PR DESCRIPTION
# Issue

Sometimes we need to use the same instance of GraphTile from different threads. This PR adds compile-time option to make GraphTile's reference counter thread-safe.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [x] Generally use squash merge to rebase and clean comments before merging
 - [x] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

https://github.com/valhalla/valhalla/pull/2730