### PR TITLE
Waypoints near edges with poor reachability leads to no route

### DIFF
--- a/test/gurka/test_reachability.cc
+++ b/test/gurka/test_reachability.cc
@@ -1,0 +1,43 @@
+#include "gurka.h"
+#include <gtest/gtest.h>
+
+using namespace valhalla;
+
+TEST(Reachability, dont_snap_waypoints_to_deadends) {
+  const std::string ascii_map = R"(
+  A--1-B-2--C
+      / \
+     D   E)";
+
+  // BE and EH are highway=path, so no cars
+  // EI is a shortcut that's not accessible to bikes
+  const gurka::ways ways = {{"AB", {{"highway", "primary"}}},
+                            {"BC", {{"highway", "primary"}}},
+                            {"BD", {{"highway", "secondary"}, {"oneway","yes"}}},
+                            {"BE", {{"highway", "secondary"}, {"oneway","-1"}}}};
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, 25);
+
+  auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/reachability");
+
+  {
+    // Verify simple waypoint routing works
+    auto result1 = gurka::do_action(valhalla::Options::route, map, {"A", "1", "C"}, "auto");
+    gurka::assert::raw::expect_path(result1, {"AB", "AB", "AB", "BC"});
+    auto result2 = gurka::do_action(valhalla::Options::route, map, {"A", "2", "C"}, "auto");
+    gurka::assert::raw::expect_path(result2, {"AB", "BC", "BC"});
+  }
+  {
+    // BD is a oneway leading away from ABC with no escape
+    // input coordinate at D should get snapped to the ABC way
+    // Should give the same result as A->1->C
+    auto result = gurka::do_action(valhalla::Options::route, map, {"A", "D", "C"}, "auto");
+    gurka::assert::raw::expect_path(result, {"AB", "AB", "AB", "BC"});
+  }
+  {
+    // BE is a oneway leading towards ABC with no way in
+    // input coordinate at E should get snapped to the ABC way
+    // Should give the same result as A->2->C
+    auto result = gurka::do_action(valhalla::Options::route, map, {"A", "E", "C"}, "auto");
+    gurka::assert::raw::expect_path(result, {"AB", "BC", "BC"});
+  }
+}

--- a/test/gurka/test_reachability.cc
+++ b/test/gurka/test_reachability.cc
@@ -9,8 +9,7 @@ TEST(Reachability, dont_snap_waypoints_to_deadends) {
       / \
      D   E)";
 
-  // BE and EH are highway=path, so no cars
-  // EI is a shortcut that's not accessible to bikes
+  // BD and BE are oneways that lead away, and toward the main road A-B-C
   const gurka::ways ways = {{"AB", {{"highway", "primary"}}},
                             {"BC", {{"highway", "primary"}}},
                             {"BD", {{"highway", "secondary"}, {"oneway","yes"}}},


### PR DESCRIPTION
# Issue

When a route waypoint that is not the source or origin is near an edge with dubious connectivity (like oneways-to-nowhere), we are still snapping to it.  This leads to us being able to route *to* that point from the origin, but not onward from that point to the next waypoint in a multi-waypoint route, leading to an overall routing failure.

What we should be doing here is snapping to a different location with better reachability.

So far, this PR just adds a test case that describes the problem.  Fix is still TODO.

## Tasklist

 - [x] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
