### PR TITLE
Fix improper iterator usage in ManeuversBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
    * FIXED: Fixed incorrect dead-end roundabout labels. [#3129](https://github.com/valhalla/valhalla/pull/3129)
    * FIXED: googletest wasn't really updated in #3166 [#3187](https://github.com/valhalla/valhalla/pull/3187)
    * FIXED: avoid_polygons intersected edges as polygons instead of linestrings [#3194]((https://github.com/valhalla/valhalla/pull/3194)
+   * FIXED: Fix improper iterator usage in ManeuversBuilder [#3205](https://github.com/valhalla/valhalla/pull/3205)
 
 * **Enhancement**
    * CHANGED: Refactor base costing options parsing to handle more common stuff in a one place [#3125](https://github.com/valhalla/valhalla/pull/3125)

--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -564,6 +564,7 @@ void ManeuversBuilder::Combine(std::list<Maneuver>& maneuvers) {
         // Update with no combine
         prev_man = curr_man;
         curr_man = next_man;
+        assert(next_man != maneuvers.end());
         ++next_man;
       }
 
@@ -2940,6 +2941,7 @@ void ManeuversBuilder::ProcessRoundabouts(std::list<Maneuver>& maneuvers) {
     // on to the next maneuver...
     prev_man = curr_man;
     curr_man = next_man;
+    assert(next_man != maneuvers.end());
     ++next_man;
   }
 }
@@ -3255,7 +3257,9 @@ void ManeuversBuilder::ProcessTurnLanes(std::list<Maneuver>& maneuvers) {
     // on to the next maneuver...
     prev_man = curr_man;
     curr_man = next_man;
-    ++next_man;
+    if (next_man != maneuvers.end()) {
+      ++next_man;
+    }
   }
 }
 
@@ -3631,6 +3635,7 @@ void ManeuversBuilder::CollapseMergeManeuvers(std::list<Maneuver>& maneuvers) {
     }
     // on to the next maneuver...
     curr_man = next_man;
+    assert(next_man != maneuvers.end());
     ++next_man;
   }
 }


### PR DESCRIPTION
# Issue
I found it with a help of `-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC`: https://kristerw.blogspot.com/2018/03/detecting-incorrect-c-stl-usage.html
There is similar flag in [libc++](https://libcxx.llvm.org//DesignDocs/DebugMode.html).

Was trying to enable it on CI, but it was too difficult for me to implement since I'm limited in the time.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
