### PR TITLE
Hide werror under cmake option in mjolnir module

### DIFF
--- a/src/mjolnir/CMakeLists.txt
+++ b/src/mjolnir/CMakeLists.txt
@@ -59,7 +59,7 @@ set(sources
   util.cc
   validatetransit.cc)
 
-if (UNIX)
+if (UNIX AND ENABLE_SINGLE_FILES_WERROR)
   # Enables stricter compiler checks on a file-by-file basis
   # which allows us to migrate piecemeal
   set_source_files_properties(


### PR DESCRIPTION
# Issue

We enable `Werror` for individual files only if `ENABLE_SINGLE_FILES_WERROR` is enabled (e.g https://github.com/valhalla/valhalla/blob/master/src/midgard/CMakeLists.txt#L3). But mjolnir is missing this check for some reason

I guess it doesn't worth editing changelog as it's minor fix

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
