### PR TITLE
Call correct isochrone compute method depending on requested expansion type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
    * FIXED: Restore compatibility with gcc 6.3.0, libprotobuf 3.0.0, boost v1.62.0 [#2953](https://github.com/valhalla/valhalla/pull/2953)
    * FIXED: Dont abort bidirectional a-star search if only one direction is exhausted [#2936](https://github.com/valhalla/valhalla/pull/2936)
    * FIXED: Fixed missing comma in the scripts/valhalla_build_config [#2963](https://github.com/valhalla/valhalla/pull/2963)
+   * FIXED: Reverse and Multimodal Isochrones were returning forward results [#2967](https://github.com/valhalla/valhalla/pull/2967)
 
 * **Enhancement**
    * CHANGED: Azure uses ninja as generator [#2779](https://github.com/valhalla/valhalla/pull/2779)

--- a/src/thor/dijkstras.cc
+++ b/src/thor/dijkstras.cc
@@ -235,10 +235,10 @@ void Dijkstras::Expand(ExpansionType expansion_type,
       Compute(*api.mutable_options()->mutable_locations(), reader, costings, mode);
       break;
     case ExpansionType::reverse:
-      Compute(*api.mutable_options()->mutable_locations(), reader, costings, mode);
+      ComputeReverse(*api.mutable_options()->mutable_locations(), reader, costings, mode);
       break;
     case ExpansionType::multimodal:
-      Compute(*api.mutable_options()->mutable_locations(), reader, costings, mode);
+      ComputeMultiModal(*api.mutable_options()->mutable_locations(), reader, costings, mode);
       break;
     default:
       throw std::runtime_error("Unknown expansion type");


### PR DESCRIPTION
# Issue

Looks like this was a typo introduced in the refactoring done [here](https://github.com/valhalla/valhalla/commit/d7a4e787615c54e2bf72fd452ba47d59051005c1#diff-c9004ab6fb25d790ff2f519dc4d705e5d336521654a5b74dba0bb5f18d2c703aL207)

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
