### PR TITLE
Check parent dir exists before building live traffic extract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
    * ADDED: Added support for destination for conditional access restrictions [#2857](https://github.com/valhalla/valhalla/pull/2857)
    * CHANGED: Large sequences are now merge sorted which can be dramatically faster with certain hardware configurations. This is especially useful in speeding up the earlier stages (parsing, graph construction) of tile building [#2850](https://github.com/valhalla/valhalla/pull/2850)
    * CHANGED: When creating the intial graph edges by setting at which nodes they start and end, first mark the indices of those nodes in another sequence and then sort them by edgeid so that we can do the setting of start and end node sequentially in the edges file. This is much more efficient on certain hardware configurations [#2851](https://github.com/valhalla/valhalla/pull/2851)
+   * CHANGED: Throw an exception if directory does not exist when building traffic extract [#2871](https://github.com/valhalla/valhalla/pull/2871)
 
 ## Release Date: 2021-01-25 Valhalla 3.1.0
 * **Removed**

--- a/test/gurka/test_match.cc
+++ b/test/gurka/test_match.cc
@@ -168,7 +168,7 @@ protected:
                                 {"mjolnir.shortcuts", "false"},
                                 {"mjolnir.timezone", VALHALLA_BUILD_DIR "test/data/tz.sqlite"},
                             });
-    map.config.put("mjolnir.traffic_extract", "test/data/algorithm_selection/traffic.tar");
+    map.config.put("mjolnir.traffic_extract", "test/data/match_timedep/traffic.tar");
 
     // add live traffic
     test::build_live_traffic_data(map.config);

--- a/test/test.cc
+++ b/test/test.cc
@@ -21,6 +21,7 @@
 
 #include <boost/algorithm/string.hpp>
 
+#include "filesystem.h"
 #include "microtar.h"
 
 namespace {
@@ -438,6 +439,13 @@ void build_live_traffic_data(const boost::property_tree::ptree& config,
   std::string tile_dir = config.get<std::string>("mjolnir.tile_dir");
   std::string traffic_extract = config.get<std::string>("mjolnir.traffic_extract");
 
+  filesystem::path parent_dir = filesystem::path(traffic_extract).parent_path();
+  if (!filesystem::exists(parent_dir)) {
+    std::stringstream ss;
+    ss << "Traffic extract directory " << parent_dir.string() << " does not exist";
+    throw std::runtime_error(ss.str());
+  }
+
   // Begin by seeding the traffic file,
   // per-edge customizations come in the step after
   {
@@ -453,7 +461,7 @@ void build_live_traffic_data(const boost::property_tree::ptree& config,
     // Traffic data works like this:
     //   1. There is a separate .tar file containing tile entries matching the main tiles
     //   2. Each tile is a fixed-size, with a header, and entries
-    // This loop iterates ofer the routing tiles, and creates blank
+    // This loop iterates over the routing tiles, and creates blank
     // traffic tiles with empty records.
     // Valhalla mmap()'s this file and reads from it during route calculation.
     // This loop below creates initial .tar file entries .  Lower down, we make changes to


### PR DESCRIPTION
fopen (used within mtar_open) will fail if the parent directories don't
exist. Throw an exception if traffic extract directory does not exist.