### PR TITLE
adding an action to check the changelog has been modified on PRs

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Validate
         shell: bash
         run: |
-          PR_BASE=$(jq --raw-output .base.ref "$GITHUB_EVENT_PATH")
+          PR_BASE=$(jq --raw-output .pull_request.base.ref "$GITHUB_EVENT_PATH")
           PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
           PR_TITLE=$(jq --raw-output .pull_request.title "$GITHUB_EVENT_PATH")
           git fetch origin {PR_BASE} --depth 1

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,7 +13,7 @@ jobs:
           git fetch origin master --depth 1
           LINE_COUNT=$(git diff origin/master -- CHANGELOG.md | wc -l)
           if [ ${LINE_COUNT} -eq 0 ]; then
-            >&2 echo "No CHANGELOG entries detected. Consider whether this PR warrents one"
+            echo "No CHANGELOG entries detected. Consider whether this PR warrents one" &>2
             exit 1
           fi
           #TODO: validate changes

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,9 +15,9 @@ jobs:
           PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
           PR_TITLE=$(jq --raw-output .pull_request.title "$GITHUB_EVENT_PATH")
           if [ ${LINE_COUNT} -eq 0 ]; then
-            printf "\x1b[31;1mNo CHANGELOG entries detected. Consider whether this PR warrents one\x1b[0m"
-            printf "Please consider the following: "
-            printf "   * ${PR_TITLE} [#${PR_NUMBER}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/l${PR_NUMBER})"
+            printf "\x1b[31;1mNo CHANGELOG entries detected. Consider whether this PR warrents one\x1b[0m\n"
+            printf "Please consider the following:\n"
+            printf "   * ${PR_TITLE} [#${PR_NUMBER}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${PR_NUMBER})\n"
             exit 1
           fi
           #TODO: validate changelog line format

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -10,9 +10,10 @@ jobs:
       - name: Validate
         shell: bash
         run: |
-          PR_BASE=$(jq --raw-output .pull_request.base.ref "$GITHUB_EVENT_PATH")
-          PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-          PR_TITLE=$(jq --raw-output .pull_request.title "$GITHUB_EVENT_PATH")
+          cat ${GITHUB_EVENT_PATH}
+          PR_BASE=$(jq --raw-output .pull_request.base.ref ${GITHUB_EVENT_PATH})
+          PR_NUMBER=$(jq --raw-output .pull_request.number ${GITHUB_EVENT_PATH})
+          PR_TITLE=$(jq --raw-output .pull_request.title ${GITHUB_EVENT_PATH})
           git fetch origin {PR_BASE} --depth 1
           LINE_COUNT=$(git diff origin/${PR_BASE} -- CHANGELOG.md | wc -l)
           if [ ${LINE_COUNT} -eq 0 ]; then

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -10,11 +10,10 @@ jobs:
       - name: Validate
         shell: bash
         run: |
-          cat ${GITHUB_EVENT_PATH}
           PR_BASE=$(jq --raw-output .pull_request.base.ref ${GITHUB_EVENT_PATH})
           PR_NUMBER=$(jq --raw-output .pull_request.number ${GITHUB_EVENT_PATH})
           PR_TITLE=$(jq --raw-output .pull_request.title ${GITHUB_EVENT_PATH})
-          git fetch origin {PR_BASE} --depth 1
+          git fetch origin ${PR_BASE} --depth 1
           LINE_COUNT=$(git diff origin/${PR_BASE} -- CHANGELOG.md | wc -l)
           if [ ${LINE_COUNT} -eq 0 ]; then
             printf "\x1b[31;1mNo CHANGELOG entries detected. Consider whether this PR warrents one, for example:\x1b[0m\n"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,6 +13,7 @@ jobs:
           git fetch origin master --depth 1
           LINE_COUNT=$(git diff origin/master -- CHANGELOG.md | wc -l)
           if [ ${LINE_COUNT} -eq 0 ]; then
+            echo "No CHANGELOG entries detected. Consider whether this PR warrents one"
             exit 1
           fi
           #TODO: validate changes

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,7 +13,7 @@ jobs:
           git fetch origin master --depth 1
           LINE_COUNT=$(git diff origin/master -- CHANGELOG.md | wc -l)
           if [ ${LINE_COUNT} -eq 0 ]; then
-            echo "No CHANGELOG entries detected. Consider whether this PR warrents one"
+            >&2 echo "No CHANGELOG entries detected. Consider whether this PR warrents one"
             exit 1
           fi
           #TODO: validate changes

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -10,10 +10,11 @@ jobs:
       - name: Validate
         shell: bash
         run: |
-          git fetch origin master --depth 1
-          LINE_COUNT=$(git diff origin/master -- CHANGELOG.md | wc -l)
+          PR_BASE=$(jq --raw-output .base.ref "$GITHUB_EVENT_PATH")
           PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
           PR_TITLE=$(jq --raw-output .pull_request.title "$GITHUB_EVENT_PATH")
+          git fetch origin {PR_BASE} --depth 1
+          LINE_COUNT=$(git diff origin/${PR_BASE} -- CHANGELOG.md | wc -l)
           if [ ${LINE_COUNT} -eq 0 ]; then
             printf "\x1b[31;1mNo CHANGELOG entries detected. Consider whether this PR warrents one, for example:\x1b[0m\n"
             printf "\x1b[33;1m* ${PR_TITLE} [#${PR_NUMBER}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${PR_NUMBER})\x1b[0m\n"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,13 @@
+name: Valhalla Changelog Validation
+on: [pull_request]
+
+jobs:
+  build:
+    name: Changelog Validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Validate
+        shell: bash
+        run: |
+          git diff origin/master -- CHANGELOG.md

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,9 +15,8 @@ jobs:
           PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
           PR_TITLE=$(jq --raw-output .pull_request.title "$GITHUB_EVENT_PATH")
           if [ ${LINE_COUNT} -eq 0 ]; then
-            printf "\x1b[31;1mNo CHANGELOG entries detected. Consider whether this PR warrents one\x1b[0m\n"
-            printf "Please consider the following:\n"
-            printf "   * ${PR_TITLE} [#${PR_NUMBER}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${PR_NUMBER})\n"
+            printf "\x1b[31;1mNo CHANGELOG entries detected. Consider whether this PR warrents one, for example:\x1b[0m\n"
+            printf "\x1b[33;1m* ${PR_TITLE} [#${PR_NUMBER}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${PR_NUMBER})\x1b[0m\n"
             exit 1
           fi
           #TODO: validate changelog line format

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -10,4 +10,9 @@ jobs:
       - name: Validate
         shell: bash
         run: |
-          git diff origin/master -- CHANGELOG.md
+          git fetch origin master --depth 1
+          LINE_COUNT=$(git diff origin/master -- CHANGELOG.md | wc -l)
+          if [ ${LINE_COUNT} -eq 0 ]; then
+            exit 1
+          fi
+          #TODO: validate changes

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,8 +12,12 @@ jobs:
         run: |
           git fetch origin master --depth 1
           LINE_COUNT=$(git diff origin/master -- CHANGELOG.md | wc -l)
+          PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+          PR_TITLE=$(jq --raw-output .pull_request.title "$GITHUB_EVENT_PATH")
           if [ ${LINE_COUNT} -eq 0 ]; then
-            echo "No CHANGELOG entries detected. Consider whether this PR warrents one" &>2
+            printf "\x1b[31;1mNo CHANGELOG entries detected. Consider whether this PR warrents one\x1b[0m"
+            printf "Please consider the following: "
+            printf "   * ${PR_TITLE} [#${PR_NUMBER}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/l${PR_NUMBER})"
             exit 1
           fi
-          #TODO: validate changes
+          #TODO: validate changelog line format


### PR DESCRIPTION
we semi-recently removed the changelog validation from our CI. this was because some changes didnt really warrent it. i want to add it back but make it optional. this way we can see that the job fails but we have to mentally evaluate whether that is ok or not, which should make us think twice about whether we actually need a changelog entry or not for a particular change