### PR TITLE
Continuous lane guidance fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
    * FIXED: Handle day_on/day_off/hour_on/hour_off restrictions [#3029](https://github.com/valhalla/valhalla/pull/3029)
    * FIXED: Apply conditional restrictions with dow only to the edges when routing [#3039](https://github.com/valhalla/valhalla/pull/3039)
    * FIXED: Missing locking in incident handler needed to hang out to scop lock rather than let the temporary disolve [#3046](https://github.com/valhalla/valhalla/pull/3046)
+   * FIXED: Continuous lane guidance fix [#3054](https://github.com/valhalla/valhalla/pull/3054)
 
 * **Enhancement**
    * CHANGED: Refactor timedep forward/reverse to reduce code repetition [#2987](https://github.com/valhalla/valhalla/pull/2987)

--- a/src/odin/enhancedtrippath.cc
+++ b/src/odin/enhancedtrippath.cc
@@ -624,21 +624,23 @@ EnhancedTripLeg_Edge::ActivateTurnLanes(uint16_t turn_lane_direction,
     // and next maneuver is not a straight
     // Activate only specific matching turn lanes
     switch (next_maneuver_type) {
-      case DirectionsLeg_Maneuver_Type_kUturnLeft:
-      case DirectionsLeg_Maneuver_Type_kSharpLeft:
-      case DirectionsLeg_Maneuver_Type_kLeft:
       case DirectionsLeg_Maneuver_Type_kSlightLeft:
-      case DirectionsLeg_Maneuver_Type_kExitLeft:
+      case DirectionsLeg_Maneuver_Type_kLeft:
+      case DirectionsLeg_Maneuver_Type_kSharpLeft:
+      case DirectionsLeg_Maneuver_Type_kUturnLeft:
       case DirectionsLeg_Maneuver_Type_kRampLeft:
+      case DirectionsLeg_Maneuver_Type_kExitLeft:
+      case DirectionsLeg_Maneuver_Type_kStayLeft:
       case DirectionsLeg_Maneuver_Type_kDestinationLeft:
       case DirectionsLeg_Maneuver_Type_kMergeLeft:
         return ActivateTurnLanesFromLeft(turn_lane_direction, curr_maneuver_type, 1);
       case DirectionsLeg_Maneuver_Type_kSlightRight:
-      case DirectionsLeg_Maneuver_Type_kExitRight:
-      case DirectionsLeg_Maneuver_Type_kRampRight:
       case DirectionsLeg_Maneuver_Type_kRight:
       case DirectionsLeg_Maneuver_Type_kSharpRight:
       case DirectionsLeg_Maneuver_Type_kUturnRight:
+      case DirectionsLeg_Maneuver_Type_kRampRight:
+      case DirectionsLeg_Maneuver_Type_kExitRight:
+      case DirectionsLeg_Maneuver_Type_kStayRight:
       case DirectionsLeg_Maneuver_Type_kDestinationRight:
       case DirectionsLeg_Maneuver_Type_kMergeRight:
         return ActivateTurnLanesFromRight(turn_lane_direction, curr_maneuver_type, 1);

--- a/src/odin/maneuver.cc
+++ b/src/odin/maneuver.cc
@@ -170,23 +170,25 @@ bool Maneuver::IsMergeType() const {
 }
 
 bool Maneuver::IsLeftType() const {
-  return ((type_ == DirectionsLeg_Maneuver_Type_kUturnLeft ||
-           type_ == DirectionsLeg_Maneuver_Type_kSharpLeft ||
+  return ((type_ == DirectionsLeg_Maneuver_Type_kSlightLeft ||
            type_ == DirectionsLeg_Maneuver_Type_kLeft ||
-           type_ == DirectionsLeg_Maneuver_Type_kSlightLeft ||
-           type_ == DirectionsLeg_Maneuver_Type_kExitLeft ||
+           type_ == DirectionsLeg_Maneuver_Type_kSharpLeft ||
+           type_ == DirectionsLeg_Maneuver_Type_kUturnLeft ||
            type_ == DirectionsLeg_Maneuver_Type_kRampLeft ||
+           type_ == DirectionsLeg_Maneuver_Type_kExitLeft ||
+           type_ == DirectionsLeg_Maneuver_Type_kStayLeft ||
            type_ == DirectionsLeg_Maneuver_Type_kDestinationLeft ||
            type_ == DirectionsLeg_Maneuver_Type_kMergeLeft));
 }
 
 bool Maneuver::IsRightType() const {
   return ((type_ == DirectionsLeg_Maneuver_Type_kSlightRight ||
-           type_ == DirectionsLeg_Maneuver_Type_kExitRight ||
-           type_ == DirectionsLeg_Maneuver_Type_kRampRight ||
            type_ == DirectionsLeg_Maneuver_Type_kRight ||
            type_ == DirectionsLeg_Maneuver_Type_kSharpRight ||
            type_ == DirectionsLeg_Maneuver_Type_kUturnRight ||
+           type_ == DirectionsLeg_Maneuver_Type_kRampRight ||
+           type_ == DirectionsLeg_Maneuver_Type_kExitRight ||
+           type_ == DirectionsLeg_Maneuver_Type_kStayRight ||
            type_ == DirectionsLeg_Maneuver_Type_kDestinationRight ||
            type_ == DirectionsLeg_Maneuver_Type_kMergeRight));
 }

--- a/test/gurka/test_turn_lanes.cc
+++ b/test/gurka/test_turn_lanes.cc
@@ -973,8 +973,10 @@ TEST(Standalone, TurnLanesForks) {
 
   auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_turn_lanes_11");
 
-  // A -> H
-  auto result = gurka::do_action(valhalla::Options::route, map, {"A", "E"}, "auto");
+  valhalla::Api result;
+
+  // Keep left
+  result = gurka::do_action(valhalla::Options::route, map, {"A", "E"}, "auto");
 
   gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
                                                 DirectionsLeg_Maneuver_Type_kStayLeft,
@@ -983,5 +985,17 @@ TEST(Standalone, TurnLanesForks) {
   validate_turn_lanes(result, {{3, "[ left | *through* ACTIVE | *through*;right ACTIVE ]"},
                                {3, "[ left | *through* ACTIVE | *through*;right ACTIVE ]"},
                                {2, "[ *through* ACTIVE | slight_right ]"},
+                               {0, ""}});
+
+  // Keep right
+  result = gurka::do_action(valhalla::Options::route, map, {"A", "F"}, "auto");
+
+  gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
+                                                DirectionsLeg_Maneuver_Type_kStayRight,
+                                                DirectionsLeg_Maneuver_Type_kDestination});
+
+  validate_turn_lanes(result, {{3, "[ left | *through* ACTIVE | *through*;right ACTIVE ]"},
+                               {3, "[ left | *through* ACTIVE | *through*;right ACTIVE ]"},
+                               {2, "[ through | *slight_right* ACTIVE ]"},
                                {0, ""}});
 }

--- a/test/gurka/test_turn_lanes.cc
+++ b/test/gurka/test_turn_lanes.cc
@@ -930,16 +930,14 @@ TEST(Standalone, TurnLanesSerializedResponse) {
 }
 
 TEST(Standalone, TurnLanesForks) {
-  constexpr double gridsize_metres = 100;
+  constexpr double gridsize_metres = 500;
 
   const std::string ascii_map = R"(
-                        W
-             V----U     |
-      N    Q       >P---O---M
-      |     >F---G<     |
-  A---B---D<       H    X
-      |     K----L
-      C
+        H   J     
+        |   |          E
+    A---B---C---D<
+        |   |          F
+        G   I
   )";
 
   const gurka::ways ways =
@@ -949,44 +947,25 @@ TEST(Standalone, TurnLanesForks) {
          {"oneway", "yes"},
          {"lanes", "3"},
          {"turn:lanes", "left|through|through;right"}}},
-       {"BC", {{"highway", "tertiary"}, {"name", "Knorrstraße"}}},
-       {"BN", {{"highway", "tertiary"}, {"name", "Knorrstraße"}}},
-       {"BD",
-        {{"highway", "primary"},
-         {"name", "Frankfurter Ring"},
-         {"oneway", "yes"},
-         {"lanes", "2"},
-         {"turn:lanes", "through|slight_right"}}},
-       {"DF",
-        {{"highway", "primary"}, {"name", "Frankfurter Ring"}, {"oneway", "yes"}, {"lanes", "1"}}},
-       {"FG", {{"highway", "primary"}, {"name", "Frankfurter Ring"}, {"lanes", "2"}}},
-       {"GH",
-        {{"highway", "primary"}, {"name", "Frankfurter Ring"}, {"oneway", "yes"}, {"lanes", "1"}}},
-       {"DK",
-        {{"highway", "primary"}, {"name", "Frankfurter Ring"}, {"oneway", "yes"}, {"lanes", "2"}}},
-       {"KL",
-        {{"highway", "primary"}, {"name", "Frankfurter Ring"}, {"oneway", "yes"}, {"lanes", "2"}}},
-       {"MO",
+       {"BG", {{"highway", "tertiary"}, {"name", "Knorrstraße"}}},
+       {"BH", {{"highway", "tertiary"}, {"name", "Knorrstraße"}}},
+       {"BC",
         {{"highway", "primary"},
          {"name", "Frankfurter Ring"},
          {"oneway", "yes"},
          {"lanes", "3"},
          {"turn:lanes", "left|through|through;right"}}},
-       {"OW", {{"highway", "tertiary"}, {"name", "Am Nordring"}}},
-       {"OX", {{"highway", "tertiary"}, {"name", "Am Nordring"}}},
-       {"OP",
+       {"CI", {{"highway", "tertiary"}, {"name", "Am Nordring"}}},
+       {"CJ", {{"highway", "tertiary"}, {"name", "Am Nordring"}}},
+       {"CD",
         {{"highway", "primary"},
          {"name", "Frankfurter Ring"},
          {"oneway", "yes"},
          {"lanes", "2"},
          {"turn:lanes", "through|slight_right"}}},
-       {"PG",
+       {"DE",
         {{"highway", "primary"}, {"name", "Frankfurter Ring"}, {"oneway", "yes"}, {"lanes", "1"}}},
-       {"FQ",
-        {{"highway", "primary"}, {"name", "Frankfurter Ring"}, {"oneway", "yes"}, {"lanes", "1"}}},
-       {"PU",
-        {{"highway", "primary"}, {"name", "Frankfurter Ring"}, {"oneway", "yes"}, {"lanes", "2"}}},
-       {"UV",
+       {"DF",
         {{"highway", "primary"}, {"name", "Frankfurter Ring"}, {"oneway", "yes"}, {"lanes", "2"}}}};
 
   const auto layout =
@@ -995,10 +974,14 @@ TEST(Standalone, TurnLanesForks) {
   auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_turn_lanes_11");
 
   // A -> H
-  auto result = gurka::do_action(valhalla::Options::route, map, {"A", "H"}, "auto");
+  auto result = gurka::do_action(valhalla::Options::route, map, {"A", "E"}, "auto");
+
+  gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
+                                                DirectionsLeg_Maneuver_Type_kStayLeft,
+                                                DirectionsLeg_Maneuver_Type_kDestination});
+
   validate_turn_lanes(result, {{3, "[ left | *through* ACTIVE | *through*;right ACTIVE ]"},
+                               {3, "[ left | *through* ACTIVE | *through*;right ACTIVE ]"},
                                {2, "[ *through* ACTIVE | slight_right ]"},
-                               {0, ""},
-                               {0, ""},
                                {0, ""}});
 }


### PR DESCRIPTION
# Issue

Fix the continuous lane guidance logic to properly activate turn lanes when the next maneuver type is stay left or stay right.

## Example #1
### Before vs. After diff
![image](https://user-images.githubusercontent.com/7515853/117195797-bad1e080-adb3-11eb-8221-0aca6eea44b8.png)

### The continuous active lanes are now fixed to match the path
![image](https://user-images.githubusercontent.com/7515853/117195945-e5bc3480-adb3-11eb-891f-6dc829f3abc1.png)

---

## Example #2

### Before vs. After diff
![image](https://user-images.githubusercontent.com/7515853/117194564-3cc10a00-adb2-11eb-8100-2b1320da1a2d.png)

### Suggests that the user should be in the left most slight_right lane to be ready to keep left at the fork in the ramp
![image](https://user-images.githubusercontent.com/7515853/117194846-94f80c00-adb2-11eb-9c25-64d7afaf79f3.png)

---

## This update improved `23%` of user routes

## Tasklist

 - [x] Add tests
 - [x] Add #fixes with the issue number that this PR addresses
 - [x] Update the [changelog](CHANGELOG.md)


