### PR TITLE
Fixes CMake if-clauses

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -187,7 +187,7 @@ if (UNIX AND ENABLE_SINGLE_FILES_WERROR)
   # Enables stricter compiler checks on a file-by-file basis
   # which allows us to migrate piecemeal
   set_source_files_properties(proto_conversions.cc PROPERTIES COMPILE_FLAGS "-Wall -Werror")
-endif (UNIX)
+endif (UNIX AND ENABLE_SINGLE_FILES_WERROR)
 
 if (ENABLE_SERVICES)
   set(valhalla_hdrs ${valhalla_hdrs} ${VALHALLA_SOURCE_DIR}/valhalla/tile_server.h)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -187,7 +187,7 @@ if (UNIX AND ENABLE_SINGLE_FILES_WERROR)
   # Enables stricter compiler checks on a file-by-file basis
   # which allows us to migrate piecemeal
   set_source_files_properties(proto_conversions.cc PROPERTIES COMPILE_FLAGS "-Wall -Werror")
-endif (UNIX AND ENABLE_SINGLE_FILES_WERROR)
+endif()
 
 if (ENABLE_SERVICES)
   set(valhalla_hdrs ${valhalla_hdrs} ${VALHALLA_SOURCE_DIR}/valhalla/tile_server.h)

--- a/src/baldr/CMakeLists.txt
+++ b/src/baldr/CMakeLists.txt
@@ -94,7 +94,7 @@ if (UNIX AND ENABLE_SINGLE_FILES_WERROR)
   # Enables stricter compiler checks on a file-by-file basis
   # which allows us to migrate piecemeal
   set_source_files_properties(openlr.cc PROPERTIES COMPILE_FLAGS "-Werror")
-endif (UNIX)
+endif (UNIX AND ENABLE_SINGLE_FILES_WERROR)
 
 #ios we have more work to make use of system tzdb
 if(APPLE)

--- a/src/baldr/CMakeLists.txt
+++ b/src/baldr/CMakeLists.txt
@@ -94,7 +94,7 @@ if (UNIX AND ENABLE_SINGLE_FILES_WERROR)
   # Enables stricter compiler checks on a file-by-file basis
   # which allows us to migrate piecemeal
   set_source_files_properties(openlr.cc PROPERTIES COMPILE_FLAGS "-Werror")
-endif (UNIX AND ENABLE_SINGLE_FILES_WERROR)
+endif()
 
 #ios we have more work to make use of system tzdb
 if(APPLE)

--- a/src/sif/CMakeLists.txt
+++ b/src/sif/CMakeLists.txt
@@ -17,7 +17,7 @@ if (UNIX AND ENABLE_SINGLE_FILES_WERROR)
   # Enables stricter compiler checks on a file-by-file basis
   # which allows us to migrate piecemeal
   set_source_files_properties(${sources} PROPERTIES COMPILE_FLAGS "-Werror")
-endif (UNIX)
+endif (UNIX AND ENABLE_SINGLE_FILES_WERROR)
 
 valhalla_module(NAME sif
   SOURCES ${sources}

--- a/src/sif/CMakeLists.txt
+++ b/src/sif/CMakeLists.txt
@@ -17,7 +17,7 @@ if (UNIX AND ENABLE_SINGLE_FILES_WERROR)
   # Enables stricter compiler checks on a file-by-file basis
   # which allows us to migrate piecemeal
   set_source_files_properties(${sources} PROPERTIES COMPILE_FLAGS "-Werror")
-endif (UNIX AND ENABLE_SINGLE_FILES_WERROR)
+endif()
 
 valhalla_module(NAME sif
   SOURCES ${sources}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,7 +56,7 @@ if (UNIX AND ENABLE_SINGLE_FILES_WERROR)
     incidents.cc
     incident_loading.cc
     PROPERTIES COMPILE_FLAGS "-Wall -Werror")
-endif (UNIX AND ENABLE_SINGLE_FILES_WERROR)
+endif()
 
 ## Add executable targets
 foreach(test ${tests})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,7 +56,7 @@ if (UNIX AND ENABLE_SINGLE_FILES_WERROR)
     incidents.cc
     incident_loading.cc
     PROPERTIES COMPILE_FLAGS "-Wall -Werror")
-endif (UNIX)
+endif (UNIX AND ENABLE_SINGLE_FILES_WERROR)
 
 ## Add executable targets
 foreach(test ${tests})

--- a/test/gurka/CMakeLists.txt
+++ b/test/gurka/CMakeLists.txt
@@ -14,7 +14,7 @@ if(ENABLE_DATA_TOOLS)
       test_incident_loading.cc
       test_closure_annotations.cc
     PROPERTIES COMPILE_FLAGS "-Werror")
-  endif (UNIX AND ENABLE_SINGLE_FILES_WERROR)
+  endif()
 
   ## Add executable targets
   foreach(FULLFILENAME IN ITEMS ${TEST_FILES})

--- a/test/gurka/CMakeLists.txt
+++ b/test/gurka/CMakeLists.txt
@@ -14,7 +14,7 @@ if(ENABLE_DATA_TOOLS)
       test_incident_loading.cc
       test_closure_annotations.cc
     PROPERTIES COMPILE_FLAGS "-Werror")
-  endif (UNIX)
+  endif (UNIX AND ENABLE_SINGLE_FILES_WERROR)
 
   ## Add executable targets
   foreach(FULLFILENAME IN ITEMS ${TEST_FILES})


### PR DESCRIPTION
Non-matching `endif` clauses are triggering

```
CMake Warning (dev) in src/CMakeLists.txt:
  A logical block opening on the line

    /home/anders/Documents/Programming/mapbox/valhalla/src/CMakeLists.txt:186 (if)

  closes on the line

    /home/anders/Documents/Programming/mapbox/valhalla/src/CMakeLists.txt:190 (endif)

  with mis-matching arguments.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

Introduced in 1696d9ad1b
