### PR TITLE
Use kServiceRoad edges while reclassifying ferry connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
    * FIXED: Python bindings installation [#2751](https://github.com/valhalla/valhalla/issues/2751)
    * FIXED: Skip bindings if there's no Python development version [#2893](https://github.com/valhalla/valhalla/pull/2878)
    * FIXED: Use CMakes built-in Python variables to configure installation [#2931](https://github.com/valhalla/valhalla/pull/2931)
+   * FIXED: Use kServiceRoad edges while searching for ferry connection [#2933](https://github.com/valhalla/valhalla/pull/2933)
 
 * **Enhancement**
    * CHANGED: Azure uses ninja as generator [#2779](https://github.com/valhalla/valhalla/pull/2779)

--- a/src/mjolnir/ferry_connections.cc
+++ b/src/mjolnir/ferry_connections.cc
@@ -119,7 +119,7 @@ uint32_t ShortestPath(const uint32_t start_node_idx,
 
       // Skip uses other than road / other (service?)
       const OSMWay w = *ways[edge.wayindex_];
-      if (w.use() != baldr::Use::kOther &&
+      if (w.use() != baldr::Use::kOther && w.use() != baldr::Use::kServiceRoad &&
           static_cast<int>(w.use()) > static_cast<int>(baldr::Use::kTurnChannel)) {
         continue;
       }

--- a/test/gurka/test_ferry_connections.cc
+++ b/test/gurka/test_ferry_connections.cc
@@ -1,0 +1,74 @@
+#include "gurka.h"
+#include <gtest/gtest.h>
+
+using namespace valhalla;
+
+baldr::RoadClass
+ReclassifyFerryConnectionEdge(std::map<std::string, std::string> const& way_description) {
+  constexpr double gridsize_metres = 1000;
+
+  const std::string ascii_map = R"(
+          A--B--b--C----D--E
+    )";
+
+  const gurka::ways ways = {{"AB", {{"highway", "trunk"}, {"name", ""}}},
+                            {"Bb", way_description},
+                            {"bC", way_description},
+                            {"CD",
+                             {{"motor_vehicle", "yes"},
+                              {"motorcar", "yes"},
+                              {"bicycle", "yes"},
+                              {"foot", "yes"},
+                              {"horse", "no"},
+                              {"duration", "01:25"},
+                              {"route", "ferry"},
+                              {"operator", "Cape May-Lewes Ferry"},
+                              {"name", "Cape May-Lewes Ferry"},
+                              {"destination:forward", "Cape May"},
+                              {"destination:backward", "Lewes"}}},
+                            {"DE", {{"highway", "trunk"}, {"name", ""}}}};
+
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, gridsize_metres);
+
+  auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_reclassify_ferry_connections");
+  baldr::GraphReader graph_reader(map.config.get_child("mjolnir"));
+
+  auto edge = std::get<1>(gurka::findEdgeByNodes(graph_reader, layout, "B", "b"));
+  return edge->classification();
+}
+
+TEST(Standalone, ReclassifyFerryConnection) {
+  // for these values of 'highway' tag edge class is upgraded in order to connect ferry to a
+  // high-class road
+  const std::vector<std::string> reclassifiable_ways = {"secondary",      "tertiary",
+                                                        "unclassified",   "service",
+                                                        "secondary_link", "tertiary_link"};
+  for (const auto& cls : reclassifiable_ways) {
+    std::map<std::string, std::string> desc = {{"highway", cls}, {"name", ""}};
+    auto edge_class = ReclassifyFerryConnectionEdge(desc);
+    EXPECT_EQ(edge_class, baldr::RoadClass::kPrimary);
+  }
+}
+
+TEST(Standalone, DoNotReclassifyFerryConnection) {
+  // roads with these values of 'highway' tag do not participate in search for ferry connection so
+  // edge class remains low
+  const std::vector<std::string> not_reclassifiable_ways = {"track", "living_street"};
+  for (const auto& cls : not_reclassifiable_ways) {
+    std::map<std::string, std::string> desc = {{"highway", cls}, {"name", ""}};
+    auto edge_class = ReclassifyFerryConnectionEdge(desc);
+    EXPECT_GE(edge_class, baldr::RoadClass::kPrimary);
+  }
+
+  // roads with these values of 'service' tag do not participate in search for ferry connection so
+  // edge class remains low
+  const std::vector<std::string> not_reclassifiable_use = {"parking_aisle", "driveway", "alley",
+                                                           "emergency_access", "drive-through"};
+  for (const auto& use : not_reclassifiable_use) {
+    std::map<std::string, std::string> desc = {{"highway", "tertiary"},
+                                               {"service", use},
+                                               {"name", ""}};
+    auto edge_class = ReclassifyFerryConnectionEdge(desc);
+    EXPECT_GE(edge_class, baldr::RoadClass::kPrimary);
+  }
+}

--- a/test/gurka/test_ferry_connections.cc
+++ b/test/gurka/test_ferry_connections.cc
@@ -57,7 +57,7 @@ TEST(Standalone, DoNotReclassifyFerryConnection) {
   for (const auto& cls : not_reclassifiable_ways) {
     std::map<std::string, std::string> desc = {{"highway", cls}, {"name", ""}};
     auto edge_class = ReclassifyFerryConnectionEdge(desc);
-    EXPECT_GE(edge_class, baldr::RoadClass::kPrimary);
+    EXPECT_GT(edge_class, baldr::RoadClass::kPrimary);
   }
 
   // roads with these values of 'service' tag do not participate in search for ferry connection so
@@ -69,6 +69,6 @@ TEST(Standalone, DoNotReclassifyFerryConnection) {
                                                {"service", use},
                                                {"name", ""}};
     auto edge_class = ReclassifyFerryConnectionEdge(desc);
-    EXPECT_GE(edge_class, baldr::RoadClass::kPrimary);
+    EXPECT_GT(edge_class, baldr::RoadClass::kPrimary);
   }
 }


### PR DESCRIPTION
# Issue

At some point the enum value `Use::kServiceRoad` was added but the code part that looks for ferry connection wasn't updated
Partially solves ferry connection problems described in https://github.com/valhalla/valhalla/issues/2919

## Tasklist

 - [x] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
