### PR TITLE
Evaluate restrictions with dow only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
    * FIXED: Odin undefined behaviour: handle case when xedgeuse is not initialized [#3020](https://github.com/valhalla/valhalla/pull/3020)
    * FIXED: Isochrone (::Generalize()) fix to avoid generating self-intersecting polygons [#3026](https://github.com/valhalla/valhalla/pull/3026)
    * FIXED: Handle day_on/day_off/hour_on/hour_off restrictions [#3029](https://github.com/valhalla/valhalla/pull/3029)
+   * FIXED: Apply conditional restrictions with dow only to the edges when routing [#3039](https://github.com/valhalla/valhalla/pull/3039)
 
 * **Enhancement**
    * Pedestrian crossing should be a separate TripLeg_Use [#2950](https://github.com/valhalla/valhalla/pull/2950)

--- a/src/baldr/datetime.cc
+++ b/src/baldr/datetime.cc
@@ -282,7 +282,7 @@ bool is_conditional_active(const bool type,
     return false;
 
   bool dow_in_range = true;
-  bool dt_in_range = false;
+  bool dt_in_range = true;
 
   // date::time_of_day()
   std::chrono::minutes b_td = std::chrono::hours(0);
@@ -448,7 +448,7 @@ bool is_conditional_active(const bool type,
         end_date = date::year_month_day(date::year(e_year), date::month(e_month),
                                         date::day(e_day_dow)); // Dec 5 to Mar 3
       }
-    } else { // do we have just time?
+    } else { // just time or dow with or without time
 
       if (begin_hrs || begin_mins || end_hrs || end_mins) {
         b_td = std::chrono::hours(begin_hrs) + std::chrono::minutes(begin_mins);

--- a/test/datetime.cc
+++ b/test/datetime.cc
@@ -481,6 +481,75 @@ TEST(DateTime, TestIsRestricted) {
 
   TryIsRestricted(td, "2020-03-02T22:21", true);
   TryIsRestricted(td, "2020-03-02T21:21", false);
+
+  td = TimeDomain(74766824767740); // Jan 04-Jan 01 Mo-Sa
+  // Jan 03
+  TryIsRestricted(td, "2020-01-03T22:21", false);
+  TryIsRestricted(td, "2021-01-03T21:21", false);
+  // sundays
+  TryIsRestricted(td, "2020-01-05T23:00", false);
+  TryIsRestricted(td, "2020-01-05T20:00", false);
+  TryIsRestricted(td, "2020-03-01T23:00", false);
+
+  TryIsRestricted(td, "2020-01-06T21:21", true);
+  TryIsRestricted(td, "2020-01-01T22:21", true);
+  TryIsRestricted(td, "2020-01-04T20:00", true);
+  TryIsRestricted(td, "2020-03-02T16:00", true);
+
+  td = TimeDomain(74766824773120); // Jan 04-Jan 01 22:00-24:00
+  // Jan 03
+  TryIsRestricted(td, "2020-01-03T22:21", false);
+  TryIsRestricted(td, "2021-01-03T21:21", false);
+
+  TryIsRestricted(td, "2020-01-05T22:30", true);
+  TryIsRestricted(td, "2020-01-05T16:00", false);
+
+  TryIsRestricted(td, "2020-01-01T22:21", true);
+  TryIsRestricted(td, "2020-01-01T21:21", false);
+
+  TryIsRestricted(td, "2020-03-01T22:21", true);
+  TryIsRestricted(td, "2020-03-01T21:21", false);
+
+  td = TimeDomain(74766824767488); // Jan 04-Jan 01
+  // Jan 03
+  TryIsRestricted(td, "2020-01-03T22:21", false);
+  TryIsRestricted(td, "2020-01-03T21:21", false);
+
+  TryIsRestricted(td, "2020-01-05T23:59", true);
+  TryIsRestricted(td, "2020-01-05T08:00", true);
+  TryIsRestricted(td, "2021-01-01T00:00", true);
+  TryIsRestricted(td, "2022-01-01T22:00", true);
+  TryIsRestricted(td, "2020-03-10T22:00", true);
+  TryIsRestricted(td, "2020-06-20T16:30", true);
+
+  td = TimeDomain(124); // Mo-Fr
+  TryIsRestricted(td, "2021-04-22T05:00", true);
+  TryIsRestricted(td, "2021-04-22T23:58", true);
+  TryIsRestricted(td, "2021-04-23T10:00", true);
+  TryIsRestricted(td, "2021-04-24T11:00", false);
+  TryIsRestricted(td, "2021-04-26T01:11", true);
+
+  td = TimeDomain(20); // Mo,We
+  TryIsRestricted(td, "2021-04-21T08:00", true);
+  TryIsRestricted(td, "2021-04-20T08:00", false);
+  TryIsRestricted(td, "2021-04-18T16:00", false);
+  TryIsRestricted(td, "2021-04-26T18:00", true);
+
+  td = TimeDomain(21990234128384); // March-May
+  TryIsRestricted(td, "2021-04-03T08:00", true);
+  TryIsRestricted(td, "2020-03-15T23:59", true);
+  TryIsRestricted(td, "2022-05-10T16:00", true);
+  TryIsRestricted(td, "2021-02-18T16:00", false);
+  TryIsRestricted(td, "2021-06-26T19:00", false);
+
+  td = TimeDomain(2128654663942144); // March 18-April 30
+  TryIsRestricted(td, "2021-04-03T08:00", true);
+  TryIsRestricted(td, "2021-03-21T20:00", true);
+  TryIsRestricted(td, "2021-04-30T23:59", true);
+  TryIsRestricted(td, "2020-03-15T16:00", false);
+  TryIsRestricted(td, "2022-05-10T16:00", false);
+  TryIsRestricted(td, "2021-02-18T16:00", false);
+  TryIsRestricted(td, "2021-06-26T16:00", false);
 }
 
 TEST(DateTime, TestTimezoneDiff) {

--- a/test/timeparsing.cc
+++ b/test/timeparsing.cc
@@ -430,6 +430,34 @@ TEST(TimeParsing, TestConditionalRestrictions) {
     TryConditionalRestrictions(conditions.at(x), 0, 0, 62, 0, 0, 0, 7, 0, 0, 0, 0, 9, 30);
     TryConditionalRestrictions(conditions.at(x), 1, 0, 62, 0, 0, 0, 13, 0, 0, 0, 0, 15, 0);
   }
+
+  // includes end of year
+  str = "Jan 04-Jan 01 Mo-Sa;Jan 04-Jan 01 22:00-24:00;Jan 04-Jan 01";
+  conditions = GetTagTokens(str, ';');
+  for (uint32_t x = 0; x < conditions.size(); x++) {
+    if (x == 0) { // Jan 04-Jan 01 Mo-Sa
+      TryConditionalRestrictions(conditions.at(x), {74766824767740});
+    } else if (x == 1) { // Jan 04-Jan 01 22:00-24:00
+      TryConditionalRestrictions(conditions.at(x), {74766824773120});
+    } else if (x == 2) { // Jan 04-Jan 01
+      TryConditionalRestrictions(conditions.at(x), {74766824767488});
+    }
+  }
+
+  // ranges without time
+  str = "Mon-Friday;Mo,Wed;March-May;March 18-April 30";
+  conditions = GetTagTokens(str, ';');
+  for (uint32_t x = 0; x < conditions.size(); x++) {
+    if (x == 0) { // Mon-Friday
+      TryConditionalRestrictions(conditions.at(x), {124});
+    } else if (x == 1) { // Mo,Wed
+      TryConditionalRestrictions(conditions.at(x), {20});
+    } else if (x == 2) { // March-May
+      TryConditionalRestrictions(conditions.at(x), {21990234128384});
+    } else if (x == 3) { // March 18-April 30
+      TryConditionalRestrictions(conditions.at(x), {2128654663942144});
+    }
+  }
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
# Issue

Noticed, that restrictions with dow only, like Monday-Friday were not applied after routing to the edges. They are not applied to the edges when validating the routing path. 

In the example below, if I set conditional restriction `no_entry @ Mo-Fr` for `AB->BC` left turn
the restriction is ignored,  at any time we receive `AB->BC->CF` path from A to F instead of  `AB->BD->DE->EC->CF` for workdays.

          D----B----A
          |    |
          |    |
          E----C----F


## Tasklist

 - [x] Add tests
 - [x] Add gurka tests with day_on/day_off and no hour info [#3029](https://github.com/valhalla/valhalla/pull/3029)
 - [x] Update the [changelog](CHANGELOG.md)