### PR TITLE
Avoid useless blank line logged to stderr

### DIFF
--- a/src/baldr/tz_alt.cpp
+++ b/src/baldr/tz_alt.cpp
@@ -3481,7 +3481,7 @@ init_tzdb()
                 }
                 else
                 {
-                    std::cerr << line << '\n';
+                    ;
                 }
             }
         }
@@ -4105,7 +4105,7 @@ init_tzdb_strings()
                 }
                 else
                 {
-                    std::cerr << line << '\n';
+                    ;
                 }
             }
         }


### PR DESCRIPTION
# Issue

A non-functional correction to avoid printing blank line to stderr.

It's confusing to see one or two blank screens scroll up, especially if one configures all `"logging"` with `"type": "file"`.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md) - my usual question, @kevinkreiser, is this one necessary for such trivial stuff?
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.
