### PR TITLE
Fix compression_utils.cc::inflate(...) throw - make it catchable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * **Removed**
 
 * **Bug Fix**
+   * FIXED: Fix compression_utils.cc::inflate(...) throw - make it catchable [#2839](https://github.com/valhalla/valhalla/pull/2839)
    * FIXED: Fix compiler errors if HAVE_HTTP not enabled [#2807](https://github.com/valhalla/valhalla/pull/2807)
    * FIXED: Fix alternate route serialization [#2811](https://github.com/valhalla/valhalla/pull/2811)
    * FIXED: Store restrictions in the right tile [#2781](https://github.com/valhalla/valhalla/pull/2781)

--- a/src/baldr/compression_utils.cc
+++ b/src/baldr/compression_utils.cc
@@ -83,7 +83,7 @@ bool inflate(const std::function<void(z_stream&)>& src_func,
       if (stream.avail_in == 0)
         src_func(stream);
       if (stream.avail_in == 0)
-        throw;
+        throw std::exception();
     } catch (...) {
       inflateEnd(&stream);
       return false;

--- a/test/compression.cc
+++ b/test/compression.cc
@@ -95,6 +95,9 @@ TEST(Compression, fail_inflate) {
     s.next_in = static_cast<Byte*>(static_cast<void*>(&bad[0]));
     s.avail_in = static_cast<unsigned int>(bad.size() * sizeof(std::string::value_type));
   };
+  auto inflate_src_fail3 = [](z_stream& s) -> void {
+    /* Nothing to do, simulates 'cannot inflate' - reproducible if no disk space. */
+  };
   auto inflate_dst_fail = [](z_stream& s) -> int {
     throw std::runtime_error("im the gingerbread man");
     return Z_NO_FLUSH;
@@ -124,6 +127,13 @@ TEST(Compression, fail_inflate) {
       valhalla::baldr::inflate(std::bind(inflate_src, std::placeholders::_1, std::ref(deflated)),
                                inflate_dst_fail))
       << "dst should fail";
+
+  bool inflate_result;
+  EXPECT_NO_THROW(
+      inflate_result =
+          valhalla::baldr::inflate(inflate_src_fail3, std::bind(inflate_dst, std::placeholders::_1,
+                                                                std::ref(inflated))));
+  EXPECT_FALSE(inflate_result);
 }
 
 } // namespace


### PR DESCRIPTION
# Issue

In the `compression_utils.cc::inflate(...)` body:
```
try {
  if (stream.avail_in == 0)
    src_func(stream);
  if (stream.avail_in == 0)
    throw;
} catch (...) {
  inflateEnd(&stream);
  return false;
}
```
The `throw;` expression cannot be caught in further `catch (...)` block - it rethrows exception to the next level (https://en.cppreference.com/w/cpp/language/throw - "its compound-statement is considered to have been 'exited' ").
But from the `inflate(...)` declaration and definition it seems like the intention is to handle this exception and return `false`, isn't it?
If the expression `throw std::exception();` is used instead - this exception is catchable in further `catch (...)` block, it can be handled, so the `inflate(...)` returns `false` without exception rethrowing.

The added unit test expectation (test/compression.cc) fails on old version of the `compression_utils.cc::inflate(...)` (exception is thrown outside), but succeeds with current update.

## Tasklist

 - [x] Add tests
 - [x] Update the [changelog](CHANGELOG.md)
