### PR TITLE
Fix Recently Added Valhalla Alternates Serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 * **Bug Fix**
    * FIXED: Fix compiler errors if HAVE_HTTP not enabled [#2807](https://github.com/valhalla/valhalla/pull/2807)
+   * FIXED: Fix alternate route serialization [#2811](https://github.com/valhalla/valhalla/pull/2811)
 
 * **Enhancement**
 

--- a/src/tyr/route_serializer_valhalla.cc
+++ b/src/tyr/route_serializer_valhalla.cc
@@ -549,16 +549,16 @@ std::string serialize(const Api& api) {
     writer.start_object("trip");
 
     // the locations in the trip
-    locations(api, 0, writer);
+    locations(api, i, writer);
 
     // the actual meat of the route
-    legs(api, 0, writer);
+    legs(api, i, writer);
 
     // openlr references of the edges in the route
-    valhalla::tyr::openlr(api, 0, writer);
+    valhalla::tyr::openlr(api, i, writer);
 
     // summary time/distance and other stats
-    summary(api, 0, writer);
+    summary(api, i, writer);
 
     writer.end_object(); // trip
 

--- a/src/tyr/route_serializer_valhalla.cc
+++ b/src/tyr/route_serializer_valhalla.cc
@@ -1,7 +1,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include "baldr/json.h"
 #include "midgard/aabb2.h"
 #include "midgard/logging.h"
 #include "odin/util.h"
@@ -538,7 +537,6 @@ void legs(const valhalla::Api& api, int route_index, rapidjson::writer_wrapper_t
 std::string serialize(const Api& api) {
   // build up the json object, reserve 4k bytes
   rapidjson::writer_wrapper_t writer(4096);
-  writer.start_object();
 
   // for each route
   for (int i = 0; i < api.directions().routes_size(); ++i) {
@@ -546,7 +544,8 @@ std::string serialize(const Api& api) {
       writer.start_array("alternates");
     }
 
-    // the main route
+    // the route itself
+    writer.start_object();
     writer.start_object("trip");
 
     // the locations in the trip
@@ -562,6 +561,11 @@ std::string serialize(const Api& api) {
     summary(api, 0, writer);
 
     writer.end_object(); // trip
+
+    // leave space for alternates by closing this one outside the loop
+    if (i > 0) {
+      writer.end_object();
+    }
   }
 
   if (api.directions().routes_size() > 1) {

--- a/test/alternates.cc
+++ b/test/alternates.cc
@@ -56,6 +56,11 @@ void test_alternates(int num_alternates) {
   auto response = tester.test(request, json);
   const auto& routes = response.trip().routes();
   ASSERT_EQ(routes.size(), num_alternates + 1);
+  std::unordered_set<std::string> shapes;
+  for (const auto& route : routes) {
+    shapes.insert(route.legs(0).shape());
+  }
+  ASSERT_EQ(shapes.size(), num_alternates + 1);
 
   rapidjson::Document doc;
   doc.Parse(json);


### PR DESCRIPTION
In adding #2734 we needed a way to represent alternate routes in the valhalla serializer. In the first iteration of that PR it was added while we were still using the old json serializer. Before I merged the PR though many other PRs made it into master which caused a huge merge parade. As a part of that merge process I needed to reconcile the new json serialization (using rapidjson) with the old code. I thought I had done that but infact I was wrong and there wasnt any test coverage of it. I've added test coverage in this pr and also fixed the serialization.