### PR TITLE
Fix Mac Builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ commands:
     steps:
       - run: brew install protobuf cmake ccache libtool boost libspatialite pkg-config luajit curl wget czmq lz4 spatialite-tools unzip
       - run: pip3 install requests
+      - run: git clone https://github.com/kevinkreiser/prime_server --recurse-submodules && cd prime_server && ./autogen.sh && ./configure && make -j4 && make install
 
 jobs:
   build-docker-images:
@@ -140,8 +141,6 @@ jobs:
           keys:
             - ccache-release-macos-{{ .Branch }}
             - ccache-release-macos
-      - run: git clone https://github.com/kevinkreiser/prime_server --recurse-submodules && cd prime_server && ./autogen.sh && ./configure
-      - run: make -j4 && make install && cd ..
       - run: mkdir -p build
       - run: cd build && cmake ..
       - run: make -C build -j4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,8 +140,8 @@ jobs:
           keys:
             - ccache-release-macos-{{ .Branch }}
             - ccache-release-macos
-      - run: wget https://raw.githubusercontent.com/valhalla/homebrew-valhalla/master/Formula/prime_server.rb
-      - run: brew install --build-from-source ./prime_server.rb
+      - run: git clone https://github.com/kevinkreiser/prime_server --recurse-submodules && cd prime_server && ./autogen.sh && ./configure
+      - run: make -j4 && make install && cd ..
       - run: mkdir -p build
       - run: cd build && cmake ..
       - run: make -C build -j4


### PR DESCRIPTION
fixes #3036 

for some reason homebrew doesnt like the way the cli build tools look on mac and it borks the install of prime server from the brew formula. so i say forget  homebrew and will just install it manually. long term we should probably submodule prime_server but that does mean we'll have a bit of an odd situation when we want the binary targets that prime_server creates. so i think ill hold off on that for a little while..