### PR TITLE
Use distance instead of time to check limited sharing criteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
    * ADDED: Allow going through accessible `barrier=bollard` and penalize routing through it, when the access is private [#3175](https://github.com/valhalla/valhalla/pull/3175)
 
    * ADDED: Add country code to incident metadata [#3169](https://github.com/valhalla/valhalla/pull/3169)
+   * CHANGED: Use distance instead of time to check limited sharing criteria [#3183](https://github.com/valhalla/valhalla/pull/3183)
 
 ## Release Date: 2021-05-26 Valhalla 3.1.2
 * **Removed**

--- a/src/thor/alternates.cc
+++ b/src/thor/alternates.cc
@@ -81,19 +81,20 @@ bool validate_alternate_by_sharing(std::vector<std::unordered_set<GraphId>>& sha
 
     // if an edge on the candidate_path is encountered that is also on one of the existing paths,
     // we count it as a "shared" edge
-    float shared_duration = 0.f, total_duration = 0.f;
+    float shared_length = 0.f, total_length = 0.f;
     for (const auto& cpi : candidate_path) {
-      const auto duration = &cpi == &candidate_path.front()
-                                ? cpi.elapsed_cost.secs
-                                : cpi.elapsed_cost.secs - (&cpi - 1)->elapsed_cost.secs;
-      total_duration += duration;
+      const auto length = &cpi == &candidate_path.front()
+                              ? cpi.path_distance
+                              : cpi.path_distance - (&cpi - 1)->path_distance;
+      total_length += length;
       if (shared.find(cpi.edgeid) != shared.end()) {
-        shared_duration += duration;
+        shared_length += length;
       }
     }
 
     // throw this alternate away if it shares more than at_most_shared with any of the chosen paths
-    if ((shared_duration / total_duration) > at_most_shared) {
+    assert(total_length > 0);
+    if ((shared_length / total_length) > at_most_shared) {
       LOG_DEBUG("Candidate alternate rejected");
       return false;
     }

--- a/src/thor/astar_bss.cc
+++ b/src/thor/astar_bss.cc
@@ -534,7 +534,8 @@ std::vector<PathInfo> AStarBSSAlgorithm::FormPath(baldr::GraphReader& graphreade
        edgelabel_index = edgelabels_[edgelabel_index].predecessor()) {
     const EdgeLabel& edgelabel = edgelabels_[edgelabel_index];
     path.emplace_back(edgelabel.mode(), edgelabel.cost(), edgelabel.edgeid(), 0,
-                      edgelabel.restriction_idx(), edgelabel.transition_cost());
+                      edgelabel.path_distance(), edgelabel.restriction_idx(),
+                      edgelabel.transition_cost());
 
     graph_tile_ptr tile = graphreader.GetGraphTile(edgelabel.edgeid());
     const DirectedEdge* directededge = tile->directededge(edgelabel.edgeid());

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -1127,8 +1127,9 @@ std::vector<std::vector<PathInfo>> BidirectionalAStar::FormPath(GraphReader& gra
     };
 
     const auto label_cb = [&path, &recovered_inner_edges](const EdgeLabel& label) {
-      path.emplace_back(label.mode(), label.cost(), label.edgeid(), 0, label.restriction_idx(),
-                        label.transition_cost(), recovered_inner_edges.count(label.edgeid()));
+      path.emplace_back(label.mode(), label.cost(), label.edgeid(), 0, label.path_distance(),
+                        label.restriction_idx(), label.transition_cost(),
+                        recovered_inner_edges.count(label.edgeid()));
     };
 
     float source_pct;

--- a/src/thor/centroid.cc
+++ b/src/thor/centroid.cc
@@ -225,8 +225,8 @@ Centroid::FormPaths(const ExpansionType& expansion_type,
       auto path_edge_id = expansion_type == ExpansionType::reverse
                               ? reader.GetOpposingEdgeId(label.edgeid(), tile)
                               : label.edgeid();
-      path.emplace_back(label.mode(), label.cost(), path_edge_id, 0, label.restriction_idx(),
-                        label.transition_cost());
+      path.emplace_back(label.mode(), label.cost(), path_edge_id, 0, label.path_distance(),
+                        label.restriction_idx(), label.transition_cost());
     }
 
     // reverse the path since we recovered it starting at the beginning

--- a/src/thor/map_matcher.cc
+++ b/src/thor/map_matcher.cc
@@ -292,7 +292,7 @@ MapMatcher::FormPath(meili::MapMatcher* matcher,
             static_cast<bool>(flow_sources & kDefaultFlowMask),
             turn};
     paths.back().first.emplace_back(
-        PathInfo{mode, elapsed, edge_id, 0, edge_segment.restriction_idx, transition_cost});
+        PathInfo{mode, elapsed, edge_id, 0, 0, edge_segment.restriction_idx, transition_cost});
     paths.back().second.emplace_back(&edge_segment);
     --num_segments;
 

--- a/src/thor/multimodal.cc
+++ b/src/thor/multimodal.cc
@@ -846,7 +846,8 @@ std::vector<PathInfo> MultiModalPathAlgorithm::FormPath(const uint32_t dest) {
        edgelabel_index = edgelabels_[edgelabel_index].predecessor()) {
     const MMEdgeLabel& edgelabel = edgelabels_[edgelabel_index];
     path.emplace_back(edgelabel.mode(), edgelabel.cost(), edgelabel.edgeid(), edgelabel.tripid(),
-                      edgelabel.restriction_idx(), edgelabel.transition_cost());
+                      edgelabel.path_distance(), edgelabel.restriction_idx(),
+                      edgelabel.transition_cost());
 
     // Check if this is a ferry
     if (edgelabel.use() == Use::kFerry) {

--- a/src/thor/route_matcher.cc
+++ b/src/thor/route_matcher.cc
@@ -196,7 +196,7 @@ bool expand_from_node(const mode_costing_t& mode_costing,
           elapsed.secs = shape.Get(index).time() - shape.Get(0).time();
 
         // Add edge and update correlated index
-        path_infos.emplace_back(mode, elapsed, edge_id, 0, -1, transition_cost);
+        path_infos.emplace_back(mode, elapsed, edge_id, 0, 0.f, -1, transition_cost);
 
         InternalTurn turn = nodeinfo
                                 ? costing->TurnType(prev_edge_label.opp_local_idx(), nodeinfo, de)
@@ -401,7 +401,7 @@ bool RouteMatcher::FormPath(const sif::mode_costing_t& mode_costing,
           elapsed.secs = options.shape(index).time() - options.shape(0).time();
 
         // Add begin edge
-        path_infos.emplace_back(mode, elapsed, graphid, 0, -1);
+        path_infos.emplace_back(mode, elapsed, graphid, 0, 0.f, -1);
 
         InternalTurn turn =
             nodeinfo ? mode_costing[static_cast<int>(mode)]->TurnType(prev_edge_label.opp_local_idx(),
@@ -468,7 +468,7 @@ bool RouteMatcher::FormPath(const sif::mode_costing_t& mode_costing,
             elapsed.secs = options.shape().rbegin()->time() - options.shape(0).time();
 
           // Add end edge
-          path_infos.emplace_back(mode, elapsed, end_edge_graphid, 0, -1, transition_cost);
+          path_infos.emplace_back(mode, elapsed, end_edge_graphid, 0, 0.f, -1, transition_cost);
           return true;
         } else {
           // Did not find an edge that correlates with the trace, return false.
@@ -491,7 +491,7 @@ bool RouteMatcher::FormPath(const sif::mode_costing_t& mode_costing,
           elapsed.secs = options.shape().rbegin()->time() - options.shape(0).time();
 
         // Add end edge
-        path_infos.emplace_back(mode, elapsed, GraphId(edge.graph_id()), 0, -1);
+        path_infos.emplace_back(mode, elapsed, GraphId(edge.graph_id()), 0, 0.f, -1);
         return true;
       }
     }

--- a/src/thor/unidirectional_astar.cc
+++ b/src/thor/unidirectional_astar.cc
@@ -340,7 +340,8 @@ std::vector<PathInfo> UnidirectionalAStar<ExpansionType::forward>::FormPath(cons
        edgelabel_index = edgelabels_[edgelabel_index].predecessor()) {
     const EdgeLabel& edgelabel = edgelabels_[edgelabel_index];
     path.emplace_back(edgelabel.mode(), edgelabel.cost(), edgelabel.edgeid(), 0,
-                      edgelabel.restriction_idx(), edgelabel.transition_cost());
+                      edgelabel.path_distance(), edgelabel.restriction_idx(),
+                      edgelabel.transition_cost());
 
     // Check if this is a ferry
     if (edgelabel.use() == Use::kFerry) {
@@ -383,8 +384,8 @@ std::vector<PathInfo> UnidirectionalAStar<ExpansionType::reverse>::FormPath(cons
     cost -= edgelabel.transition_cost();
     cost += previous_transition_cost;
 
-    path.emplace_back(edgelabel.mode(), cost, edgelabel.opp_edgeid(), 0, edgelabel.restriction_idx(),
-                      previous_transition_cost);
+    path.emplace_back(edgelabel.mode(), cost, edgelabel.opp_edgeid(), 0, edgelabel.path_distance(),
+                      edgelabel.restriction_idx(), previous_transition_cost);
 
     // Check if this is a ferry
     if (edgelabel.use() == Use::kFerry) {

--- a/valhalla/thor/pathinfo.h
+++ b/valhalla/thor/pathinfo.h
@@ -18,6 +18,7 @@ struct PathInfo {
                           // of the edge
   uint32_t trip_id;       // Trip Id (0 if not a transit edge).
   baldr::GraphId edgeid;  // Directed edge Id
+  float path_distance;    // Distance (in meters) from the start to the edge
   uint8_t restriction_index;    // Record which restriction
   sif::Cost transition_cost;    // Turn cost at the beginning of the edge
   bool start_node_is_recovered; // Indicates if the start node of the edge is an inner node
@@ -29,11 +30,13 @@ struct PathInfo {
            const sif::Cost c,
            const baldr::GraphId& edge,
            const uint32_t tripid,
+           const float path_distance,
            const uint8_t restriction_idx = baldr::kInvalidRestriction,
            const sif::Cost tc = {},
            bool start_node_is_recovered = false)
-      : mode(m), elapsed_cost(c), trip_id(tripid), edgeid(edge), restriction_index(restriction_idx),
-        transition_cost(tc), start_node_is_recovered(start_node_is_recovered) {
+      : mode(m), elapsed_cost(c), trip_id(tripid), edgeid(edge), path_distance(path_distance),
+        restriction_index(restriction_idx), transition_cost(tc),
+        start_node_is_recovered(start_node_is_recovered) {
   }
 
   // Stream output
@@ -41,7 +44,8 @@ struct PathInfo {
     os << std::fixed << std::setprecision(3);
     os << "mode: " << static_cast<int>(p.mode) << ", elapsed_time: " << p.elapsed_cost.secs
        << ", elapsed_cost: " << p.elapsed_cost.cost << ", trip_id: " << p.trip_id
-       << ", edgeid: " << p.edgeid << ", transition_time: " << p.transition_cost.secs
+       << ", edgeid: " << p.edgeid << ", path_distance" << p.path_distance
+       << ", transition_time: " << p.transition_cost.secs
        << ", transition_cost: " << p.transition_cost.cost;
     return os;
   }


### PR DESCRIPTION
# Issue

This PR changes limited sharing criteria that is used to find good alternatives.
Right now to check if alternative candidate is different enough we calculate how much time (sum of duration on the shared edges) this alternative candidate shares with already chosen routes. In some cases it leads to a situation when alternative is geometrically too similar to the main route. Our goal is to avoid proposing such alternatives that are not very "alternative". If we use distance instead of time we will guarantee that at least 25% of route geometry will be different from the main route.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
