### PR TITLE
Updates google benchmark to v1.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
    * CHANGED: Refactor base costing options parsing to handle more common stuff in a one place [#3125](https://github.com/valhalla/valhalla/pull/3125)
    * CHANGED: Unified Sign/SignElement into sign.proto [#3146](https://github.com/valhalla/valhalla/pull/3146)
    * ADDED: New verbal succinct transition instruction to maneuver & narrativebuilder. Currently this instruction will be used in place of a very long street name to avoid repetition of long names [#2844](https://github.com/valhalla/valhalla/pull/2844)
+   * CHORE: Updates google-benchmark to v1.5.5
    * ADDED: Added oneway support for pedestrian access and foot restrictions [#3123](https://github.com/valhalla/valhalla/pull/3123)
 
 ## Release Date: 2021-05-26 Valhalla 3.1.2


### PR DESCRIPTION
due to compile error on clang 12.0 on Linux

```
FAILED: benchmark/src/CMakeFiles/benchmark.dir/benchmark_register.cc.o
sccache /usr/bin/c++ -DBOOST_NO_CXX11_SCOPED_ENUMS -DDATA_TOOLS -DHAVE_POSIX_REGEX -DHAVE_STD_REGEX -DHAVE_STEADY_CLOCK -Dbenchmark_EXPORTS -I../third_party/benchmark/include -I../third_party/benchmark/src -I../third_party/benchmark/src/../include -fdiagnostics-color=auto   -std=c++11  -Wall  -Wextra  -Wshadow  -fstrict-aliasing  -Wno-deprecated-declarations  -Wstrict-aliasing -O2 -g -DNDEBUG  -Werror  -Wno-deprecated -fPIC -std=gnu++14 -MD -MT benchmark/src/CMakeFiles/benchmark.dir/benchmark_register.cc.o -MF benchmark/src/CMakeFiles/benchmark.dir/benchmark_register.cc.o.d -o benchmark/src/CMakeFiles/benchmark.dir/benchmark_register.cc.o -c ../third_party/benchmark/src/benchmark_register.cc
In file included from ../third_party/benchmark/src/benchmark_register.cc:15:
../third_party/benchmark/src/benchmark_register.h: In function ‘typename std::vector<T>::iterator benchmark::internal::AddPowers(std::vector<T>*, T, T, int)’:
../third_party/benchmark/src/benchmark_register.h:22:30: error: ‘numeric_limits’ is not a member of ‘std’
   22 |   static const T kmax = std::numeric_limits<T>::max();
      |                              ^~~~~~~~~~~~~~
../third_party/benchmark/src/benchmark_register.h:22:46: error: expected primary-expression before ‘>’ token
   22 |   static const T kmax = std::numeric_limits<T>::max();
      |                                              ^
../third_party/benchmark/src/benchmark_register.h:22:49: error: ‘::max’ has not been declared; did you mean ‘std::max’?
   22 |   static const T kmax = std::numeric_limits<T>::max();
      |                                                 ^~~
      |                                                 std::max
In file included from /usr/include/c++/11.1.0/algorithm:62,
                 from ../third_party/benchmark/include/benchmark/benchmark.h:172,
                 from ../third_party/benchmark/src/internal_macros.h:4,
                 from ../third_party/benchmark/src/check.h:8,
                 from ../third_party/benchmark/src/benchmark_register.h:6,
                 from ../third_party/benchmark/src/benchmark_register.cc:15:
/usr/include/c++/11.1.0/bits/stl_algo.h:3467:5: note: ‘std::max’ declared here
 3467 |     max(initializer_list<_Tp> __l, _Compare __comp)
      |     ^~~
```
