### PR TITLE
revert highway factor typo

### DIFF
--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -104,7 +104,7 @@ constexpr ranged_default_t<float> kUseDistanceRange{0, kDefaultUseDistance, 1.0f
 constexpr ranged_default_t<float> kUseLivingStreetsRange{0.f, kDefaultUseLivingStreets, 1.0f};
 
 constexpr float kHighwayFactor[] = {
-    10.0f, // Motorway
+    1.0f, // Motorway
     0.5f,  // Trunk
     0.0f,  // Primary
     0.0f,  // Secondary

--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -104,14 +104,14 @@ constexpr ranged_default_t<float> kUseDistanceRange{0, kDefaultUseDistance, 1.0f
 constexpr ranged_default_t<float> kUseLivingStreetsRange{0.f, kDefaultUseLivingStreets, 1.0f};
 
 constexpr float kHighwayFactor[] = {
-    1.0f,  // Motorway
-    0.5f,  // Trunk
-    0.0f,  // Primary
-    0.0f,  // Secondary
-    0.0f,  // Tertiary
-    0.0f,  // Unclassified
-    0.0f,  // Residential
-    0.0f   // Service, other
+    1.0f, // Motorway
+    0.5f, // Trunk
+    0.0f, // Primary
+    0.0f, // Secondary
+    0.0f, // Tertiary
+    0.0f, // Unclassified
+    0.0f, // Residential
+    0.0f  // Service, other
 };
 
 constexpr float kSurfaceFactor[] = {

--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -104,7 +104,7 @@ constexpr ranged_default_t<float> kUseDistanceRange{0, kDefaultUseDistance, 1.0f
 constexpr ranged_default_t<float> kUseLivingStreetsRange{0.f, kDefaultUseLivingStreets, 1.0f};
 
 constexpr float kHighwayFactor[] = {
-    1.0f, // Motorway
+    1.0f,  // Motorway
     0.5f,  // Trunk
     0.0f,  // Primary
     0.0f,  // Secondary


### PR DESCRIPTION
Once upon a time, i made a horrible horrible mistake:
https://github.com/valhalla/valhalla/pull/2026/files#diff-3b95c3b6cad47a8b18380f94765b22cb96a80fdbc8e2def2ed090756ac2cdca8R87

Which causes us to favor highways above anything else... It was so long ago that even though I've noticed it several times since then I had assumed it was always that way. :facepalm: 

Thanks to @dgearhart and @gknisely for noticing it and asking me about it!