### PR TITLE
Updates googletest to release-1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
    * ADDED: Maintain `access=permit|residents` tags as private [#3149](https://github.com/valhalla/valhalla/pull/3149)
    * CHANGED: Replace `avoid_*` API parameters with more accurate `exclude_*` [#3093](https://github.com/valhalla/valhalla/pull/3093)
    * ADDED: Penalize private gates [#3144](https://github.com/valhalla/valhalla/pull/3144)
+   * CHORE: Updates googletest to release-1.11.0 [#3166](Updates googletest to release-1.11.0)
 
 ## Release Date: 2021-05-26 Valhalla 3.1.2
 * **Removed**


### PR DESCRIPTION
Compiles on both `gcc 11.1.0` and `clang 12.0.0` on Linux 5.12.11-arch1-1(Archlinux).

Related to https://github.com/valhalla/valhalla/issues/3157 and https://github.com/valhalla/valhalla/pull/3112

cc @merkispavel @nilsnolde 