### PR TITLE
Remove unused functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Release Date: 2021-??-?? Valhalla 3.1.3
 * **Removed**
+   * REMOVED: Unused overloads of `to_response` function [#3167](https://github.com/valhalla/valhalla/pull/3167)
+
 * **Bug Fix**
    * FIXED: Fix heading on small edge [#3114](https://github.com/valhalla/valhalla/pull/3114)
    * FIXED: Added support for `access=psv`, which disables routing on these nodes and edges unless the mode is taxi or bus [#3107](https://github.com/valhalla/valhalla/pull/3107)

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -1208,49 +1208,6 @@ worker_t::result_t jsonify_error(const valhalla_exception_t& exception,
   return result;
 }
 
-worker_t::result_t to_response(const baldr::json::ArrayPtr& array,
-                               http_request_info_t& request_info,
-                               const Api& request) {
-  std::ostringstream stream;
-  // jsonp callback if need be
-  if (request.options().has_jsonp()) {
-    stream << request.options().jsonp() << '(';
-  }
-  stream << *array;
-  if (request.options().has_jsonp()) {
-    stream << ')';
-  }
-
-  worker_t::result_t result{false, std::list<std::string>(), ""};
-  http_response_t response(200, "OK", stream.str(),
-                           headers_t{CORS, request.options().has_jsonp() ? worker::JS_MIME
-                                                                         : worker::JSON_MIME});
-  response.from_info(request_info);
-  result.messages.emplace_back(response.to_string());
-  return result;
-}
-
-worker_t::result_t
-to_response(const baldr::json::MapPtr& map, http_request_info_t& request_info, const Api& request) {
-  std::ostringstream stream;
-  // jsonp callback if need be
-  if (request.options().has_jsonp()) {
-    stream << request.options().jsonp() << '(';
-  }
-  stream << *map;
-  if (request.options().has_jsonp()) {
-    stream << ')';
-  }
-
-  worker_t::result_t result{false, std::list<std::string>(), ""};
-  http_response_t response(200, "OK", stream.str(),
-                           headers_t{CORS, request.options().has_jsonp() ? worker::JS_MIME
-                                                                         : worker::JSON_MIME});
-  response.from_info(request_info);
-  result.messages.emplace_back(response.to_string());
-  return result;
-}
-
 worker_t::result_t to_response(const std::string& data,
                                http_request_info_t& request_info,
                                const Api& request,

--- a/valhalla/worker.h
+++ b/valhalla/worker.h
@@ -180,12 +180,6 @@ std::string jsonify_error(const valhalla_exception_t& exception, const Api& opti
 prime_server::worker_t::result_t jsonify_error(const valhalla_exception_t& exception,
                                                prime_server::http_request_info_t& request_info,
                                                const Api& options);
-prime_server::worker_t::result_t to_response(const baldr::json::ArrayPtr& array,
-                                             prime_server::http_request_info_t& request_info,
-                                             const Api& options);
-prime_server::worker_t::result_t to_response(const baldr::json::MapPtr& map,
-                                             prime_server::http_request_info_t& request_info,
-                                             const Api& options);
 namespace worker {
 using content_type = prime_server::headers_t::value_type;
 const content_type JSON_MIME{"Content-type", "application/json;charset=utf-8"};


### PR DESCRIPTION
# Issue

Looks like these two `to_response` function overloads are unused. Maybe we can remove them?

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
