### PR TITLE
Bidirectional A* bug: IsBridgingEdge function doesn't work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
    * FIXED: Fix alternate route serialization [#2811](https://github.com/valhalla/valhalla/pull/2811)
    * FIXED: Store restrictions in the right tile [#2781](https://github.com/valhalla/valhalla/pull/2781)
    * FIXED: Regression in stopping expansion on transitions down in time-dependent routes [#2815](https://github.com/valhalla/valhalla/pull/2815)
-   * FIXED: Fix crash in loki when trace_route is called with 2 locations.[#2871](https://github.com/valhalla/valhalla/pull/2817)
+   * FIXED: Fix crash in loki when trace_route is called with 2 locations.[#2817](https://github.com/valhalla/valhalla/pull/2817)
+   * FIXED: Mark the restriction start and end as via ways to fix IsBridgingEdge function in Bidirectional Astar [#2796](https://github.com/valhalla/valhalla/pull/2796)
 
 * **Enhancement**
 

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -1922,6 +1922,7 @@ public:
         // complex restrictions -- add to end map.
         if (vias.size()) {
           osmdata_.via_set.insert(from_way_id);
+          osmdata_.via_set.insert(restriction.to());
           restriction.set_from(from_way_id);
           restriction.set_vias(vias);
           // for bi-directional we need to create the restriction in reverse.  flip the to and from.

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -1921,6 +1921,7 @@ public:
 
         // complex restrictions -- add to end map.
         if (vias.size()) {
+          osmdata_.via_set.insert(from_way_id);
           restriction.set_from(from_way_id);
           restriction.set_vias(vias);
           // for bi-directional we need to create the restriction in reverse.  flip the to and from.


### PR DESCRIPTION
# Issue

Imagine we have complex restriction `A -> B -> C -> D`. 

Bidir-a* tries to `SetReverseConnection`([link](https://github.com/valhalla/valhalla/blob/8dad19e5b42e758d5c489f693009a6c81b72a1ac/src/thor/bidirectional_astar.cc#L646)) using `B-C` as the bridging edge.  So we go along the edges and check if the next one is on the complex restriction([link](https://github.com/valhalla/valhalla/blob/8dad19e5b42e758d5c489f693009a6c81b72a1ac/src/thor/bidirectional_astar.cc#L1162)). The bug comes when we check `AB` edge. The deal is it is marked as the `start_restriction`(whether it's opposite edge `BA` is marked) nor as `end_restriction`(because it's not the end 🙂 ) nor as `part_of_complex_restriction`(we don't treat start ways as vias: see pbfgraphparser.cc)`. 

tldr: We say that `AB` edge isn't from the complex restriction but it's not true.

## Plan
 - [x] Check if we have same bug in `SetForwardRestriction` 
 - [x] Add gurka test to avoid regressions
 - [x] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
