### PR TITLE
Fix Fast Route Rejection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
    * FIXED: Fixed incorrect dead-end roundabout labels. [#3129](https://github.com/valhalla/valhalla/pull/3129)
    * FIXED: googletest wasn't really updated in #3166 [#3187](https://github.com/valhalla/valhalla/pull/3187)
    * FIXED: avoid_polygons intersected edges as polygons instead of linestrings [#3194]((https://github.com/valhalla/valhalla/pull/3194)
+   * FIXED: when binning horizontal edge shapes using single precision floats (converted from not double precision floats) allowed for the possiblity of marking many many tiles no where near the shape [#3204](https://github.com/valhalla/valhalla/pull/3204) 
 
 * **Enhancement**
    * CHANGED: Refactor base costing options parsing to handle more common stuff in a one place [#3125](https://github.com/valhalla/valhalla/pull/3125)

--- a/src/midgard/tiles.cc
+++ b/src/midgard/tiles.cc
@@ -17,20 +17,20 @@ namespace {
 // at each step it decides to either move in the x or y direction based on which pixels midpoint
 // forms a smaller triangle with the line. to avoid edge cases we allow set_pixel to make the
 // the loop bail if we leave the valid drawing region
-void bresenham_line(float x0,
-                    float y0,
-                    float x1,
-                    float y1,
+void bresenham_line(double x0,
+                    double y0,
+                    double x1,
+                    double y1,
                     const std::function<bool(int32_t, int32_t)>& set_pixel) {
   // this one for sure
   bool outside = set_pixel(std::floor(x0), std::floor(y0));
   // steps in the proper direction and constants for shoelace formula
-  float sx = x0 < x1 ? 1 : -1, dx = x1 - x0, x = std::floor(x0) + .5f;
-  float sy = y0 < y1 ? 1 : -1, dy = y1 - y0, y = std::floor(y0) + .5f;
+  double sx = x0 < x1 ? 1 : -1, dx = x1 - x0, x = std::floor(x0) + .5f;
+  double sy = y0 < y1 ? 1 : -1, dy = y1 - y0, y = std::floor(y0) + .5f;
   // keep going until we make it to the ending pixel
   while (std::floor(x) != std::floor(x1) || std::floor(y) != std::floor(y1)) {
-    float tx = std::abs(dx * (y - y0) - dy * ((x + sx) - x0));
-    float ty = std::abs(dx * ((y + sy) - y0) - dy * (x - x0));
+    double tx = std::abs(dx * (y - y0) - dy * ((x + sx) - x0));
+    double ty = std::abs(dx * ((y + sy) - y0) - dy * (x - x0));
     // less error moving in the x
     if (tx < ty) {
       x += sx;

--- a/src/midgard/tiles.cc
+++ b/src/midgard/tiles.cc
@@ -32,10 +32,9 @@ void bresenham_line(double x0,
     double tx = std::abs(dx * (y - y0) - dy * ((x + sx) - x0));
     double ty = std::abs(dx * ((y + sy) - y0) - dy * (x - x0));
     // less error moving in the x
-    if (tx < ty) {
+    if (tx < ty || (tx == ty && y0 == y1)) {
       x += sx;
-    }
-    // less error moving in the y
+    } // less error moving in the y
     else {
       y += sy;
     }

--- a/test/tiles.cc
+++ b/test/tiles.cc
@@ -1,6 +1,8 @@
 #include "midgard/tiles.h"
 #include "midgard/aabb2.h"
+#include "midgard/encoded.h"
 #include "midgard/pointll.h"
+#include "midgard/polyline2.h"
 #include "midgard/util.h"
 
 #include <random>
@@ -262,7 +264,7 @@ TEST(Tiles, test_intersect_linestring) {
   assert_answer(t, {{1, 2}, {2, 4}}, intersect_t{{0, {6, 7, 12, 13, 19, 20, 25, 26}}});
   assert_answer(t, {{2, 4}, {1, 2}}, intersect_t{{0, {6, 7, 12, 13, 19, 20, 25, 26}}});
 
-  // some real locations on earth (without polar coordinates accounted for)
+  // some real locations on earth
   Tiles<PointLL> ll(AABB2<PointLL>{-180, -90, 180, 90}, .25, 5);
   std::vector<PointLL> shape{{9.5499754, 47.250248}, {9.55031681, 47.2501144}};
   auto intersection = ll.Intersect(shape);
@@ -275,6 +277,37 @@ TEST(Tiles, test_intersect_linestring) {
   for (const auto& i : intersection)
     count += i.second.size();
   EXPECT_LE(count, 2) << "Unexpected number of intersections for this shape";
+
+  std::vector<std::string> shapes{
+      R"({wvueB{knms@GdU)",
+      R"(}~etdBcnwfk@dE}YnS_oA|OwaAjAwIGudBEuD_Ey^wHwk@]mVxFss@eTu}G_Iuk@}@mZt@mW\sNcLueAN{PvXseBrFq\)",
+      R"({d{gbBwdpsZ]s~AG}bAFqhAd@goA\_pAUq`B)",
+      R"(eibz`Bc_ysVFse@)",
+      R"(uhbz`BziwcnEUgyl@)",
+      R"(m{~s`B_qbfOu@rDiBxDqCbK]tH?dOd@v\t@x`@l@tZe@dU?bc@Lxh@NrTt@h[\nWN`WmAbTiB`V]vOyClTuDzT)",
+      R"(_qwg`Bkf}qQgN}g@kAkLiCs`@gCm_@_@wHEcHr@qKbBwK`CqM)",
+      R"(cqsa~Aym}kSbBqH|c@ikBd@oH?aEm@eDaC}FwCiG}D}FkGeIyWeVwCgCcAqB}@uD{@gMe@wT_@_UN{I)",
+      R"(swk{yAm{vp\fIiKtJ}[bU}_AbW{{AdEyXl@cNGagAqBut@wD_t@{F}{@wCmy@aCca@mEyYcFyQ)",
+      R"(o_}tyAfwu_iC{FqaDkQgaBiCgaBlEed@rLiWhu@cp@pHk`@t@ce@kLumAav@skDkQ?{P|_@eTlgAaShXuThBipA_s@ag@mJw\aRyRia@uEoSOkqDcKi_Bz_@y_AeE}Tst@qq@kFaSm@mJnNia@L}i@{Jsd@{Vyk@cj@_J_JwNk[wfEyV{k@afAijAcL_^iC_Tf@ce@dYaaEqB}_@)",
+      R"(wqkdxA_cbeeAG|E)",
+      R"(q_lgxAkorvq@ud@|}@}@lEEfCLpCd@`CdKnNrPhW|~@|tAv\zg@)",
+      R"(qbjvpAjpjlcDwDcG{AuEUuEFwMGya@O{~@e@orA]mT)",
+      R"(ehtwkAznrdgELxhB^|@z@z@~eBkAnDm@`CM)",
+      R"(uvwijArilewCiCaHmEqGsLl@yLz@}IiBiMOaSfDsPbFkFjBmEtEkB~HFxzE)",
+      R"(c}kweA~|lpNNnAu@`GgDfG{AdEe@fC{@dAkAZsAA}@cAqBeEwHkQuEmHyBsDe@mD)",
+      R"(u`sidA`nzecF]m@W{AMkBF_S)",
+      R"({{at_Ajmkj`F]o|@O{_@?O?aRNekCz@eFbBiBbFkAly@}@jL??g`BlJen@r@m@d~@cz@)",
+      R"(syhxt@kqlv~CyByCkD}IyBkBkD]uD]aA{ANkAdB]nDz@dE\~CMjD{AtBiCt@uDfAuEdAwDTsFlBqG~FuE|GeE`KeEpEeF~C_IzCoHfGaHtGeFbGaGlGsGzCqGrAoI\_IbBaHFqHpBsPt@sQWiL]mJQsF`BuEhCgDfCkBdFqGfFcFnLyMxDmJ~DuErE{K`FaHnC]jEm@jCiBfBwCr@aHl@eFrAgDxB]tCNhDLxCkA`EcGdCgDrCwC)",
+      R"(kchiYyi`x~DPkk@)",
+      R"(r`egLc~vakEf@]d@m@n@gCf@iCFiBIgDQwD?{A@?FM~@_@xA]|A]p@O~CgCnDcG^]h@m@hC}@`A{@^m@DkAUkBkAqGOiCHwCpEmUhCiL\m@^m@^]nDkB`CgCjDeEhCyCpAkAn@{ATyBCyBK{AE{@B]Hm@fAiCD{@A}@aBwNo@oHGmJ)",
+      R"(tcyyTunevjAbc@dhAJpg@zB`GKdd@dIzz@q@vH}IvIaBnXrEv]yE`l@oGpv@)",
+      R"(_n_gnAlrqwuDFyLl@_}@VuwA?sf@Wk}At@qzAe@enALk_@t@afAm@emBl@ocDGg~Cd@e~D]wsDUsxATieOkAojGFse@r@snA?_i@)",
+  };
+  for (const auto& shape : shapes) {
+    auto decoded = decode<std::vector<PointLL>>(shape);
+    auto intersected = ll.Intersect(decoded);
+    ASSERT_LE(intersected.size(), 3) << " too many level 2 tiles intersected by " << shape;
+  }
 }
 
 TEST(Tiles, test_random_linestring) {

--- a/test/tiles.cc
+++ b/test/tiles.cc
@@ -2,7 +2,6 @@
 #include "midgard/aabb2.h"
 #include "midgard/encoded.h"
 #include "midgard/pointll.h"
-#include "midgard/polyline2.h"
 #include "midgard/util.h"
 
 #include <random>


### PR DESCRIPTION
fixes #3202 

@dnesbitt61 was right switching to double fixed all instances of this. i took all of the shapes that i could find that exposed the issue from an older planet, added them to the unit test, they failed in that they were thought to intersect hundreds of tiles. i changed to double precision and then they all passed.

~i still want to add a protection in the algorithm against this so we dont have to worry about it in the future.~ ive done that

as for an explanation, here is the first unit test case:

![image](https://user-images.githubusercontent.com/697548/125166265-cd2c1a00-e168-11eb-8ba1-ddff5c995019.png)

in the debugger it looks like this:

![image](https://user-images.githubusercontent.com/697548/125166183-6f97cd80-e168-11eb-858c-627a93438c1b.png)

so you can see that x1 ends up just slightly smaller than x0 and y0 and y1 are equal, which means the the line is traveling only left/west. looking at the loop that does the "rasterization" you can see that it will stop when the pixel we iterate ends at the last discretized (floored) coordinate of the line. 

floor of y and y1 are already equal, which makes perfect sense because we are just moving in the x direction (the line is horizontal). so the loop should stop when we go far enough to the left to hit that last line coordinate, ie when floor of x and x1 are equal. given that they are so close together (much closer than a tiles distance) that should happen in one iteration.

stepping further we see something very unfortunate. if you look at the calculations for triangle areas (tx and ty)  you'll see that the right hand sides of both equations cancel out (because we arent moving in the y direction at all). this leaves two triangle areas with different signs because they are formed on different sides of the line but they have the same area. then we hit the if block that says should we move in the x or the y. since they are the same the tie breaker is the else clause which just happens to pick the y direction, which is wrong in this case.

now lets see what happens when we go to double precision:

![image](https://user-images.githubusercontent.com/697548/125166703-c9999280-e16a-11eb-81a2-bb650b71b9db.png)

look at y0 and y1. you will see that now we have the slightest upward slope. this leads to the triangle areas not being equal and us not having to handle that case. basically single precision float quantized the y values to be perfectly horizontal which lead to us hitting the unhandled case of what to do when the areas are equal.

i think its pretty clear by now we need to handle the case when the triangle areas are equal. now there are cases where it doesnt matter which one we choose. thinking of a line that is perfectly diagonal, going in the x vs the y would create equal areas but we dont actually care who wins as long as its consistent. however in the case of purely horizontal or purely vertical lines we need to move in the direction of the line only. 

i will add tests that show this breaking for double precision and then add code to handle the equal area case.

its actually slightly more complex than this, turns out for spherical coords we dont need to add code to handle the equal area case because we wont ever send a perfectly horizontal line that covers more than 2 subdivisions to the bresenham algorithm, for more info see this comment: https://github.com/valhalla/valhalla/pull/3204#discussion_r667413227