### PR TITLE
GraphTile::FileSuffix Should not Allow Invalid Ids

### DIFF
--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -418,8 +418,8 @@ GraphTile::FileSuffix(const GraphId& graphid, const std::string& fname_suffix, b
   // figure the largest id for this level
   if (graphid.level() >= TileHierarchy::levels().size() &&
       graphid.level() != TileHierarchy::GetTransitLevel().level) {
-    throw std::runtime_error("Could not compute FileSuffix for non-existent level: " +
-                             std::to_string(graphid.level()));
+    throw std::runtime_error("Could not compute FileSuffix for GraphId with invalid level: " +
+                             std::to_string(graphid));
   }
 
   // get the level info
@@ -429,6 +429,10 @@ GraphTile::FileSuffix(const GraphId& graphid, const std::string& fname_suffix, b
 
   // figure out how many digits in tile-id
   const auto max_id = level.tiles.ncolumns() * level.tiles.nrows() - 1;
+  if (graphid.tileid() > max_id) {
+    throw std::runtime_error("Could not compute FileSuffix for GraphId with invalid tile id:" +
+                             std::to_string(graphid));
+  }
   size_t max_length = static_cast<size_t>(std::log10(std::max(1, max_id))) + 1;
   const size_t remainder = max_length % 3;
   if (remainder) {

--- a/test/graphtile.cc
+++ b/test/graphtile.cc
@@ -28,6 +28,7 @@ TEST(Graphtile, FileSuffix) {
   EXPECT_EQ(GraphTile::FileSuffix(GraphId(64799, 1, 0)), "1/064/799.gph");
   EXPECT_EQ(GraphTile::FileSuffix(GraphId(49, 0, 0)), "0/000/049.gph");
   EXPECT_EQ(GraphTile::FileSuffix(GraphId(1000000, 3, 1)), "3/001/000/000.gph");
+  EXPECT_EQ(GraphTile::FileSuffix(GraphId(795646, 1, 0)), "1/795/646.gph");
 }
 
 TEST(Graphtile, IdFromString) {

--- a/test/graphtile.cc
+++ b/test/graphtile.cc
@@ -24,11 +24,14 @@ struct testable_graphtile : public valhalla::baldr::GraphTile {
 TEST(Graphtile, FileSuffix) {
   EXPECT_EQ(GraphTile::FileSuffix(GraphId(2, 2, 0)), "2/000/000/002.gph");
   EXPECT_EQ(GraphTile::FileSuffix(GraphId(4, 2, 0)), "2/000/000/004.gph");
-  EXPECT_EQ(GraphTile::FileSuffix(GraphId(1197468, 2, 0)), "2/001/197/468.gph");
   EXPECT_EQ(GraphTile::FileSuffix(GraphId(64799, 1, 0)), "1/064/799.gph");
   EXPECT_EQ(GraphTile::FileSuffix(GraphId(49, 0, 0)), "0/000/049.gph");
   EXPECT_EQ(GraphTile::FileSuffix(GraphId(1000000, 3, 1)), "3/001/000/000.gph");
-  EXPECT_EQ(GraphTile::FileSuffix(GraphId(795646, 1, 0)), "1/795/646.gph");
+  EXPECT_THROW(GraphTile::FileSuffix(GraphId(64800, 1, 0)), std::runtime_error);
+  EXPECT_THROW(GraphTile::FileSuffix(GraphId(1337, 6, 0)), std::runtime_error);
+  EXPECT_THROW(GraphTile::FileSuffix(GraphId(1036800, 2, 0)), std::runtime_error);
+  EXPECT_THROW(GraphTile::FileSuffix(GraphId(4050, 0, 0)), std::runtime_error);
+  EXPECT_THROW(GraphTile::FileSuffix(GraphId(1036800, 3, 0)), std::runtime_error);
 }
 
 TEST(Graphtile, IdFromString) {


### PR DESCRIPTION
Previously this method allowed you to use invalid tile ids so long as the the tile level was valid. Now we reject invalid tile ids as well (the rest of the math in the function relies on that so without it we can attempt to read memory that doesnt belong to us).