### PR TITLE
Add shoulder to trace_attributes output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
    * CHANGED: Refactor isochrone/reachability forward/reverse search to reduce code repetition [#2969](https://github.com/valhalla/valhalla/pull/2969)
    * ADDED: Set the roundabout exit shape index when we are collapsing the roundabout maneuvers. [#2975](https://github.com/valhalla/valhalla/pull/2975)
    * CHANGED: Penalized closed edges if using them at start/end locations [#2964](https://github.com/valhalla/valhalla/pull/2964)
+   * ADDED: Add shoulder to trace_attributes output. [#2980](https://github.com/valhalla/valhalla/pull/2980)
 
 ## Release Date: 2021-01-25 Valhalla 3.1.0
 * **Removed**

--- a/docs/api/map-matching/api-reference.md
+++ b/docs/api/map-matching/api-reference.md
@@ -108,6 +108,7 @@ edge.lane_count
 edge.cycle_lane
 edge.bicycle_network
 edge.sac_scale
+edge.shoulder
 edge.sidewalk
 edge.density
 edge.speed_limit
@@ -204,6 +205,7 @@ Each `edge` may include:
 | `cycle_lane` | The type (if any) of bicycle lane along this edge. |
 | `bicycle_network` | The bike network for this edge. |
 | `sac_scale` | Classification of hiking trails based on difficulty. Values:<ul><li>`0 - No Sac Scale`</li><li>`1 - Hiking`</li><li>`2 - Mountain hiking`<li>`3 - Demanding mountain hiking`<li>`4 - Alpine hiking`<li>`5 - Demanding alpine hiking`<li>`6 - Difficult alpine hiking`</li></ul> |
+| `shoulder` | True if the edge has a shoulder. |
 | `sidewalk` | Sidewalk values:<ul><li>`left`</li><li>`right`</li><li>`both`</li></ul> |
 | `density` | The relative density along the edge. |
 | `speed_limit` | Edge speed limit in the units specified. The default is kilometers per hour. |

--- a/proto/trip.proto
+++ b/proto/trip.proto
@@ -252,6 +252,7 @@ message TripLeg {
     optional float target_along_edge = 50;
 
     optional SacScale sac_scale = 51;
+    optional bool shoulder = 52;
   }
 
   message IntersectingEdge {

--- a/src/thor/attributes_controller.cc
+++ b/src/thor/attributes_controller.cc
@@ -67,6 +67,7 @@ const std::unordered_map<std::string, bool> AttributesController::kDefaultAttrib
     {kEdgeCycleLane, true},
     {kEdgeBicycleNetwork, true},
     {kEdgeSacScale, true},
+    {kEdgeShoulder, true},
     {kEdgeSidewalk, true},
     {kEdgeDensity, true},
     {kEdgeSpeedLimit, true},

--- a/src/thor/triplegbuilder.cc
+++ b/src/thor/triplegbuilder.cc
@@ -862,6 +862,10 @@ TripLeg_Edge* AddTripEdge(const AttributesController& controller,
     trip_edge->set_sac_scale(GetTripLegSacScale(directededge->sac_scale()));
   }
 
+  if (controller.attributes.at(kEdgeShoulder)) {
+    trip_edge->set_shoulder(directededge->shoulder());
+  }
+
   if (controller.attributes.at(kEdgeSidewalk)) {
     if (directededge->sidewalk_left() && directededge->sidewalk_right()) {
       trip_edge->set_sidewalk(TripLeg_Sidewalk::TripLeg_Sidewalk_kBothSides);

--- a/src/tyr/trace_serializer.cc
+++ b/src/tyr/trace_serializer.cc
@@ -84,6 +84,9 @@ json::ArrayPtr serialize_edges(const AttributesController& controller,
       if (edge.has_sac_scale()) {
         edge_map->emplace("sac_scale", static_cast<uint64_t>(edge.sac_scale()));
       }
+      if (edge.has_shoulder()) {
+        edge_map->emplace("shoulder", static_cast<bool>(edge.shoulder()));
+      }
       if (edge.has_sidewalk()) {
         edge_map->emplace("sidewalk", to_string(edge.sidewalk()));
       }

--- a/test/gurka/test_trace_attributes.cc
+++ b/test/gurka/test_trace_attributes.cc
@@ -44,3 +44,32 @@ TEST(Standalone, SacScaleAttributes) {
   EXPECT_TRUE(edges[2].HasMember("sac_scale"));
   EXPECT_EQ(edges[2]["sac_scale"].GetInt(), 0);
 }
+
+TEST(Standalone, ShoulderAttributes) {
+
+  const std::string ascii_map = R"(
+      1
+    A---2B-3-4C)";
+
+  const gurka::ways ways = {{"AB", {{"highway", "primary"}, {"shoulder", "both"}}},
+                            {"BC", {{"highway", "primary"}}}};
+
+  const double gridsize = 10;
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, gridsize);
+  auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/shoulder_attributes");
+
+  std::string trace_json;
+  auto api =
+      gurka::do_action(valhalla::Options::trace_attributes, map, {"1", "2", "3", "4"},
+                       "bicycle", {}, {}, &trace_json, "via");
+
+  rapidjson::Document result;
+  result.Parse(trace_json.c_str());
+
+  auto edges = result["edges"].GetArray();
+  ASSERT_EQ(edges.Size(), 2);
+  EXPECT_TRUE(edges[0].HasMember("shoulder"));
+  EXPECT_TRUE(edges[0]["shoulder"].GetBool());
+  EXPECT_TRUE(edges[1].HasMember("shoulder"));
+  EXPECT_FALSE(edges[1]["shoulder"].GetBool());
+}

--- a/test/gurka/test_trace_attributes.cc
+++ b/test/gurka/test_trace_attributes.cc
@@ -59,9 +59,8 @@ TEST(Standalone, ShoulderAttributes) {
   auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/shoulder_attributes");
 
   std::string trace_json;
-  auto api =
-      gurka::do_action(valhalla::Options::trace_attributes, map, {"1", "2", "3", "4"},
-                       "bicycle", {}, {}, &trace_json, "via");
+  auto api = gurka::do_action(valhalla::Options::trace_attributes, map, {"1", "2", "3", "4"},
+                              "bicycle", {}, {}, &trace_json, "via");
 
   rapidjson::Document result;
   result.Parse(trace_json.c_str());

--- a/valhalla/thor/attributes_controller.h
+++ b/valhalla/thor/attributes_controller.h
@@ -64,6 +64,7 @@ const std::string kEdgeLaneConnectivity = "edge.lane_connectivity";
 const std::string kEdgeCycleLane = "edge.cycle_lane";
 const std::string kEdgeBicycleNetwork = "edge.bicycle_network";
 const std::string kEdgeSacScale = "edge.sac_scale";
+const std::string kEdgeShoulder = "edge.shoulder";
 const std::string kEdgeSidewalk = "edge.sidewalk";
 const std::string kEdgeDensity = "edge.density";
 const std::string kEdgeSpeedLimit = "edge.speed_limit";


### PR DESCRIPTION
# Issue

Trace attributes does not include edge shoulder. Added this as it can be useful for bicycle routes.

## Tasklist

 - [x] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [x] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
