### PR TITLE
testing: Refactors mock-incident loading

### DIFF
--- a/test/gurka/gurka.h
+++ b/test/gurka/gurka.h
@@ -22,6 +22,7 @@
 #include "mjolnir/util.h"
 #include "odin/worker.h"
 #include "proto/trip.pb.h"
+#include "test.h"
 #include "thor/worker.h"
 #include "tyr/actor.h"
 #include "tyr/serializers.h"
@@ -288,6 +289,35 @@ void expect_path(const valhalla::Api& result, const std::vector<std::string>& ex
 
 } // namespace raw
 } // namespace assert
+
+/*
+ * A description of incident coverage on a gurka-edge
+ *
+ * The `name` would be something like "AB" where "A" and "B" are nodes in a gurka map.
+ * The offsets describe incident coverage on that edge.
+ *
+ * For use in `GurkaEdge` and `setup_graph_with_incidents`
+ */
+struct GurkaEdge {
+  std::string name;
+  float start_offset;
+  float end_offset;
+};
+
+/* A mocked incident, for use with `setup_graph_with_incidents`
+ */
+struct IncidentArgs {
+  std::vector<GurkaEdge> edges;
+  uint64_t incident_id;
+  std::string incident_description;
+};
+
+/* Adds mocked incidents to the special graph-reader returned from this function
+ *
+ * For live examples, look in test/gurka/test_route_incidents.cc
+ */
+std::shared_ptr<test::IncidentsReader>
+setup_graph_with_incidents(const gurka::map& map, const std::vector<IncidentArgs>& incidents);
 
 } // namespace gurka
 } // namespace valhalla

--- a/test/gurka/test_admin.cc
+++ b/test/gurka/test_admin.cc
@@ -10,7 +10,7 @@ using namespace valhalla;
 const std::unordered_map<std::string, std::string> build_config{
     {"mjolnir.data_processing.use_admin_db", "false"}};
 
-class Admin : public ::testing::Test {
+class AdminTest : public ::testing::Test {
 protected:
   static gurka::map map;
 
@@ -39,13 +39,13 @@ protected:
     map = gurka::buildtiles(layout, ways, nodes, {}, "test/data/gurka_admin", build_config);
   }
 };
-gurka::map Admin::map = {};
+gurka::map AdminTest::map = {};
 Api api;
 rapidjson::Document d;
 
 /*************************************************************/
 
-TEST_F(Admin, Iso) {
+TEST_F(AdminTest, Iso) {
   auto result = gurka::do_action(valhalla::Options::route, map, {"A", "C"}, "auto");
 
   // rest_area
@@ -59,7 +59,7 @@ TEST_F(Admin, Iso) {
   EXPECT_FALSE(leg.node(1).edge().drive_on_right());
 }
 
-TEST_F(Admin, test_admin_response) {
+TEST_F(AdminTest, test_admin_response) {
   auto result = gurka::do_action(valhalla::Options::route, map, {"A", "C"}, "auto");
   auto d = gurka::convert_to_json(result, valhalla::Options_Format_osrm);
 

--- a/test/gurka/test_node_type.cc
+++ b/test/gurka/test_node_type.cc
@@ -10,7 +10,7 @@ using namespace valhalla;
 const std::unordered_map<std::string, std::string> build_config{
     {"mjolnir.data_processing.use_admin_db", "true"}};
 
-class NodeType : public ::testing::Test {
+class NodeTypeTest : public ::testing::Test {
 protected:
   static gurka::map map;
 
@@ -20,14 +20,14 @@ protected:
     const std::string ascii_map = R"(
                           A
                           |
-                          |     
+                          |
                           B----E
                           |
                           |
                           C
                           |
                           |
-                          D----F   
+                          D----F
   )";
 
     const gurka::ways ways = {{"AB", {{"highway", "motorway"}}},
@@ -43,13 +43,13 @@ protected:
     map = gurka::buildtiles(layout, ways, nodes, {}, "test/data/gurka_node_type", build_config);
   }
 };
-gurka::map NodeType::map = {};
+gurka::map NodeTypeTest::map = {};
 Api api;
 rapidjson::Document d;
 
 /*************************************************************/
 
-TEST_F(NodeType, Toll) {
+TEST_F(NodeTypeTest, Toll) {
   auto result = gurka::do_action(valhalla::Options::route, map, {"A", "E"}, "auto");
 
   ASSERT_EQ(result.trip().routes(0).legs_size(), 1);
@@ -61,7 +61,7 @@ TEST_F(NodeType, Toll) {
   EXPECT_EQ(leg.node(3).type(), TripLeg::Node::Type::TripLeg_Node_Type_kTollGantry); // AF
 }
 
-TEST_F(NodeType, test_toll_response) {
+TEST_F(NodeTypeTest, test_toll_response) {
   std::string locations = R"({"lon":)" + std::to_string(map.nodes["A"].lng()) + R"(,"lat":)" +
                           std::to_string(map.nodes["A"].lat()) + R"(},{"lon":)" +
                           std::to_string(map.nodes["E"].lng()) + R"(,"lat":)" +
@@ -94,7 +94,7 @@ TEST_F(NodeType, test_toll_response) {
   }
 }
 
-TEST_F(NodeType, test_toll_response2) {
+TEST_F(NodeTypeTest, test_toll_response2) {
   std::string locations = R"({"lon":)" + std::to_string(map.nodes["C"].lng()) + R"(,"lat":)" +
                           std::to_string(map.nodes["C"].lat()) + R"(},{"lon":)" +
                           std::to_string(map.nodes["F"].lng()) + R"(,"lat":)" +

--- a/test/gurka/test_time_tracking.cc
+++ b/test/gurka/test_time_tracking.cc
@@ -35,7 +35,7 @@ TEST(TimeTracking, make) {
     // get some loki results
     auto costing = sif::CostFactory().Create(Costing::none_);
     auto found = loki::Search({baldr::Location(map.nodes.begin()->second)}, reader, costing);
-    Location location;
+    valhalla::Location location;
     baldr::PathLocation::toPBF(found.begin()->second, &location, reader);
 
     // no time

--- a/test/gurka/test_use.cc
+++ b/test/gurka/test_use.cc
@@ -8,7 +8,7 @@
 
 using namespace valhalla;
 
-class Use : public ::testing::Test {
+class UseTest : public ::testing::Test {
 protected:
   static gurka::map map;
 
@@ -50,11 +50,11 @@ protected:
                             {{"mjolnir.data_processing.use_rest_area", "true"}});
   }
 };
-gurka::map Use::map = {};
+gurka::map UseTest::map = {};
 
 /*************************************************************/
 
-TEST_F(Use, EdgeUse) {
+TEST_F(UseTest, EdgeUse) {
   auto result = gurka::do_action(valhalla::Options::route, map, {"A", "C"}, "auto");
 
   // rest_area
@@ -69,7 +69,7 @@ TEST_F(Use, EdgeUse) {
   EXPECT_EQ(leg.node(3).edge().use(), TripLeg::Use::TripLeg_Use_kServiceAreaUse); // EF
 }
 
-TEST_F(Use, test_passing_rest_area) {
+TEST_F(UseTest, test_passing_rest_area) {
   auto result = gurka::do_action(valhalla::Options::route, map, {"A", "D"}, "auto");
   auto d = gurka::convert_to_json(result, valhalla::Options_Format_osrm);
 
@@ -97,7 +97,7 @@ TEST_F(Use, test_passing_rest_area) {
   EXPECT_FALSE(steps[step_idx]["intersections"][0].HasMember("rest_stop"));
 }
 
-TEST_F(Use, test_entering_rest_area) {
+TEST_F(UseTest, test_entering_rest_area) {
   auto result = gurka::do_action(valhalla::Options::route, map, {"A", "C"}, "auto");
   auto d = gurka::convert_to_json(result, valhalla::Options_Format_osrm);
 
@@ -134,7 +134,7 @@ TEST_F(Use, test_entering_rest_area) {
   EXPECT_FALSE(steps[step_idx]["intersections"][0].HasMember("rest_stop"));
 }
 
-TEST_F(Use, test_passing_service_area) {
+TEST_F(UseTest, test_passing_service_area) {
   auto result = gurka::do_action(valhalla::Options::route, map, {"D", "G"}, "auto");
   auto d = gurka::convert_to_json(result, valhalla::Options_Format_osrm);
 
@@ -162,7 +162,7 @@ TEST_F(Use, test_passing_service_area) {
   EXPECT_FALSE(steps[step_idx]["intersections"][0].HasMember("rest_stop"));
 }
 
-TEST_F(Use, test_entering_service_area) {
+TEST_F(UseTest, test_entering_service_area) {
   auto result = gurka::do_action(valhalla::Options::route, map, {"D", "F"}, "auto");
   auto d = gurka::convert_to_json(result, valhalla::Options_Format_osrm);
 

--- a/test/test.h
+++ b/test/test.h
@@ -92,4 +92,67 @@ void customize_historical_traffic(const boost::property_tree::ptree& config,
 using EdgesCustomize = std::function<void(const GraphId&, DirectedEdge&)>;
 void customize_edges(const boost::property_tree::ptree& config, const EdgesCustomize& setter_cb);
 
+// provides us an easy way to mock having incident tiles, each test can override the tile in question
+// a bit more work is needed if we want to do it for more than one tile at a time
+struct IncidentsReader : public valhalla::baldr::GraphReader {
+  IncidentsReader(const boost::property_tree::ptree& pt) : valhalla::baldr::GraphReader(pt) {
+    tile_extract_.reset(new valhalla::baldr::GraphReader::tile_extract_t(pt));
+    enable_incidents_ = true;
+  }
+  virtual std::shared_ptr<const valhalla::IncidentsTile>
+  GetIncidentTile(const valhalla::baldr::GraphId& tile_id) const override {
+    auto i = incidents.find(tile_id.Tile_Base());
+    if (i == incidents.cend())
+      return {};
+    return std::shared_ptr<valhalla::IncidentsTile>(&i->second, [](valhalla::IncidentsTile*) {});
+  }
+  void add_incident(const valhalla::baldr::GraphId& id,
+                    valhalla::IncidentsTile::Location&& _incident_location,
+                    uint64_t incident_id,
+                    const std::string& incident_description = "") {
+
+    // Grab the incidents-tile we need to add to
+    valhalla::IncidentsTile& incidents_tile = incidents[id.Tile_Base()];
+
+    // See if we have this incident metadata already
+    int metadata_index =
+        std::find_if(incidents_tile.metadata().begin(), incidents_tile.metadata().end(),
+                     [incident_id](const valhalla::IncidentsTile::Metadata& m) {
+                       return incident_id == m.id();
+                     }) -
+        incidents_tile.metadata().begin();
+
+    // We're not yet tracking this incident, so add it new
+    if (metadata_index == incidents_tile.metadata_size()) {
+      auto* metadata = incidents_tile.mutable_metadata()->Add();
+      metadata->set_id(incident_id);
+      metadata->set_description(incident_description);
+    }
+
+    // Finally, add the relation from edge to the incident metadata
+    auto* locations = incidents_tile.mutable_locations()->Add();
+    locations->Swap(&_incident_location);
+    locations->set_metadata_index(metadata_index);
+  }
+  void sort_incidents() {
+    for (auto& kv : incidents) {
+      std::sort(kv.second.mutable_locations()->begin(), kv.second.mutable_locations()->end(),
+                [](const valhalla::IncidentsTile::Location& a,
+                   const valhalla::IncidentsTile::Location& b) {
+                  if (a.edge_index() == b.edge_index()) {
+                    if (a.start_offset() == b.start_offset()) {
+                      if (a.end_offset() == b.end_offset()) {
+                        return a.metadata_index() < b.metadata_index();
+                      }
+                      return a.end_offset() < b.end_offset();
+                    }
+                    return a.start_offset() < b.start_offset();
+                  }
+                  return a.edge_index() < b.edge_index();
+                });
+    }
+  }
+  mutable std::unordered_map<valhalla::baldr::GraphId, valhalla::IncidentsTile> incidents;
+};
+
 } // namespace test


### PR DESCRIPTION
for easier testing with fake incidents.

`test/gurka/test_route_incidents.cc` implements a special graph-reader and some helper functions that allows the test-file to mock incidents.

This PR does a refactor of said mocked helper functions and moves them out to the header files in `test/test.h` and `test/gurka/gurka.h` to allow reuse in other test-files.
