### PR TITLE
Fix linux build failures with -Werror enabled in mjolnir

### DIFF
--- a/src/mjolnir/CMakeLists.txt
+++ b/src/mjolnir/CMakeLists.txt
@@ -26,10 +26,8 @@ set(sources
   ${CMAKE_CURRENT_BINARY_DIR}/admin_lua_proc.h
   admin.cc
   adminbuilder.cc
-  bssbuilder.cc
   complexrestrictionbuilder.cc
   countryaccess.cc
-  dataquality.cc
   directededgebuilder.cc
   graphtilebuilder.cc
   edgeinfobuilder.cc
@@ -52,11 +50,15 @@ set(sources
   pbfgraphparser.cc
   restrictionbuilder.cc
   servicedays.cc
-  shortcutbuilder.cc
   speed_assigner.h
   timeparsing.cc
+  util.cc)
+
+set (sources_with_warnings
+  bssbuilder.cc
+  dataquality.cc
+  shortcutbuilder.cc
   transitbuilder.cc
-  util.cc
   validatetransit.cc)
 
 if (UNIX AND ENABLE_SINGLE_FILES_WERROR)
@@ -68,7 +70,7 @@ if (UNIX AND ENABLE_SINGLE_FILES_WERROR)
 endif (UNIX)
 
 valhalla_module(NAME mjolnir
-  SOURCES ${sources}
+  SOURCES ${sources} ${sources_with_warnings}
   HEADERS ${headers}
   INCLUDE_DIRECTORIES
     PUBLIC


### PR DESCRIPTION
Some files in mjolnir still have warnings which cause build failures
when -Werror is enabled.

Removed affected files from having -Werror enabled.
