### PR TITLE
upgrade to latest prime_server

### DIFF
--- a/docker/install-shared-deps.sh
+++ b/docker/install-shared-deps.sh
@@ -14,7 +14,7 @@ if [ $(grep -Fc bionic /etc/lsb-release) -gt 0 ]; then
     boost_version="1.62"
 fi
 
-readonly primeserver_version=0.6.7
+readonly primeserver_version=0.7.0
 
 # Now, go through and install the build dependencies
 apt-get update --assume-yes


### PR DESCRIPTION
this is a prerequisite for #2907 

changes in this release of prime_server are:

https://github.com/kevinkreiser/prime_server/pull/91 - optional health check canned response, optional sig term handling
https://github.com/kevinkreiser/prime_server/pull/90 - format code to look the same as valhalla
https://github.com/kevinkreiser/prime_server/pull/89 - fix all warnings

for peoples local machines you'll need to upgrade your prime_server as well. ubuntu should be like this:

```
sudo apt get remove libprime-server* prime-server* # this removes the old ones
sudo apt update # gets the new ones from valhalla ppa
sudo apt install libprime-server0.7.0-dev prime-server0.7.0-bin
```