### PR TITLE
Remove allocation/sizing of mapped_cache when no elevation source is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
    * ADDED: Add Bulgarian locale [#2825](https://github.com/valhalla/valhalla/pull/2825)
    * FIXED: No need for write permissions on tarball indices [#2822](https://github.com/valhalla/valhalla/pull/2822)
    * ADDED: Add costing option `use_living_streets` to avoid or favor living streets in route. [#2788](https://github.com/valhalla/valhalla/pull/2788)
+   * CHANGED: Do not allocate mapped_cache vector in skadi when no elevation source is provided. [#2841](https://github.com/valhalla/valhalla/pull/2841)
 
 ## Release Date: 2021-01-25 Valhalla 3.1.0
 * **Removed**

--- a/src/skadi/sample.cc
+++ b/src/skadi/sample.cc
@@ -81,12 +81,19 @@ namespace valhalla {
 namespace skadi {
 
 ::valhalla::skadi::sample::sample(const std::string& data_source)
-    : mapped_cache(TILE_COUNT), unzipped_cache(-1, std::vector<int16_t>()), data_source(data_source) {
+    : unzipped_cache(-1, std::vector<int16_t>()), data_source(data_source) {
   // messy but needed
   while (this->data_source.size() &&
          this->data_source.back() == filesystem::path::preferred_separator) {
     this->data_source.pop_back();
   }
+
+  // If data_source is empty, do not allocate/resize mapped cache.
+  if (data_source.empty()) {
+    LOG_DEBUG("No elevation data_source was provided");
+    return;
+  }
+  mapped_cache.resize(TILE_COUNT);
 
   // check the directory for files that look like what we need
   auto files = get_files(data_source);


### PR DESCRIPTION
For embedded use where skadi elevation is not present, we want to remove allocation for mapped_cache and return. When additional_data.elevation is empty or not in the config we do not allocate/resize the mapped_cache vector.

# Issue

What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
