### PR TITLE
Add edgeinfo overload

### DIFF
--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -792,7 +792,7 @@ std::string GraphReader::encoded_edge_shape(const valhalla::baldr::GraphId& edge
   }
 
   const baldr::DirectedEdge* directedEdge = t_debug->directededge(edgeid);
-  auto shape = t_debug->edgeinfo(directedEdge->edgeinfo_offset()).shape();
+  auto shape = t_debug->edgeinfo(directedEdge).shape();
   if (!directedEdge->forward()) {
     std::reverse(shape.begin(), shape.end());
   }
@@ -886,7 +886,7 @@ AABB2<PointLL> GraphReader::GetMinimumBoundingBox(const AABB2<PointLL>& bb) {
         // Look at the shape of each edge leaving the node
         const auto* diredge = tile->directededge(node->edge_index());
         for (uint32_t i = 0; i < node->edge_count(); i++, diredge++) {
-          auto shape = tile->edgeinfo(diredge->edgeinfo_offset()).lazy_shape();
+          auto shape = tile->edgeinfo(diredge).lazy_shape();
           while (!shape.empty()) {
             min_bb.Expand(shape.pop());
           }

--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -614,6 +614,10 @@ EdgeInfo GraphTile::edgeinfo(const size_t offset) const {
   return EdgeInfo(edgeinfo_ + offset, textlist_, textlist_size_);
 }
 
+EdgeInfo GraphTile::edgeinfo(const DirectedEdge* edge) const {
+  return edgeinfo(edge->edgeinfo_offset());
+}
+
 // Get the complex restrictions in the forward or reverse order based on
 // the id and modes.
 std::vector<ComplexRestriction*>

--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -295,7 +295,7 @@ struct bin_handler_t {
         // get some info about this edge and the opposing
         GraphId id = tile->id();
         id.set_id(node->edge_index() + (edge - start_edge));
-        auto info = tile->edgeinfo(edge->edgeinfo_offset());
+        auto info = tile->edgeinfo(edge);
         // calculate the heading of the snapped point to the shape for use in heading filter
         size_t index = edge->forward() ? 0 : info.shape().size() - 2;
         float angle =
@@ -527,7 +527,7 @@ struct bin_handler_t {
       // a trivial half plane test as maybe a single dot product and comparison?
 
       // get some shape of the edge
-      auto edge_info = std::make_shared<const EdgeInfo>(tile->edgeinfo(edge->edgeinfo_offset()));
+      auto edge_info = std::make_shared<const EdgeInfo>(tile->edgeinfo(edge));
       auto shape = edge_info->lazy_shape();
       PointLL v;
       if (!shape.empty()) {

--- a/src/loki/trace_route_action.cc
+++ b/src/loki/trace_route_action.cc
@@ -214,7 +214,7 @@ void loki_worker_t::locations_from_shape(Api& request) {
         GraphId edgeid(e.graph_id());
         graph_tile_ptr tile = reader->GetGraphTile(edgeid);
         const DirectedEdge* de = tile->directededge(edgeid);
-        auto shape = tile->edgeinfo(de->edgeinfo_offset()).shape();
+        auto shape = tile->edgeinfo(de).shape();
         auto closest = orig_ll.ClosestPoint(shape);
 
         // TODO - consider consolidating side of street logic into a common method
@@ -241,7 +241,7 @@ void loki_worker_t::locations_from_shape(Api& request) {
         GraphId edgeid(e.graph_id());
         graph_tile_ptr tile = reader->GetGraphTile(edgeid);
         const DirectedEdge* de = tile->directededge(edgeid);
-        auto shape = tile->edgeinfo(de->edgeinfo_offset()).shape();
+        auto shape = tile->edgeinfo(de).shape();
         auto closest = dest_ll.ClosestPoint(shape);
 
         // TODO - consider consolidating side of street logic into a common method

--- a/src/meili/candidate_search.cc
+++ b/src/meili/candidate_search.cc
@@ -59,7 +59,7 @@ CandidateCollector::WithinSquaredDistance(const midgard::PointLL& location,
     }
 
     // Get at the shape
-    auto shape = tile->edgeinfo(edge->edgeinfo_offset()).lazy_shape();
+    auto shape = tile->edgeinfo(edge).lazy_shape();
     if (shape.empty()) {
       // Otherwise Project will fail
       continue;
@@ -150,7 +150,7 @@ void IndexBin(const graph_tile_ptr& tile,
 
     // Get the edge shape and add to grid. Use lazy_shape to avoid allocations
     // NOTE: bins do not contain transition edges and transit connection edges
-    auto shape = bin_tile->edgeinfo(bin_tile->directededge(edge_id)->edgeinfo_offset()).lazy_shape();
+    auto shape = bin_tile->edgeinfo(bin_tile->directededge(edge_id)).lazy_shape();
     if (!shape.empty()) {
       PointLL v = shape.pop();
       while (!shape.empty()) {

--- a/src/meili/map_matcher.cc
+++ b/src/meili/map_matcher.cc
@@ -108,7 +108,7 @@ Interpolation InterpolateMeasurement(const MapMatcher& mapmatcher,
       continue;
     }
 
-    const auto edgeinfo = tile->edgeinfo(directededge->edgeinfo_offset());
+    const auto edgeinfo = tile->edgeinfo(directededge);
 
     auto shape = edgeinfo.lazy_shape();
     if (shape.empty()) {

--- a/src/meili/routing.cc
+++ b/src/meili/routing.cc
@@ -274,7 +274,7 @@ inline uint16_t get_inbound_edgelabel_heading(baldr::GraphReader& reader,
     // Have to get the heading from the edge shape...
     graph_tile_ptr tile;
     const auto directededge = reader.directededge(label.edgeid(), tile);
-    const auto edgeinfo = tile->edgeinfo(directededge->edgeinfo_offset());
+    const auto edgeinfo = tile->edgeinfo(directededge);
     const auto& shape = edgeinfo.shape();
     if (shape.size() >= 2) {
       float heading = (directededge->forward()) ? shape.back().Heading(shape.rbegin()[1])
@@ -303,7 +303,7 @@ inline uint16_t get_outbound_edge_heading(const graph_tile_ptr& tile,
   if (idx < 8) {
     return nodeinfo->heading(idx);
   } else {
-    const auto edgeinfo = tile->edgeinfo(outbound_edge->edgeinfo_offset());
+    const auto edgeinfo = tile->edgeinfo(outbound_edge);
     const auto& shape = edgeinfo.shape();
     if (shape.size() >= 2) {
       float heading = (outbound_edge->forward()) ? shape.front().Heading(shape[1])

--- a/src/mjolnir/bssbuilder.cc
+++ b/src/mjolnir/bssbuilder.cc
@@ -190,7 +190,7 @@ std::vector<BSSConnection> project(const GraphTile& local_tile, const std::vecto
       const NodeInfo* node = local_tile.node(i);
       for (uint32_t j = 0; j < node->edge_count(); ++j) {
         const DirectedEdge* directededge = local_tile.directededge(node->edge_index() + j);
-        auto edgeinfo = local_tile.edgeinfo(directededge->edgeinfo_offset());
+        auto edgeinfo = local_tile.edgeinfo(directededge);
 
         if (directededge->use() == Use::kTransitConnection ||
             directededge->use() == Use::kEgressConnection ||
@@ -235,7 +235,7 @@ std::vector<BSSConnection> project(const GraphTile& local_tile, const std::vecto
       continue;
     }
 
-    auto edgeinfo_ped = local_tile.edgeinfo(best_ped.directededge->edgeinfo_offset());
+    auto edgeinfo_ped = local_tile.edgeinfo(best_ped.directededge);
     // Store the information of the edge start <-> bss for pedestrian
     auto start_ped = BSSConnection{bss_ll,
                                    {local_tile.id().tileid(), local_level, best_ped.startnode},
@@ -249,7 +249,7 @@ std::vector<BSSConnection> project(const GraphTile& local_tile, const std::vecto
     auto end_ped =
         BSSConnection{bss_ll, best_ped.directededge->endnode(), edgeinfo_ped, false, best_ped};
 
-    auto edgeinfo_bicycle = local_tile.edgeinfo(best_bicycle.directededge->edgeinfo_offset());
+    auto edgeinfo_bicycle = local_tile.edgeinfo(best_bicycle.directededge);
 
     // Store the information of the edge start <-> bss for bicycle
     auto start_bicycle =

--- a/src/mjolnir/elevationbuilder.cc
+++ b/src/mjolnir/elevationbuilder.cc
@@ -88,7 +88,7 @@ void add_elevation(const boost::property_tree::ptree& pt,
       auto found = geo_attribute_cache.find(edge_info_offset);
       if (found == geo_attribute_cache.cend()) {
         // Get the shape and length
-        auto shape = tilebuilder.edgeinfo(edge_info_offset).shape();
+        auto shape = tilebuilder.edgeinfo(&directededge).shape();
         auto length = directededge.length();
 
         // Grade estimation and max slopes

--- a/src/mjolnir/graphenhancer.cc
+++ b/src/mjolnir/graphenhancer.cc
@@ -210,7 +210,7 @@ void GetTurnTypes(const DirectedEdge& directededge,
                   GraphReader& reader,
                   std::mutex& lock) {
   // Get the heading value at the end of incoming edge based on edge shape
-  auto incoming_shape = tile->edgeinfo(directededge.edgeinfo_offset()).shape();
+  auto incoming_shape = tile->edgeinfo(&directededge).shape();
   if (directededge.forward()) {
     std::reverse(incoming_shape.begin(), incoming_shape.end());
   }
@@ -241,7 +241,7 @@ void GetTurnTypes(const DirectedEdge& directededge,
 
     // Get the heading of the outbound edge (unfortunately GraphEnhancer may
     // not have yet computed and stored headings for this node).
-    auto shape = tile->edgeinfo(diredge->edgeinfo_offset()).shape();
+    auto shape = tile->edgeinfo(diredge).shape();
     if (!diredge->forward()) {
       std::reverse(shape.begin(), shape.end());
     }
@@ -755,7 +755,7 @@ bool IsIntersectionInternal(const graph_tile_ptr& start_tile,
   for (uint32_t i = 0; i < node->edge_count(); i++, diredge++) {
     // Find the opposing directed edge and its heading
     if (i == directededge.opp_local_idx()) {
-      auto shape = tile->edgeinfo(diredge->edgeinfo_offset()).shape();
+      auto shape = tile->edgeinfo(diredge).shape();
       if (!diredge->forward()) {
         std::reverse(shape.begin(), shape.end());
       }
@@ -789,7 +789,7 @@ bool IsIntersectionInternal(const graph_tile_ptr& start_tile,
 
     // Get the heading of the outbound edge (unfortunately GraphEnhancer may
     // not have yet computed and stored headings for this node).
-    auto shape = tile->edgeinfo(diredge->edgeinfo_offset()).shape();
+    auto shape = tile->edgeinfo(diredge).shape();
     if (!diredge->forward()) {
       std::reverse(shape.begin(), shape.end());
     }
@@ -842,7 +842,7 @@ void GetHeadings(const graph_tile_ptr& tile, NodeInfo& nodeinfo, uint32_t ntrans
   for (uint32_t j = 0; j < ntrans; j++) {
     const DirectedEdge* de = tile->directededge(nodeinfo.edge_index() + j);
 
-    auto e_offset = tile->edgeinfo(de->edgeinfo_offset());
+    auto e_offset = tile->edgeinfo(de);
     auto shape = e_offset.shape();
     if (!de->forward()) {
       std::reverse(shape.begin(), shape.end());
@@ -877,8 +877,7 @@ bool IsNextEdgeInternalImpl(const DirectedEdge directededge,
 
     // if the edge from the endnode is the next edge for this way, then
     // check if it is internal.
-    if (tilebuilder->edgeinfo(directededge.edgeinfo_offset()).wayid() ==
-        end_node_tile->edgeinfo(diredge->edgeinfo_offset()).wayid()) {
+    if (tilebuilder->edgeinfo(&directededge).wayid() == end_node_tile->edgeinfo(diredge).wayid()) {
 
       if (!infer_internal_intersections)
         return diredge->internal();
@@ -1389,8 +1388,8 @@ uint32_t GetOpposingEdgeIndex(const graph_tile_ptr& endnodetile,
       } else {
         // Need to compare shape if not in the same tile or different EdgeInfo (could be different
         // names in opposing directions)
-        if (shapes_match(tile->edgeinfo(edge.edgeinfo_offset()).shape(),
-                         endnodetile->edgeinfo(directededge->edgeinfo_offset()).shape())) {
+        if (shapes_match(tile->edgeinfo(&edge).shape(),
+                         endnodetile->edgeinfo(directededge).shape())) {
           return i;
         }
       }
@@ -1523,7 +1522,7 @@ void enhance(const boost::property_tree::ptree& pt,
       for (uint32_t j = 0; j < ntrans; j++) {
         DirectedEdge& directededge = tilebuilder->directededge_builder(nodeinfo.edge_index() + j);
 
-        auto e_offset = tilebuilder->edgeinfo(directededge.edgeinfo_offset());
+        auto e_offset = tilebuilder->edgeinfo(&directededge);
         auto shape = e_offset.shape();
         if (!directededge.forward()) {
           std::reverse(shape.begin(), shape.end());
@@ -1604,7 +1603,7 @@ void enhance(const boost::property_tree::ptree& pt,
       for (uint32_t j = 0; j < nodeinfo.edge_count(); j++) {
         DirectedEdge& directededge = tilebuilder->directededge_builder(nodeinfo.edge_index() + j);
 
-        auto e_offset = tilebuilder->edgeinfo(directededge.edgeinfo_offset());
+        auto e_offset = tilebuilder->edgeinfo(&directededge);
         std::string end_node_code = "";
         uint32_t end_admin_index = 0;
         // Get the tile at the end node
@@ -1723,7 +1722,7 @@ void enhance(const boost::property_tree::ptree& pt,
         UpdateSpeed(directededge, density, urban_rc_speed, infer_turn_channels);
 
         // Update the named flag
-        auto names = tilebuilder->edgeinfo(directededge.edgeinfo_offset()).GetNamesAndTypes(true);
+        auto names = tilebuilder->edgeinfo(&directededge).GetNamesAndTypes(true);
         directededge.set_named(names.size() > 0);
 
         // Name continuity - on the directededge.
@@ -1731,7 +1730,7 @@ void enhance(const boost::property_tree::ptree& pt,
         for (uint32_t k = 0; k < ntrans; k++) {
           DirectedEdge& fromedge = tilebuilder->directededge(nodeinfo.edge_index() + k);
           if (ConsistentNames(country_code, names,
-                              tilebuilder->edgeinfo(fromedge.edgeinfo_offset()).GetNamesAndTypes())) {
+                              tilebuilder->edgeinfo(&fromedge).GetNamesAndTypes())) {
             directededge.set_name_consistency(k, true);
           }
         }

--- a/src/mjolnir/graphfilter.cc
+++ b/src/mjolnir/graphfilter.cc
@@ -143,7 +143,7 @@ void FilterTiles(GraphReader& reader,
         // encoded shape plus way Id.
         bool added;
         uint32_t idx = directededge->edgeinfo_offset();
-        auto edgeinfo = tile->edgeinfo(idx);
+        auto edgeinfo = tile->edgeinfo(directededge);
         std::string encoded_shape = edgeinfo.encoded_shape();
         uint32_t w = hasher(encoded_shape + std::to_string(edgeinfo.wayid()));
         uint32_t edge_info_offset =

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -916,7 +916,7 @@ std::array<std::vector<GraphId>, kBinCount> GraphTileBuilder::BinEdges(const gra
     }
 
     // get the shape or bail if none
-    auto info = tile->edgeinfo(edge->edgeinfo_offset());
+    auto info = tile->edgeinfo(edge);
     const auto& shape = info.shape();
     if (shape.empty()) {
       continue;

--- a/src/mjolnir/graphvalidator.cc
+++ b/src/mjolnir/graphvalidator.cc
@@ -95,7 +95,7 @@ uint32_t GetOpposingEdgeIndex(const GraphId& startnode,
 
     // Transit connections. Match opposing edge if same way Id
     if (edge.use() == Use::kTransitConnection && directededge->use() == Use::kTransitConnection &&
-        wayid == end_tile->edgeinfo(directededge->edgeinfo_offset()).wayid()) {
+        wayid == end_tile->edgeinfo(directededge).wayid()) {
       opp_index = i;
       continue;
     }
@@ -104,8 +104,8 @@ uint32_t GetOpposingEdgeIndex(const GraphId& startnode,
     }
     if ((edge.use() == Use::kPlatformConnection && directededge->use() == Use::kPlatformConnection) ||
         (edge.use() == Use::kEgressConnection && directededge->use() == Use::kEgressConnection)) {
-      auto shape1 = tile->edgeinfo(edge.edgeinfo_offset()).shape();
-      auto shape2 = end_tile->edgeinfo(directededge->edgeinfo_offset()).shape();
+      auto shape1 = tile->edgeinfo(&edge).shape();
+      auto shape2 = end_tile->edgeinfo(directededge).shape();
       if (shapes_match(shape1, shape2)) {
         opp_index = i;
         continue;
@@ -144,13 +144,13 @@ uint32_t GetOpposingEdgeIndex(const GraphId& startnode,
       } else {
         // Regular edges - match wayids and edge info offset (if in same tile)
         // or shape (if not in same tile)
-        wayid2 = end_tile->edgeinfo(directededge->edgeinfo_offset()).wayid();
+        wayid2 = end_tile->edgeinfo(directededge).wayid();
         if (wayid == wayid2) {
           if (sametile && edge.edgeinfo_offset() == directededge->edgeinfo_offset()) {
             match = true;
           } else {
-            auto shape1 = tile->edgeinfo(edge.edgeinfo_offset()).shape();
-            auto shape2 = end_tile->edgeinfo(directededge->edgeinfo_offset()).shape();
+            auto shape1 = tile->edgeinfo(&edge).shape();
+            auto shape2 = end_tile->edgeinfo(directededge).shape();
             if (shapes_match(shape1, shape2)) {
               match = true;
             }
@@ -163,7 +163,7 @@ uint32_t GetOpposingEdgeIndex(const GraphId& startnode,
         // Check if multiple edges match - log any duplicates
         if (opp_index != absurd_index && startnode.level() != transit_level) {
           if (edge.is_shortcut()) {
-            std::vector<std::string> names = tile->edgeinfo(edge.edgeinfo_offset()).GetNames();
+            std::vector<std::string> names = tile->edgeinfo(&edge).GetNames();
             std::string name = (names.size() > 0) ? names[0] : "unnamed";
             LOG_DEBUG("Duplicate shortcut for " + name +
                       " at LL = " + std::to_string(tile->get_node_ll(endnode).lat()) + "," +
@@ -224,8 +224,7 @@ uint32_t GetOpposingEdgeIndex(const GraphId& startnode,
         if (edge.is_shortcut() == directededge->is_shortcut()) {
           LOG_WARN((boost::format("    Length = %1% Endnode: %2% WayId = %3% EdgeInfoOffset = %4%") %
                     directededge->length() % directededge->endnode() %
-                    end_tile->edgeinfo(directededge->edgeinfo_offset()).wayid() %
-                    directededge->edgeinfo_offset())
+                    end_tile->edgeinfo(directededge).wayid() % directededge->edgeinfo_offset())
                        .str());
           n++;
         }
@@ -385,7 +384,7 @@ void validate(
         // node. Set the deadend flag and internal flag (if the opposing
         // edge is internal then make sure this edge is as well)
         std::string end_node_iso;
-        uint64_t wayid = tile->edgeinfo(directededge.edgeinfo_offset()).wayid();
+        uint64_t wayid = tile->edgeinfo(&directededge).wayid();
         uint32_t opp_index =
             GetOpposingEdgeIndex(node, directededge, wayid, tile, endnode_tile, problem_ways,
                                  dupcount, end_node_iso, transit_level);

--- a/src/mjolnir/hierarchybuilder.cc
+++ b/src/mjolnir/hierarchybuilder.cc
@@ -316,7 +316,7 @@ void FormTilesInNewLevel(GraphReader& reader,
       // new. Cannot use edge info offset since edges in arterial and
       // highway hierarchy can cross base tiles! Use a hash based on the
       // encoded shape plus way Id.
-      auto edgeinfo = tile->edgeinfo(idx);
+      auto edgeinfo = tile->edgeinfo(directededge);
       std::string encoded_shape = edgeinfo.encoded_shape();
       uint32_t w = hasher(encoded_shape + std::to_string(edgeinfo.wayid()));
       uint32_t edge_info_offset =

--- a/src/mjolnir/restrictionbuilder.cc
+++ b/src/mjolnir/restrictionbuilder.cc
@@ -66,7 +66,7 @@ bool ExpandFromNodeInner(GraphReader& reader,
     if (accessible && de->endnode() != prev_node &&
         !(de->IsTransitLine() || de->is_shortcut() || de->use() == Use::kTransitConnection ||
           de->use() == Use::kEgressConnection || de->use() == Use::kPlatformConnection)) {
-      auto edge_info = tile->edgeinfo(de->edgeinfo_offset());
+      auto edge_info = tile->edgeinfo(de);
       if (edge_info.wayid() == way_id) {
         edge_ids.push_back({way_id, edge_id});
 
@@ -253,7 +253,7 @@ void build(const std::string& complex_restriction_from_file,
             directededge.use() == Use::kPlatformConnection) {
           continue;
         }
-        auto e_offset = tilebuilder.edgeinfo(directededge.edgeinfo_offset());
+        auto e_offset = tilebuilder.edgeinfo(&directededge);
         //    |      |       |
         //    |      |  to   |
         // ---O------O---x---O---

--- a/src/mjolnir/shortcutbuilder.cc
+++ b/src/mjolnir/shortcutbuilder.cc
@@ -115,7 +115,7 @@ GraphId GetOpposingEdge(const GraphId& node,
     if (directededge->endnode() == node && directededge->classification() == edge->classification() &&
         directededge->length() == edge->length() &&
         ((directededge->link() && edge->link()) || (directededge->use() == edge->use())) &&
-        wayid == tile->edgeinfo(directededge->edgeinfo_offset()).wayid()) {
+        wayid == tile->edgeinfo(directededge).wayid()) {
       return edgeid;
     }
   }
@@ -227,8 +227,8 @@ bool CanContract(GraphReader& reader,
     }*/
 
   // Get the opposing directed edges - these are the inbound edges to the node.
-  uint64_t wayid1 = tile->edgeinfo(edge1->edgeinfo_offset()).wayid();
-  uint64_t wayid2 = tile->edgeinfo(edge2->edgeinfo_offset()).wayid();
+  uint64_t wayid1 = tile->edgeinfo(edge1).wayid();
+  uint64_t wayid2 = tile->edgeinfo(edge2).wayid();
   GraphId oppedge1 = GetOpposingEdge(node, edge1, reader, wayid1);
   GraphId oppedge2 = GetOpposingEdge(node, edge2, reader, wayid2);
   const DirectedEdge* oppdiredge1 = reader.GetGraphTile(oppedge1)->directededge(oppedge1);
@@ -329,7 +329,7 @@ uint32_t ConnectEdges(GraphReader& reader,
   restrictions = directededge->restrictions();
 
   // Get the shape for this edge. Reverse if directed edge is not forward.
-  auto encoded = tile->edgeinfo(directededge->edgeinfo_offset()).encoded_shape();
+  auto encoded = tile->edgeinfo(directededge).encoded_shape();
   std::list<PointLL> edgeshape = valhalla::midgard::decode7<std::list<PointLL>>(encoded);
   if (!directededge->forward()) {
     std::reverse(edgeshape.begin(), edgeshape.end());
@@ -416,7 +416,7 @@ uint32_t AddShortcutEdges(GraphReader& reader,
       // Get the shape for this edge. If this initial directed edge is not
       // forward - reverse the shape so the edge info stored is forward for
       // the first added edge info
-      auto edgeinfo = tile->edgeinfo(directededge->edgeinfo_offset());
+      auto edgeinfo = tile->edgeinfo(directededge);
       std::list<PointLL> shape =
           valhalla::midgard::decode7<std::list<PointLL>>(edgeinfo.encoded_shape());
       if (!directededge->forward()) {
@@ -464,7 +464,7 @@ uint32_t AddShortcutEdges(GraphReader& reader,
           // direction from the node).
           const DirectedEdge* de = tile->directededge(next_edge_id);
           LOG_ERROR("Edge not found in edge pairs. WayID = " +
-                    std::to_string(tile->edgeinfo(de->edgeinfo_offset()).wayid()));
+                    std::to_string(tile->edgeinfo(de).wayid()));
           break;
         }
 
@@ -677,7 +677,7 @@ uint32_t FormShortcuts(GraphReader& reader, const TileLevel& level) {
         // to the new. Use prior edgeinfo offset as the key to make sure
         // edges that have the same end nodes are differentiated (this
         // should be a valid key since tile sizes aren't changed)
-        auto edgeinfo = tile->edgeinfo(directededge->edgeinfo_offset());
+        auto edgeinfo = tile->edgeinfo(directededge);
         uint32_t edge_info_offset =
             tilebuilder.AddEdgeInfo(directededge->edgeinfo_offset(), node_id, directededge->endnode(),
                                     edgeinfo.wayid(), edgeinfo.mean_elevation(),

--- a/src/mjolnir/transitbuilder.cc
+++ b/src/mjolnir/transitbuilder.cc
@@ -412,7 +412,7 @@ void FindOSMConnection(const PointLL& stop_ll,
       if (approximator.DistanceSquared(node->latlng(base_ll)) < mr2) {
         for (uint32_t j = 0, n = node->edge_count(); j < n; j++) {
           const DirectedEdge* directededge = newtile->directededge(node->edge_index() + j);
-          auto edgeinfo = newtile->edgeinfo(directededge->edgeinfo_offset());
+          auto edgeinfo = newtile->edgeinfo(directededge);
 
           // Get shape and find closest point
           auto this_shape = edgeinfo.shape();
@@ -467,7 +467,7 @@ void AddOSMConnection(const GraphId& transit_stop_node,
     const NodeInfo* node = tile->node(i);
     for (uint32_t j = 0, n = node->edge_count(); j < n; j++) {
       const DirectedEdge* directededge = tile->directededge(node->edge_index() + j);
-      auto edgeinfo = tile->edgeinfo(directededge->edgeinfo_offset());
+      auto edgeinfo = tile->edgeinfo(directededge);
 
       if (edgeinfo.wayid() == wayid) {
 

--- a/src/mjolnir/valhalla_build_statistics.cc
+++ b/src/mjolnir/valhalla_build_statistics.cc
@@ -131,13 +131,12 @@ bool IsLoopTerminal(const graph_tile_ptr& tile,
       if (loop_node_info->edge_count() == 2 ||
           (loop_node_info->edge_count() == 3 && !outboundIsRestrictive())) {
         // Victory
-        auto shape = tile->edgeinfo(first_edge->edgeinfo_offset()).shape();
-        auto second_shape = tile->edgeinfo(last_edge->edgeinfo_offset()).shape();
+        auto shape = tile->edgeinfo(first_edge).shape();
+        auto second_shape = tile->edgeinfo(last_edge).shape();
         for (auto& point : second_shape) {
           shape.push_back(point);
         }
-        rd.AddTask(AABB2<PointLL>(shape), tile->edgeinfo(first_edge->edgeinfo_offset()).wayid(),
-                   shape);
+        rd.AddTask(AABB2<PointLL>(shape), tile->edgeinfo(first_edge).wayid(), shape);
         return true;
       }
     }
@@ -186,9 +185,8 @@ bool IsLoop(GraphReader& reader,
     }
     // continue the loop if you haven't finished it
     if (next == &directededge) {
-      rd.AddTask(AABB2<PointLL>(tile->edgeinfo(next->edgeinfo_offset()).shape()),
-                 tile->edgeinfo(next->edgeinfo_offset()).wayid(),
-                 tile->edgeinfo(next->edgeinfo_offset()).shape());
+      rd.AddTask(AABB2<PointLL>(tile->edgeinfo(next).shape()), tile->edgeinfo(next).wayid(),
+                 tile->edgeinfo(next).shape());
       return true;
     }
     if (next) {
@@ -349,7 +347,7 @@ void AddStatistics(statistics& stats,
       stats.add_country_speed_info(begin_node_iso, rclass, edge_length);
     }
     // Check if edge has any names
-    if (tile.edgeinfo(directededge.edgeinfo_offset()).name_count() > 0) {
+    if (tile.edgeinfo(&directededge).name_count() > 0) {
       stats.add_tile_named(tileid, rclass, edge_length);
       stats.add_country_named(begin_node_iso, rclass, edge_length);
     }

--- a/src/mjolnir/valhalla_ways_to_edges.cc
+++ b/src/mjolnir/valhalla_ways_to_edges.cc
@@ -136,7 +136,7 @@ int main(int argc, char** argv) {
       }
 
       // Get the way Id
-      uint64_t wayid = tile->edgeinfo(edge->edgeinfo_offset()).wayid();
+      uint64_t wayid = tile->edgeinfo(edge).wayid();
       ways_edges[wayid].push_back({edge->forward(), edge_id});
     }
   }

--- a/src/thor/centroid.cc
+++ b/src/thor/centroid.cc
@@ -17,7 +17,7 @@ valhalla::Location make_centroid(const valhalla::baldr::GraphId& edge_id,
   using namespace valhalla;
   valhalla::baldr::graph_tile_ptr tile;
   const auto* edge = reader.directededge(baldr::GraphId(edge_id), tile);
-  auto info = tile->edgeinfo(edge->edgeinfo_offset());
+  auto info = tile->edgeinfo(edge);
   const auto& shape = info.shape();
   auto length = midgard::length(shape);
   auto mid_point = midgard::resample_spherical_polyline(shape, length / 2.)[1];

--- a/src/thor/isochrone.cc
+++ b/src/thor/isochrone.cc
@@ -233,7 +233,7 @@ void Isochrone::UpdateIsoTile(const EdgeLabel& pred,
   // the shape interval to get regular spacing. Use the faster resample method.
   // This does not use spherical interpolation - so it is not as accurate but
   // interpolation is over short distances so accuracy should be fine.
-  auto shape = tile->edgeinfo(edge->edgeinfo_offset()).shape();
+  auto shape = tile->edgeinfo(edge).shape();
   auto resampled = resample_polyline(shape, edge->length(), shape_interval_);
   if (!edge->forward()) {
     std::reverse(resampled.begin(), resampled.end());

--- a/src/thor/route_action.cc
+++ b/src/thor/route_action.cc
@@ -150,7 +150,7 @@ std::string thor_worker_t::expansion(Api& request) {
     // full shape might be overkill but meh, its trace
     auto tile = reader.GetGraphTile(edgeid);
     const auto* edge = tile->directededge(edgeid);
-    auto shape = tile->edgeinfo(edge->edgeinfo_offset()).shape();
+    auto shape = tile->edgeinfo(edge).shape();
     if (!edge->forward())
       std::reverse(shape.begin(), shape.end());
     if (!full_shape && shape.size() > 2)

--- a/src/thor/triplegbuilder.cc
+++ b/src/thor/triplegbuilder.cc
@@ -265,7 +265,7 @@ void SetShapeAttributes(const AttributesController& controller,
   }
 
   // Find the first cut to the right of where we start on this edge
-  auto edgeinfo = tile->edgeinfo(edge->edgeinfo_offset());
+  auto edgeinfo = tile->edgeinfo(edge);
   double distance_total_pct = src_pct;
   auto cut_itr = std::find_if(cuts.cbegin(), cuts.cend(),
                               [distance_total_pct](const decltype(cuts)::value_type& s) {
@@ -496,7 +496,7 @@ TripLeg_Edge* AddTripEdge(const AttributesController& controller,
   TripLeg_Edge* trip_edge = trip_node->mutable_edge();
 
   // Get the edgeinfo
-  auto edgeinfo = graphtile->edgeinfo(directededge->edgeinfo_offset());
+  auto edgeinfo = graphtile->edgeinfo(directededge);
 
   // Add names to edge if requested
   if (controller.attributes.at(kEdgeNames)) {
@@ -1283,7 +1283,7 @@ void TripLegBuilder::Build(
 
     // Process the shape for edges where a route discontinuity occurs
     uint32_t begin_index = (is_first_edge) ? 0 : trip_shape.size() - 1;
-    auto edgeinfo = graphtile->edgeinfo(directededge->edgeinfo_offset());
+    auto edgeinfo = graphtile->edgeinfo(directededge);
     if (edge_trimming && !edge_trimming->empty() && edge_trimming->count(edge_index) > 0) {
       // Get edge shape and reverse it if directed edge is not forward.
       auto edge_shape = edgeinfo.shape();

--- a/src/tyr/locate_serializer.cc
+++ b/src/tyr/locate_serializer.cc
@@ -59,7 +59,7 @@ json::ArrayPtr serialize_edges(const PathLocation& location, GraphReader& reader
       // get the osm way id
       auto tile = reader.GetGraphTile(edge.id);
       auto* directed_edge = tile->directededge(edge.id);
-      auto edge_info = tile->edgeinfo(directed_edge->edgeinfo_offset());
+      auto edge_info = tile->edgeinfo(directed_edge);
       // they want MOAR!
       if (verbose) {
         // live traffic information

--- a/src/valhalla_associate_segments.cc
+++ b/src/valhalla_associate_segments.cc
@@ -109,7 +109,7 @@ uint16_t bearing(const std::vector<vm::PointLL>& shape) {
 
 uint16_t bearing(const vb::GraphTile* tile, vb::GraphId edge_id, float dist) {
   const auto* edge = tile->directededge(edge_id);
-  std::vector<vm::PointLL> shape = tile->edgeinfo(edge->edgeinfo_offset()).shape();
+  std::vector<vm::PointLL> shape = tile->edgeinfo(edge).shape();
   if (!edge->forward()) {
     std::reverse(shape.begin(), shape.end());
   }

--- a/src/valhalla_export_edges.cc
+++ b/src/valhalla_export_edges.cc
@@ -110,7 +110,7 @@ edge_t next(const std::unordered_map<GraphId, uint64_t>& tile_set,
       continue;
     }
     // names have to match
-    auto candidate_names = tile->edgeinfo(candidate.e->edgeinfo_offset()).GetNames();
+    auto candidate_names = tile->edgeinfo(candidate.e).GetNames();
     if (names.size() == candidate_names.size() &&
         std::equal(names.cbegin(), names.cend(), candidate_names.cbegin())) {
       return candidate;
@@ -129,7 +129,7 @@ void extend(GraphReader& reader,
     tile = reader.GetGraphTile(edge.i);
   }
   // get the shape
-  auto info = tile->edgeinfo(edge.e->edgeinfo_offset());
+  auto info = tile->edgeinfo(edge.e);
   auto more = valhalla::midgard::decode7<std::list<PointLL>>(info.encoded_shape());
   // this shape runs the other way
   if (!edge.e->forward()) {
@@ -274,7 +274,7 @@ int main(int argc, char* argv[]) {
       }
 
       // no name no thanks
-      auto edge_info = tile->edgeinfo(edge.e->edgeinfo_offset());
+      auto edge_info = tile->edgeinfo(edge.e);
       auto names = edge_info.GetNames();
       if (names.size() == 0 && !unnamed) {
         continue;

--- a/src/valhalla_path_comparison.cc
+++ b/src/valhalla_path_comparison.cc
@@ -43,7 +43,7 @@ void print_edge(GraphReader& reader,
   // std::cout << "id: " << current_id << "\n";
   auto tile = reader.GetGraphTile(current_id);
   auto edge = tile->directededge(current_id);
-  auto edgeinfo = tile->edgeinfo(edge->edgeinfo_offset());
+  auto edgeinfo = tile->edgeinfo(edge);
 
   if (edgeinfo.wayid() != current_osmid) {
     current_osmid = edgeinfo.wayid();
@@ -57,7 +57,7 @@ void print_edge(GraphReader& reader,
   if (pred_id != kInvalidGraphId) {
     auto pred_tile = reader.GetGraphTile(pred_id);
     auto pred_edge = pred_tile->directededge(pred_id);
-    auto predinfo = tile->edgeinfo(pred_edge->edgeinfo_offset());
+    auto predinfo = tile->edgeinfo(pred_edge);
     auto node_id = pred_edge->endnode();
     auto node_tile = reader.GetGraphTile(node_id);
     auto node = node_tile->node(node_id);

--- a/test/astar.cc
+++ b/test/astar.cc
@@ -1018,7 +1018,7 @@ TEST(Astar, TestBacktrackComplexRestrictionForwardDetourAfterRestriction) {
     for (auto path_info : paths) {
       LOG_INFO("Got pathinfo " + std::to_string(path_info.edgeid.id()));
       auto directededge = tile->directededge(path_info.edgeid);
-      auto edgeinfo = tile->edgeinfo(directededge->edgeinfo_offset());
+      auto edgeinfo = tile->edgeinfo(directededge);
       auto names = edgeinfo.GetNames();
       walked_path.push_back(names.front());
     }

--- a/test/countryaccess.cc
+++ b/test/countryaccess.cc
@@ -130,7 +130,7 @@ void CountryAccess(const std::string& config_file) {
     for (uint32_t j = 0; j < count; j++) {
       DirectedEdge& directededge = tilebuilder.directededge_builder(nodeinfo.edge_index() + j);
 
-      auto e_offset = tilebuilder.edgeinfo(directededge.edgeinfo_offset());
+      auto e_offset = tilebuilder.edgeinfo(&directededge);
 
       uint32_t forward = directededge.forwardaccess();
       uint32_t reverse = directededge.reverseaccess();
@@ -203,7 +203,7 @@ void CountryAccess(const std::string& config_file) {
     for (uint32_t j = 0; j < count; j++) {
       DirectedEdge& directededge = tilebuilder2.directededge_builder(nodeinfo.edge_index() + j);
 
-      auto e_offset = tilebuilder2.edgeinfo(directededge.edgeinfo_offset());
+      auto e_offset = tilebuilder2.edgeinfo(&directededge);
 
       uint32_t forward = directededge.forwardaccess();
       uint32_t reverse = directededge.reverseaccess();

--- a/test/graphtilebuilder.cc
+++ b/test/graphtilebuilder.cc
@@ -69,8 +69,8 @@ void assert_tile_equalish(const GraphTile& a,
       ah->schedulecount() == bh->schedulecount() && ah->version() == bh->version()) {
     // make sure the edges' shape and names match
     for (size_t i = 0; i < ah->directededgecount(); ++i) {
-      auto a_info = a.edgeinfo(a.directededge(i)->edgeinfo_offset());
-      auto b_info = b.edgeinfo(b.directededge(i)->edgeinfo_offset());
+      auto a_info = a.edgeinfo(a.directededge(i));
+      auto b_info = b.edgeinfo(b.directededge(i));
       ASSERT_EQ(a_info.encoded_shape(), b_info.encoded_shape());
       ASSERT_EQ(a_info.GetNames().size(), b_info.GetNames().size());
       for (size_t j = 0; j < a_info.GetNames().size(); ++j)
@@ -294,7 +294,7 @@ TEST(GraphTileBuilder, TestBinEdges) {
   auto decoded_shape = valhalla::midgard::decode<std::vector<PointLL>>(encoded_shape5);
   auto encoded_shape7 = valhalla::midgard::encode7(decoded_shape);
   graph_tile_ptr fake = new fake_tile(encoded_shape5);
-  auto info = fake->edgeinfo(fake->directededge(0)->edgeinfo_offset());
+  auto info = fake->edgeinfo(fake->directededge(0));
   EXPECT_EQ(info.encoded_shape(), encoded_shape7);
   GraphTileBuilder::tweeners_t tweeners;
   auto bins = GraphTileBuilder::BinEdges(fake, tweeners);

--- a/test/graphtilebuilder.cc
+++ b/test/graphtilebuilder.cc
@@ -119,7 +119,7 @@ TEST(GraphTileBuilder, TestDuplicateEdgeInfo) {
 
   test.StoreTileData();
   test_graph_tile_builder test2(test_dir, GraphId(0, 2, 0), false);
-  auto ei = test2.edgeinfo(0);
+  auto ei = test2.edgeinfo(static_cast<size_t>(0));
   EXPECT_NEAR(ei.mean_elevation(), 555.0f, kElevationBinSize);
   EXPECT_EQ(ei.speed_limit(), 120);
 

--- a/test/graphtilebuilder.cc
+++ b/test/graphtilebuilder.cc
@@ -106,6 +106,7 @@ TEST(GraphTileBuilder, TestDuplicateEdgeInfo) {
   // load a test builder
   std::string test_dir = "test/data/builder_tiles";
   test_graph_tile_builder test(test_dir, GraphId(0, 2, 0), false);
+  test.directededges().emplace_back();
   // add edge info for node 0 to node 1
   bool added = false;
   test.AddEdgeInfo(0, GraphId(0, 2, 0), GraphId(0, 2, 1), 1234, 555, 0, 120,
@@ -119,7 +120,7 @@ TEST(GraphTileBuilder, TestDuplicateEdgeInfo) {
 
   test.StoreTileData();
   test_graph_tile_builder test2(test_dir, GraphId(0, 2, 0), false);
-  auto ei = test2.edgeinfo(static_cast<size_t>(0));
+  auto ei = test2.edgeinfo(&test2.directededge(0));
   EXPECT_NEAR(ei.mean_elevation(), 555.0f, kElevationBinSize);
   EXPECT_EQ(ei.speed_limit(), 120);
 

--- a/test/gurka/gurka.cc
+++ b/test/gurka/gurka.cc
@@ -670,7 +670,7 @@ std::string dump_geojson_graph(const map& graph) {
     for (const auto& edge : tile->GetDirectedEdges()) {
       valhalla::baldr::GraphId edge_id(tile_id.tileid(), tile_id.level(),
                                        &edge - tile->directededge(0));
-      auto info = tile->edgeinfo(edge.edgeinfo_offset());
+      auto info = tile->edgeinfo(&edge);
 
       // add some properties
       rapidjson::Value properties(rapidjson::kObjectType);

--- a/test/gurka/test_64bit_wayid.cc
+++ b/test/gurka/test_64bit_wayid.cc
@@ -9,7 +9,7 @@ void find_ids(baldr::GraphReader& reader, std::multiset<uint64_t> osm_way_ids) {
     auto tile = reader.GetGraphTile(tile_id);
     for (auto edge = tile_id; edge.id() < tile->header()->directededgecount(); ++edge) {
       // we should find every way id in the tile set
-      auto info = tile->edgeinfo(tile->directededge(edge)->edgeinfo_offset());
+      auto info = tile->edgeinfo(tile->directededge(edge));
       auto id = info.wayid();
       auto found = osm_way_ids.find(id);
       if (found == osm_way_ids.cend()) {

--- a/test/gurka/test_reproduce_tile_build.cc
+++ b/test/gurka/test_reproduce_tile_build.cc
@@ -75,8 +75,8 @@ void assert_tile_equalish(const GraphTile& a, const GraphTile& b) {
 
   // make sure the edges' shape and names match
   for (size_t i = 0; i < ah->directededgecount(); ++i) {
-    const EdgeInfo a_info = a.edgeinfo(a.directededge(i)->edgeinfo_offset());
-    const EdgeInfo b_info = b.edgeinfo(b.directededge(i)->edgeinfo_offset());
+    const EdgeInfo a_info = a.edgeinfo(a.directededge(i));
+    const EdgeInfo b_info = b.edgeinfo(b.directededge(i));
     ASSERT_EQ(a_info.encoded_shape(), b_info.encoded_shape());
     ASSERT_EQ(a_info.GetNames().size(), b_info.GetNames().size());
     for (size_t j = 0; j < a_info.GetNames().size(); ++j)

--- a/test/gurka/test_trimming.cc
+++ b/test/gurka/test_trimming.cc
@@ -43,10 +43,10 @@ TEST(Trimming, routes) {
 
   // we start by getting the shape for the two edges we want a route on
   auto tile = reader.GetGraphTile(start_id);
-  auto start_shape = tile->edgeinfo(start_edge->edgeinfo_offset()).shape();
+  auto start_shape = tile->edgeinfo(start_edge).shape();
   if (!start_edge->forward())
     std::reverse(start_shape.begin(), start_shape.end());
-  auto end_shape = tile->edgeinfo(end_edge->edgeinfo_offset()).shape();
+  auto end_shape = tile->edgeinfo(end_edge).shape();
   if (!end_edge->forward())
     std::reverse(end_shape.begin(), end_shape.end());
   auto start_length = midgard::length<decltype(start_shape)>(start_shape);

--- a/test/minbb.cc
+++ b/test/minbb.cc
@@ -32,7 +32,7 @@ struct bb_tester {
       auto t = reader.GetGraphTile(id);
       for (const auto& node : t->GetNodes()) {
         const auto* edge = t->directededge(node.edge_index());
-        const std::vector<PointLL> shape = t->edgeinfo(edge->edgeinfo_offset()).shape();
+        const std::vector<PointLL> shape = t->edgeinfo(edge).shape();
         for (const auto& p : shape) {
           if (bb.maxpt().IsValid()) {
             bb.Expand(p);

--- a/test/reach.cc
+++ b/test/reach.cc
@@ -49,7 +49,7 @@ TEST(Reach, check_all_reach) {
       auto reach = reach_finder(edge, edge_id, 50, reader, costing, kInbound | kOutbound);
 
       // shape is nice to have
-      auto shape = tile->edgeinfo(edge->edgeinfo_offset()).shape();
+      auto shape = tile->edgeinfo(edge).shape();
       if (!edge->forward())
         std::reverse(shape.begin(), shape.end());
       auto shape_str = midgard::encode(shape);

--- a/test/recover_shortcut.cc
+++ b/test/recover_shortcut.cc
@@ -59,7 +59,7 @@ void recover(bool cache) {
           continue;
 
         // we'll have the shape to compare to
-        auto shortcut_shape = tile->edgeinfo(edge->edgeinfo_offset()).shape();
+        auto shortcut_shape = tile->edgeinfo(edge).shape();
         if (!edge->forward())
           std::reverse(shortcut_shape.begin(), shortcut_shape.end());
 
@@ -82,7 +82,7 @@ void recover(bool cache) {
         for (auto edgeid : edgeids) {
           auto tile = graphreader.GetGraphTile(edgeid);
           const auto* de = tile->directededge(edgeid);
-          auto de_shape = tile->edgeinfo(de->edgeinfo_offset()).shape();
+          auto de_shape = tile->edgeinfo(de).shape();
           if (!de->forward()) {
             std::reverse(de_shape.begin(), de_shape.end());
           }

--- a/valhalla/baldr/graphreader.h
+++ b/valhalla/baldr/graphreader.h
@@ -824,7 +824,7 @@ public:
     if (edge == nullptr) {
       throw std::runtime_error("Cannot find edgeinfo for edge: " + std::to_string(edgeid));
     }
-    return tile->edgeinfo(edge->edgeinfo_offset());
+    return tile->edgeinfo(edge);
   }
 
   /**

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -327,6 +327,12 @@ public:
   EdgeInfo edgeinfo(const size_t offset) const;
 
   /**
+   * Get a pointer to edge info.
+   * @return  Returns edge info.
+   */
+  EdgeInfo edgeinfo(const DirectedEdge* edge) const;
+
+  /**
    * Get the complex restrictions in the forward or reverse order.
    * @param   forward - do we want the restrictions in reverse order?
    * @param   id - edge id


### PR DESCRIPTION
# Issue

The main change is in the `graphtile.h` file: `edgeinfo` overload is added. This is done for convenience to get rid of redundancy in the valhalla code

Not sure if it should be tracked in the changelog as it's minor "refactoring". But I don't mind if it should be there

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
