### PR TITLE
Added documentation example of decoding encoded path shapes using R.

### DIFF
--- a/docs/decoding.md
+++ b/docs/decoding.md
@@ -161,3 +161,65 @@ def decode(encoded):
 
 print(decode(sys.argv[1]))
 ```
+
+## R
+
+Here is an example of decoding in R.
+
+``` r
+library(tidyverse)
+
+decode <- function(encoded) {
+  chars <- stringr::str_split(encoded, "")[[1]]
+  lats <- vector(mode = "integer", length = 1)
+  lons <- vector(mode = "integer", length = 1)
+  i <- 0
+  
+  while (i < length(chars)){
+    shift <- 0
+    result <- 0
+    byte <- 0x20L
+    
+    while (byte >= 0x20) {  
+      i <- i + 1
+      byte <- chars[[i]] %>% utf8ToInt() - 63
+      result <- bitwOr(result, bitwAnd(byte, 0x1f) %>% bitwShiftL(shift))
+      shift <- shift + 5
+      if (byte < 0x20) break
+    }
+    
+    if (bitwAnd(result, 1)) {
+      result <- result %>% bitwShiftR(1) %>% bitwNot()
+    } else {
+      result <- result %>% bitwShiftR(1)
+    }
+    
+    lats <- c(lats, (lats[[length(lats)]] + result))
+    
+    shift <- 0
+    result <- 0
+    byte <- 10000L
+    
+    while (byte >= 0x20) {  
+      i <- i + 1
+      byte <- chars[[i]] %>% utf8ToInt() - 63
+      result <- bitwOr(result, bitwAnd(byte, 0x1f) %>% bitwShiftL(shift))
+      shift <- shift + 5
+      if (byte < 0x20) break
+    }
+    
+    if (bitwAnd(result, 1)) {
+      result <- result %>% bitwShiftR(1) %>% bitwNot()
+    } else {
+      result <- result %>% bitwShiftR(1)
+    }
+    
+    lons <- c(lons, (lons[[length(lons)]] + result))
+  }
+  
+  decoded <- tibble::tibble(lat = lats[2:length(lats)]/1000000,
+                            lng = lons[2:length(lons)]/1000000)
+  
+  return (decoded)
+}
+```


### PR DESCRIPTION
This PR adds an example of how to decode Valhalla's encoded paths using R to the documentation. It's a straightforward (i.e. not optimized) R implementation of the path decoding algorithm used in the examples for the other languages. I've tested it and it worked fine.

Since this is just a minor addition to the documentation, please let me know if you need anything else from me.