### PR TITLE
ci: Update cache key to trigger clearing it

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -35,7 +35,7 @@ jobs:
       - task: Cache@2
         displayName: "Cache build"
         inputs:
-          key: 'build | "$(Build.SourceBranch)"'
+          key: 'build | "$(Build.SourceBranch)" | "msvc-v16.9.0"'
           path: "$(BUILD_DIR)"
           restoreKeys: |
             build | "$(Build.SourceBranch)"

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -35,11 +35,11 @@ jobs:
       - task: Cache@2
         displayName: "Cache build"
         inputs:
-          key: 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+          key: '"msvc-v16.9.0" | build | "$(Build.SourceBranch)"'
           path: "$(BUILD_DIR)"
           restoreKeys: |
-            build | "$(Build.SourceBranch)"
-            build
+            "msvc-v16.9.0" | build | "$(Build.SourceBranch)"
+            "msvc-v16.9.0" | build
           cacheHitVar: BUILD_CACHE_RESTORED
 
       - task: UsePythonVersion@0

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -35,7 +35,7 @@ jobs:
       - task: Cache@2
         displayName: "Cache build"
         inputs:
-          key: '"msvc-v16.9.0" | build | "$(Build.SourceBranch)"'
+          key: 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
           path: "$(BUILD_DIR)"
           restoreKeys: |
             build | "$(Build.SourceBranch)"

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -35,7 +35,7 @@ jobs:
       - task: Cache@2
         displayName: "Cache build"
         inputs:
-          key: 'build | "$(Build.SourceBranch)" | "msvc-v16.9.0"'
+          key: '"msvc-v16.9.0" | build | "$(Build.SourceBranch)"'
           path: "$(BUILD_DIR)"
           restoreKeys: |
             build | "$(Build.SourceBranch)"


### PR DESCRIPTION
# Issue

Visual Studio 2019 has been updated from v16.8.5 to v16.9.0
and MSVC 14.28.29333 cached in CMake configuration is
no longer accessible

There is no way invalidate cache other than updating its cache:
https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching#can-i-clear-a-cache

## Requirements / Relations

Fixes #2945
