### PR TITLE
WIP: Avoid LogLevel clash with Win32 common macros with unfortunate names

### DIFF
--- a/valhalla/midgard/logging.h
+++ b/valhalla/midgard/logging.h
@@ -1,8 +1,13 @@
 #ifndef VALHALLA_MIDGARD_LOGGING_H_
 #define VALHALLA_MIDGARD_LOGGING_H_
 
-#if defined(_WIN32) && defined(ERROR)
+#if defined(_WIN32)
+#pragma push_macro("DEBUG")
+#undef DEBUG
+#pragma push_macro("ERROR")
 #undef ERROR
+#pragma push_macro("TRACE")
+#undef TRACE
 #endif
 
 #if defined(__MINGW32__) && !defined(NOGDI)
@@ -183,5 +188,11 @@ void Configure(const LoggingConfig& config);
 
 } // namespace midgard
 } // namespace valhalla
+
+#if defined(_WIN32)
+#pragma pop_macro("DEBUG")
+#pragma pop_macro("ERROR")
+#pragma pop_macro("TRACE")
+#endif
 
 #endif


### PR DESCRIPTION
# Issue

Further refinement to PR #1120

By the way, [push_macro and pop_macro are also supported by GCC](https://gcc.gnu.org/onlinedocs/gcc/Push_002fPop-Macro-Pragmas.html), so I hope they are also available for MinGW.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.
