### PR TITLE
Add potential tile to all GetGraphTile calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
    * CHANGED: implement valhalla_build_elevation in python and add more --from-geojson & --from-graph options [#3318](https://github.com/valhalla/valhalla/pull/3318)
    * ADDED: Add boolean parameter to clear memory for edge labels from thor. [#2789](https://github.com/valhalla/valhalla/pull/2789)
    * CHANGED: Do not create statsd client in workers if it is not configured [#3394](https://github.com/valhalla/valhalla/pull/3394)
+   * ADDED: Add potential tile to all GetGraphTile calls [#2780](https://github.com/valhalla/valhalla/pull/2780)
 
 ## Release Date: 2021-10-07 Valhalla 3.1.4
 * **Removed**

--- a/valhalla/thor/bidirectional_astar.h
+++ b/valhalla/thor/bidirectional_astar.h
@@ -154,6 +154,7 @@ protected:
    */
   template <const ExpansionType expansion_direction>
   bool Expand(baldr::GraphReader& graphreader,
+              graph_tile_ptr& potential_tile,
               const baldr::GraphId& node,
               sif::BDEdgeLabel& pred,
               const uint32_t pred_idx,
@@ -173,6 +174,7 @@ protected:
   //
   template <const ExpansionType expansion_direction>
   inline bool ExpandInner(baldr::GraphReader& graphreader,
+                          graph_tile_ptr& potential_tile,
                           const sif::BDEdgeLabel& pred,
                           const baldr::DirectedEdge* opp_pred_edge,
                           const baldr::NodeInfo* nodeinfo,
@@ -188,6 +190,7 @@ protected:
    * @param time_info    What time is it when we start the route
    */
   void SetOrigin(baldr::GraphReader& graphreader,
+                 graph_tile_ptr& potential_tile,
                  valhalla::Location& origin,
                  const baldr::TimeInfo& time_info);
 
@@ -198,6 +201,7 @@ protected:
    * @param time_info    What time is it when we end the route
    */
   void SetDestination(baldr::GraphReader& graphreader,
+                      graph_tile_ptr& potential_tile,
                       const valhalla::Location& dest,
                       const baldr::TimeInfo& time_info);
 


### PR DESCRIPTION
I change `GetGraphTile(graph_id)` to `GetGraphTile(graph_id, potential_tile)` to reduce time for searching required tile
