### PR TITLE
Odin undefined behaviour: handle case when xedgeuse is not initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
    * FIXED: Fix run_with_server.py to work on macOS [#3003](https://github.com/valhalla/valhalla/pull/3003)
    * FIXED: Removed unexpected maneuvers at sharp bends [#2968](https://github.com/valhalla/valhalla/pull/2968)
    * FIXED: Remove large number formatting for non-US countries [#3015](https://github.com/valhalla/valhalla/pull/3015)
+   * FIXED: Odin undefined behaviour: handle case when xedgeuse is not initialized [#3020](https://github.com/valhalla/valhalla/pull/3020)
 
 * **Enhancement**
    * Pedestrian crossing should be a separate TripLeg_Use [#2950](https://github.com/valhalla/valhalla/pull/2950)

--- a/src/odin/enhancedtrippath.cc
+++ b/src/odin/enhancedtrippath.cc
@@ -1728,7 +1728,7 @@ bool EnhancedTripLeg_Node::HasSpecifiedRoadClassXEdge(const RoadClass road_class
 uint32_t EnhancedTripLeg_Node::GetStraightestTraversableIntersectingEdgeTurnDegree(
     uint32_t from_heading,
     const TripLeg_TravelMode travel_mode,
-    TripLeg_Use* use) {
+    boost::optional<TripLeg_Use>* use) {
 
   uint32_t staightest_turn_degree = 180; // Initialize to reverse turn degree
   uint32_t staightest_delta = 180;       // Initialize to reverse delta

--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -2260,7 +2260,7 @@ bool ManeuversBuilder::IsPedestrianFork(int node_index,
     node->CalculateRightLeftIntersectingEdgeCounts(prev_edge->end_heading(), prev_edge->travel_mode(),
                                                    xedge_counts);
 
-    TripLeg_Use xedge_use;
+    boost::optional<TripLeg_Use> xedge_use;
     uint32_t straightest_traversable_xedge_turn_degree =
         node->GetStraightestTraversableIntersectingEdgeTurnDegree(prev_edge->end_heading(),
                                                                   prev_edge->travel_mode(),
@@ -2269,9 +2269,10 @@ bool ManeuversBuilder::IsPedestrianFork(int node_index,
     // This is needed to ensure we don't consider footways and crosswalks as
     // different uses for determining pedestrian forks
     bool is_current_and_intersecting_edge_of_similar_use =
-        (curr_edge->use() == xedge_use ||
-         (curr_edge->IsFootwayUse() &&
-          (xedge_use == TripLeg_Use_kPedestrianCrossingUse || xedge_use == TripLeg_Use_kFootwayUse)));
+        (xedge_use.has_value() &&
+         (curr_edge->use() == *xedge_use ||
+          (curr_edge->IsFootwayUse() && (*xedge_use == TripLeg_Use_kPedestrianCrossingUse ||
+                                         *xedge_use == TripLeg_Use_kFootwayUse))));
 
     // if there is a similar traversable intersecting edge
     //    or there is a relative straight traversable intersecting edge

--- a/valhalla/odin/enhancedtrippath.h
+++ b/valhalla/odin/enhancedtrippath.h
@@ -9,6 +9,8 @@
 #include <utility>
 #include <vector>
 
+#include <boost/optional.hpp>
+
 #include <valhalla/baldr/turn.h>
 #include <valhalla/proto/directions.pb.h>
 #include <valhalla/proto/options.pb.h>
@@ -700,9 +702,10 @@ public:
 
   uint32_t GetStraightestIntersectingEdgeTurnDegree(uint32_t from_heading);
 
-  uint32_t GetStraightestTraversableIntersectingEdgeTurnDegree(uint32_t from_heading,
-                                                               const TripLeg_TravelMode travel_mode,
-                                                               TripLeg_Use* use = nullptr);
+  uint32_t
+  GetStraightestTraversableIntersectingEdgeTurnDegree(uint32_t from_heading,
+                                                      const TripLeg_TravelMode travel_mode,
+                                                      boost::optional<TripLeg_Use>* use = nullptr);
 
   bool IsStraightestTraversableIntersectingEdgeReversed(uint32_t from_heading,
                                                         const TripLeg_TravelMode travel_mode);


### PR DESCRIPTION
# Issue

There real world cases when xedge is not initialized after `GetStraightestTraversableIntersectingEdgeTurnDegree` call, i.e if the list is intersecting edge_size = 0 https://github.com/valhalla/valhalla/blob/ce8ab9d82610cfbe90959b7fd3422ef7e4ed1851/src/odin/enhancedtrippath.cc#L1736

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
