### PR TITLE
replace the python version finding mess with cmake builtins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
    * FIXED: Allow u-turns at no-access barriers when forced by heading [#2875](https://github.com/valhalla/valhalla/pull/2875)
    * FIXED: Python bindings installation [#2751](https://github.com/valhalla/valhalla/issues/2751)
    * FIXED: Skip bindings if there's no Python development version [#2893](https://github.com/valhalla/valhalla/pull/2878)
+   * FIXED: Use CMakes built-in Python variables to configure installation [#2931](https://github.com/valhalla/valhalla/pull/2931)
 
 * **Enhancement**
    * CHANGED: Azure uses ninja as generator [#2779](https://github.com/valhalla/valhalla/pull/2779)

--- a/docker/Dockerfile-run
+++ b/docker/Dockerfile-run
@@ -30,7 +30,7 @@ RUN rm -f valhalla_*.debug
 RUN strip --strip-debug --strip-unneeded valhalla_* || true
 RUN strip /usr/local/lib/libvalhalla.a
 # TODO: fix https://github.com/valhalla/valhalla/issues/2929 and update this line
-#RUN strip /usr/local/lib/python3.8/dist-packages/python_valhalla.cpython-38-x86_64-linux-gnu.so
+RUN strip /usr/lib/python3/dist-packages/valhalla/python_valhalla.cpython-38-x86_64-linux-gnu.so
 
 ####################################################################
 # copy the important stuff from the build stage to the runner image

--- a/docker/Dockerfile-run
+++ b/docker/Dockerfile-run
@@ -29,7 +29,6 @@ RUN tar -cvf valhalla.debug.tar valhalla_*.debug && gzip -9 valhalla.debug.tar
 RUN rm -f valhalla_*.debug
 RUN strip --strip-debug --strip-unneeded valhalla_* || true
 RUN strip /usr/local/lib/libvalhalla.a
-# TODO: fix https://github.com/valhalla/valhalla/issues/2929 and update this line
 RUN strip /usr/lib/python3/dist-packages/valhalla/python_valhalla.cpython-38-x86_64-linux-gnu.so
 
 ####################################################################

--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -7,43 +7,11 @@ set_target_properties(valhalla PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/__init__.py ${CMAKE_CURRENT_BINARY_DIR}/valhalla/__init__.py COPYONLY)
 
-# Part of OpenCVDetectPython.cmake
-set(_executable ${PYTHON_EXECUTABLE})
-set(_version_major_minor "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")
-if(CMAKE_HOST_UNIX)
-execute_process(COMMAND ${_executable} -c "from distutils.sysconfig import *; print(get_python_lib())"
-  RESULT_VARIABLE _cvpy_process
-  OUTPUT_VARIABLE _std_packages_path
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
-if("${_std_packages_path}" MATCHES "site-packages")
-  set(_packages_path "python${_version_major_minor}/site-packages")
-else() #debian based assumed, install to the dist-packages.
-  set(_packages_path "python${_version_major_minor}/dist-packages")
-endif()
-if(EXISTS "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/${${packages_path}}")
-  set(_packages_path "lib${LIB_SUFFIX}/${_packages_path}")
-else()
-  set(_packages_path "lib/${_packages_path}")
-endif()
-elseif(CMAKE_HOST_WIN32)
-get_filename_component(_path "${_executable}" PATH)
-file(TO_CMAKE_PATH "${_path}" _path)
-if(NOT EXISTS "${_path}/Lib/site-packages")
-  unset(_path)
-  get_filename_component(_path "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Python\\PythonCore\\${_version_major_minor}\\InstallPath]" ABSOLUTE)
-  if(NOT _path)
-    get_filename_component(_path "[HKEY_CURRENT_USER\\SOFTWARE\\Python\\PythonCore\\${_version_major_minor}\\InstallPath]" ABSOLUTE)
-  endif()
-  file(TO_CMAKE_PATH "${_path}" _path)
-endif()
-set(_packages_path "${_path}/Lib/site-packages")
-unset(_path)
-endif()
-message(STATUS "Installing python modules to ${CMAKE_INSTALL_PREFIX}/${_packages_path}")
+message(STATUS "Installing python modules to ${Python_SITEARCH}")
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/valhalla
-DESTINATION "${_packages_path}"
+DESTINATION "${Python_SITEARCH}"
 COMPONENT python_valhalla
 FILES_MATCHING PATTERN "*.py")
 install(TARGETS python_valhalla
-DESTINATION "${_packages_path}/valhalla"
+DESTINATION "${Python_SITEARCH}/valhalla"
 COMPONENT python_valhalla)


### PR DESCRIPTION
fixes #2929 

it uses the "new" CMake builtin approach to get the right python lib path from the actual python installation used to build the bindings. Meaning it'll install now to `/usr/lib/python3/dist-packages/valhalla` instead of `/usr/local...`, but that's actually better IMO