### PR TITLE
Replace edgeinfo offset parameter with DirectedEdge parameter for convinience

### DIFF
--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -613,13 +613,8 @@ iterable_t<const DirectedEdge> GraphTile::GetDirectedEdges(const size_t idx) con
   return iterable_t<const DirectedEdge>{edge, nodeinfo.edge_count()};
 }
 
-// Get a pointer to edge info.
-EdgeInfo GraphTile::edgeinfo(const size_t offset) const {
-  return EdgeInfo(edgeinfo_ + offset, textlist_, textlist_size_);
-}
-
 EdgeInfo GraphTile::edgeinfo(const DirectedEdge* edge) const {
-  return edgeinfo(edge->edgeinfo_offset());
+  return EdgeInfo(edgeinfo_ + edge->edgeinfo_offset(), textlist_, textlist_size_);
 }
 
 // Get the complex restrictions in the forward or reverse order based on
@@ -659,17 +654,12 @@ GraphTile::GetDirectedEdges(const uint32_t node_index, uint32_t& count, uint32_t
   return directededge(nodeinfo->edge_index());
 }
 
-// Convenience method to get the names for an edge given the offset to the
-// edge info
-std::vector<std::string> GraphTile::GetNames(const uint32_t edgeinfo_offset,
-                                             bool only_tagged_names) const {
-  return edgeinfo(edgeinfo_offset).GetNames(only_tagged_names);
+std::vector<std::string> GraphTile::GetNames(const DirectedEdge* edge, bool only_tagged_names) const {
+  return edgeinfo(edge).GetNames(only_tagged_names);
 }
 
-// Convenience method to get the types for the names given the offset to the
-// edge info
-uint16_t GraphTile::GetTypes(const uint32_t edgeinfo_offset) const {
-  return edgeinfo(edgeinfo_offset).GetTypes();
+uint16_t GraphTile::GetTypes(const DirectedEdge* edge) const {
+  return edgeinfo(edge).GetTypes();
 }
 
 // Get the admininfo at the specified index.

--- a/src/loki/polygon_search.cc
+++ b/src/loki/polygon_search.cc
@@ -120,7 +120,7 @@ edges_in_rings(const google::protobuf::RepeatedPtrField<valhalla::Options_Ring>&
 
         // TODO: some logic to set percent_along for origin/destination edges
         // careful: polygon can intersect a single edge multiple times
-        auto edge_info = tile->edgeinfo(edge->edgeinfo_offset());
+        auto edge_info = tile->edgeinfo(edge);
         bool intersects = false;
         for (const auto& ring_loc : bin.second) {
           intersects = bg::intersects(rings_bg[ring_loc], edge_info.shape());

--- a/src/mjolnir/graphfilter.cc
+++ b/src/mjolnir/graphfilter.cc
@@ -142,15 +142,14 @@ void FilterTiles(GraphReader& reader,
         // highway hierarchy can cross base tiles! Use a hash based on the
         // encoded shape plus way Id.
         bool added;
-        uint32_t idx = directededge->edgeinfo_offset();
         auto edgeinfo = tile->edgeinfo(directededge);
         std::string encoded_shape = edgeinfo.encoded_shape();
         uint32_t w = hasher(encoded_shape + std::to_string(edgeinfo.wayid()));
         uint32_t edge_info_offset =
             tilebuilder.AddEdgeInfo(w, nodeid, directededge->endnode(), edgeinfo.wayid(),
                                     edgeinfo.mean_elevation(), edgeinfo.bike_network(),
-                                    edgeinfo.speed_limit(), encoded_shape, tile->GetNames(idx),
-                                    tile->GetNames(idx, true), tile->GetTypes(idx), added);
+                                    edgeinfo.speed_limit(), encoded_shape, edgeinfo.GetNames(),
+                                    edgeinfo.GetNames(true), edgeinfo.GetTypes(), added);
         newedge.set_edgeinfo_offset(edge_info_offset);
         wayid.push_back(edgeinfo.wayid());
         endnode.push_back(directededge->endnode());

--- a/src/mjolnir/hierarchybuilder.cc
+++ b/src/mjolnir/hierarchybuilder.cc
@@ -308,7 +308,6 @@ void FormTilesInNewLevel(GraphReader& reader,
       // Do we need to force adding edgeinfo (opposing edge could have diff names)?
       // If end node is in the same tile and there is no opposing edge with matching
       // edge_info_offset).
-      uint32_t idx = directededge->edgeinfo_offset();
       bool diff_names = directededge->endnode().tileid() == base_edge_id.tileid() &&
                         !OpposingEdgeInfoMatches(tile, directededge);
 
@@ -322,8 +321,8 @@ void FormTilesInNewLevel(GraphReader& reader,
       uint32_t edge_info_offset =
           tilebuilder->AddEdgeInfo(w, nodea, nodeb, edgeinfo.wayid(), edgeinfo.mean_elevation(),
                                    edgeinfo.bike_network(), edgeinfo.speed_limit(), encoded_shape,
-                                   tile->GetNames(idx), tile->GetNames(idx, true),
-                                   tile->GetTypes(idx), added, diff_names);
+                                   edgeinfo.GetNames(), edgeinfo.GetNames(true), edgeinfo.GetTypes(),
+                                   added, diff_names);
       newedge.set_edgeinfo_offset(edge_info_offset);
 
       // Add directed edge

--- a/src/mjolnir/restrictionbuilder.cc
+++ b/src/mjolnir/restrictionbuilder.cc
@@ -58,7 +58,7 @@ GraphId GetOpposingEdge(GraphReader& reader,
     if (opp_edge->endnode() == node && opp_edge->classification() == edge->classification() &&
         opp_edge->length() == edge->length() &&
         ((opp_edge->link() && edge->link()) || (opp_edge->use() == edge->use())) &&
-        way_id == end_node_tile->edgeinfo(opp_edge->edgeinfo_offset()).wayid()) {
+        way_id == end_node_tile->edgeinfo(opp_edge).wayid()) {
       return opp_id;
     }
   }

--- a/src/mjolnir/shortcutbuilder.cc
+++ b/src/mjolnir/shortcutbuilder.cc
@@ -425,7 +425,7 @@ uint32_t AddShortcutEdges(GraphReader& reader,
 
       // Get names and types - they apply over all edges of the shortcut
       auto names = edgeinfo.GetNames();
-      auto tagged_names = edgeinfo.GetNames();
+      auto tagged_names = edgeinfo.GetNames(true);
       auto types = edgeinfo.GetTypes();
 
       // Add any access restriction records. TODO - make sure we don't contract

--- a/src/mjolnir/shortcutbuilder.cc
+++ b/src/mjolnir/shortcutbuilder.cc
@@ -73,8 +73,8 @@ bool EdgesMatch(const graph_tile_ptr& tile, const DirectedEdge* edge1, const Dir
   // Names must match
   // TODO - this allows matches in any order. Do we need to maintain order?
   // TODO - should allow near matches?
-  std::vector<std::string> edge1names = tile->GetNames(edge1->edgeinfo_offset());
-  std::vector<std::string> edge2names = tile->GetNames(edge2->edgeinfo_offset());
+  std::vector<std::string> edge1names = tile->GetNames(edge1);
+  std::vector<std::string> edge2names = tile->GetNames(edge2);
   if (edge1names.size() != edge2names.size()) {
     return false;
   }
@@ -423,11 +423,10 @@ uint32_t AddShortcutEdges(GraphReader& reader,
         std::reverse(shape.begin(), shape.end());
       }
 
-      // Get names - they apply over all edges of the shortcut
-      auto names = tile->GetNames(directededge->edgeinfo_offset());
-      auto tagged_names = tile->GetNames(directededge->edgeinfo_offset(), true);
-
-      auto types = tile->GetTypes(directededge->edgeinfo_offset());
+      // Get names and types - they apply over all edges of the shortcut
+      auto names = edgeinfo.GetNames();
+      auto tagged_names = edgeinfo.GetNames();
+      auto types = edgeinfo.GetTypes();
 
       // Add any access restriction records. TODO - make sure we don't contract
       // across edges with different restrictions.
@@ -682,10 +681,8 @@ uint32_t FormShortcuts(GraphReader& reader, const TileLevel& level) {
             tilebuilder.AddEdgeInfo(directededge->edgeinfo_offset(), node_id, directededge->endnode(),
                                     edgeinfo.wayid(), edgeinfo.mean_elevation(),
                                     edgeinfo.bike_network(), edgeinfo.speed_limit(),
-                                    edgeinfo.encoded_shape(),
-                                    tile->GetNames(directededge->edgeinfo_offset()),
-                                    tile->GetNames(directededge->edgeinfo_offset(), true),
-                                    tile->GetTypes(directededge->edgeinfo_offset()), added);
+                                    edgeinfo.encoded_shape(), edgeinfo.GetNames(),
+                                    edgeinfo.GetNames(true), edgeinfo.GetTypes(), added);
         newedge.set_edgeinfo_offset(edge_info_offset);
 
         // Set the superseded mask - this is the shortcut mask that supersedes this edge

--- a/test/graphtilebuilder.cc
+++ b/test/graphtilebuilder.cc
@@ -124,15 +124,15 @@ TEST(GraphTileBuilder, TestDuplicateEdgeInfo) {
   EXPECT_NEAR(ei.mean_elevation(), 555.0f, kElevationBinSize);
   EXPECT_EQ(ei.speed_limit(), 120);
 
-  auto n1 = test2.GetNames(0, false);
+  auto n1 = ei.GetNames(false);
   EXPECT_EQ(n1.size(), 1);
   EXPECT_EQ(n1.at(0), "einzelweg");
 
-  auto n2 = test2.GetNames(0); // defaults to false
+  auto n2 = ei.GetNames(); // defaults to false
   EXPECT_EQ(n2.size(), 1);
   EXPECT_EQ(n2.at(0), "einzelweg");
 
-  auto n3 = test2.GetNames(0, true);
+  auto n3 = ei.GetNames(true);
   EXPECT_EQ(n3.size(), 1);
   EXPECT_EQ(n3.at(0), "1xyz tunnel"); // we always return the tag type in getnames
 

--- a/test/gurka/gurka.cc
+++ b/test/gurka/gurka.cc
@@ -513,7 +513,7 @@ findEdge(valhalla::baldr::GraphReader& reader,
       const auto threshold = 0.00001; // Degrees.  About 1m at the equator
       if (std::abs(de_endnode_coordinates.lng() - end_node_coordinates.lng()) < threshold &&
           std::abs(de_endnode_coordinates.lat() - end_node_coordinates.lat()) < threshold) {
-        auto names = tile->GetNames(forward_directed_edge->edgeinfo_offset());
+        auto names = tile->GetNames(forward_directed_edge);
         for (const auto& name : names) {
           if (name == way_name) {
             auto forward_edge_id = tile_id;

--- a/test/gurka/test_config_speed.cc
+++ b/test/gurka/test_config_speed.cc
@@ -187,7 +187,7 @@ TEST(Standalone, DefaultSpeedConfig) {
   for (auto tile_id : reader.GetTileSet()) {
     auto tile = reader.GetGraphTile(tile_id);
     for (const auto& edge : tile->GetDirectedEdges()) {
-      auto info = tile->edgeinfo(edge.edgeinfo_offset());
+      auto info = tile->edgeinfo(&edge);
       auto name = info.GetNames().front();
       // skip anything that looks like the extra length we added to make it urban
       if (name.front() >= 'a' && name.front() <= 'j')
@@ -340,7 +340,7 @@ TEST(Standalone, SuburbanSpeedConfig) {
   for (auto tile_id : reader.GetTileSet()) {
     auto tile = reader.GetGraphTile(tile_id);
     for (const auto& edge : tile->GetDirectedEdges()) {
-      auto info = tile->edgeinfo(edge.edgeinfo_offset());
+      auto info = tile->edgeinfo(&edge);
       auto name = info.GetNames().front();
       // skip anything that looks like the extra length we added to make it urban
       if (name.front() >= 'a' && name.front() <= 'j')

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -322,12 +322,6 @@ public:
    * Get a pointer to edge info.
    * @return  Returns edge info.
    */
-  EdgeInfo edgeinfo(const size_t offset) const;
-
-  /**
-   * Get a pointer to edge info.
-   * @return  Returns edge info.
-   */
   EdgeInfo edgeinfo(const DirectedEdge* edge) const;
 
   /**
@@ -352,23 +346,20 @@ public:
   GetDirectedEdges(const uint32_t node_index, uint32_t& count, uint32_t& edge_index) const;
 
   /**
-   * Convenience method to get the names for an edge given the offset to the
-   * edge information.
-   * @param  edgeinfo_offset  Offset to the edge info.
+   * Convenience method to get the names for an edge
+   * @param  edge  Directed edge
    * @param  only_tagged_names  Bool indicating whether or not to return only the tagged names
    *
    * @return  Returns a list (vector) of names.
    */
-  std::vector<std::string> GetNames(const uint32_t edgeinfo_offset,
-                                    bool only_tagged_names = false) const;
+  std::vector<std::string> GetNames(const DirectedEdge* edge, bool only_tagged_names = false) const;
 
   /**
-   * Convenience method to get the types for the names given the offset to the
-   * edge information.
-   * @param  edgeinfo_offset  Offset to the edge info.
+   * Convenience method to get the types for the names given the edge
+   * @param  edge  Directed edge
    * @return  Returns unit16_t.  If a bit is set, then it is a ref.
    */
-  uint16_t GetTypes(const uint32_t edgeinfo_offset) const;
+  uint16_t GetTypes(const DirectedEdge* edge) const;
 
   /**
    * Get the admininfo at the specified index. Populates the state name and


### PR DESCRIPTION
# Issue

... continue of https://github.com/valhalla/valhalla/pull/2905#discussion_r584300351

Main changes are in the `graphtile.h` file/`GraphTile` class
- Dropped `GraphTile::edgeinfo(uint edgeinfo_offset)` overload
- Changed signature of `GraphTile::GetTypes` and `GraphTile::GetNames`

```cpp
// Usage before
tile->GetNames(edge->edgeinfo_offset());
tile->GetTypes(edge->edgeinfo_offset());

// Usage after
tile->GetNames(edge);
tile->GetTypes(edge);
```

Q: Not sure about changelog as it's a minor refactoring

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
