### PR TITLE
Increased kDefaultServicePenalty.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * **Bug Fix**
    * FIXED: Fix heading on small edge [#3114](https://github.com/valhalla/valhalla/pull/3114)
    * FIXED: Added support for `access=psv`, which disables routing on these nodes and edges unless the mode is taxi or bus [#3107](https://github.com/valhalla/valhalla/pull/3107)
+   * FIXED: Fixed U-turns through service roads [#3082](https://github.com/valhalla/valhalla/pull/3082)
 
 * **Enhancement**
 

--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -39,7 +39,7 @@ constexpr float kDefaultFerryCost = 300.0f;              // Seconds
 constexpr float kDefaultRailFerryCost = 300.0f;          // Seconds
 constexpr float kDefaultCountryCrossingCost = 600.0f;    // Seconds
 constexpr float kDefaultCountryCrossingPenalty = 0.0f;   // Seconds
-constexpr float kDefaultServicePenalty = 15.0f;          // Seconds
+constexpr float kDefaultServicePenalty = 75.0f;          // Seconds
 
 // Other options
 constexpr float kDefaultUseFerry = 0.5f;     // Default preference of using a ferry 0-1

--- a/test/parse_request.cc
+++ b/test/parse_request.cc
@@ -32,7 +32,7 @@ constexpr float kDefaultAuto_UseHighways = 0.5f;              // Factor between 
 constexpr float kDefaultAuto_UseTolls = 0.5f;                 // Factor between 0 and 1
 constexpr float kDefaultAuto_UseTracks = 0.f;                 // Factor between 0 and 1
 constexpr float kDefaultAuto_UseLivingStreets = 0.1f;         // Factor between 0 and 1
-constexpr float kDefaultAuto_ServicePenalty = 15.0f;          // Seconds
+constexpr float kDefaultAuto_ServicePenalty = 75.0f;          // Seconds
 constexpr float kDefaultAuto_ServiceFactor = 1.f;             // Positive factor
 
 // Motor Scooter defaults

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -1021,7 +1021,7 @@ protected:
               (edge->use() == baldr::Use::kLivingStreet && pred->use() != baldr::Use::kLivingStreet);
     c.cost +=
         track_penalty_ * (edge->use() == baldr::Use::kTrack && pred->use() != baldr::Use::kTrack);
-    
+
     if (edge->use() == baldr::Use::kServiceRoad && pred->use() != baldr::Use::kServiceRoad) {
       // Do not penalize internal roads that are marked as service.
       if (!edge->internal())

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -1021,8 +1021,13 @@ protected:
               (edge->use() == baldr::Use::kLivingStreet && pred->use() != baldr::Use::kLivingStreet);
     c.cost +=
         track_penalty_ * (edge->use() == baldr::Use::kTrack && pred->use() != baldr::Use::kTrack);
-    c.cost += service_penalty_ *
-              (edge->use() == baldr::Use::kServiceRoad && pred->use() != baldr::Use::kServiceRoad);
+    
+    if (edge->use() == baldr::Use::kServiceRoad && pred->use() != baldr::Use::kServiceRoad) {
+      // Do not penalize internal roads that are marked as service.
+      if (!edge->internal())
+        c.cost += service_penalty_;
+    }
+
     // shortest ignores any penalties in favor of path length
     c.cost *= !shortest_;
     return c;


### PR DESCRIPTION
# Issue

What's wrong?
Was found case in which, at first, driver received a 3 reroutes (as such U-turn and shortcuts) through service roads to back on the original route, before was suggested correct reroute.
For correct routing driver shouldn't receive such reroutes. This issue can be especially acute in USA due to specific road network.
This issue can't be fixed in the OSM data, because US driver rules allow make left turn to service roads in most this place.

Where were you routing from/to?
Long Island, NY, USA.

What did you expect to happen?
The driver should be suggest U-turn on the main road or reroute through higher class roads then service roads

![](https://user-images.githubusercontent.com/55541433/113160735-6aacaf00-9246-11eb-9497-a4fd51c936e4.png)

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
