### PR TITLE
Binary Artifacts Docker Image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,48 +13,28 @@ commands:
       - run: brew install protobuf cmake ccache libtool boost-python libspatialite pkg-config luajit curl wget czmq lz4 spatialite-tools unzip
 
 jobs:
-  build-base:
+  build-docker-images:
     docker:
       - image: docker:18.06.3-ce-git
     steps:
       - setup_remote_docker
       - checkout
       - run:
-          name: Build Valhalla base Dockerfile
+          name: Build Valhalla Docker Images
           command: |
             docker build -f ./docker/Dockerfile-build --tag valhalla/valhalla:build-latest ./docker
-      - run:
-          name: Push Valhalla base image
-          command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-              docker push valhalla/valhalla:build-latest
-            elif [[ ! -z "${CIRCLE_TAG}" ]]; then
-              echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-              docker push valhalla/valhalla:build-${CIRCLE_TAG}
-            fi
-
-  build-binary:
-    requires: build-base
-    docker:
-      - image: docker:18.06.3-ce-git
-    steps:
-      - setup_remote_docker
-      - checkout
-      - run:
-          name: Build Valhalla binary artifacts Dockerfile
-          command: |
             if [[ "${CIRCLE_BRANCH}" == "master" ]] || [[ ! -z "${CIRCLE_TAG}" ]]; then
               docker build -f ./docker/Dockerfile-run --tag valhalla/valhalla:run-latest .
             fi
       - run:
-          name: Push Valhalla binary artifacts image
+          name: Push Valhalla Docker Images
           command: |
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+              docker push valhalla/valhalla:build-latest
               docker push valhalla/valhalla:run-latest
             elif [[ ! -z "${CIRCLE_TAG}" ]]; then
-              echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+              docker push valhalla/valhalla:build-${CIRCLE_TAG}
               docker push valhalla/valhalla:run-${CIRCLE_TAG}
             fi
 
@@ -238,7 +218,7 @@ workflows:
   version: 2
   build_test_publish:
     jobs:
-      - build-base
+      - build-docker-images
       - lint-build-debug
       - build-release
       - build-osx

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,33 @@ jobs:
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
               echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
               docker push valhalla/valhalla:build-latest
+            elif [[ ! -z "${CIRCLE_TAG}" ]]; then
+              echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+              docker push valhalla/valhalla:build-${CIRCLE_TAG}
+            fi
+
+  build-binary:
+    requires: build-base
+    docker:
+      - image: docker:18.06.3-ce-git
+    steps:
+      - setup_remote_docker
+      - checkout
+      - run:
+          name: Build Valhalla binary artifacts Dockerfile
+          command: |
+            if [[ "${CIRCLE_BRANCH}" == "master" ]] || [[ ! -z "${CIRCLE_TAG}" ]]; then
+              docker build -f ./docker/Dockerfile-run --tag valhalla/valhalla:run-latest .
+            fi
+      - run:
+          name: Push Valhalla binary artifacts image
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+              docker push valhalla/valhalla:run-latest
+            elif [[ ! -z "${CIRCLE_TAG}" ]]; then
+              echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+              docker push valhalla/valhalla:run-${CIRCLE_TAG}
             fi
 
   build-release-binary-linux:

--- a/docker/Dockerfile-run
+++ b/docker/Dockerfile-run
@@ -29,6 +29,7 @@ RUN tar -cvf valhalla.debug.tar valhalla_*.debug && gzip -9 valhalla.debug.tar
 RUN rm -f valhalla_*.debug
 RUN strip --strip-debug --strip-unneeded valhalla_* || true
 RUN strip /usr/local/lib/libvalhalla.a
+RUN strip /usr/local/lib/python3.8/dist-packages/python_valhalla.cpython-38-x86_64-linux-gnu.so
 
 ####################################################################
 # copy the important stuff from the build stage to the runner image

--- a/docker/Dockerfile-run
+++ b/docker/Dockerfile-run
@@ -36,12 +36,16 @@ RUN strip /usr/local/lib/python3.8/dist-packages/python_valhalla.cpython-38-x86_
 FROM ubuntu:20.04 as runner
 MAINTAINER Kevin Kreiser <kevinkreiser@gmail.com>
 COPY --from=builder /usr/local /usr/local
+COPY --from=builder /usr/bin/prime_* /usr/bin/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libprime* /usr/lib/x86_64-linux-gnu/
 
 # we need to add back some runtime dependencies for binaries and scripts
-RUN apt update && apt install -y software-properties-common
-RUN add-apt-repository -y ppa:valhalla-core/valhalla && apt update
-RUN apt install -y libboost-program-options1.71.0 libcurl3-gnutls libluajit-5.1-2 libprotobuf-lite17 libsqlite3-0 libsqlite3-mod-spatialite zlib1g
-RUN apt install -y curl gdb locales parallel prime-server-bin python spatialite-bin unzip wget
-
 # install all the posix locales that we support
-RUN cat /usr/local/src/valhalla_locales | xargs -d '\n' -n1 locale-gen
+RUN export DEBIAN_FRONTEND=noninteractive && apt update && \
+    apt install -y \
+      libboost-program-options1.71.0 libcurl4 libczmq4 libluajit-5.1-2 \
+      libprotobuf-lite17 libsqlite3-0 libsqlite3-mod-spatialite libzmq5 zlib1g \
+      curl gdb locales parallel python3.8-minimal python-is-python3 \
+      spatialite-bin unzip wget && \
+    cat /usr/local/src/valhalla_locales | xargs -d '\n' -n1 locale-gen && \
+    rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile-run
+++ b/docker/Dockerfile-run
@@ -1,0 +1,46 @@
+####################################################################
+# base image contains all the dependencies we need to build the code
+FROM valhalla/valhalla:build-3.0.9 as builder
+MAINTAINER Kevin Kreiser <kevinkreiser@gmail.com>
+
+# get the code into the right place and prepare to build it
+WORKDIR /usr/local/src/valhalla
+ADD . /usr/local/src/valhalla
+RUN ls
+RUN git submodule sync && git submodule update --init --recursive
+RUN mkdir build
+
+# configure the build with symbols turned on so that crashes can be triaged
+WORKDIR /usr/local/src/valhalla/build
+RUN cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo
+RUN make all -j$(nproc)
+RUN make install
+
+# we wont leave the source around but we'll drop the commit hash we'll also keep the locales
+WORKDIR /usr/local/src
+RUN cd valhalla && echo "https://github.com/valhalla/valhalla/tree/$(git rev-parse HEAD)" > ../valhalla_version
+RUN for f in valhalla/locales/*.json; do cat ${f} | python3 -c 'import sys; import json; print(json.load(sys.stdin)["posix_locale"])'; done > valhalla_locales
+RUN rm -rf valhalla
+
+# the binaries are huge with all the symbols so we strip them but keep the debug there if we need it
+WORKDIR /usr/local/bin
+RUN for f in valhalla_*; do objcopy --only-keep-debug $f $f.debug; done
+RUN tar -cvf valhalla.debug.tar valhalla_*.debug && gzip -9 valhalla.debug.tar
+RUN rm -f valhalla_*.debug
+RUN strip --strip-debug --strip-unneeded valhalla_* || true
+RUN strip /usr/local/lib/libvalhalla.a
+
+####################################################################
+# copy the important stuff from the build stage to the runner image
+FROM ubuntu:20.04 as runner
+MAINTAINER Kevin Kreiser <kevinkreiser@gmail.com>
+COPY --from=builder /usr/local /usr/local
+
+# we need to add back some runtime dependencies for binaries and scripts
+RUN apt update && apt install -y software-properties-common
+RUN add-apt-repository -y ppa:valhalla-core/valhalla && apt update
+RUN apt install -y libboost-program-options1.71.0 libcurl3-gnutls libluajit-5.1-2 libprotobuf-lite17 libsqlite3-0 libsqlite3-mod-spatialite zlib1g
+RUN apt install -y curl gdb locales parallel prime-server-bin python spatialite-bin unzip wget
+
+# install all the posix locales that we support
+RUN cat /usr/local/src/valhalla_locales | xargs -d '\n' -n1 locale-gen


### PR DESCRIPTION
Many others around the internet have made some nice docker images of valhalla for various purposes (heres one from @nilsnolde https://github.com/gis-ops/docker-valhalla/blob/master/Dockerfile). I'd like to make their lives a bit easier by making a generic image that has all of the binaries installed but doesnt actually run anything. Then all they have to do is grab this image to start with and figure out what exactly they want to run whether its data making or a server or CI or analytical stuff.

To that end a made a basic dockerfile here that accomplishes that. I tried to make the image reasonably small but still include debug information in case someone needs to triage a crash. Its a bit cumbersome as you have to gunzip the debug symbols but lets hope its few and far between. The final size of the image is 1.2gb. I'm sure more could be trimmed but we can get it in a follow up if anyone has ideas.