### PR TITLE
Add support for closure annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
    * CHANGED: Throw an exception if directory does not exist when building traffic extract [#2871](https://github.com/valhalla/valhalla/pull/2871)
    * CHANGED: Support for ignoring multiple consecutive closures at start/end locations [#2846](https://github.com/valhalla/valhalla/pull/2846)
    * ADDED: Ukrainian language translations [#2882](https://github.com/valhalla/valhalla/pull/2882)
+   * ADDED: Add support for closure annotations [#2816](https://github.com/valhalla/valhalla/pull/2816)
 
 ## Release Date: 2021-01-25 Valhalla 3.1.0
 * **Removed**

--- a/proto/trip.proto
+++ b/proto/trip.proto
@@ -319,6 +319,11 @@ message TripLeg {
     optional uint32 end_shape_index = 4;
   };
 
+  message Closure {
+    optional uint32 begin_shape_index = 1;
+    optional uint32 end_shape_index = 2;
+  };
+
   optional uint64 osm_changeset = 1;
   optional uint64 trip_id = 2;
   optional uint32 leg_id = 3;
@@ -331,6 +336,7 @@ message TripLeg {
   optional ShapeAttributes shape_attributes = 10;
   repeated Incident incidents = 11;
   repeated string algorithms = 12;
+  repeated Closure closures = 13;
 }
 
 message TripRoute {

--- a/src/thor/attributes_controller.cc
+++ b/src/thor/attributes_controller.cc
@@ -131,6 +131,7 @@ const std::unordered_map<std::string, bool> AttributesController::kDefaultAttrib
     {kShapeAttributesLength, false},
     {kShapeAttributesSpeed, false},
     {kShapeAttributesSpeedLimit, false},
+    {kShapeAttributesClosure, false},
 };
 
 AttributesController::AttributesController() {

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -773,6 +773,21 @@ void serializeIncidents(const google::protobuf::RepeatedPtrField<TripLeg::Incide
   doc.emplace("incidents", serialized_incidents);
 }
 
+void serializeClosures(const valhalla::TripLeg& leg, json::Jmap& doc) {
+  if (!leg.closures_size()) {
+    return;
+  }
+  auto closures = json::array({});
+  closures->reserve(leg.closures_size());
+  for (const valhalla::TripLeg_Closure& closure : leg.closures()) {
+    auto closure_obj = json::map({});
+    closure_obj->emplace("geometry_index_start", static_cast<uint64_t>(closure.begin_shape_index()));
+    closure_obj->emplace("geometry_index_end", static_cast<uint64_t>(closure.end_shape_index()));
+    closures->emplace_back(std::move(closure_obj));
+  }
+  doc.emplace("closures", closures);
+}
+
 // Compile and return the refs of the specified list
 // TODO we could enhance by limiting results by using consecutive count
 std::string get_sign_element_refs(const google::protobuf::RepeatedPtrField<
@@ -1594,6 +1609,9 @@ json::ArrayPtr serialize_legs(const google::protobuf::RepeatedPtrField<valhalla:
 
     // Add incidents to the leg
     serializeIncidents(path_leg.incidents(), *output_leg);
+
+    // Add closures
+    serializeClosures(path_leg, *output_leg);
 
     // Keep the leg
     output_legs->emplace_back(std::move(output_leg));

--- a/test/gurka/CMakeLists.txt
+++ b/test/gurka/CMakeLists.txt
@@ -12,6 +12,7 @@ if(ENABLE_DATA_TOOLS)
     set_source_files_properties(
       test_route_incidents.cc
       test_incident_loading.cc
+      test_closure_annotations.cc
     PROPERTIES COMPILE_FLAGS "-Werror")
   endif (UNIX)
 

--- a/test/gurka/test_closure_annotations.cc
+++ b/test/gurka/test_closure_annotations.cc
@@ -9,7 +9,7 @@ using LiveTrafficCustomize = test::LiveTrafficCustomize;
 
 namespace {
 
-  inline void SetLiveSpeedFrom(baldr::TrafficSpeed* live_speed, uint8_t speed, uint8_t breakpoint1) {
+inline void SetLiveSpeedFrom(baldr::TrafficSpeed* live_speed, uint8_t speed, uint8_t breakpoint1) {
   live_speed->breakpoint1 = breakpoint1;
   live_speed->breakpoint2 = 255;
   live_speed->speed2 = speed >> 1;

--- a/test/gurka/test_closure_annotations.cc
+++ b/test/gurka/test_closure_annotations.cc
@@ -211,17 +211,6 @@ const std::string req_with_closure_annotations = R"({
 }
 )";
 
-#include "rapidjson/stringbuffer.h"
-#include "rapidjson/writer.h"
-#include <iostream>
-
-void print_json(const rapidjson::Document& doc) {
-  rapidjson::StringBuffer buffer;
-  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-  doc.Accept(writer);
-  std::cout << buffer.GetString() << std::endl;
-}
-
 void expect_closures(const rapidjson::Document& response,
                      const std::vector<std::pair<int, int>>& expected_closures,
                      int expected_coord_count) {

--- a/test/gurka/test_closure_annotations.cc
+++ b/test/gurka/test_closure_annotations.cc
@@ -9,29 +9,53 @@ using LiveTrafficCustomize = test::LiveTrafficCustomize;
 
 namespace {
 
-inline void
-SetSubsegmentLiveSpeed(baldr::TrafficSpeed* live_speed, uint64_t speed, uint8_t subsegment) {
+inline void SetLiveSpeedFrom(baldr::TrafficSpeed* live_speed, uint64_t speed, uint8_t subsegment) {
   live_speed->breakpoint1 = subsegment;
-  live_speed->overall_speed = speed >> 1;
+  live_speed->breakpoint2 = 255;
+  live_speed->speed2 = speed >> 1;
+  live_speed->speed3 = UNKNOWN_TRAFFIC_SPEED_RAW;
+}
+
+inline void SetLiveSpeedUpto(baldr::TrafficSpeed* live_speed, uint64_t speed, uint8_t subsegment) {
+  live_speed->breakpoint1 = subsegment;
   live_speed->speed1 = speed >> 1;
 }
 
 inline void SetLiveSpeed(baldr::TrafficSpeed* live_speed, uint64_t speed) {
-  SetSubsegmentLiveSpeed(live_speed, speed, 255);
+  live_speed->breakpoint1 = 255;
+  live_speed->overall_speed = speed >> 1;
+  live_speed->speed1 = speed >> 1;
 }
 
-void close_partial_dir_edge(baldr::GraphReader& reader,
-                            baldr::TrafficTile& tile,
-                            uint32_t index,
-                            double percent_along,
-                            baldr::TrafficSpeed* current,
-                            const std::string& edge_name,
-                            const std::string& start_node,
-                            const gurka::map& map) {
+void close_partial_dir_edge_from(baldr::GraphReader& reader,
+                                 baldr::TrafficTile& tile,
+                                 uint32_t index,
+                                 double percent_along,
+                                 baldr::TrafficSpeed* current,
+                                 const std::string& edge_name,
+                                 const std::string& end_node,
+                                 const gurka::map& map) {
   baldr::GraphId tile_id(tile.header->tile_id);
-  auto edge = std::get<0>(gurka::findEdge(reader, map.nodes, edge_name, start_node));
+  auto edge = std::get<0>(gurka::findEdge(reader, map.nodes, edge_name, end_node));
   if (edge.Tile_Base() == tile_id && edge.id() == index) {
-    SetSubsegmentLiveSpeed(current, 0, static_cast<uint8_t>(255 * percent_along));
+    uint8_t subsegment = static_cast<uint8_t>(255 * percent_along);
+    SetLiveSpeedFrom(current, 0, subsegment);
+  }
+}
+
+void close_partial_dir_edge_upto(baldr::GraphReader& reader,
+                                 baldr::TrafficTile& tile,
+                                 uint32_t index,
+                                 double percent_along,
+                                 baldr::TrafficSpeed* current,
+                                 const std::string& edge_name,
+                                 const std::string& end_node,
+                                 const gurka::map& map) {
+  baldr::GraphId tile_id(tile.header->tile_id);
+  auto edge = std::get<0>(gurka::findEdge(reader, map.nodes, edge_name, end_node));
+  if (edge.Tile_Base() == tile_id && edge.id() == index) {
+    uint8_t subsegment = static_cast<uint8_t>(255 * percent_along);
+    SetLiveSpeedUpto(current, 0, subsegment);
   }
 }
 
@@ -40,9 +64,13 @@ void close_dir_edge(baldr::GraphReader& reader,
                     uint32_t index,
                     baldr::TrafficSpeed* current,
                     const std::string& edge_name,
-                    const std::string& start_node,
+                    const std::string& end_node,
                     const gurka::map& map) {
-  close_partial_dir_edge(reader, tile, index, 1., current, edge_name, start_node, map);
+  baldr::GraphId tile_id(tile.header->tile_id);
+  auto edge = std::get<0>(gurka::findEdge(reader, map.nodes, edge_name, end_node));
+  if (edge.Tile_Base() == tile_id && edge.id() == index) {
+    SetLiveSpeed(current, 0);
+  }
 }
 
 void close_bidir_edge(baldr::GraphReader& reader,
@@ -71,15 +99,15 @@ protected:
   static void SetUpTestSuite() {
     const std::string ascii_map = R"(
 
-    A-1----2-B
-             |
-             3
-             |
-             C
-             |
-             4
-             |
-             D-5----6-E
+     A-1----2-B
+              |
+              3
+              |
+              C
+              |
+              4
+              |
+              D-5---E
     )";
 
     const std::string speed_str = std::to_string(default_speed);
@@ -108,30 +136,28 @@ protected:
   virtual void SetUp() {
     set_default_speed_on_all_edges();
 
-    // Partially(50%) close 12
+    // Partially close AB from 50%
     test::customize_live_traffic_data(closure_map.config,
                                       [](baldr::GraphReader& reader, baldr::TrafficTile& tile,
                                          uint32_t index, baldr::TrafficSpeed* current) -> void {
-                                        // close_partial_dir_edge(reader, tile, index, 0.5, current,
-                                        // "AB", "B", closure_map);
-                                        close_partial_dir_edge(reader, tile, index, 0.5, current,
-                                                               "AB", "B", closure_map);
+                                        close_partial_dir_edge_from(reader, tile, index, 0.5, current,
+                                                                    "AB", "B", closure_map);
                                       });
 
-#if 0
     // Fully close BC
     test::customize_live_traffic_data(closure_map.config,
                                       [](baldr::GraphReader& reader, baldr::TrafficTile& tile,
                                          uint32_t index, baldr::TrafficSpeed* current) -> void {
-      close_bidir_edge(reader, tile, index, current, "BC", closure_map);
+                                        close_bidir_edge(reader, tile, index, current, "BC",
+                                                         closure_map);
                                       });
-    // Partially(50%) close DE
+    // Partially close DE upto 50%
     test::customize_live_traffic_data(closure_map.config,
                                       [](baldr::GraphReader& reader, baldr::TrafficTile& tile,
                                          uint32_t index, baldr::TrafficSpeed* current) -> void {
-      close_partial_dir_edge(reader, tile, index, 0.5, current, "DE", "D", closure_map);
+                                        close_partial_dir_edge_upto(reader, tile, index, 0.5, current,
+                                                                    "DE", "E", closure_map);
                                       });
-#endif
   }
 
   virtual void TearDown() {
@@ -185,6 +211,37 @@ const std::string req_with_closure_annotations = R"({
 }
 )";
 
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/writer.h"
+#include <iostream>
+
+void print_json(const rapidjson::Document& doc) {
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+  doc.Accept(writer);
+  std::cout << buffer.GetString() << std::endl;
+}
+
+void expect_closures(const rapidjson::Document& response,
+                     const std::vector<std::pair<int, int>>& expected_closures,
+                     int expected_coord_count) {
+  auto route = response["routes"][0].GetObject();
+  auto leg = route["legs"][0].GetObject();
+  size_t num_coordinates = route["geometry"]["coordinates"].Size();
+  size_t num_closures = leg["closures"].Size();
+
+  ASSERT_EQ(num_coordinates, expected_coord_count);
+  ASSERT_EQ(num_closures, expected_closures.size());
+  int idx = 0;
+  for (const auto& start_end_pair : expected_closures) {
+    EXPECT_EQ(leg["closures"][idx]["geometry_index_start"].GetInt(), start_end_pair.first);
+    EXPECT_EQ(leg["closures"][idx]["geometry_index_end"].GetInt(), start_end_pair.second);
+    idx++;
+  }
+  auto last_closure = leg["closures"][num_closures - 1].GetObject();
+  ASSERT_LE(last_closure["geometry_index_end"].GetInt(), num_coordinates);
+}
+
 TEST_F(ClosureAnnotations, EndOnClosure) {
   const std::string& req =
       (boost::format(req_with_closure_annotations) % std::to_string(closure_map.nodes.at("1").lat()) %
@@ -195,5 +252,76 @@ TEST_F(ClosureAnnotations, EndOnClosure) {
   auto result = gurka::do_action(Options::route, closure_map, req, reader);
   gurka::assert::raw::expect_path(result, {"AB"});
 
-  // rapidjson::Document response = gurka::convert_to_json(result, valhalla::Options_Format_osrm);
+  rapidjson::Document response = gurka::convert_to_json(result, valhalla::Options_Format_osrm);
+  expect_closures(response, {{1, 2}}, 3);
+}
+
+TEST_F(ClosureAnnotations, EndWithConsecutiveClosures) {
+  const std::string& req =
+      (boost::format(req_with_closure_annotations) % std::to_string(closure_map.nodes.at("1").lat()) %
+       std::to_string(closure_map.nodes.at("1").lng()) %
+       std::to_string(closure_map.nodes.at("3").lat()) %
+       std::to_string(closure_map.nodes.at("3").lng()))
+          .str();
+  auto result = gurka::do_action(Options::route, closure_map, req, reader);
+  gurka::assert::raw::expect_path(result, {"AB", "BC"});
+
+  rapidjson::Document response = gurka::convert_to_json(result, valhalla::Options_Format_osrm);
+  expect_closures(response, {{1, 3}}, 4);
+}
+
+TEST_F(ClosureAnnotations, IntermediateClosure) {
+  const std::string& req =
+      (boost::format(req_with_closure_annotations) % std::to_string(closure_map.nodes.at("1").lat()) %
+       std::to_string(closure_map.nodes.at("1").lng()) %
+       std::to_string(closure_map.nodes.at("4").lat()) %
+       std::to_string(closure_map.nodes.at("4").lng()))
+          .str();
+  auto result = gurka::do_action(Options::route, closure_map, req, reader);
+  gurka::assert::raw::expect_path(result, {"AB", "BC", "CD"});
+
+  rapidjson::Document response = gurka::convert_to_json(result, valhalla::Options_Format_osrm);
+  expect_closures(response, {{1, 3}}, 5);
+}
+
+TEST_F(ClosureAnnotations, BeginAtClosure) {
+  const std::string& req =
+      (boost::format(req_with_closure_annotations) % std::to_string(closure_map.nodes.at("2").lat()) %
+       std::to_string(closure_map.nodes.at("2").lng()) %
+       std::to_string(closure_map.nodes.at("4").lat()) %
+       std::to_string(closure_map.nodes.at("4").lng()))
+          .str();
+  auto result = gurka::do_action(Options::route, closure_map, req, reader);
+  gurka::assert::raw::expect_path(result, {"AB", "BC", "CD"});
+
+  rapidjson::Document response = gurka::convert_to_json(result, valhalla::Options_Format_osrm);
+  expect_closures(response, {{0, 2}}, 4);
+}
+
+TEST_F(ClosureAnnotations, AllWithinClosure) {
+  const std::string& req =
+      (boost::format(req_with_closure_annotations) % std::to_string(closure_map.nodes.at("2").lat()) %
+       std::to_string(closure_map.nodes.at("2").lng()) %
+       std::to_string(closure_map.nodes.at("3").lat()) %
+       std::to_string(closure_map.nodes.at("3").lng()))
+          .str();
+  auto result = gurka::do_action(Options::route, closure_map, req, reader);
+  gurka::assert::raw::expect_path(result, {"AB", "BC"});
+
+  rapidjson::Document response = gurka::convert_to_json(result, valhalla::Options_Format_osrm);
+  expect_closures(response, {{0, 2}}, 3);
+}
+
+TEST_F(ClosureAnnotations, DiscontinuousClosures) {
+  const std::string& req =
+      (boost::format(req_with_closure_annotations) % std::to_string(closure_map.nodes.at("A").lat()) %
+       std::to_string(closure_map.nodes.at("A").lng()) %
+       std::to_string(closure_map.nodes.at("E").lat()) %
+       std::to_string(closure_map.nodes.at("E").lng()))
+          .str();
+  auto result = gurka::do_action(Options::route, closure_map, req, reader);
+  gurka::assert::raw::expect_path(result, {"AB", "BC", "CD", "DE"});
+
+  rapidjson::Document response = gurka::convert_to_json(result, valhalla::Options_Format_osrm);
+  expect_closures(response, {{1, 3}, {4, 5}}, 7);
 }

--- a/test/gurka/test_closure_annotations.cc
+++ b/test/gurka/test_closure_annotations.cc
@@ -115,7 +115,7 @@ protected:
                                         // close_partial_dir_edge(reader, tile, index, 0.5, current,
                                         // "AB", "B", closure_map);
                                         close_partial_dir_edge(reader, tile, index, 0.5, current,
-                                                               "AB", "A", closure_map);
+                                                               "AB", "B", closure_map);
                                       });
 
 #if 0

--- a/test/gurka/test_closure_annotations.cc
+++ b/test/gurka/test_closure_annotations.cc
@@ -1,0 +1,199 @@
+#include "gurka.h"
+#include "test.h"
+
+#include <boost/format.hpp>
+#include <gtest/gtest.h>
+
+using namespace valhalla;
+using LiveTrafficCustomize = test::LiveTrafficCustomize;
+
+namespace {
+
+inline void
+SetSubsegmentLiveSpeed(baldr::TrafficSpeed* live_speed, uint64_t speed, uint8_t subsegment) {
+  live_speed->breakpoint1 = subsegment;
+  live_speed->overall_speed = speed >> 1;
+  live_speed->speed1 = speed >> 1;
+}
+
+inline void SetLiveSpeed(baldr::TrafficSpeed* live_speed, uint64_t speed) {
+  SetSubsegmentLiveSpeed(live_speed, speed, 255);
+}
+
+void close_partial_dir_edge(baldr::GraphReader& reader,
+                            baldr::TrafficTile& tile,
+                            uint32_t index,
+                            double percent_along,
+                            baldr::TrafficSpeed* current,
+                            const std::string& edge_name,
+                            const std::string& start_node,
+                            const gurka::map& map) {
+  baldr::GraphId tile_id(tile.header->tile_id);
+  auto edge = std::get<0>(gurka::findEdge(reader, map.nodes, edge_name, start_node));
+  if (edge.Tile_Base() == tile_id && edge.id() == index) {
+    SetSubsegmentLiveSpeed(current, 0, static_cast<uint8_t>(255 * percent_along));
+  }
+}
+
+void close_dir_edge(baldr::GraphReader& reader,
+                    baldr::TrafficTile& tile,
+                    uint32_t index,
+                    baldr::TrafficSpeed* current,
+                    const std::string& edge_name,
+                    const std::string& start_node,
+                    const gurka::map& map) {
+  close_partial_dir_edge(reader, tile, index, 1., current, edge_name, start_node, map);
+}
+
+void close_bidir_edge(baldr::GraphReader& reader,
+                      baldr::TrafficTile& tile,
+                      uint32_t index,
+                      baldr::TrafficSpeed* current,
+                      const std::string& edge_name,
+                      const gurka::map& map) {
+  baldr::GraphId tile_id(tile.header->tile_id);
+  std::string start_node(1, edge_name.front());
+  std::string end_node(1, edge_name.back());
+
+  close_dir_edge(reader, tile, index, current, edge_name, start_node, map);
+  close_dir_edge(reader, tile, index, current, edge_name, end_node, map);
+}
+
+} // namespace
+
+class ClosureAnnotations : public ::testing::Test {
+protected:
+  static gurka::map closure_map;
+  static int const default_speed;
+  static std::string const tile_dir;
+  static std::shared_ptr<baldr::GraphReader> reader;
+
+  static void SetUpTestSuite() {
+    const std::string ascii_map = R"(
+
+    A-1----2-B
+             |
+             3
+             |
+             C
+             |
+             4
+             |
+             D-5----6-E
+    )";
+
+    const std::string speed_str = std::to_string(default_speed);
+    const gurka::ways ways = {{"AB", {{"highway", "primary"}, {"maxspeed", speed_str}}},
+                              {"BC", {{"highway", "primary"}, {"maxspeed", speed_str}}},
+                              {"CD", {{"highway", "primary"}, {"maxspeed", speed_str}}},
+                              {"DE", {{"highway", "primary"}, {"maxspeed", speed_str}}}};
+
+    const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100, {.05f, .2f});
+    closure_map = gurka::buildtiles(layout, ways, {}, {}, tile_dir);
+
+    closure_map.config.put("mjolnir.traffic_extract", tile_dir + "/traffic.tar");
+    test::build_live_traffic_data(closure_map.config);
+
+    reader = test::make_clean_graphreader(closure_map.config.get_child("mjolnir"));
+  }
+
+  void set_default_speed_on_all_edges() {
+    test::customize_live_traffic_data(closure_map.config,
+                                      [](baldr::GraphReader&, baldr::TrafficTile&, uint32_t,
+                                         baldr::TrafficSpeed* current) -> void {
+                                        SetLiveSpeed(current, default_speed);
+                                      });
+  }
+
+  virtual void SetUp() {
+    set_default_speed_on_all_edges();
+
+    // Partially(50%) close 12
+    test::customize_live_traffic_data(closure_map.config,
+                                      [](baldr::GraphReader& reader, baldr::TrafficTile& tile,
+                                         uint32_t index, baldr::TrafficSpeed* current) -> void {
+                                        // close_partial_dir_edge(reader, tile, index, 0.5, current,
+                                        // "AB", "B", closure_map);
+                                        close_partial_dir_edge(reader, tile, index, 0.5, current,
+                                                               "AB", "A", closure_map);
+                                      });
+
+#if 0
+    // Fully close BC
+    test::customize_live_traffic_data(closure_map.config,
+                                      [](baldr::GraphReader& reader, baldr::TrafficTile& tile,
+                                         uint32_t index, baldr::TrafficSpeed* current) -> void {
+      close_bidir_edge(reader, tile, index, current, "BC", closure_map);
+                                      });
+    // Partially(50%) close DE
+    test::customize_live_traffic_data(closure_map.config,
+                                      [](baldr::GraphReader& reader, baldr::TrafficTile& tile,
+                                         uint32_t index, baldr::TrafficSpeed* current) -> void {
+      close_partial_dir_edge(reader, tile, index, 0.5, current, "DE", "D", closure_map);
+                                      });
+#endif
+  }
+
+  virtual void TearDown() {
+    set_default_speed_on_all_edges();
+  }
+};
+
+gurka::map ClosureAnnotations::closure_map = {};
+const int ClosureAnnotations::default_speed = 36;
+const std::string ClosureAnnotations::tile_dir = "test/data/closure_annotations";
+std::shared_ptr<baldr::GraphReader> ClosureAnnotations::reader;
+
+const std::string req_without_closure_annotations = R"({
+  "locations": [
+    {"lat": %s, "lon": %s},
+    {"lat": %s, "lon": %s}
+  ],
+  "costing": "auto",
+  "costing_options": {
+    "auto": {
+      "speed_types": [ "freeflow", "constrained", "predicted", "current"],
+      "ignore_closures": true
+    }
+  },
+  "date_time": { "type": 3, "value": "current" },
+  "format": "osrm"
+}
+)";
+
+const std::string req_with_closure_annotations = R"({
+  "locations": [
+    {"lat": %s, "lon": %s},
+    {"lat": %s, "lon": %s}
+  ],
+  "costing": "auto",
+  "costing_options": {
+    "auto": {
+      "speed_types": [ "freeflow", "constrained", "predicted", "current"],
+      "ignore_closures": true
+    }
+  },
+  "date_time": { "type": 3, "value": "current" },
+  "format": "osrm",
+  "shape_format": "geojson",
+  "filters": {
+    "attributes": [
+      "shape_attributes.closure"
+    ],
+    "action": "include"
+  }
+}
+)";
+
+TEST_F(ClosureAnnotations, EndOnClosure) {
+  const std::string& req =
+      (boost::format(req_with_closure_annotations) % std::to_string(closure_map.nodes.at("1").lat()) %
+       std::to_string(closure_map.nodes.at("1").lng()) %
+       std::to_string(closure_map.nodes.at("2").lat()) %
+       std::to_string(closure_map.nodes.at("2").lng()))
+          .str();
+  auto result = gurka::do_action(Options::route, closure_map, req, reader);
+  gurka::assert::raw::expect_path(result, {"AB"});
+
+  // rapidjson::Document response = gurka::convert_to_json(result, valhalla::Options_Format_osrm);
+}

--- a/test/gurka/test_closure_annotations.cc
+++ b/test/gurka/test_closure_annotations.cc
@@ -9,19 +9,19 @@ using LiveTrafficCustomize = test::LiveTrafficCustomize;
 
 namespace {
 
-inline void SetLiveSpeedFrom(baldr::TrafficSpeed* live_speed, uint64_t speed, uint8_t subsegment) {
-  live_speed->breakpoint1 = subsegment;
+  inline void SetLiveSpeedFrom(baldr::TrafficSpeed* live_speed, uint8_t speed, uint8_t breakpoint1) {
+  live_speed->breakpoint1 = breakpoint1;
   live_speed->breakpoint2 = 255;
   live_speed->speed2 = speed >> 1;
   live_speed->speed3 = UNKNOWN_TRAFFIC_SPEED_RAW;
 }
 
-inline void SetLiveSpeedUpto(baldr::TrafficSpeed* live_speed, uint64_t speed, uint8_t subsegment) {
-  live_speed->breakpoint1 = subsegment;
+inline void SetLiveSpeedUpto(baldr::TrafficSpeed* live_speed, uint8_t speed, uint8_t breakpoint1) {
+  live_speed->breakpoint1 = breakpoint1;
   live_speed->speed1 = speed >> 1;
 }
 
-inline void SetLiveSpeed(baldr::TrafficSpeed* live_speed, uint64_t speed) {
+inline void SetLiveSpeed(baldr::TrafficSpeed* live_speed, uint8_t speed) {
   live_speed->breakpoint1 = 255;
   live_speed->overall_speed = speed >> 1;
   live_speed->speed1 = speed >> 1;
@@ -38,8 +38,8 @@ void close_partial_dir_edge_from(baldr::GraphReader& reader,
   baldr::GraphId tile_id(tile.header->tile_id);
   auto edge = std::get<0>(gurka::findEdge(reader, map.nodes, edge_name, end_node));
   if (edge.Tile_Base() == tile_id && edge.id() == index) {
-    uint8_t subsegment = static_cast<uint8_t>(255 * percent_along);
-    SetLiveSpeedFrom(current, 0, subsegment);
+    uint8_t breakpoint1 = static_cast<uint8_t>(255 * percent_along);
+    SetLiveSpeedFrom(current, 0, breakpoint1);
   }
 }
 
@@ -54,8 +54,8 @@ void close_partial_dir_edge_upto(baldr::GraphReader& reader,
   baldr::GraphId tile_id(tile.header->tile_id);
   auto edge = std::get<0>(gurka::findEdge(reader, map.nodes, edge_name, end_node));
   if (edge.Tile_Base() == tile_id && edge.id() == index) {
-    uint8_t subsegment = static_cast<uint8_t>(255 * percent_along);
-    SetLiveSpeedUpto(current, 0, subsegment);
+    uint8_t breakpoint1 = static_cast<uint8_t>(255 * percent_along);
+    SetLiveSpeedUpto(current, 0, breakpoint1);
   }
 }
 

--- a/valhalla/thor/attributes_controller.h
+++ b/valhalla/thor/attributes_controller.h
@@ -136,6 +136,7 @@ const std::string kShapeAttributesTime = "shape_attributes.time";
 const std::string kShapeAttributesLength = "shape_attributes.length";
 const std::string kShapeAttributesSpeed = "shape_attributes.speed";
 const std::string kShapeAttributesSpeedLimit = "shape_attributes.speed_limit";
+const std::string kShapeAttributesClosure = "shape_attributes.closure";
 
 // Categories
 const std::string kNodeCategory = "node.";


### PR DESCRIPTION
Adds a new shape attribute filter for getting closure locations in the
directions response. Similar to incidents, each closure annotation has
a start & end geometry index, which indexes into the coordinates list.