### PR TITLE
Update turn channel logic to call out specific turn at the end of the turn channel if needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
    * FIXED: Added forgotten penalties for kLivingStreet and kTrack for pedestrian costing model [#3116](https://github.com/valhalla/valhalla/pull/3116)
    * FIXED: Updated the reverse turn bounds [#3122](https://github.com/valhalla/valhalla/pull/3122)
    * FIXED: Missing fork maneuver [#3134](https://github.com/valhalla/valhalla/pull/3134)
+   * FIXED: Update turn channel logic to call out specific turn at the end of the turn channel if needed [#3140](https://github.com/valhalla/valhalla/pull/3140)
 
 * **Enhancement**
    * CHANGED: Refactor base costing options parsing to handle more common stuff in a one place [#3125](https://github.com/valhalla/valhalla/pull/3125)

--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -41,6 +41,11 @@ namespace {
 constexpr uint32_t kRelativeStraightTurnDegreeLowerBound = 330;
 constexpr uint32_t kRelativeStraightTurnDegreeUpperBound = 30;
 
+constexpr uint32_t kTurnChannelTurnDegreeLowerBound = 290;
+constexpr uint32_t kTurnChannelTurnDegreeUpperBound = 70;
+
+constexpr float kShortTurnChannelThreshold = 0.036f; // Kilometers
+
 constexpr float kShortForkThreshold = 0.05f; // Kilometers
 
 // Kilometers - picked since the next rounded maneuver announcement will happen
@@ -2638,13 +2643,34 @@ bool ManeuversBuilder::IsTurnChannelManeuverCombinable(std::list<Maneuver>::iter
 
     Turn::Type new_turn_type = Turn::GetType(new_turn_degree);
 
+    auto turn_channel_end_node_index = curr_man->end_node_index();
+    auto node = trip_path_->GetEnhancedNode(turn_channel_end_node_index);
+    auto prev_edge = trip_path_->GetPrevEdge(turn_channel_end_node_index);
+    auto curr_edge = trip_path_->GetCurrEdge(turn_channel_end_node_index);
+
+    // Validate node and edges
+    if (!node || !prev_edge || !curr_edge) {
+      return false;
+    }
+    // Calculate this value in case next maneuver turn degree is modified
+    // because of internal intersection collapsing
+    auto post_turn_channel_turn_degree =
+        GetTurnDegree(prev_edge->end_heading(), curr_edge->begin_heading());
+
+    auto is_within_turn_channel_range = [](uint32_t turn_degree) -> bool {
+      return ((turn_degree >= kTurnChannelTurnDegreeLowerBound) ||
+              (turn_degree <= kTurnChannelTurnDegreeUpperBound));
+    };
+
     // Turn channel cannot exceed kMaxTurnChannelLength (200m)
     // and turn channel cannot have forward traversable intersecting edge
-    auto node = trip_path_->GetEnhancedNode(next_man->begin_node_index());
+    // and (the post turn channel degree is somewhat straight or the turn channel is short)
     bool common_turn_channel_criteria =
         ((curr_man->length(Options::kilometers) <= (kMaxTurnChannelLength * kKmPerMeter)) &&
          !node->HasForwardTraversableIntersectingEdge(curr_man->end_heading(),
-                                                      curr_man->travel_mode()));
+                                                      curr_man->travel_mode()) &&
+         (is_within_turn_channel_range(post_turn_channel_turn_degree) ||
+          (curr_man->length(Options::kilometers) < kShortTurnChannelThreshold)));
 
     // Verify common turn channel criteria
     if (!common_turn_channel_criteria) {

--- a/test/maneuversbuilder.cc
+++ b/test/maneuversbuilder.cc
@@ -1563,6 +1563,9 @@ TEST(Maneuversbuilder, TestSimpleRightTurnChannelCombine) {
                valhalla::RoadClass::kSecondary, 188, 188, 11, 14, TripLeg_Traversability_kBoth, 0, 0,
                0, 0, 0, 0, 0, 0, 0, 0, {}, {}, {}, {});
 
+  // node:3 end node
+  node = path.add_node();
+
   EnhancedTripLeg etp(path);
   ManeuversBuilderTest mbTest(options, &etp);
 

--- a/test_requests/ramp_vs_turn_routes.txt
+++ b/test_requests/ramp_vs_turn_routes.txt
@@ -31,3 +31,5 @@
 -j '{"locations":[{"lat":53.92824412679647,"lon":27.50899576679126},{"lat":53.92551332645405,"lon":27.521586966855693}],"costing":"auto","units":"miles"}'
 -j '{"locations":[{"lat":39.992585,"lon":-76.024084,"street":"US 30"},{"lat":39.990999,"lon":-76.021027,"street":"PA 41"}],"costing":"auto","units":"miles"}'
 -j '{"locations":[{"lat":39.885051,"lon":-75.529767,"street":"US 1 North"},{"lat":39.884298,"lon":-75.526149,"street":"US 322 East"}],"costing":"auto","units":"miles"}'
+-j '{"locations":[{"lat":50.886183,"lon":4.686228,"street":"Den Boschsingel"},{"lat":50.883620,"lon":4.681439,"street":"Brusselsesteenweg"}],"costing":"auto","units":"kilometers"}'
+-j '{"locations":[{"lat":50.886183,"lon":4.686228,"street":"Den Boschsingel"},{"lat":50.882707,"lon":4.685079,"street":"Brusselsestraat"}],"costing":"auto","units":"kilometers"}'


### PR DESCRIPTION
# Issue

Fix missing explicit turn at the end of turn channel

## Example
``` diff
< BEFORE
< 2: Turn right toward N2/Brusselsesteenweg.
> AFTER
> 2: Bear right toward N2/Centrum/Brussel.
> 3: Turn right onto Brusselsesteenweg/N2.
```
![image](https://user-images.githubusercontent.com/7515853/121562978-fa5d9f00-c9e7-11eb-80c3-50576d7ba154.png)
![image](https://user-images.githubusercontent.com/7515853/121562854-de59fd80-c9e7-11eb-9a58-0e5da63aaf20.png)


## This update improves `1%` of user routes

## Tasklist

 - [x] Add gurka and RAD tests
 - [x] Add #fixes with the issue number that this PR addresses
 - [x] Update the [changelog](CHANGELOG.md)
