### PR TITLE
An Experiment in More Alternates on Longer Routes

### DIFF
--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -23,6 +23,7 @@ constexpr uint32_t kInitialEdgeLabelCountBD = 1000000;
 // the PA Turnpike which have very long edges). Using a metric based on maximum edge
 // cost creates large performance drops - so perhaps some other metric can be found?
 constexpr float kThresholdDelta = 420.0f;
+constexpr float kExtendSearch = 1.02f;
 
 inline float find_percent_along(const valhalla::Location& location, const GraphId& edge_id) {
   for (const auto& e : location.path_edges()) {
@@ -758,7 +759,7 @@ bool BidirectionalAStar::SetForwardConnection(GraphReader& graphreader, const BD
 
   // Set a threshold to extend search
   if (threshold_ == std::numeric_limits<float>::max()) {
-    threshold_ = (pred.sortcost() + cost_diff_) + kThresholdDelta;
+    threshold_ = (pred.sortcost() + cost_diff_) * kExtendSearch; // + kThresholdDelta;
   }
 
   // setting this edge as connected
@@ -811,7 +812,7 @@ bool BidirectionalAStar::SetReverseConnection(GraphReader& graphreader, const BD
 
   // Set a threshold to extend search
   if (threshold_ == std::numeric_limits<float>::max()) {
-    threshold_ = rev_pred.sortcost() + kThresholdDelta;
+    threshold_ = rev_pred.sortcost() * kExtendSearch; // + kThresholdDelta;
   }
 
   // setting this edge as connected, sending the opposing because this is the reverse tree


### PR DESCRIPTION
Currently when we search for alternate routes we rely on a hardcoded extension of the search past the first shortest path that we find. At the moment that extension is hardcoded to "approximately" 7 minutes (not exactly because its cost units so YMMV).

The problem with this approach is that it assumes one size fits all for all routes. If you have a short route we will check for paths up to 420 cost units greater than the best path we found. That path may only be a couple hundred cost units large so this is a significant extension of the search. For longer routes though, that additional searching doesnt amount to much. Instead we end up almost never finding viable alternates for longer routes (as the alternates have to be very close in cost but also different enough in terms of the path taken).

Intuitively we should base this extension of the search on the same criteria we use to judge whether or not an alternate is viable (at least in the case alternates are requested (SEE SIDE NOTE). I've not really done that  yet here I just wanted to see what playing with the values could do for longer routes. This is what I get if I simply scale the best paths cost by 1.02 to extend the search:

![image](https://user-images.githubusercontent.com/697548/105942288-ec0c7900-602c-11eb-817c-c625024024c1.png)

Previously we only returned a single route here but now we have 3 alternates. This does of course come at the cost of time spend expanding the graph. The time for such a cross country route went from 130ms to 200ms. Quite significant in my opinion but I didnt do any type of scientific measurements just a quick in browser reading. Also this change almost entirely removes alternates for short routes as the extension is so short it makes no difference in the overall scheme of things.

We should see if we can make some more complex rules as to how we extend the search to either find more alternates in certain scenarios. It seems at current we can only offer this for short and medium length routes. It seems we need an extension that is inversely proportional to the length/cost of the route. So a short route might extend to 1.5x cost units while a longer route might only need 1.01x.

SIDE NOTE: Extending the search is not only done for the sake of finding alternates. We also do it because it can sometimes lead to finding a better main route candidate, this is likely due to the use of shortcuts or hierarchy culling or bucketized costing in the queue or lack of precision in floating point numbers when the values become high or moonbeams and unicorns.