### PR TITLE
Avoid UB on converting NaN to int in annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
    * FIXED: Isochrone: orient segments/rings acoording to the right-hand rule [#2932](https://github.com/valhalla/valhalla/pull/2932)
    * FIXED: Parsenodes fix: check if index is out-of-bound first [#2984](https://github.com/valhalla/valhalla/pull/2984)
    * FIXED: Isochrone: handle origin edges properly [#2990](https://github.com/valhalla/valhalla/pull/2990)
+   * FIXED: Annotations fail with returning NaN speed when the same point is duplicated in route geometry [#2992](https://github.com/valhalla/valhalla/pull/2992)
 
 * **Enhancement**
    * Pedestrian crossing should be a separate TripLeg_Use [#2950](https://github.com/valhalla/valhalla/pull/2950)

--- a/src/thor/triplegbuilder.cc
+++ b/src/thor/triplegbuilder.cc
@@ -328,6 +328,9 @@ void SetShapeAttributes(const AttributesController& controller,
     }
     distance_total_pct = next_total;
     double time = distance / cut_itr->speed; // seconds
+    if (std::isnan(time)) {
+      time = 0.;
+    }
 
     // Set shape attributes time per shape point if requested
     if (controller.attributes.at(kShapeAttributesTime)) {
@@ -344,7 +347,11 @@ void SetShapeAttributes(const AttributesController& controller,
     // Set shape attributes speed per shape point if requested
     if (controller.attributes.at(kShapeAttributesSpeed)) {
       // convert speed to decimeters per sec and then round to an integer
-      leg.mutable_shape_attributes()->add_speed((distance * kDecimeterPerMeter / time) + 0.5);
+      double speed = (distance * kDecimeterPerMeter / time) + 0.5;
+      if (std::isnan(speed) || time == 0.) { // avoid NaN
+        speed = 0.;
+      }
+      leg.mutable_shape_attributes()->add_speed(speed);
     }
 
     // Set the maxspeed if requested

--- a/test/shape_attributes.cc
+++ b/test/shape_attributes.cc
@@ -80,6 +80,66 @@ TEST(ShapeAttributes, test_shape_attributes_included) {
   }
 }
 
+TEST(ShapeAttributes, test_shape_attributes_duplicated_point) {
+  tyr::actor_t actor(conf);
+
+  auto result_json = actor.trace_attributes(
+      R"({"shape":[
+        {"lat":52.09110,"lon":5.09806},
+        {"lat":52.09110,"lon":5.09806},
+        {"lat":52.09050,"lon":5.09769},
+        {"lat":52.09098,"lon":5.09679}
+      ],"costing":"auto","shape_match":"map_snap",
+      "filters":{"attributes":["edge.length","edge.speed","edge.begin_shape_index",
+      "edge.end_shape_index","shape","shape_attributes.length","shape_attributes.time","shape_attributes.speed"],
+      "action":"include"}})");
+
+  rapidjson::Document doc;
+  doc.Parse(result_json);
+  EXPECT_FALSE(doc.HasParseError()) << "Could not parse json response";
+
+  auto shape =
+      midgard::decode<std::vector<PointLL>>(rapidjson::Pointer("/shape").Get(doc)->GetString());
+  auto shape_attributes_time = rapidjson::Pointer("/shape_attributes/time").Get(doc)->GetArray();
+  auto shape_attributes_length = rapidjson::Pointer("/shape_attributes/length").Get(doc)->GetArray();
+  auto shape_attributes_speed = rapidjson::Pointer("/shape_attributes/speed").Get(doc)->GetArray();
+  auto edges = rapidjson::Pointer("/edges").Get(doc)->GetArray();
+
+  EXPECT_EQ(shape_attributes_time.Size(), shape.size() - 1);
+  EXPECT_EQ(shape_attributes_length.Size(), shape.size() - 1);
+  EXPECT_EQ(shape_attributes_speed.Size(), shape.size() - 1);
+
+  // Measures the length between point
+  for (int i = 1; i < shape.size(); i++) {
+    auto distance = shape[i].Distance(shape[i - 1]) * .001f;
+
+    // Measuring that the length between shape pts is approx. to the shape attributes length
+    EXPECT_NEAR(distance, shape_attributes_length[i - 1].GetFloat(), .01f);
+  }
+
+  // Assert that the shape attributes (time, length, speed) are equal to their corresponding edge
+  // attributes
+  for (int e = 0; e < edges.Size(); e++) {
+    auto edge_length = edges[e]["length"].GetDouble();
+    auto edge_speed = edges[e]["speed"].GetDouble();
+
+    double sum_times = 0;
+    double sum_lengths = 0;
+    for (int j = edges[e]["begin_shape_index"].GetInt(); j < edges[e]["end_shape_index"].GetInt();
+         j++) {
+      sum_times += shape_attributes_time[j].GetDouble();
+      sum_lengths += shape_attributes_length[j].GetDouble();
+
+      EXPECT_NEAR(edge_speed, shape_attributes_speed[j].GetDouble(), .15);
+    }
+
+    // Can't assert that sum of shape times equals edge's elapsed_time because elapsed_time includes
+    // transition costs and shape times do not.
+    EXPECT_NEAR(3600 * edge_length / edge_speed, sum_times, .1);
+    EXPECT_NEAR(edge_length, sum_lengths, .1);
+  }
+}
+
 TEST(ShapeAttributes, test_shape_attributes_no_turncosts) {
   tyr::actor_t actor(conf);
   auto result_json = actor.trace_attributes(


### PR DESCRIPTION
# Issue

Speed annotation may fail with converting NaN to integer if the same geometry point in duplicated in a route. 

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
