### PR TITLE
Decide at Runtime (based on storage config) What Thread Saftey is Required

### DIFF
--- a/valhalla/baldr/graphtileptr.h
+++ b/valhalla/baldr/graphtileptr.h
@@ -3,7 +3,6 @@
 // we type alias the tile pointers as they are ubiquitous throughout the library
 
 #include <boost/intrusive_ptr.hpp>
-#include <boost/smart_ptr/intrusive_ref_counter.hpp>
 
 namespace valhalla {
 namespace baldr {


### PR DESCRIPTION
fixes #2867

The idea here is that we want graphtile to know whether its reference counting should be threadsafe or not based on what tile cache created it. For virtually all tile caches except the `globally_synchronized_cache` thread unsafe reference counting is ok because there is only ever one reference to the graph tile.

At the moment i still need to figure out a way to keep the `GraphTIle` move assignable but the guts of the thread safe counting is prohibiting that..