### PR TITLE
restore compatibility with gcc 6.3.0, libprotobuf 3.0.0, boost v1.62.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
    * FIXED: Fix map-match segfault when gps-points project very near a node [#2946](https://github.com/valhalla/valhalla/pull/2946)
    * FIXED: Use kServiceRoad edges while searching for ferry connection [#2933](https://github.com/valhalla/valhalla/pull/2933)
    * FIXED: Enhanced logic for IsTurnChannelManeuverCombinable [#2952](https://github.com/valhalla/valhalla/pull/2952)
+   * FIXED: Restore compatibility with gcc 6.3.0, libprotobuf 3.0.0, boost v1.62.0 [#2953](https://github.com/valhalla/valhalla/pull/2953)
 
 * **Enhancement**
    * CHANGED: Azure uses ninja as generator [#2779](https://github.com/valhalla/valhalla/pull/2779)

--- a/src/loki/polygon_search.cc
+++ b/src/loki/polygon_search.cc
@@ -38,8 +38,6 @@ ring_bg_t PBFToRing(const valhalla::Options::Ring& ring_pbf) {
   for (const auto& coord : ring_pbf.coords()) {
     new_ring.push_back({coord.lng(), coord.lat()});
   }
-  // corrects geometry and handedness as expected by bg for rings
-  bg::correct(new_ring);
   return new_ring;
 }
 

--- a/src/thor/route_action.cc
+++ b/src/thor/route_action.cc
@@ -424,7 +424,8 @@ void thor_worker_t::path_arrive_by(Api& api, const std::string& costing) {
 
   auto route_two_locations = [&, this](auto& origin, auto& destination) -> bool {
     // Get the algorithm type for this location pair
-    thor::PathAlgorithm* path_algorithm = get_path_algorithm(costing, *origin, *destination, options);
+    thor::PathAlgorithm* path_algorithm =
+        this->get_path_algorithm(costing, *origin, *destination, options);
     path_algorithm->Clear();
     algorithms.push_back(path_algorithm->name());
     LOG_INFO(std::string("algorithm::") + path_algorithm->name());
@@ -437,7 +438,7 @@ void thor_worker_t::path_arrive_by(Api& api, const std::string& costing) {
     }
 
     // Get best path and keep it
-    auto temp_paths = get_path(path_algorithm, *origin, *destination, costing, options);
+    auto temp_paths = this->get_path(path_algorithm, *origin, *destination, costing, options);
     if (temp_paths.empty())
       return false;
 
@@ -567,7 +568,8 @@ void thor_worker_t::path_depart_at(Api& api, const std::string& costing) {
 
   auto route_two_locations = [&, this](auto& origin, auto& destination) -> bool {
     // Get the algorithm type for this location pair
-    thor::PathAlgorithm* path_algorithm = get_path_algorithm(costing, *origin, *destination, options);
+    thor::PathAlgorithm* path_algorithm =
+        this->get_path_algorithm(costing, *origin, *destination, options);
     path_algorithm->Clear();
     algorithms.push_back(path_algorithm->name());
     LOG_INFO(std::string("algorithm::") + path_algorithm->name());
@@ -580,7 +582,7 @@ void thor_worker_t::path_depart_at(Api& api, const std::string& costing) {
     }
 
     // Get best path and keep it
-    auto temp_paths = get_path(path_algorithm, *origin, *destination, costing, options);
+    auto temp_paths = this->get_path(path_algorithm, *origin, *destination, costing, options);
     if (temp_paths.empty())
       return false;
 

--- a/src/thor/route_action.cc
+++ b/src/thor/route_action.cc
@@ -422,7 +422,7 @@ void thor_worker_t::path_arrive_by(Api& api, const std::string& costing) {
   valhalla::Trip& trip = *api.mutable_trip();
   trip.mutable_routes()->Reserve(options.alternates() + 1);
 
-  auto route_two_locations = [&, this](auto& origin, auto& destination) -> bool {
+  auto route_two_locations = [&](auto& origin, auto& destination) -> bool {
     // Get the algorithm type for this location pair
     thor::PathAlgorithm* path_algorithm =
         this->get_path_algorithm(costing, *origin, *destination, options);

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -1582,7 +1582,7 @@ summarize_route_legs(const google::protobuf::RepeatedPtrField<DirectionsRoute>& 
   // unique the same leg (leg_idx) between all routes.
   for (size_t route_i = 0; route_i < routes.size(); route_i++) {
 
-    size_t num_legs_i = routes[route_i].legs_size();
+    size_t num_legs_i = routes.Get(route_i).legs_size();
     std::vector<std::string> leg_summaries;
     leg_summaries.reserve(num_legs_i);
 
@@ -1602,7 +1602,7 @@ summarize_route_legs(const google::protobuf::RepeatedPtrField<DirectionsRoute>& 
         if (route_i == route_j)
           continue;
 
-        size_t num_legs_j = routes[route_j].legs_size();
+        size_t num_legs_j = routes.Get(route_j).legs_size();
 
         // there should be the same number of legs in every route. however, some
         // unit tests break this rule, so we cannot enable this assert.

--- a/src/tyr/route_summary_cache.h
+++ b/src/tyr/route_summary_cache.h
@@ -95,7 +95,7 @@ public:
     // Combine the distances for same named roads - store in a NamedSegment.
     route_leg_segs_by_dist.reserve(routes.size());
     for (size_t i = 0; i < routes.size(); i++) {
-      const DirectionsRoute& route = routes[i];
+      const DirectionsRoute& route = routes.Get(i);
       std::vector<std::vector<NamedSegment>> leg_segs_by_dist;
       leg_segs_by_dist.reserve(route.legs_size());
       for (size_t j = 0; j < route.legs_size(); j++) {

--- a/test/gurka/test_avoids.cc
+++ b/test/gurka/test_avoids.cc
@@ -176,20 +176,24 @@ TEST_P(AvoidTest, TestAvoid2Polygons) {
   // create 2 small polygons intersecting all connecting roads so it fails to find a path
   //      A------B
   //  x---|-x  y-|---y
-  //  |   |    | |   |
+  //  |   | |  | |   |
   //  x---|-x  y-|---y
   //      |      |
   //      D------E
+  
+  // one clockwise ring
   std::vector<ring_bg_t> rings;
   rings.push_back({{node_a.lng() + 0.1 * dx, node_a.lat() - 0.01 * dy},
                    {node_a.lng() + 0.1 * dx, node_a.lat() - 0.1 * dy},
                    {node_a.lng() - 0.1 * dx, node_a.lat() - 0.1 * dy},
                    {node_a.lng() - 0.1 * dx, node_a.lat() - 0.01 * dy},
                    {node_a.lng() + 0.1 * dx, node_a.lat() - 0.01 * dy}});
+  
+  // one counterclockwise ring
   rings.push_back({{node_b.lng() - 0.1 * dx, node_b.lat() - 0.01 * dy},
-                   {node_b.lng() + 0.1 * dx, node_b.lat() - 0.01 * dy},
-                   {node_b.lng() + 0.1 * dx, node_b.lat() - 0.1 * dy},
                    {node_b.lng() - 0.1 * dx, node_b.lat() - 0.1 * dy},
+                   {node_b.lng() + 0.1 * dx, node_b.lat() - 0.1 * dy},
+                   {node_b.lng() + 0.1 * dx, node_b.lat() - 0.01 * dy},
                    {node_b.lng() - 0.1 * dx, node_b.lat() - 0.01 * dy}});
 
   // build request manually for now

--- a/test/gurka/test_avoids.cc
+++ b/test/gurka/test_avoids.cc
@@ -180,7 +180,7 @@ TEST_P(AvoidTest, TestAvoid2Polygons) {
   //  x---|-x  y-|---y
   //      |      |
   //      D------E
-  
+
   // one clockwise ring
   std::vector<ring_bg_t> rings;
   rings.push_back({{node_a.lng() + 0.1 * dx, node_a.lat() - 0.01 * dy},
@@ -188,7 +188,7 @@ TEST_P(AvoidTest, TestAvoid2Polygons) {
                    {node_a.lng() - 0.1 * dx, node_a.lat() - 0.1 * dy},
                    {node_a.lng() - 0.1 * dx, node_a.lat() - 0.01 * dy},
                    {node_a.lng() + 0.1 * dx, node_a.lat() - 0.01 * dy}});
-  
+
   // one counterclockwise ring
   rings.push_back({{node_b.lng() - 0.1 * dx, node_b.lat() - 0.01 * dy},
                    {node_b.lng() - 0.1 * dx, node_b.lat() - 0.1 * dy},


### PR DESCRIPTION
I wanted to build python packages on debian 9 (for compatibility with [PEP600](https://www.python.org/dev/peps/pep-0600/)), which has a bunch of fairly old versions.. Note, the build was with `-DENABLE_SERVICES=OFF -DENABLE_TESTS=OFF -DENABLE_BENCHMARKS=OFF`.. 

I would've built at least with SERVICES=ON, but I couldn't get prime_server to be discovered by CMake (v3.18.3), which could be an issue with `pkg-config` which is on `v0.29` on debian 9.. 

```
-- Checking for module 'libprime_server>=0.6.3'
--   Requested 'libprime_server >= 0.6.3' but version of libprime_server is
CMake Error at /usr/local/share/cmake-3.18/Modules/FindPkgConfig.cmake:545 (message):
  A required package was not found
```