### PR TITLE
Make CI skip check more robust

### DIFF
--- a/.circleci/ciignor_disabled
+++ b/.circleci/ciignor_disabled
@@ -1,3 +1,0 @@
-*.md
-.circleci/ciignore
-run_route_scripts/*

--- a/.circleci/ciignore
+++ b/.circleci/ciignore
@@ -1,0 +1,3 @@
+*.md
+.circleci/ciignore
+run_route_scripts/*

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ commands:
   install_macos_dependencies:
     steps:
       - run: brew install protobuf cmake ccache libtool boost libspatialite pkg-config luajit curl wget czmq lz4 spatialite-tools unzip
+      - run: pip3 install requests
 
 jobs:
   build-docker-images:
@@ -123,6 +124,7 @@ jobs:
     executor: macos
     steps:
       - checkout
+      - install_macos_dependencies
       - run: |
             if ! ./scripts/needs_ci_run; then
                 echo "Changes in last commit do not need CI. Skipping step"
@@ -130,7 +132,6 @@ jobs:
             fi
       - run: ./scripts/format.sh && ./scripts/error_on_dirty.sh
       - run: git submodule sync && git submodule update --init
-      - install_macos_dependencies
       - restore_cache:
           keys:
             - ccache-release-macos-{{ .Branch }}

--- a/scripts/needs_ci_run
+++ b/scripts/needs_ci_run
@@ -75,7 +75,7 @@ def last_build_successful():
 
     if sorted(job_status.keys()) != sorted(JOBS):
         print(f'Unexpected job name fetched ({sorted(job_status)}). Expected {sorted(JOBS)}')
-        return False
+        return False, None
 
     # Return False if any of the jobs were not in 'success' state
     for status, gitsha in job_status.values():

--- a/scripts/needs_ci_run
+++ b/scripts/needs_ci_run
@@ -7,7 +7,6 @@ import requests
 
 from os import path, environ
 
-token = '8193cb473902c29f1a360547e9d4126b4df302ea'
 
 # jobs defined in .circleci/config.yml
 JOBS = ['build-docker-images',
@@ -15,7 +14,7 @@ JOBS = ['build-docker-images',
         'build-release',
         'build-osx']
 
-CIRCLE_JOB_STATUS_SUCCESS = 'success';
+CIRCLE_JOB_STATUS_SUCCESS = 'success'
 
 '''
 Returns a tuple of status & gitsha of the PR that triggered the build.
@@ -40,21 +39,24 @@ def last_build_successful():
 
     if not branch:
         print('CIRCLE_BRANCH env not set! Unable to do CI skip check')
+        sys.exit(0)
     if not current_workflow_id:
         print('CIRCLE_WORKFLOW_ID env not set! Unable to do CI skip check')
+        sys.exit(0)
     if not token:
         print('CIRCLE_API_TOKEN env not set! Unable to do CI skip check')
+        sys.exit(0)
 
     # Get twice the number of jobs configured. There would be len(JOBS) from this
     # run, while the rest will be from the last run
     cci_api_url = \
-        f'https://circleci.com/api/v1.1/project/github/valhalla/valhalla/tree/{branch}?circle-token={token}&shallow=true&limit={len(JOBS)*2}';
+        f'https://circleci.com/api/v1.1/project/github/valhalla/valhalla/tree/{branch}?circle-token={token}&shallow=true&limit={len(JOBS)*2}'
 
     resp = requests.get(cci_api_url)
     resp.raise_for_status()
 
     builds = resp.json()
-    #print(builds)
+    # print(builds)
 
     # this should never happen. since this script is run from within a CI run
     # there should be at least 1 entry (i.e this run)
@@ -83,11 +85,11 @@ def last_build_successful():
     return True, job_status[JOBS[0]][1]
 
 
-CI_IGNORE_FILE='.circleci/ciignore'
+CI_IGNORE_FILE = '.circleci/ciignore'
 
 if not path.isfile(CI_IGNORE_FILE):
-  # no CI ignore rules configured, run CI
-  sys.exit(0)
+    # no CI ignore rules configured, run CI
+    sys.exit(0)
 
 # Check if a previous build of this branch was successful or not
 status, last_pr_gitsha = last_build_successful()
@@ -98,25 +100,27 @@ if not status:
     sys.exit(0)
 
 # Get all changes since the last succesful CI run
-GIT_CMD=['git', 'diff', f'HEAD..{last_pr_gitsha}', '--name-only']
+GIT_CMD = ['git', 'diff', f'HEAD..{last_pr_gitsha}', '--name-only']
 
 # Get list of changed files staged for commit
-changed_files=subprocess.run(GIT_CMD, capture_output=True, text=True).stdout.splitlines()
+changed_files = subprocess.run(GIT_CMD,
+                               capture_output=True,
+                               text=True).stdout.splitlines()
 
 # Get CI ignore rules
 with open(CI_IGNORE_FILE, 'r') as f:
-  CI_IGNORE_RULES = f.readlines()
+    CI_IGNORE_RULES = f.readlines()
 CI_IGNORE_RULES = [x.strip() for x in CI_IGNORE_RULES]
 
-ignored_files=[]
+ignored_files = []
 for changed_file in changed_files:
-  for ignore_rule in CI_IGNORE_RULES:
-    if fnmatch.fnmatch(changed_file, ignore_rule):
-      ignored_files.append(changed_file)
+    for ignore_rule in CI_IGNORE_RULES:
+        if fnmatch.fnmatch(changed_file, ignore_rule):
+            ignored_files.append(changed_file)
 
 if sorted(ignored_files) == sorted(changed_files):
-  # everything was ignored, skip CI
-  sys.exit(1)
+    # everything was ignored, skip CI
+    sys.exit(1)
 
 # Not everything was ignored, run CI
 sys.exit(0)

--- a/scripts/needs_ci_run
+++ b/scripts/needs_ci_run
@@ -1,21 +1,104 @@
 #!/usr/bin/env python3
 import fnmatch
-import os.path
 import sys
 import subprocess
+import requests
+
+
+from os import path, environ
+
+token = '8193cb473902c29f1a360547e9d4126b4df302ea'
+
+# jobs defined in .circleci/config.yml
+JOBS = ['build-docker-images',
+        'lint-build-debug',
+        'build-release',
+        'build-osx']
+
+CIRCLE_JOB_STATUS_SUCCESS = 'success';
+
+'''
+Returns a tuple of status & gitsha of the PR that triggered the build.
+status is True if all jobs of the last build were in 'success' state
+otherwise False
+
+Each push to a branch triggers a new CI run, and any previous run is cancelled.
+A CI run starts 4 jobs (see JOBS above) and each job has a unique "workflow ID"
+attached to it. This workflow ID changes for every CI run. In order to get the
+status of the last run, we do the following:
+- Get status of last 8 jobs from the PR branch - 4 jobs will be from the
+  current run and 4 from the previous run
+- Ignore jobs of the current workflow (using workflow ID)
+- The last run is successful if ALL jobs had a status of 'success'
+- Store the gitsha of the last successful run. This is later used to fetch the
+  list of files changed since last CI run
+'''
+def last_build_successful():
+    branch = environ.get('CIRCLE_BRANCH')
+    current_workflow_id = environ.get('CIRCLE_WORKFLOW_ID')
+    token = environ.get('CIRCLE_API_TOKEN')
+
+    if not branch:
+        print('CIRCLE_BRANCH env not set! Unable to do CI skip check')
+    if not current_workflow_id:
+        print('CIRCLE_WORKFLOW_ID env not set! Unable to do CI skip check')
+    if not token:
+        print('CIRCLE_API_TOKEN env not set! Unable to do CI skip check')
+
+    # Get twice the number of jobs configured. There would be len(JOBS) from this
+    # run, while the rest will be from the last run
+    cci_api_url = \
+        f'https://circleci.com/api/v1.1/project/github/valhalla/valhalla/tree/{branch}?circle-token={token}&shallow=true&limit={len(JOBS)*2}';
+
+    resp = requests.get(cci_api_url)
+    resp.raise_for_status()
+
+    builds = resp.json()
+    #print(builds)
+
+    # this should never happen. since this script is run from within a CI run
+    # there should be at least 1 entry (i.e this run)
+    if not builds:
+        print('ERROR! No previous builds found! Not skipping build')
+        return False, None
+
+    # build a dict of {job_name: (job_status, gitsha)}
+    job_status = {}
+    for build in builds:
+        # ignore this build's status. All jobs in a build have the same
+        # workflow ID
+        if build['workflows']['workflow_id'] == current_workflow_id:
+            continue
+        job_status[build['workflows']['job_name']] = (build['status'], build['vcs_revision'])
+
+    if sorted(job_status.keys()) != sorted(JOBS):
+        print(f'Unexpected job name fetched ({sorted(job_status)}). Expected {sorted(JOBS)}')
+        return False
+
+    # Return False if any of the jobs were not in 'success' state
+    for status, gitsha in job_status.values():
+        if status != 'success':
+            return False, gitsha
+
+    return True, job_status[JOBS[0]][1]
+
 
 CI_IGNORE_FILE='.circleci/ciignore'
-# Looks for files changed in last commit only. This has the drawback
-# of skipping CI if a push's last commit was ciignore-able, even though
-# other commits might need CI
-#
-# TODO: Get all files changed in the last "push". That ensures CI is skipped
-# if ALL commits in a push don't need CI
-GIT_CMD=['git', 'diff', 'HEAD..HEAD~1', '--name-only']
 
-if not os.path.isfile(CI_IGNORE_FILE):
+if not path.isfile(CI_IGNORE_FILE):
   # no CI ignore rules configured, run CI
   sys.exit(0)
+
+# Check if a previous build of this branch was successful or not
+status, last_pr_gitsha = last_build_successful()
+print(f'last build successful?, gitsha: {status}, {last_pr_gitsha}')
+
+# if last build was not successfull, dont skip
+if not status:
+    sys.exit(0)
+
+# Get all changes since the last succesful CI run
+GIT_CMD=['git', 'diff', f'HEAD..{last_pr_gitsha}', '--name-only']
 
 # Get list of changed files staged for commit
 changed_files=subprocess.run(GIT_CMD, capture_output=True, text=True).stdout.splitlines()
@@ -33,8 +116,6 @@ for changed_file in changed_files:
 
 if sorted(ignored_files) == sorted(changed_files):
   # everything was ignored, skip CI
-  # TODO: Use circleci API to check if a prior build of this branch is running.
-  # If so, don't skip CI
   sys.exit(1)
 
 # Not everything was ignored, run CI


### PR DESCRIPTION
Implements the 2 TODOs which make the CI check robust to erroneous
skips.

The script will now:
- not skip CI if previous CI was not successful
- will check all files since the last successful CI run for determining
  if the commits can skip CI