### PR TITLE
more test fixes for historical traffic regression

### DIFF
--- a/test/gurka/test_recost.cc
+++ b/test/gurka/test_recost.cc
@@ -32,7 +32,7 @@ TEST(recosting, same_historical) {
     e.set_speed(55);
     e.set_constrained_flow_speed(10);
     // TODO: add historical 5 minutely buckets
-    return std::array<float, kBucketsPerWeek>{};
+    return boost::none;
   });
 
   // run a route and check that the costs are the same for the same options

--- a/test/gurka/test_use_tracks.cc
+++ b/test/gurka/test_use_tracks.cc
@@ -43,7 +43,7 @@ protected:
     test::customize_historical_traffic(use_tracks_map.config, [](baldr::DirectedEdge& e) {
       e.set_free_flow_speed(40);
       e.set_constrained_flow_speed(40);
-      return std::array<float, kBucketsPerWeek>{};
+      return boost::none;
     });
   }
 };

--- a/test/test.cc
+++ b/test/test.cc
@@ -557,11 +557,11 @@ void customize_historical_traffic(const boost::property_tree::ptree& config,
     for (const auto& edge : tile.GetDirectedEdges()) {
       edges.push_back(edge);
       const auto historical = cb(edges.back());
-      if (historical.size() == kBucketsPerWeek) {
-        auto coefs = valhalla::baldr::compress_speed_buckets(historical.data());
+      if (historical) {
+        auto coefs = valhalla::baldr::compress_speed_buckets(historical->data());
         tile.AddPredictedSpeed(edges.size() - 1, coefs, tile.header()->directededgecount());
       }
-      edges.back().set_has_predicted_speed(!historical.empty());
+      edges.back().set_has_predicted_speed(historical.has_value());
     }
     tile.UpdatePredictedSpeeds(edges);
   }

--- a/test/test.h
+++ b/test/test.h
@@ -84,7 +84,8 @@ using LiveTrafficCustomize = std::function<void(valhalla::baldr::GraphReader&,
 void customize_live_traffic_data(const boost::property_tree::ptree& config,
                                  const LiveTrafficCustomize& setter_cb);
 
-using HistoricalTrafficCustomize = std::function<std::array<float, kBucketsPerWeek>(DirectedEdge&)>;
+using HistoricalTrafficCustomize =
+    std::function<boost::optional<std::array<float, kBucketsPerWeek>>(DirectedEdge&)>;
 void customize_historical_traffic(const boost::property_tree::ptree& config,
                                   const HistoricalTrafficCustomize& cb);
 


### PR DESCRIPTION
this is an addendum to a previous fix that @merkispavel did in #2826 for the regression that i introduced in #2712 basically it does the same thing but also for the test helper functions