### PR TITLE
Fix recognition of invalid speed values in live traffic feed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@
    * FIXED: Reduce verbose instructions by collapsing small end ramp forks [#2762](https://github.com/valhalla/valhalla/issues/2762)
    * FIXED: Remove redundant return statements [#2776](https://github.com/valhalla/valhalla/pull/2776)
    * FIXED: Add support for geos-3.9 c++ api [#2739](https://github.com/valhalla/valhalla/issues/2739)
+   * FIXED: Fix check for live speed validness [#2797](https://github.com/valhalla/valhalla/pull/2797)
 
 * **Enhancement**
    * ADDED: Add ability to provide custom implementation for candidate collection in CandidateQuery. [#2328](https://github.com/valhalla/valhalla/pull/2328)

--- a/test/gurka/test_traffic.cc
+++ b/test/gurka/test_traffic.cc
@@ -36,7 +36,7 @@ TEST(Traffic, BasicUpdates) {
   test::build_live_traffic_data(map.config);
 
   auto clean_reader = test::make_clean_graphreader(map.config.get_child("mjolnir"));
-  printf("Do a route with initial traffic");
+  std::cout << "[          ] Do a route with initial traffic" << std::endl;
   {
     auto result = gurka::do_action(valhalla::Options::route, map, {"A", "C"}, "auto",
                                    {{"/date_time/type", "0"}}, clean_reader);
@@ -44,9 +44,10 @@ TEST(Traffic, BasicUpdates) {
     gurka::assert::raw::expect_path(result, {"AB", "BC"});
     gurka::assert::raw::expect_eta(result, 360.0177);
   }
-  printf("Make some updates to the traffic .tar file. "
-         "Mostly just updates every edge in the file to 24km/h, except for one "
-         "specific edge (B->D) where we simulate a closure (speed=0, congestion high)");
+  std::cout << "[          ] Make some updates to the traffic .tar file. "
+               "Mostly just updates every edge in the file to 24km/h, except for one "
+               "specific edge (B->D) where we simulate a closure (speed=0, congestion high)"
+            << std::endl;
   auto cb_setter_24kmh = [&map](baldr::GraphReader& reader, baldr::TrafficTile& tile, int index,
                                 valhalla::baldr::TrafficSpeed* current) -> void {
     baldr::GraphId tile_id(tile.header->tile_id);
@@ -62,8 +63,9 @@ TEST(Traffic, BasicUpdates) {
   };
   test::customize_live_traffic_data(map.config, cb_setter_24kmh);
 
-  printf(" Now do another route with the same (not restarted) actor to see if"
-         " it's noticed the changes in the live traffic file");
+  std::cout << "[          ] Now do another route with the same (not restarted) actor to see if"
+               " it's noticed the changes in the live traffic file"
+            << std::endl;
   {
     auto result = gurka::do_action(valhalla::Options::route, map, {"A", "C"}, "auto",
                                    {{"/date_time/type", "0"}}, clean_reader);
@@ -72,7 +74,8 @@ TEST(Traffic, BasicUpdates) {
     gurka::assert::raw::expect_eta(result, 150.0177);
   }
 
-  printf("Next, set the speed to the highest possible to ensure nothing breaks");
+  std::cout << "[          ] Next, set the speed to the highest possible to ensure nothing breaks"
+            << std::endl;
   auto cb_setter_max = [&map](baldr::GraphReader& reader, baldr::TrafficTile& tile, int index,
                               baldr::TrafficSpeed* current) -> void {
     baldr::GraphId tile_id(tile.header->tile_id);
@@ -81,7 +84,7 @@ TEST(Traffic, BasicUpdates) {
     if (std::get<1>(BD) != nullptr && std::get<0>(BD).id() == index) {
       current->overall_speed = 0;
     } else {
-      current->overall_speed = valhalla::baldr::kMaxAssumedSpeed >> 1;
+      current->overall_speed = UNKNOWN_TRAFFIC_SPEED_RAW - 1;
     }
   };
   test::customize_live_traffic_data(map.config, cb_setter_max);
@@ -93,7 +96,7 @@ TEST(Traffic, BasicUpdates) {
     gurka::assert::raw::expect_eta(result, 25.731991);
   }
 
-  printf("Back to previous speed");
+  std::cout << "[          ] Back to previous speed" << std::endl;
   test::customize_live_traffic_data(map.config, cb_setter_24kmh);
   // And verify that without the "current" timestamp, the live traffic
   // results aren't used
@@ -105,8 +108,9 @@ TEST(Traffic, BasicUpdates) {
     gurka::assert::raw::expect_eta(result, 360.0177);
   }
 
-  printf("Now do another route with the same (not restarted) actor to see if "
-         "it's noticed the changes in the live traffic file");
+  std::cout << "[          ] Now do another route with the same (not restarted) actor to see if "
+               "it's noticed the changes in the live traffic file"
+            << std::endl;
   {
 
     auto result = gurka::do_action(valhalla::Options::route, map, {"B", "D"}, "auto",
@@ -123,8 +127,10 @@ TEST(Traffic, BasicUpdates) {
     gurka::assert::raw::expect_eta(result, 30., 0.01);
   }
 
-  printf(" Repeat the B->D route, but this time with no timestamp - this should disable "
-         "using live traffc and the road should be open again");
+  std::cout
+      << "[          ] Repeat the B->D route, but this time with no timestamp - this should disable "
+         "using live traffc and the road should be open again"
+      << std::endl;
   {
     auto result =
         gurka::do_action(valhalla::Options::route, map, {"B", "D"}, "auto", {}, clean_reader);

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -551,7 +551,7 @@ public:
       auto directed_edge_index = std::distance(const_cast<const DirectedEdge*>(directededges_), de);
       auto volatile& live_speed = traffic_tile.trafficspeed(directed_edge_index);
       // only use current speed if its valid and non zero, a speed of 0 makes costing values crazy
-      if (live_speed.valid() && (partial_live_speed = live_speed.get_overall_speed()) > 0) {
+      if (live_speed.speed_valid() && (partial_live_speed = live_speed.get_overall_speed()) > 0) {
         *flow_sources |= kCurrentFlowMask;
         // Live speed covers entire edge, can return early here
         if (live_speed.breakpoint1 == 255) {
@@ -563,9 +563,11 @@ public:
         partial_live_pct =
             (
                 // First section
-                (live_speed.breakpoint1 > 0 ? live_speed.breakpoint1 : 0)
+                (live_speed.speed1 != UNKNOWN_TRAFFIC_SPEED_RAW ? live_speed.breakpoint1 : 0)
                 // Second section
-                + (live_speed.breakpoint2 > 0 ? (live_speed.breakpoint2 - live_speed.breakpoint1) : 0)
+                + (live_speed.speed2 != UNKNOWN_TRAFFIC_SPEED_RAW
+                       ? (live_speed.breakpoint2 - live_speed.breakpoint1)
+                       : 0)
                 // Third section
                 + (live_speed.speed3 != baldr::UNKNOWN_TRAFFIC_SPEED_RAW
                        ? (255 - live_speed.breakpoint2)

--- a/valhalla/baldr/traffictile.h
+++ b/valhalla/baldr/traffictile.h
@@ -64,15 +64,16 @@ struct TrafficSpeed {
   uint64_t spare : 1;
 
 #ifndef C_ONLY_INTERFACE
-  inline bool valid() const volatile {
-    return breakpoint1 != 0;
+  inline bool speed_valid() const volatile {
+    return breakpoint1 != 0 && overall_speed != UNKNOWN_TRAFFIC_SPEED_RAW;
   }
+
   inline bool closed() const volatile {
-    return valid() && overall_speed == 0;
+    return breakpoint1 != 0 && overall_speed == 0;
   }
 
   inline bool closed(std::size_t subsegment) const volatile {
-    if (!valid())
+    if (!speed_valid())
       return false;
     switch (subsegment) {
       case 0:
@@ -99,7 +100,7 @@ struct TrafficSpeed {
    * @return returns the speed of the subsegment or UNKNOWN_TRAFFIC_SPEED_KPH if unknown
    */
   inline uint8_t get_speed(std::size_t subsegment) const volatile {
-    if (!valid())
+    if (!speed_valid())
       return UNKNOWN_TRAFFIC_SPEED_KPH;
     switch (subsegment) {
       case 0:
@@ -136,7 +137,7 @@ struct TrafficSpeed {
 
   json::MapPtr json() const volatile {
     auto live_speed = json::map({});
-    if (valid()) {
+    if (speed_valid()) {
       live_speed->emplace("overall_speed", static_cast<uint64_t>(get_overall_speed()));
       auto speed = static_cast<uint64_t>(get_speed(0));
       if (speed == UNKNOWN_TRAFFIC_SPEED_KPH)


### PR DESCRIPTION
# Issue

Some live traffic feeds may contain congestion information, but not speed info.  The checks for validity in `GetSpeed()` made incorrect assumptions about which live traffic fields would be set.  This PR fixes that.

## Tasklist

 - [x] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
