### PR TITLE
CI Updates for Docker Builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,59 +35,11 @@ jobs:
               docker push valhalla/valhalla:run-latest
             elif [[ ! -z "${CIRCLE_TAG}" ]]; then
               echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+              docker tag valhalla/valhalla:build-latest valhalla/valhalla:build-${CIRCLE_TAG}
               docker push valhalla/valhalla:build-${CIRCLE_TAG}
+              docker tag valhalla/valhalla:run-latest valhalla/valhalla:run-${CIRCLE_TAG}
               docker push valhalla/valhalla:run-${CIRCLE_TAG}
             fi
-
-  build-release-binary-linux:
-    docker:
-      - image: valhalla/valhalla:build-latest
-    steps:
-      - checkout
-      - run: ./scripts/format.sh && ./scripts/error_on_dirty.sh
-      - run: git submodule sync && git submodule update --init
-      - restore_cache:
-          keys:
-            - ccache-release-linux-x86_64-{{ .Branch }}
-            - ccache-release-linux-x86_64
-      - run: mkdir build
-      - run: |
-          cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=Off -DENABLE_PYTHON_BINDINGS=On \
-              -DCMAKE_CXX_FLAGS="-fuse-ld=lld" \
-              -DCPACK_GENERATOR=DEB \
-              -DCPACK_PACKAGE_VERSION_SUFFIX="-0ubuntu1-$(lsb_release -sc)" -DENABLE_SERVICES=OFF
-      - run: make -C build -j4
-      - save_cache:
-          key: ccache-release-linux-x86_64-{{ .Branch }}-{{ epoch }}
-          paths:
-            - ~/.ccache
-      - run: make -C build install
-      - run: make -C build package
-
-  build-debug-binary-linux:
-    docker:
-      - image: valhalla/valhalla:build-latest
-    steps:
-      - checkout
-      - run: ./scripts/format.sh && ./scripts/error_on_dirty.sh
-      - run: git submodule sync && git submodule update --init
-      - restore_cache:
-          keys:
-            - ccache-debug-linux-x86_64-{{ .Branch }}
-            - ccache-debug-linux-x86_64
-      - run: mkdir build
-      - run: |
-          cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=Off -DENABLE_PYTHON_BINDINGS=On \
-                -DCMAKE_CXX_FLAGS="-fuse-ld=lld" \
-                -DCPACK_GENERATOR=DEB \
-                -DCPACK_PACKAGE_VERSION_SUFFIX="-0ubuntu1-$(lsb_release -sc)" -DENABLE_SERVICES=OFF
-      - run: make -C build -j4
-      - save_cache:
-          key: ccache-debug-linux-x86_64-{{ .Branch }}-{{ epoch }}
-          paths:
-            - ~/.ccache
-      - run: make -C build install
-      - run: make -C build package
 
   lint-build-debug:
     docker:
@@ -198,73 +150,20 @@ jobs:
           paths:
             - ~/.ccache
 
-  build-release-binary-osx:
-    executor: macos
-    steps:
-      - install_macos_dependencies
-      - checkout
-      - run: ./scripts/format.sh && ./scripts/error_on_dirty.sh
-      - run: git submodule sync && git submodule update --init
-      - restore_cache:
-          keys:
-            - ccache-release-macos-{{ .Branch }}
-            - ccache-release-macos
-      - run: mkdir -p build
-      - run: cd build && cmake .. -DBUILD_SHARED_LIBS=Off -DENABLE_PYTHON_BINDINGS=Off -DENABLE_DATA_TOOLS=OFF -DENABLE_SERVICES=OFF -DBoost_USE_STATIC_LIBS=ON -DProtobuf_USE_STATIC_LIBS=ON -DLZ4_USE_STATIC_LIBS=ON
-      - run: make -C build -j4
-      - save_cache:
-          key: ccache-release-macos-{{ .Branch }}-{{ epoch }}
-          paths:
-            - ~/.ccache
-
-  build-debug-binary-osx:
-    executor: macos
-    steps:
-      - install_macos_dependencies
-      - checkout
-      - run: ./scripts/format.sh && ./scripts/error_on_dirty.sh
-      - run: git submodule sync && git submodule update --init
-      - restore_cache:
-          keys:
-            - ccache-debug-macos-{{ .Branch }}
-            - ccache-debug-macos
-      - run: mkdir -p build
-      - run: cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_PYTHON_BINDINGS=Off -DBUILD_SHARED_LIBS=Off -DENABLE_DATA_TOOLS=OFF -DENABLE_SERVICES=OFF -DBoost_USE_STATIC_LIBS=ON -DProtobuf_USE_STATIC_LIBS=ON -DLZ4_USE_STATIC_LIBS=ON
-      - run: make -C build -j4
-      - save_cache:
-          key: ccache-debug-macos-{{ .Branch }}-{{ epoch }}
-          paths:
-            - ~/.ccache
-
 workflows:
   version: 2
   build_test_publish:
     jobs:
       - build-docker-images
       - lint-build-debug
+          filters:
+            tags:
+              ignore: /.*/
       - build-release
+          filters:
+            tags:
+              ignore: /.*/
       - build-osx
-      - build-release-binary-osx:
           filters:
             tags:
-              only: /.*/
-            branches:
-              ignore: /.*/
-      - build-debug-binary-osx:
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              ignore: /.*/
-      - build-release-binary-linux:
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              ignore: /.*/
-      - build-debug-binary-linux:
-          filters:
-            tags:
-              only: /.*/
-            branches:
               ignore: /.*/


### PR DESCRIPTION
This pr attempts to do 3 things:

1. fix the tagging mechanism for docker builds, basically the command wouldnt have worked if CI would have tried to run it
2. remove builds that we only ran on tag but no one cared about
3. modify the workflows so that tags will run only docker (previously they only ran the jobs that i removed in `2.` of this list)