### PR TITLE
Remove duplicate names being used across different gurka tests

### DIFF
--- a/test/gurka/test_avoids.cc
+++ b/test/gurka/test_avoids.cc
@@ -98,7 +98,7 @@ protected:
                               {"BE", {{"highway", "residential"}, {"name", "2nd"}}}};
     const auto layout = gurka::detail::map_to_coordinates(ascii_map, 10);
     // Add low length limit for avoid_polygons so it throws an error
-    avoid_map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_shortcut",
+    avoid_map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_avoids",
                                   {{"service_limits.max_avoid_polygons_length", "1000"}});
   }
 };

--- a/test/gurka/test_centroid.cc
+++ b/test/gurka/test_centroid.cc
@@ -11,7 +11,7 @@ TEST(centroid, minimal) {
       {"CD", {{"highway", "residential"}}},
   };
   const auto layout = gurka::detail::map_to_coordinates(ascii_map, 10);
-  auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_flat_loop");
+  auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_centroid_minimal");
   auto api = gurka::do_action(Options::centroid, map, {"A", "D"}, "pedestrian");
   ASSERT_EQ(api.trip().routes_size(), 2);
   ASSERT_EQ(api.trip().routes(0).legs_size(), 1);


### PR DESCRIPTION
These would cause random failures when running multiple tests together
as 1 test would overwrite the other tests map dat and fail in
unexpected ways.
