### PR TITLE
Move RAPIDJSON_HAS_STDSTRING define from CMakeLists.txt to rapidjson_util.sh

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,7 +92,6 @@ function(valhalla_module)
       # However, NOGDI needs to be undefined in logging.h
       $<$<BOOL:${WIN32}>:NOGDI;WIN32_LEAN_AND_MEAN>
       $<$<BOOL:${MSVC}>:NOMINMAX>
-      RAPIDJSON_HAS_STDSTRING
       HAS_REMOTE_API=0
       AUTO_DOWNLOAD=0
     PRIVATE
@@ -204,9 +203,6 @@ target_compile_definitions(valhalla
   PUBLIC
     $<$<BOOL:${WIN32}>:NOGDI;WIN32_LEAN_AND_MEAN>
     $<$<BOOL:${MSVC}>:NOMINMAX>
-    RAPIDJSON_HAS_STDSTRING  # this is a part of the workaround for OBJECT libraries,
-                             # because ${libvalhalla_compile_definitions} must be private.
-                             # To be removed with ${libvalhalla_compile_definitions} below
     HAS_REMOTE_API=0
     AUTO_DOWNLOAD=0
   PRIVATE

--- a/valhalla/baldr/rapidjson_utils.h
+++ b/valhalla/baldr/rapidjson_utils.h
@@ -20,6 +20,8 @@
   throw std::logic_error(RAPIDJSON_STRINGIFY(x))
 // Because we now throw exceptions, we need to turn of RAPIDJSON_NOEXCEPT
 #define RAPIDJSON_HAS_CXX11_NOEXCEPT 0
+// Enbale std::string overloads
+#define RAPIDJSON_HAS_STDSTRING 1
 
 #include <rapidjson/document.h>
 #include <rapidjson/error/en.h>


### PR DESCRIPTION
# Issue

The header is public while the CMakeLists.txt is private.

The consumers (e.g. #2798) of the Valhalla (3.1.1) library should appreciate
more self-contained headers, without having to look into the library
build configuration to figure the additional requirements.

Besides, `RAPIDJSON_HAS_CXX11_NOEXCEPT` is already in the header.

## Tasklist

- [ ] Update the [changelog](CHANGELOG.md) - Is it necessary for this one? @kevinkreiser 
- [ ] Pass CI

## Requirements / Relations

- #2798
