### PR TITLE
Allow config object to be passed-in to path algorithms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
    * ADDED: Status endpoint for future status info and health checking of running service [#2907](https://github.com/valhalla/valhalla/pull/2907)
    * ADDED: Add min_level argument to valhalla_ways_to_edges [#2918](https://github.com/valhalla/valhalla/pull/2918)
    * ADDED: Adding ability to store the roundabout_exit_turn_degree to the maneuver [#2941](https://github.com/valhalla/valhalla/pull/2941)
+   * CHANGED: Allow config object to be passed-in to path algorithms [#2949](https://github.com/valhalla/valhalla/pull/2949)
 
 ## Release Date: 2021-01-25 Valhalla 3.1.0
 * **Removed**

--- a/scripts/valhalla_build_config
+++ b/scripts/valhalla_build_config
@@ -354,7 +354,7 @@ help_text = {
     'service': {
       'proxy': 'IPC linux domain socket file location'
     },
-    'max_reserved_labels_count': 'Maximum capacity that allowed to keep reserved in path algorithm.'
+    'max_reserved_labels_count': 'Maximum capacity for edge labels reserved in path algorithm'
   },
   'odin': {
     'logging': {

--- a/src/thor/astar_bss.cc
+++ b/src/thor/astar_bss.cc
@@ -29,10 +29,11 @@ constexpr uint32_t kInitialEdgeLabelCount = 500000;
 constexpr uint32_t kMaxIterationsWithoutConvergence = 200000;
 
 // Default constructor
-AStarBSSAlgorithm::AStarBSSAlgorithm(uint32_t max_reserved_labels_count)
+AStarBSSAlgorithm::AStarBSSAlgorithm(const boost::property_tree::ptree& config)
     : PathAlgorithm(), max_label_count_(std::numeric_limits<uint32_t>::max()),
       mode_(TravelMode::kDrive), travel_type_(0),
-      max_reserved_labels_count_(max_reserved_labels_count) {
+      max_reserved_labels_count_(
+                config.get<uint32_t>("max_reserved_labels_count", kInitialEdgeLabelCount)) {
 }
 
 // Destructor

--- a/src/thor/astar_bss.cc
+++ b/src/thor/astar_bss.cc
@@ -33,7 +33,7 @@ AStarBSSAlgorithm::AStarBSSAlgorithm(const boost::property_tree::ptree& config)
     : PathAlgorithm(), max_label_count_(std::numeric_limits<uint32_t>::max()),
       mode_(TravelMode::kDrive), travel_type_(0),
       max_reserved_labels_count_(
-                config.get<uint32_t>("max_reserved_labels_count", kInitialEdgeLabelCount)) {
+          config.get<uint32_t>("max_reserved_labels_count", kInitialEdgeLabelCount)) {
 }
 
 // Destructor

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -46,8 +46,9 @@ namespace valhalla {
 namespace thor {
 
 // Default constructor
-BidirectionalAStar::BidirectionalAStar(uint32_t max_reserved_labels_count)
-    : PathAlgorithm(), max_reserved_labels_count_(max_reserved_labels_count) {
+BidirectionalAStar::BidirectionalAStar(const boost::property_tree::ptree& config)
+    : PathAlgorithm(), max_reserved_labels_count_(config.get<uint32_t>("max_reserved_labels_count",
+                                                                       kInitialEdgeLabelCountBD)) {
   cost_threshold_ = 0;
   iterations_threshold_ = 0;
   desired_paths_count_ = 1;

--- a/src/thor/dijkstras.cc
+++ b/src/thor/dijkstras.cc
@@ -45,7 +45,7 @@ namespace thor {
 Dijkstras::Dijkstras(const boost::property_tree::ptree& config)
     : mode_(TravelMode::kDrive), access_mode_(kAutoAccess),
       max_reserved_labels_count_(
-                config.get<uint32_t>("max_reserved_labels_count", kInitialEdgeLabelCount)),
+          config.get<uint32_t>("max_reserved_labels_count", kInitialEdgeLabelCount)),
       multipath_(false) {
 }
 

--- a/src/thor/dijkstras.cc
+++ b/src/thor/dijkstras.cc
@@ -9,6 +9,8 @@ using namespace valhalla::midgard;
 using namespace valhalla::baldr;
 using namespace valhalla::sif;
 
+constexpr uint32_t kInitialEdgeLabelCount = 500000;
+
 namespace {
 
 // Method to get an operator Id from a map of operator strings vs. Id.
@@ -40,9 +42,11 @@ namespace valhalla {
 namespace thor {
 
 // Default constructor
-Dijkstras::Dijkstras(uint32_t max_reserved_labels_count)
+Dijkstras::Dijkstras(const boost::property_tree::ptree& config)
     : mode_(TravelMode::kDrive), access_mode_(kAutoAccess),
-      max_reserved_labels_count_(max_reserved_labels_count), multipath_(false) {
+      max_reserved_labels_count_(
+                config.get<uint32_t>("max_reserved_labels_count", kInitialEdgeLabelCount)),
+      multipath_(false) {
 }
 
 // Clear the temporary information generated during path construction.

--- a/src/thor/isochrone.cc
+++ b/src/thor/isochrone.cc
@@ -43,8 +43,8 @@ namespace thor {
 constexpr uint32_t kInitialEdgeLabelCount = 500000;
 
 // Default constructor
-Isochrone::Isochrone(uint32_t max_reserved_labels_count)
-    : Dijkstras(max_reserved_labels_count), shape_interval_(50.0f) {
+Isochrone::Isochrone(const boost::property_tree::ptree& config)
+    : Dijkstras(config), shape_interval_(50.0f) {
 }
 
 // Construct the isotile. Use a fixed grid size. Convert time in minutes to

--- a/src/thor/multimodal.cc
+++ b/src/thor/multimodal.cc
@@ -41,10 +41,11 @@ namespace thor {
 constexpr uint32_t kInitialEdgeLabelCount = 200000;
 
 // Default constructor
-MultiModalPathAlgorithm::MultiModalPathAlgorithm(uint32_t max_reserved_labels_count)
+MultiModalPathAlgorithm::MultiModalPathAlgorithm(const boost::property_tree::ptree& config)
     : PathAlgorithm(), walking_distance_(0), max_label_count_(std::numeric_limits<uint32_t>::max()),
       mode_(TravelMode::kPedestrian), travel_type_(0),
-      max_reserved_labels_count_(max_reserved_labels_count) {
+      max_reserved_labels_count_(
+                config.get<uint32_t>("max_reserved_labels_count", kInitialEdgeLabelCount)) {
 }
 
 // Destructor

--- a/src/thor/multimodal.cc
+++ b/src/thor/multimodal.cc
@@ -45,7 +45,7 @@ MultiModalPathAlgorithm::MultiModalPathAlgorithm(const boost::property_tree::ptr
     : PathAlgorithm(), walking_distance_(0), max_label_count_(std::numeric_limits<uint32_t>::max()),
       mode_(TravelMode::kPedestrian), travel_type_(0),
       max_reserved_labels_count_(
-                config.get<uint32_t>("max_reserved_labels_count", kInitialEdgeLabelCount)) {
+          config.get<uint32_t>("max_reserved_labels_count", kInitialEdgeLabelCount)) {
 }
 
 // Destructor

--- a/src/thor/timedep_forward.cc
+++ b/src/thor/timedep_forward.cc
@@ -17,10 +17,11 @@ constexpr uint32_t kInitialEdgeLabelCount = 500000;
 constexpr uint32_t kMaxIterationsWithoutConvergence = 1800000;
 
 // Default constructor
-TimeDepForward::TimeDepForward(uint32_t max_reserved_labels_count)
+TimeDepForward::TimeDepForward(const boost::property_tree::ptree& config)
     : PathAlgorithm(), max_label_count_(std::numeric_limits<uint32_t>::max()),
       mode_(TravelMode::kDrive), travel_type_(0),
-      max_reserved_labels_count_(max_reserved_labels_count) {
+      max_reserved_labels_count_(
+                config.get<uint32_t>("max_reserved_labels_count", kInitialEdgeLabelCount)) {
 }
 
 // Destructor

--- a/src/thor/timedep_forward.cc
+++ b/src/thor/timedep_forward.cc
@@ -21,7 +21,7 @@ TimeDepForward::TimeDepForward(const boost::property_tree::ptree& config)
     : PathAlgorithm(), max_label_count_(std::numeric_limits<uint32_t>::max()),
       mode_(TravelMode::kDrive), travel_type_(0),
       max_reserved_labels_count_(
-                config.get<uint32_t>("max_reserved_labels_count", kInitialEdgeLabelCount)) {
+          config.get<uint32_t>("max_reserved_labels_count", kInitialEdgeLabelCount)) {
 }
 
 // Destructor

--- a/src/thor/timedep_reverse.cc
+++ b/src/thor/timedep_reverse.cc
@@ -18,8 +18,7 @@ constexpr uint32_t kInitialEdgeLabelCount = 500000;
 constexpr uint32_t kMaxIterationsWithoutConvergence = 1800000;
 
 // Default constructor
-TimeDepReverse::TimeDepReverse(const boost::property_tree::ptree& config)
-    : TimeDepForward(config) {
+TimeDepReverse::TimeDepReverse(const boost::property_tree::ptree& config) : TimeDepForward(config) {
   mode_ = TravelMode::kDrive;
   travel_type_ = 0;
   max_label_count_ = std::numeric_limits<uint32_t>::max();

--- a/src/thor/timedep_reverse.cc
+++ b/src/thor/timedep_reverse.cc
@@ -12,14 +12,14 @@ namespace valhalla {
 namespace thor {
 
 // TODO - compute initial label count based on estimated route length
-constexpr uint64_t kInitialEdgeLabelCount = 500000;
+constexpr uint32_t kInitialEdgeLabelCount = 500000;
 
 // Number of iterations to allow with no convergence to the destination
 constexpr uint32_t kMaxIterationsWithoutConvergence = 1800000;
 
 // Default constructor
-TimeDepReverse::TimeDepReverse(uint32_t max_reserved_labels_count)
-    : TimeDepForward(max_reserved_labels_count) {
+TimeDepReverse::TimeDepReverse(const boost::property_tree::ptree& config)
+    : TimeDepForward(config) {
   mode_ = TravelMode::kDrive;
   travel_type_ = 0;
   max_label_count_ = std::numeric_limits<uint32_t>::max();

--- a/src/thor/worker.cc
+++ b/src/thor/worker.cc
@@ -72,15 +72,12 @@ namespace thor {
 thor_worker_t::thor_worker_t(const boost::property_tree::ptree& config,
                              const std::shared_ptr<baldr::GraphReader>& graph_reader)
     : mode(valhalla::sif::TravelMode::kPedestrian),
-      bidir_astar(config.get<uint32_t>("thor.max_reserved_labels_count", kMaxReservedLabelsCount)),
-      bss_astar(config.get<uint32_t>("thor.max_reserved_labels_count", kMaxReservedLabelsCount)),
-      multi_modal_astar(
-          config.get<uint32_t>("thor.max_reserved_labels_count", kMaxReservedLabelsCount)),
-      timedep_forward(
-          config.get<uint32_t>("thor.max_reserved_labels_count", kMaxReservedLabelsCount)),
-      timedep_reverse(
-          config.get<uint32_t>("thor.max_reserved_labels_count", kMaxReservedLabelsCount)),
-      isochrone_gen(config.get<uint32_t>("thor.max_reserved_labels_count", kMaxReservedLabelsCount)),
+      bidir_astar(config),
+      bss_astar(config),
+      multi_modal_astar(config),
+      timedep_forward(config),
+      timedep_reverse(config),
+      isochrone_gen(config),
       matcher_factory(config, graph_reader), reader(graph_reader), controller{} {
   // If we weren't provided with a graph reader make our own
   if (!reader)

--- a/src/thor/worker.cc
+++ b/src/thor/worker.cc
@@ -71,9 +71,10 @@ namespace thor {
 
 thor_worker_t::thor_worker_t(const boost::property_tree::ptree& config,
                              const std::shared_ptr<baldr::GraphReader>& graph_reader)
-    : mode(valhalla::sif::TravelMode::kPedestrian), bidir_astar(config), bss_astar(config),
-      multi_modal_astar(config), timedep_forward(config), timedep_reverse(config),
-      isochrone_gen(config), matcher_factory(config, graph_reader),
+    : mode(valhalla::sif::TravelMode::kPedestrian), bidir_astar(config.get_child("thor")),
+      bss_astar(config.get_child("thor")), multi_modal_astar(config.get_child("thor")),
+      timedep_forward(config.get_child("thor")), timedep_reverse(config.get_child("thor")),
+      isochrone_gen(config.get_child("thor")), matcher_factory(config, graph_reader),
       reader(graph_reader), controller{} {
   // If we weren't provided with a graph reader make our own
   if (!reader)

--- a/src/thor/worker.cc
+++ b/src/thor/worker.cc
@@ -71,14 +71,10 @@ namespace thor {
 
 thor_worker_t::thor_worker_t(const boost::property_tree::ptree& config,
                              const std::shared_ptr<baldr::GraphReader>& graph_reader)
-    : mode(valhalla::sif::TravelMode::kPedestrian),
-      bidir_astar(config),
-      bss_astar(config),
-      multi_modal_astar(config),
-      timedep_forward(config),
-      timedep_reverse(config),
-      isochrone_gen(config),
-      matcher_factory(config, graph_reader), reader(graph_reader), controller{} {
+    : mode(valhalla::sif::TravelMode::kPedestrian), bidir_astar(config), bss_astar(config),
+      multi_modal_astar(config), timedep_forward(config), timedep_reverse(config),
+      isochrone_gen(config), matcher_factory(config, graph_reader),
+      reader(graph_reader), controller{} {
   // If we weren't provided with a graph reader make our own
   if (!reader)
     reader = matcher_factory.graphreader();

--- a/valhalla/thor/astar_bss.h
+++ b/valhalla/thor/astar_bss.h
@@ -30,11 +30,9 @@ class AStarBSSAlgorithm : public PathAlgorithm {
 public:
   /**
    * Constructor.
-   * @param max_reserved_labels_count maximum capacity of edgelabels container
-   *                                  that allowed to keep reserved
+   * @param config A config object of key, value pairs
    */
-  explicit AStarBSSAlgorithm(
-      uint32_t max_reserved_labels_count = std::numeric_limits<uint32_t>::max());
+  explicit AStarBSSAlgorithm(const boost::property_tree::ptree& config = {});
 
   /**
    * Destructor

--- a/valhalla/thor/bidirectional_astar.h
+++ b/valhalla/thor/bidirectional_astar.h
@@ -43,11 +43,9 @@ class BidirectionalAStar : public PathAlgorithm {
 public:
   /**
    * Constructor.
-   * @param max_reserved_labels_count maximum capacity of edgelabels container
-   *                                  that allowed to keep reserved
+   * @param config A config object of key, value pairs
    */
-  explicit BidirectionalAStar(
-      uint32_t max_reserved_labels_count = std::numeric_limits<uint32_t>::max());
+  explicit BidirectionalAStar(const boost::property_tree::ptree& config = {});
 
   /**
    * Destructor

--- a/valhalla/thor/dijkstras.h
+++ b/valhalla/thor/dijkstras.h
@@ -41,10 +41,9 @@ class Dijkstras {
 public:
   /**
    * Constructor.
-   * @param max_reserved_labels_count maximum capacity of edgelabels container
-   *                                  that allowed to keep reserved
+   * @param config A config object of key, value pairs
    */
-  explicit Dijkstras(uint32_t max_reserved_labels_count = std::numeric_limits<uint32_t>::max());
+  explicit Dijkstras(const boost::property_tree::ptree& config = {});
 
   Dijkstras(const Dijkstras&) = delete;
   Dijkstras& operator=(const Dijkstras&) = delete;

--- a/valhalla/thor/isochrone.h
+++ b/valhalla/thor/isochrone.h
@@ -31,10 +31,9 @@ class Isochrone : public Dijkstras {
 public:
   /**
    * Constructor.
-   * @param max_reserved_labels_count maximum capacity of edgelabels container
-   *                                  that allowed to keep reserved
+   * @param config A config object of key, value pairs
    */
-  explicit Isochrone(uint32_t max_reserved_labels_count = std::numeric_limits<uint32_t>::max());
+  explicit Isochrone(const boost::property_tree::ptree& config = {});
 
   /**
    * Destructor

--- a/valhalla/thor/multimodal.h
+++ b/valhalla/thor/multimodal.h
@@ -32,11 +32,9 @@ class MultiModalPathAlgorithm : public PathAlgorithm {
 public:
   /**
    * Constructor.
-   * @param max_reserved_labels_count maximum capacity of edgelabels container
-   *                                  that allowed to keep reserved
+   * @param config A config object of key, value pairs
    */
-  explicit MultiModalPathAlgorithm(
-      uint32_t max_reserved_labels_count = std::numeric_limits<uint32_t>::max());
+  explicit MultiModalPathAlgorithm(const boost::property_tree::ptree& config = {});
 
   /**
    * Destructor

--- a/valhalla/thor/timedep.h
+++ b/valhalla/thor/timedep.h
@@ -31,10 +31,9 @@ class TimeDepForward : public PathAlgorithm {
 public:
   /**
    * Constructor.
-   * @param max_reserved_labels_count maximum capacity of edgelabels container
-   *                                  that allowed to keep reserved
+   * @param config A config object of key, value pairs
    */
-  explicit TimeDepForward(uint32_t max_reserved_labels_count = std::numeric_limits<uint32_t>::max());
+  explicit TimeDepForward(const boost::property_tree::ptree& config = {});
 
   /**
    * Destructor
@@ -201,10 +200,9 @@ class TimeDepReverse : public TimeDepForward {
 public:
   /**
    * Constructor.
-   * @param max_reserved_labels_count maximum capacity of edgelabels container
-   *                                  that allowed to keep reserved
+   * @param config A config object of key, value pairs
    */
-  explicit TimeDepReverse(uint32_t max_reserved_labels_count = std::numeric_limits<uint32_t>::max());
+  explicit TimeDepReverse(const boost::property_tree::ptree& config = {});
 
   /**
    * Destructor


### PR DESCRIPTION
This allows us to pass additional configuration values into path
algorithm classes without changing the signature of the constructor
each time.
