### PR TITLE
Fix trace_route crash with 2 locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 * **Bug Fix**
    * FIXED: Fix compiler errors if HAVE_HTTP not enabled [#2807](https://github.com/valhalla/valhalla/pull/2807)
+   * FIXED: Fix crash in loki when trace_route is called with 2 locations.
 
 * **Enhancement**
 

--- a/src/loki/trace_route_action.cc
+++ b/src/loki/trace_route_action.cc
@@ -212,7 +212,7 @@ void loki_worker_t::locations_from_shape(Api& request) {
         GraphId edgeid(e.graph_id());
         graph_tile_ptr tile = reader->GetGraphTile(edgeid);
         const DirectedEdge* de = tile->directededge(edgeid);
-        auto& shape = tile->edgeinfo(de->edgeinfo_offset()).shape();
+        auto shape = tile->edgeinfo(de->edgeinfo_offset()).shape();
         auto closest = orig_ll.ClosestPoint(shape);
 
         // TODO - consider consolidating side of street logic into a common method
@@ -239,7 +239,7 @@ void loki_worker_t::locations_from_shape(Api& request) {
         GraphId edgeid(e.graph_id());
         graph_tile_ptr tile = reader->GetGraphTile(edgeid);
         const DirectedEdge* de = tile->directededge(edgeid);
-        auto& shape = tile->edgeinfo(de->edgeinfo_offset()).shape();
+        auto shape = tile->edgeinfo(de->edgeinfo_offset()).shape();
         auto closest = dest_ll.ClosestPoint(shape);
 
         // TODO - consider consolidating side of street logic into a common method


### PR DESCRIPTION

# Issue

Fix crash in trace_route when 2 locations are provided along with the trace shape. Make a copy of shape since edgeinfo object goes out of scope.

#fixes #2814

## Tasklist

 - [ ] Add tests
 - [x] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
