### PR TITLE
Fix avoid polygons again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
    * FIXED: Use distance threshold in hierarchy limits for bidirectional astar to expand more important lower level roads [#3156](https://github.com/valhalla/valhalla/pull/3156)
    * FIXED: Fixed incorrect dead-end roundabout labels. [#3129](https://github.com/valhalla/valhalla/pull/3129)
    * FIXED: googletest wasn't really updated in #3166 [#3187](https://github.com/valhalla/valhalla/pull/3187)
-   * FIXED: avoid_polygons intersected edges as polygons instead of linestrings [#3192]((https://github.com/valhalla/valhalla/pull/3192)
+   * FIXED: avoid_polygons intersected edges as polygons instead of linestrings [#3194]((https://github.com/valhalla/valhalla/pull/3194)
 
 * **Enhancement**
    * CHANGED: Refactor base costing options parsing to handle more common stuff in a one place [#3125](https://github.com/valhalla/valhalla/pull/3125)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
    * FIXED: Use distance threshold in hierarchy limits for bidirectional astar to expand more important lower level roads [#3156](https://github.com/valhalla/valhalla/pull/3156)
    * FIXED: Fixed incorrect dead-end roundabout labels. [#3129](https://github.com/valhalla/valhalla/pull/3129)
    * FIXED: googletest wasn't really updated in #3166 [#3187](https://github.com/valhalla/valhalla/pull/3187)
+   * FIXED: avoid_polygons intersected edges as polygons instead of linestrings [#3192]((https://github.com/valhalla/valhalla/pull/3192)
 
 * **Enhancement**
    * CHANGED: Refactor base costing options parsing to handle more common stuff in a one place [#3125](https://github.com/valhalla/valhalla/pull/3125)

--- a/src/loki/polygon_search.cc
+++ b/src/loki/polygon_search.cc
@@ -37,6 +37,7 @@ ring_bg_t PBFToRing(const valhalla::Options::Ring& ring_pbf) {
   for (const auto& coord : ring_pbf.coords()) {
     new_ring.push_back({coord.lng(), coord.lat()});
   }
+  // fixes windedness & closes open rings
   bg::correct(new_ring);
   return new_ring;
 }
@@ -91,7 +92,7 @@ edges_in_rings(const google::protobuf::RepeatedPtrField<valhalla::Options_Ring>&
   for (const auto& ring_pbf : rings_pbf) {
     rings_bg.push_back(PBFToRing(ring_pbf));
     const ring_bg_t ring_bg = rings_bg.back();
-    rings_length += bg::perimeter(ring_bg);
+    rings_length += bg::perimeter(ring_bg, Haversine());
   }
   if (rings_length > max_length) {
     throw valhalla_exception_t(167, std::to_string(max_length));

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -330,7 +330,7 @@ void add_date_to_locations(Options& options,
 }
 
 // Parses JSON rings of the form [[lon1, lat1], [lon2, lat2], ...]] and operates on
-// PBF objects of the sort "repeated LatLng". Open rings will be closed.
+// PBF objects of the sort "repeated LatLng". Open rings will be closed during search operation.
 template <typename ring_pbf_t>
 void parse_ring(ring_pbf_t& ring, const rapidjson::Value& coord_array) {
   for (const auto& coords : coord_array.GetArray()) {
@@ -348,14 +348,6 @@ void parse_ring(ring_pbf_t& ring, const rapidjson::Value& coord_array) {
     auto* ll = ring->add_coords();
     ll->set_lng(lon);
     ll->set_lat(lat);
-  }
-
-  bool is_open = (ring->coords().begin()->lat() != ring->coords().rbegin()->lat() ||
-                  ring->coords().begin()->lng() != ring->coords().rbegin()->lng());
-
-  // close open rings
-  if (!ring->coords().empty() && is_open) {
-    ring->add_coords()->CopyFrom(*ring->coords().begin());
   }
 }
 

--- a/test/gurka/test_avoids.cc
+++ b/test/gurka/test_avoids.cc
@@ -210,6 +210,8 @@ TEST_F(AvoidTest, TestAvoidShortcutsTruck) {
     }
   }
 
+  // 2 shortcuts + 2 edges
+  ASSERT_EQ(avoid_edges.size(), 4);
   ASSERT_EQ(found_shortcuts, 2);
 }
 


### PR DESCRIPTION
Fixes #3182 

The issue was a little subtle: we register `std::vector<PointLL>` as a `bg::polygon` so the edge's `shape` was interpreted as a polygon geometry and then used to intersect with the avoid_polygons, which I guess is sorta undefined behavior (at least for me).

I also added a `to_geojson()` for debugging as you suggested @kevinkreiser, as a trace log, very helpful..

~~Could be done a bit different, by registering another structure with bg, e.g. `std::deque<PointLL>`, to avoid casting every edge to a linestring. With a few experiments I didn't see any significant performance deviation from master though, but let me know if you'd prefer that.~~ that only works if we register std::vector<PointLL> as linestring, of course bg::intersects needs two geometry types. For polygons we wouldn't need to register our own geometry type, we could use bg::model::polygon, but the Tiles::Intersect method somehow won't take that type as an argument.