### PR TITLE
Do not skip connections in bidiastar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
    * FIXED: Fix crash in loki when trace_route is called with 2 locations.[#2817](https://github.com/valhalla/valhalla/pull/2817)
    * FIXED: Mark the restriction start and end as via ways to fix IsBridgingEdge function in Bidirectional Astar [#2796](https://github.com/valhalla/valhalla/pull/2796)
    * FIXED: Dont add predictive traffic to the tile if it's empty [#2826](https://github.com/valhalla/valhalla/pull/2826)
+   * FIXED: Fix logic bidirectional astar to avoid double u-turns and extra detours [#2802](https://github.com/valhalla/valhalla/pull/2802)
 
 * **Enhancement**
    * CHANGED: Azure uses ninja as generator [#2779](https://github.com/valhalla/valhalla/pull/2779)

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -603,6 +603,9 @@ BidirectionalAStar::GetBestPath(valhalla::Location& origin,
       if (forward_pred_idx != kInvalidLabel) {
         fwd_pred = edgelabels_forward_[forward_pred_idx];
 
+        // Forward path to this edge can't be improved, so we can settle it right now.
+        edgestatus_forward_.Update(fwd_pred.edgeid(), EdgeSet::kPermanent);
+
         // Terminate if the cost threshold has been exceeded.
         if (fwd_pred.sortcost() + cost_diff_ > threshold_) {
           return FormPath(graphreader, options, origin, destination, forward_time_info, invariant);
@@ -632,6 +635,9 @@ BidirectionalAStar::GetBestPath(valhalla::Location& origin,
       reverse_pred_idx = adjacencylist_reverse_.pop();
       if (reverse_pred_idx != kInvalidLabel) {
         rev_pred = edgelabels_reverse_[reverse_pred_idx];
+
+        // Reverse path to this edge can't be improved, so we can settle it right now.
+        edgestatus_reverse_.Update(rev_pred.edgeid(), EdgeSet::kPermanent);
 
         // Terminate if the cost threshold has been exceeded.
         if (rev_pred.sortcost() > threshold_) {
@@ -665,9 +671,6 @@ BidirectionalAStar::GetBestPath(valhalla::Location& origin,
       expand_forward = true;
       expand_reverse = false;
 
-      // Settle this edge.
-      edgestatus_forward_.Update(fwd_pred.edgeid(), EdgeSet::kPermanent);
-
       // setting this edge as settled
       if (expansion_callback_) {
         expansion_callback_(graphreader, "bidirectional_astar", fwd_pred.edgeid(), "s", false);
@@ -687,9 +690,6 @@ BidirectionalAStar::GetBestPath(valhalla::Location& origin,
       // Expand reverse - set to get next edge from reverse adj. list on the next pass
       expand_forward = false;
       expand_reverse = true;
-
-      // Settle this edge
-      edgestatus_reverse_.Update(rev_pred.edgeid(), EdgeSet::kPermanent);
 
       // setting this edge as settled, sending the opposing because this is the reverse tree
       if (expansion_callback_) {

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -758,7 +758,7 @@ bool BidirectionalAStar::SetForwardConnection(GraphReader& graphreader, const BD
 
   // Set a threshold to extend search
   if (threshold_ == std::numeric_limits<float>::max()) {
-    threshold_ = (pred.sortcost() + cost_diff_) + kThresholdDelta;
+    threshold_ = std::max(pred.sortcost() + cost_diff_, opp_pred.sortcost()) + kThresholdDelta;
   }
 
   // setting this edge as connected
@@ -811,7 +811,7 @@ bool BidirectionalAStar::SetReverseConnection(GraphReader& graphreader, const BD
 
   // Set a threshold to extend search
   if (threshold_ == std::numeric_limits<float>::max()) {
-    threshold_ = rev_pred.sortcost() + kThresholdDelta;
+    threshold_ = std::max(rev_pred.sortcost(), fwd_pred.sortcost() + cost_diff_) + kThresholdDelta;
   }
 
   // setting this edge as connected, sending the opposing because this is the reverse tree

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -1193,6 +1193,15 @@ bool IsBridgingEdgeRestricted(GraphReader& graphreader,
       break;
     }
 
+    // Check for double u-turn. It might happen in the following case:
+    // forward and reverse searches traverse edges that belong to the same complex
+    // restriction. Then forward/reverse search reaches last edge and due to the
+    // restriction can't go futher and make a u-turn. After that forward and reverse
+    // searches meet at some edge and compose double u-turn.
+    if (std::find(patch_path.begin(), patch_path.end(), next_rev_pred.opp_edgeid()) !=
+        patch_path.end())
+      return true;
+
     // Since we are on the reverse expansion here, we want the opp_edgeid
     // since we're tracking everything in the forward direction
     const auto edgeid = next_rev_pred.opp_edgeid();

--- a/test/astar.cc
+++ b/test/astar.cc
@@ -1067,6 +1067,15 @@ TEST(Astar, TestBacktrackComplexRestrictionForwardDetourAfterRestriction) {
 
     verify_paths(paths);
   }
+  {
+    vt::BidirectionalAStar astar;
+    auto paths = astar
+                     .GetBestPath(*options.mutable_locations(0), *options.mutable_locations(1),
+                                  *reader, costs, mode)
+                     .front();
+
+    verify_paths(paths);
+  }
 }
 
 Api timed_access_restriction_ny(const std::string& mode, const std::string& datetime) {

--- a/test/gurka/gurka.cc
+++ b/test/gurka/gurka.cc
@@ -415,7 +415,6 @@ to_string(const ::google::protobuf::RepeatedPtrField<::valhalla::StreetName>& st
 }
 
 std::vector<std::string> get_path(const valhalla::Api& result) {
-  assert(result.trip().routes(0).legs_size() == 1);
   std::vector<std::string> actual_names;
   for (const auto& leg : result.trip().routes(0).legs()) {
     for (const auto& node : leg.node()) {

--- a/test/gurka/gurka.cc
+++ b/test/gurka/gurka.cc
@@ -414,6 +414,19 @@ to_string(const ::google::protobuf::RepeatedPtrField<::valhalla::StreetName>& st
   return str;
 }
 
+std::vector<std::string> get_path(const valhalla::Api& result) {
+  assert(result.trip().routes(0).legs_size() == 1);
+  std::vector<std::string> actual_names;
+  for (const auto& leg : result.trip().routes(0).legs()) {
+    for (const auto& node : leg.node()) {
+      if (node.has_edge()) {
+        actual_names.push_back(detail::to_string(node.edge().name()));
+      }
+    }
+  }
+  return actual_names;
+}
+
 } // namespace detail
 
 /**
@@ -989,16 +1002,7 @@ void expect_eta(const valhalla::Api& result,
  */
 void expect_path(const valhalla::Api& result, const std::vector<std::string>& expected_names) {
   EXPECT_EQ(result.trip().routes_size(), 1);
-
-  std::vector<std::string> actual_names;
-  for (const auto& leg : result.trip().routes(0).legs()) {
-    for (const auto& node : leg.node()) {
-      if (node.has_edge()) {
-        actual_names.push_back(detail::to_string(node.edge().name()));
-      }
-    }
-  }
-
+  const auto actual_names = detail::get_path(result);
   EXPECT_EQ(actual_names, expected_names) << "Actual path didn't match expected path";
 }
 

--- a/test/gurka/gurka.h
+++ b/test/gurka/gurka.h
@@ -90,6 +90,13 @@ void build_pbf(const nodelayout& node_locations,
                const relations& relations,
                const std::string& filename,
                const uint64_t initial_osm_id = 0);
+
+/**
+ * Extract list of edge names from route result.
+ * @param result the result of a /route or /match request
+ * @return list of edge names
+ */
+std::vector<std::string> get_path(const valhalla::Api& result);
 } // namespace detail
 
 /**

--- a/test/gurka/test_recost.cc
+++ b/test/gurka/test_recost.cc
@@ -53,7 +53,7 @@ TEST(recosting, same_historical) {
     for (const auto& n : api.trip().routes(0).legs(0).node()) {
       EXPECT_EQ(n.recosts_size(), 1);
       EXPECT_NEAR(n.cost().elapsed_cost().seconds(), n.recosts(0).elapsed_cost().seconds(), 0.0001);
-      EXPECT_NEAR(n.cost().elapsed_cost().cost(), n.recosts(0).elapsed_cost().cost(), 0.0001);
+      EXPECT_EQ(n.cost().elapsed_cost().cost(), n.recosts(0).elapsed_cost().cost());
       EXPECT_EQ(n.cost().transition_cost().seconds(), n.recosts(0).transition_cost().seconds());
       EXPECT_EQ(n.cost().transition_cost().cost(), n.recosts(0).transition_cost().cost());
       if (n.has_edge()) {

--- a/test/gurka/test_recost.cc
+++ b/test/gurka/test_recost.cc
@@ -53,7 +53,7 @@ TEST(recosting, same_historical) {
     for (const auto& n : api.trip().routes(0).legs(0).node()) {
       EXPECT_EQ(n.recosts_size(), 1);
       EXPECT_NEAR(n.cost().elapsed_cost().seconds(), n.recosts(0).elapsed_cost().seconds(), 0.0001);
-      EXPECT_EQ(n.cost().elapsed_cost().cost(), n.recosts(0).elapsed_cost().cost());
+      EXPECT_NEAR(n.cost().elapsed_cost().cost(), n.recosts(0).elapsed_cost().cost(), 0.0001);
       EXPECT_EQ(n.cost().transition_cost().seconds(), n.recosts(0).transition_cost().seconds());
       EXPECT_EQ(n.cost().transition_cost().cost(), n.recosts(0).transition_cost().cost());
       if (n.has_edge()) {

--- a/test/gurka/test_route.cc
+++ b/test/gurka/test_route.cc
@@ -576,7 +576,6 @@ TEST(Standalone, AvoidExtraDetours) {
   not_thru_edgeids.push_back(std::get<0>(gurka::findEdgeByNodes(*reader, nodes, "B", "A")));
   not_thru_edgeids.push_back(std::get<0>(gurka::findEdgeByNodes(*reader, nodes, "D", "E")));
   not_thru_edgeids.push_back(std::get<0>(gurka::findEdgeByNodes(*reader, nodes, "E", "F")));
-  // not_thru_edgeids.push_back(std::get<0>(gurka::findEdgeByNodes(*reader, nodes, "E", "G")));
 
   test::customize_edges(map.config, [&not_thru_edgeids](const GraphId& edgeid, DirectedEdge& edge) {
     if (std::find(not_thru_edgeids.begin(), not_thru_edgeids.end(), edgeid) != not_thru_edgeids.end())

--- a/test/test.h
+++ b/test/test.h
@@ -88,4 +88,7 @@ using HistoricalTrafficCustomize = std::function<std::array<float, kBucketsPerWe
 void customize_historical_traffic(const boost::property_tree::ptree& config,
                                   const HistoricalTrafficCustomize& cb);
 
+using EdgesCustomize = std::function<void(const GraphId&, DirectedEdge&)>;
+void customize_edges(const boost::property_tree::ptree& config, const EdgesCustomize& setter_cb);
+
 } // namespace test


### PR DESCRIPTION
# Issue

This PR should fix 2 bugs:
**1) for some cases bidirastar builds extra detours.**

After debugging:
in bidirectional astar: we mark edge as `permanent` only before call expansion method. But it's not correct, because we can mark edge earlier right after we popped this edge from the queue.

Current behavior may loose some connections in the following case: let's suppose `A->B->C->D` is the part of the shortest route. On some iteration we popped `B->C` label as `fwd_pred` from the forward queue. Then we applied reverse search from the node `C` (suppose cost for `D->C` less than cost for `B->C`). Then we popped `C->B` label as `rev_pred` from the reverse queue. And, looks like now we should set the connection `B->C`, but we don't do it because the edge `B->C` hasn't marked as `permanent` for now. So, we skip this and continue forward expansion from the node `C`.

So, now imagine that we have 2 not-thru regions `A` and `B` and one connection edge between these regions. In some cases if we skip this connection path cannot be found or may be found with extra detour.

**2) For some cases bidirastar returns pathes with double u-turns.**

It happens due to the following: let's suppose we have a complex restriction `no_u_turn: from AB via BC to CD`. Then, forward search reaches `BC`, checks that it's a deadend (because of the restriction) and makes a u-turn `CB`. After that reverse search reaches `CB`, checks that it's a deadend (because of the restriction), makes a u-turn `BC` and meets `CB` edge from forward search. So, now we have the following path: `AB -> BC -> CB -> BC -> CD` - there is no rule to forbid such path so we accept it. 

## Tasklist

 - [x] Add tests
 - [x] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
