### PR TITLE
thor::serialize_to_pbf should only be enabled if HAVE_HTTP 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * **Removed**
 
 * **Bug Fix**
+   * FIXED: Fix compiler errors if HAVE_HTTP not enabled [#2807](https://github.com/valhalla/valhalla/pull/2807)
 
 * **Enhancement**
 

--- a/src/thor/worker.cc
+++ b/src/thor/worker.cc
@@ -52,6 +52,7 @@ const std::unordered_map<std::string, float> kMaxDistances = {
 // a scale factor to apply to the score so that we bias towards closer results more
 constexpr float kDistanceScale = 10.f;
 
+#ifdef HAVE_HTTP
 std::string serialize_to_pbf(Api& request) {
   std::string buf;
   if (!request.SerializeToString(&buf)) {
@@ -61,6 +62,7 @@ std::string serialize_to_pbf(Api& request) {
   }
   return buf;
 };
+#endif
 
 } // namespace
 


### PR DESCRIPTION
...to avoid 'defined but not used' compiler errors.

cc @kevinkreiser @PureW 