### PR TITLE
nit(rename): Renames the encoded live speed properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
    * CHANGED: Factor for service roads is 1.0 by default. [#2988](https://github.com/valhalla/valhalla/pull/2988)
    * ADDED: Support for conditionally skipping CI runs [#2986](https://github.com/valhalla/valhalla/pull/2986)
    * ADDED: Add instructions for building valhalla on `arm64` macbook [#2997](https://github.com/valhalla/valhalla/pull/2997)
+   * CHANGED: nit(rename): Renames the encoded live speed properties [#2998](https://github.com/valhalla/valhalla/pull/2998)
 
 
 ## Release Date: 2021-01-25 Valhalla 3.1.0

--- a/bench/thor/routes.cc
+++ b/bench/thor/routes.cc
@@ -203,7 +203,7 @@ void customize_traffic(const boost::property_tree::ptree& config,
     if (edge_id == target_edge_id) {
       current->breakpoint1 = 255;
       current->overall_speed = target_speed >> 1;
-      current->speed1 = target_speed >> 1;
+      current->encoded_speed1 = target_speed >> 1;
     }
   };
   test::customize_live_traffic_data(config, generate_traffic);

--- a/bench/thor/routes.cc
+++ b/bench/thor/routes.cc
@@ -101,7 +101,7 @@ static void BM_UtrechtBidirectionalAstar(benchmark::State& state) {
       baldr::GraphId tile_id(tile.header->tile_id);
       if (traffic_dist(gen) < has_live_traffic) {
         current->breakpoint1 = 255;
-        current->overall_speed = traffic_dist(gen) * 100;
+        current->overall_encoded_speed = traffic_dist(gen) * 100;
       } else {
       }
     };
@@ -202,7 +202,7 @@ void customize_traffic(const boost::property_tree::ptree& config,
     auto edge_id = baldr::GraphId(tile_id.tileid(), tile_id.level(), index);
     if (edge_id == target_edge_id) {
       current->breakpoint1 = 255;
-      current->overall_speed = target_speed >> 1;
+      current->overall_encoded_speed = target_speed >> 1;
       current->encoded_speed1 = target_speed >> 1;
     }
   };

--- a/test/gurka/test_closure_annotations.cc
+++ b/test/gurka/test_closure_annotations.cc
@@ -12,19 +12,19 @@ namespace {
 inline void SetLiveSpeedFrom(baldr::TrafficSpeed* live_speed, uint8_t speed, uint8_t breakpoint1) {
   live_speed->breakpoint1 = breakpoint1;
   live_speed->breakpoint2 = 255;
-  live_speed->speed2 = speed >> 1;
+  live_speed->encoded_speed2 = speed >> 1;
   live_speed->speed3 = UNKNOWN_TRAFFIC_SPEED_RAW;
 }
 
 inline void SetLiveSpeedUpto(baldr::TrafficSpeed* live_speed, uint8_t speed, uint8_t breakpoint1) {
   live_speed->breakpoint1 = breakpoint1;
-  live_speed->speed1 = speed >> 1;
+  live_speed->encoded_speed1 = speed >> 1;
 }
 
 inline void SetLiveSpeed(baldr::TrafficSpeed* live_speed, uint8_t speed) {
   live_speed->breakpoint1 = 255;
-  live_speed->overall_speed = speed >> 1;
-  live_speed->speed1 = speed >> 1;
+  live_speed->overall_encoded_speed = speed >> 1;
+  live_speed->encoded_speed1 = speed >> 1;
 }
 
 void close_partial_dir_edge_from(baldr::GraphReader& reader,

--- a/test/gurka/test_closure_annotations.cc
+++ b/test/gurka/test_closure_annotations.cc
@@ -13,7 +13,7 @@ inline void SetLiveSpeedFrom(baldr::TrafficSpeed* live_speed, uint8_t speed, uin
   live_speed->breakpoint1 = breakpoint1;
   live_speed->breakpoint2 = 255;
   live_speed->encoded_speed2 = speed >> 1;
-  live_speed->speed3 = UNKNOWN_TRAFFIC_SPEED_RAW;
+  live_speed->encoded_speed3 = UNKNOWN_TRAFFIC_SPEED_RAW;
 }
 
 inline void SetLiveSpeedUpto(baldr::TrafficSpeed* live_speed, uint8_t speed, uint8_t breakpoint1) {

--- a/test/gurka/test_closure_penalty.cc
+++ b/test/gurka/test_closure_penalty.cc
@@ -10,8 +10,8 @@ using LiveTrafficCustomize = test::LiveTrafficCustomize;
 namespace {
 inline void SetLiveSpeed(baldr::TrafficSpeed* live_speed, uint64_t speed) {
   live_speed->breakpoint1 = 255;
-  live_speed->overall_speed = speed >> 1;
-  live_speed->speed1 = speed >> 1;
+  live_speed->overall_encoded_speed = speed >> 1;
+  live_speed->encoded_speed1 = speed >> 1;
 }
 
 void close_dir_edge(baldr::GraphReader& reader,

--- a/test/gurka/test_costing_with_traffic.cc
+++ b/test/gurka/test_costing_with_traffic.cc
@@ -14,8 +14,8 @@ const std::vector<std::string>& costing = {"auto",  "hov",           "taxi",    
 
 void SetLiveSpeed(baldr::TrafficSpeed* live_speed, uint64_t speed) {
   live_speed->breakpoint1 = 255;
-  live_speed->overall_speed = speed >> 1;
-  live_speed->speed1 = speed >> 1;
+  live_speed->overall_encoded_speed = speed >> 1;
+  live_speed->encoded_speed1 = speed >> 1;
 }
 
 void update_dir_edge(baldr::GraphReader& reader,

--- a/test/gurka/test_locate.cc
+++ b/test/gurka/test_locate.cc
@@ -39,14 +39,14 @@ TEST(locate, basic_properties) {
   // turn on some traffic for fun
   auto traffic_cb = [](baldr::GraphReader& reader, baldr::TrafficTile& tile, int index,
                        valhalla::baldr::TrafficSpeed* current) -> void {
-    current->overall_speed = 124 >> 1;
-    current->speed1 = 126 >> 1;
+    current->overall_encoded_speed = 124 >> 1;
+    current->encoded_speed1 = 126 >> 1;
     current->congestion1 = 0; // unknown
     current->breakpoint1 = 85;
-    current->speed2 = 124 >> 1;
+    current->encoded_speed2 = 124 >> 1;
     current->congestion2 = 32; // middle
     current->breakpoint2 = 170;
-    current->speed3 = 122 >> 1;
+    current->encoded_speed3 = 122 >> 1;
     current->congestion3 = 63; // high
   };
   test::customize_live_traffic_data(map.config, traffic_cb);

--- a/test/gurka/test_match.cc
+++ b/test/gurka/test_match.cc
@@ -214,7 +214,7 @@ protected:
     test::customize_live_traffic_data(map.config, [&](baldr::GraphReader&, baldr::TrafficTile&, int,
                                                       valhalla::baldr::TrafficSpeed* traffic_speed) {
       traffic_speed->overall_speed = 50 >> 1;
-      traffic_speed->speed1 = 50 >> 1;
+      traffic_speed->encoded_speed1 = 50 >> 1;
       traffic_speed->breakpoint1 = 255;
     });
 

--- a/test/gurka/test_match.cc
+++ b/test/gurka/test_match.cc
@@ -213,7 +213,7 @@ protected:
     test::build_live_traffic_data(map.config);
     test::customize_live_traffic_data(map.config, [&](baldr::GraphReader&, baldr::TrafficTile&, int,
                                                       valhalla::baldr::TrafficSpeed* traffic_speed) {
-      traffic_speed->overall_speed = 50 >> 1;
+      traffic_speed->overall_encoded_speed = 50 >> 1;
       traffic_speed->encoded_speed1 = 50 >> 1;
       traffic_speed->breakpoint1 = 255;
     });

--- a/test/gurka/test_reach.cc
+++ b/test/gurka/test_reach.cc
@@ -15,8 +15,8 @@ using LiveTrafficCustomize = test::LiveTrafficCustomize;
 namespace {
 inline void SetLiveSpeed(baldr::TrafficSpeed* live_speed, uint64_t speed) {
   live_speed->breakpoint1 = 255;
-  live_speed->overall_speed = speed >> 1;
-  live_speed->speed1 = speed >> 1;
+  live_speed->overall_encoded_speed = speed >> 1;
+  live_speed->encoded_speed1 = speed >> 1;
 }
 
 void close_dir_edge(baldr::GraphReader& reader,

--- a/test/gurka/test_route.cc
+++ b/test/gurka/test_route.cc
@@ -291,8 +291,8 @@ protected:
     test::build_live_traffic_data(map.config);
     test::customize_live_traffic_data(map.config, [&](baldr::GraphReader&, baldr::TrafficTile&, int,
                                                       valhalla::baldr::TrafficSpeed* traffic_speed) {
-      traffic_speed->overall_speed = 50 >> 1;
-      traffic_speed->speed1 = 50 >> 1;
+      traffic_speed->overall_encoded_speed = 50 >> 1;
+      traffic_speed->encoded_speed1 = 50 >> 1;
       traffic_speed->breakpoint1 = 255;
     });
 

--- a/test/gurka/test_search_filter.cc
+++ b/test/gurka/test_search_filter.cc
@@ -190,8 +190,8 @@ TEST_F(SearchFilter, ExcludeRamp) {
 namespace {
 inline void SetLiveSpeed(baldr::TrafficSpeed* live_speed, uint64_t speed) {
   live_speed->breakpoint1 = 255;
-  live_speed->overall_speed = speed >> 1;
-  live_speed->speed1 = speed >> 1;
+  live_speed->overall_encoded_speed = speed >> 1;
+  live_speed->encoded_speed1 = speed >> 1;
 }
 
 void close_dir_edge(baldr::GraphReader& reader,

--- a/test/gurka/test_traffic.cc
+++ b/test/gurka/test_traffic.cc
@@ -54,11 +54,11 @@ TEST(Traffic, BasicUpdates) {
     auto BD = gurka::findEdge(reader, map.nodes, "BD", "D", tile_id);
     current->breakpoint1 = 255;
     if (std::get<1>(BD) != nullptr && std::get<0>(BD).id() == index) {
-      current->overall_speed = 0;
-      current->speed1 = 0;
+      current->overall_encoded_speed = 0;
+      current->encoded_speed1 = 0;
     } else {
-      current->overall_speed = 24 >> 1;
-      current->speed1 = 24 >> 1;
+      current->overall_encoded_speed = 24 >> 1;
+      current->encoded_speed1 = 24 >> 1;
     }
   };
   test::customize_live_traffic_data(map.config, cb_setter_24kmh);
@@ -82,9 +82,9 @@ TEST(Traffic, BasicUpdates) {
     auto BD = gurka::findEdge(reader, map.nodes, "BD", "D", tile_id);
     current->breakpoint1 = 255;
     if (std::get<1>(BD) != nullptr && std::get<0>(BD).id() == index) {
-      current->overall_speed = 0;
+      current->overall_encoded_speed = 0;
     } else {
-      current->overall_speed = UNKNOWN_TRAFFIC_SPEED_RAW - 1;
+      current->overall_encoded_speed = UNKNOWN_TRAFFIC_SPEED_RAW - 1;
     }
   };
   test::customize_live_traffic_data(map.config, cb_setter_max);
@@ -210,8 +210,8 @@ TEST(Traffic, CutGeoms) {
         0u,
         0u,
     };
-    ts.overall_speed = 42 >> 1;
-    ts.speed1 = 42 >> 1;
+    ts.overall_encoded_speed = 42 >> 1;
+    ts.encoded_speed1 = 42 >> 1;
     ts.congestion1 = baldr::MAX_CONGESTION_VAL - 1;
     ts.breakpoint1 = 127;
 
@@ -221,8 +221,8 @@ TEST(Traffic, CutGeoms) {
       auto BD = gurka::findEdge(reader, map.nodes, "BD", "D", tile_id);
       current->breakpoint1 = 255;
       if (std::get<1>(BD) != nullptr && std::get<0>(BD).id() == index) {
-        current->overall_speed = 0;
-        current->speed1 = 0;
+        current->overall_encoded_speed = 0;
+        current->encoded_speed1 = 0;
         current->breakpoint1 = 255;
       } else {
         *current = ts;
@@ -279,13 +279,13 @@ TEST(Traffic, CutGeoms) {
           0u,
           0u,
       };
-      ts.overall_speed = 30 >> 1;
+      ts.overall_encoded_speed = 30 >> 1;
 
-      ts.speed1 = 20 >> 1;
+      ts.encoded_speed1 = 20 >> 1;
       ts.congestion1 = baldr::MAX_CONGESTION_VAL - 1;
       ts.breakpoint1 = 100;
 
-      ts.speed2 = 40 >> 1;
+      ts.encoded_speed2 = 40 >> 1;
       ts.congestion2 = 1; // low but not unknown - 0 = unknown
       ts.breakpoint2 = 200;
 
@@ -297,8 +297,8 @@ TEST(Traffic, CutGeoms) {
             const_cast<valhalla::baldr::TrafficSpeed*>(tile.speeds + index);
         current->breakpoint1 = 255;
         if (std::get<1>(BD) != nullptr && std::get<0>(BD).id() == index) {
-          current->overall_speed = 0;
-          current->speed1 = 0;
+          current->overall_encoded_speed = 0;
+          current->encoded_speed1 = 0;
         } else {
           *current = ts;
         }
@@ -360,17 +360,17 @@ TEST(Traffic, CutGeoms) {
           0u,
           0u,
       };
-      ts.overall_speed = 36 >> 1;
+      ts.overall_encoded_speed = 36 >> 1;
 
-      ts.speed1 = 20 >> 1;
+      ts.encoded_speed1 = 20 >> 1;
       ts.congestion1 = baldr::MAX_CONGESTION_VAL - 1;
       ts.breakpoint1 = 100;
 
-      ts.speed2 = 40 >> 1;
+      ts.encoded_speed2 = 40 >> 1;
       ts.congestion2 = 1;
       ts.breakpoint2 = 200;
 
-      ts.speed3 = 60 >> 1;
+      ts.encoded_speed3 = 60 >> 1;
       ts.congestion3 = 1;
 
       auto cb_setter_speed = [&map, &ts](baldr::GraphReader& reader, baldr::TrafficTile& tile,
@@ -379,8 +379,8 @@ TEST(Traffic, CutGeoms) {
         auto BD = gurka::findEdge(reader, map.nodes, "BD", "D", tile_id);
         current->breakpoint1 = 255;
         if (std::get<1>(BD) != nullptr && std::get<0>(BD).id() == index) {
-          current->overall_speed = 0;
-          current->speed1 = 0;
+          current->overall_encoded_speed = 0;
+          current->encoded_speed1 = 0;
         } else {
           *current = ts;
         }
@@ -479,17 +479,17 @@ TEST(Traffic, CutGeoms) {
             0u,
             0u,
         };
-        ts.overall_speed = 36 >> 1;
+        ts.overall_encoded_speed = 36 >> 1;
 
-        ts.speed1 = 20 >> 1;
+        ts.encoded_speed1 = 20 >> 1;
         ts.congestion1 = baldr::MAX_CONGESTION_VAL - 1;
         ts.breakpoint1 = 100;
 
-        ts.speed2 = 40 >> 1;
+        ts.encoded_speed2 = 40 >> 1;
         ts.congestion2 = 1;
         ts.breakpoint2 = 200;
 
-        ts.speed3 = 60 >> 1;
+        ts.encoded_speed3 = 60 >> 1;
         ts.congestion3 = 50;
 
         auto cb_setter_speed = [&map, &ts](baldr::GraphReader& reader, baldr::TrafficTile& tile,
@@ -498,8 +498,8 @@ TEST(Traffic, CutGeoms) {
           auto BD = gurka::findEdge(reader, map.nodes, "BD", "D", tile_id);
           current->breakpoint1 = 255;
           if (std::get<1>(BD) != nullptr && std::get<0>(BD).id() == index) {
-            current->overall_speed = 0;
-            current->speed1 = 0;
+            current->overall_encoded_speed = 0;
+            current->encoded_speed1 = 0;
           } else {
             *current = ts;
           }
@@ -716,13 +716,13 @@ TEST(Traffic, CutGeoms) {
             0u,
             0u,
         };
-        ts.overall_speed = 36 >> 1;
+        ts.overall_encoded_speed = 36 >> 1;
 
-        ts.speed1 = 20 >> 1;
+        ts.encoded_speed1 = 20 >> 1;
         ts.congestion1 = baldr::MAX_CONGESTION_VAL - 1;
         ts.breakpoint1 = 100;
 
-        ts.speed2 = 40 >> 1;
+        ts.encoded_speed2 = 40 >> 1;
         ts.congestion2 = 1;
 
         // Regression is when breakpoint2 is set to 255,
@@ -731,7 +731,7 @@ TEST(Traffic, CutGeoms) {
         ts.breakpoint2 = 255;
 
         // This needs to be set
-        ts.speed3 = 60 >> 1;
+        ts.encoded_speed3 = 60 >> 1;
         ts.congestion3 = 50;
 
         auto cb_setter_speed = [&map, &ts](baldr::GraphReader& reader, baldr::TrafficTile& tile,
@@ -740,8 +740,8 @@ TEST(Traffic, CutGeoms) {
           auto BD = gurka::findEdge(reader, map.nodes, "BD", "D", tile_id);
           current->breakpoint1 = 255;
           if (std::get<1>(BD) != nullptr && std::get<0>(BD).id() == index) {
-            current->overall_speed = 0;
-            current->speed1 = 0;
+            current->overall_encoded_speed = 0;
+            current->encoded_speed1 = 0;
           } else {
             *current = ts;
           }
@@ -835,8 +835,8 @@ std::shared_ptr<baldr::GraphReader> WaypointsOnClosuresTest::clean_reader;
 namespace {
 inline void SetLiveSpeed(baldr::TrafficSpeed* live_speed, uint64_t speed) {
   live_speed->breakpoint1 = 255;
-  live_speed->overall_speed = speed >> 1;
-  live_speed->speed1 = speed >> 1;
+  live_speed->overall_encoded_speed = speed >> 1;
+  live_speed->encoded_speed1 = speed >> 1;
 }
 } // namespace
 

--- a/test/traffictile.cc
+++ b/test/traffictile.cc
@@ -28,9 +28,9 @@ TEST(Traffic, TileConstruction) {
   TestTile testdata{};
   testdata.header.directed_edge_count = 3;
   testdata.header.traffic_tile_version = TRAFFIC_TILE_VERSION;
-  testdata.speed3.overall_speed = 98 >> 1;
-  testdata.speed3.speed1 = 98 >> 1;
-  testdata.speed3.speed2 = UNKNOWN_TRAFFIC_SPEED_RAW;
+  testdata.speed3.overall_encoded_speed = 98 >> 1;
+  testdata.speed3.encoded_speed1 = 98 >> 1;
+  testdata.speed3.encoded_speed2 = UNKNOWN_TRAFFIC_SPEED_RAW;
   testdata.speed3.speed3 = UNKNOWN_TRAFFIC_SPEED_RAW;
   testdata.speed3.breakpoint1 = 255;
 
@@ -67,7 +67,7 @@ TEST(Traffic, Closed) {
   TrafficSpeed speed = {};
   EXPECT_FALSE(speed.closed());
 
-  speed.speed1 = 0;
+  speed.encoded_speed1 = 0;
   EXPECT_FALSE(speed.closed());
   EXPECT_FALSE(speed.closed(0));
 
@@ -75,7 +75,7 @@ TEST(Traffic, Closed) {
   EXPECT_TRUE(speed.closed());
   EXPECT_TRUE(speed.closed(0));
 
-  speed.overall_speed = 0;
+  speed.overall_encoded_speed = 0;
   EXPECT_TRUE(speed.closed());
   EXPECT_TRUE(speed.closed(0));
 }
@@ -83,37 +83,37 @@ TEST(Traffic, Closed) {
 TEST(Traffic, SpeedValid) {
   using namespace valhalla::baldr;
   TrafficSpeed speed = {};
-  speed.overall_speed = UNKNOWN_TRAFFIC_SPEED_RAW;
+  speed.overall_encoded_speed = UNKNOWN_TRAFFIC_SPEED_RAW;
   EXPECT_FALSE(speed.speed_valid());
 
-  speed.speed1 = 1;
+  speed.encoded_speed1 = 1;
   EXPECT_FALSE(speed.speed_valid());
   EXPECT_FALSE(speed.closed());
 
-  speed.speed1 = 0;
+  speed.encoded_speed1 = 0;
   speed.congestion1 = 1;
   EXPECT_FALSE(speed.speed_valid());
   EXPECT_FALSE(speed.closed());
 
-  speed.speed1 = 0;
+  speed.encoded_speed1 = 0;
   speed.congestion1 = 4;
   EXPECT_FALSE(speed.speed_valid());
   EXPECT_FALSE(speed.closed());
 
-  speed.speed1 = 0;
+  speed.encoded_speed1 = 0;
   speed.breakpoint1 = 255;
   EXPECT_FALSE(speed.speed_valid());
   EXPECT_FALSE(speed.closed());
 
-  speed.speed1 = 0;
+  speed.encoded_speed1 = 0;
   speed.breakpoint1 = 255;
-  speed.overall_speed = 0;
+  speed.overall_encoded_speed = 0;
   EXPECT_TRUE(speed.speed_valid());
   EXPECT_TRUE(speed.closed());
 
   // Test wraparound
-  speed.speed1 = UNKNOWN_TRAFFIC_SPEED_RAW + 1;
-  EXPECT_EQ(speed.speed1, 0);
+  speed.encoded_speed1 = UNKNOWN_TRAFFIC_SPEED_RAW + 1;
+  EXPECT_EQ(speed.encoded_speed1, 0);
 }
 
 int main(int argc, char* argv[]) {

--- a/test/traffictile.cc
+++ b/test/traffictile.cc
@@ -31,7 +31,7 @@ TEST(Traffic, TileConstruction) {
   testdata.speed3.overall_encoded_speed = 98 >> 1;
   testdata.speed3.encoded_speed1 = 98 >> 1;
   testdata.speed3.encoded_speed2 = UNKNOWN_TRAFFIC_SPEED_RAW;
-  testdata.speed3.speed3 = UNKNOWN_TRAFFIC_SPEED_RAW;
+  testdata.speed3.encoded_speed3 = UNKNOWN_TRAFFIC_SPEED_RAW;
   testdata.speed3.breakpoint1 = 255;
 
   auto memory =

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -569,13 +569,13 @@ public:
         partial_live_pct =
             (
                 // First section
-                (live_speed.speed1 != UNKNOWN_TRAFFIC_SPEED_RAW ? live_speed.breakpoint1 : 0)
+                (live_speed.encoded_speed1 != UNKNOWN_TRAFFIC_SPEED_RAW ? live_speed.breakpoint1 : 0)
                 // Second section
-                + (live_speed.speed2 != UNKNOWN_TRAFFIC_SPEED_RAW
+                + (live_speed.encoded_speed2 != UNKNOWN_TRAFFIC_SPEED_RAW
                        ? (live_speed.breakpoint2 - live_speed.breakpoint1)
                        : 0)
                 // Third section
-                + (live_speed.speed3 != baldr::UNKNOWN_TRAFFIC_SPEED_RAW
+                + (live_speed.encoded_speed3 != baldr::UNKNOWN_TRAFFIC_SPEED_RAW
                        ? (255 - live_speed.breakpoint2)
                        : 0)) /
             255.0;

--- a/valhalla/baldr/traffictile.h
+++ b/valhalla/baldr/traffictile.h
@@ -51,10 +51,11 @@ constexpr uint8_t UNKNOWN_CONGESTION_VAL = 0;
 constexpr uint8_t MAX_CONGESTION_VAL = 63;
 
 struct TrafficSpeed {
-  uint64_t overall_speed : 7; // 0-255kph in 2kph resolution (access with `get_overall_speed()`)
-  uint64_t speed1 : 7;        // 0-255kph in 2kph resolution (access with `get_speed(0)`)
-  uint64_t speed2 : 7;
-  uint64_t speed3 : 7;
+  uint64_t
+      overall_encoded_speed : 7; // 0-255kph in 2kph resolution (access with `get_overall_speed()`)
+  uint64_t encoded_speed1 : 7;   // 0-255kph in 2kph resolution (access with `get_speed(0)`)
+  uint64_t encoded_speed2 : 7;
+  uint64_t encoded_speed3 : 7;
   uint64_t breakpoint1 : 8;   // position = length * (breakpoint1 / 255)
   uint64_t breakpoint2 : 8;   // position = length * (breakpoint2 / 255)
   uint64_t congestion1 : 6;   // Stores 0 (unknown), or 1->63 (no congestion->max congestion)
@@ -65,11 +66,11 @@ struct TrafficSpeed {
 
 #ifndef C_ONLY_INTERFACE
   inline bool speed_valid() const volatile {
-    return breakpoint1 != 0 && overall_speed != UNKNOWN_TRAFFIC_SPEED_RAW;
+    return breakpoint1 != 0 && overall_encoded_speed != UNKNOWN_TRAFFIC_SPEED_RAW;
   }
 
   inline bool closed() const volatile {
-    return breakpoint1 != 0 && overall_speed == 0;
+    return breakpoint1 != 0 && overall_encoded_speed == 0;
   }
 
   inline bool closed(std::size_t subsegment) const volatile {
@@ -77,11 +78,11 @@ struct TrafficSpeed {
       return false;
     switch (subsegment) {
       case 0:
-        return speed1 == 0 || congestion1 == MAX_CONGESTION_VAL;
+        return encoded_speed1 == 0 || congestion1 == MAX_CONGESTION_VAL;
       case 1:
-        return breakpoint1 < 255 && (speed2 == 0 || congestion2 == MAX_CONGESTION_VAL);
+        return breakpoint1 < 255 && (encoded_speed2 == 0 || congestion2 == MAX_CONGESTION_VAL);
       case 2:
-        return breakpoint2 < 255 && (speed3 == 0 || congestion3 == MAX_CONGESTION_VAL);
+        return breakpoint2 < 255 && (encoded_speed3 == 0 || congestion3 == MAX_CONGESTION_VAL);
       default:
         assert(false);
         throw std::logic_error("Bad subsegment");
@@ -90,7 +91,7 @@ struct TrafficSpeed {
 
   /// Returns overall speed in kph across edge
   inline uint8_t get_overall_speed() const volatile {
-    return overall_speed << 1;
+    return overall_encoded_speed << 1;
   }
 
   /**
@@ -104,11 +105,11 @@ struct TrafficSpeed {
       return UNKNOWN_TRAFFIC_SPEED_KPH;
     switch (subsegment) {
       case 0:
-        return speed1 << 1;
+        return encoded_speed1 << 1;
       case 1:
-        return speed2 << 1;
+        return encoded_speed2 << 1;
       case 2:
-        return speed3 << 1;
+        return encoded_speed3 << 1;
       default:
         assert(false);
         throw std::logic_error("Bad subsegment");
@@ -116,11 +117,12 @@ struct TrafficSpeed {
   }
 
   constexpr TrafficSpeed()
-      : overall_speed{0}, speed1{0}, speed2{0}, speed3{0}, breakpoint1{0}, breakpoint2{0},
-        congestion1{0}, congestion2{0}, congestion3{0}, has_incidents{0}, spare{0} {
+      : overall_encoded_speed{0}, encoded_speed1{0}, encoded_speed2{0}, encoded_speed3{0},
+        breakpoint1{0}, breakpoint2{0}, congestion1{0}, congestion2{0}, congestion3{0},
+        has_incidents{0}, spare{0} {
   }
 
-  constexpr TrafficSpeed(const uint32_t overall_speed,
+  constexpr TrafficSpeed(const uint32_t overall_encoded_speed,
                          const uint32_t s1,
                          const uint32_t s2,
                          const uint32_t s3,
@@ -130,15 +132,15 @@ struct TrafficSpeed {
                          const uint32_t c2,
                          const uint32_t c3,
                          const bool incidents)
-      : overall_speed{overall_speed}, speed1{s1}, speed2{s2}, speed3{s3}, breakpoint1{b1},
-        breakpoint2{b2}, congestion1{c1}, congestion2{c2}, congestion3{c3},
-        has_incidents{incidents}, spare{0} {
+      : overall_encoded_speed{overall_encoded_speed}, encoded_speed1{s1}, encoded_speed2{s2},
+        encoded_speed3{s3}, breakpoint1{b1}, breakpoint2{b2}, congestion1{c1}, congestion2{c2},
+        congestion3{c3}, has_incidents{incidents}, spare{0} {
   }
 
   json::MapPtr json() const volatile {
     auto live_speed = json::map({});
     if (speed_valid()) {
-      live_speed->emplace("overall_speed", static_cast<uint64_t>(get_overall_speed()));
+      live_speed->emplace("overall_encoded_speed", static_cast<uint64_t>(get_overall_speed()));
       auto speed = static_cast<uint64_t>(get_speed(0));
       if (speed == UNKNOWN_TRAFFIC_SPEED_KPH)
         live_speed->emplace("speed_0", nullptr);

--- a/valhalla/baldr/traffictile.h
+++ b/valhalla/baldr/traffictile.h
@@ -140,7 +140,7 @@ struct TrafficSpeed {
   json::MapPtr json() const volatile {
     auto live_speed = json::map({});
     if (speed_valid()) {
-      live_speed->emplace("overall_encoded_speed", static_cast<uint64_t>(get_overall_speed()));
+      live_speed->emplace("overall_speed", static_cast<uint64_t>(get_overall_speed()));
       auto speed = static_cast<uint64_t>(get_speed(0));
       if (speed == UNKNOWN_TRAFFIC_SPEED_KPH)
         live_speed->emplace("speed_0", nullptr);


### PR DESCRIPTION
to make it clear that the raw values are usually not what you want.
They are not measured in kph, but have on several occasions been
used in that way due to the non-obvious naming.

This rename adds `encoded_` to the speed properties to make it
clearer that the value within may not be what you actually want.

There already are getter-functions defined which should be preferred
in most use-cases
