### PR TITLE
replace boost::optional::has_value with more compatible is_initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
    * FIXED: Fix improper iterator usage in ManeuversBuilder [#3205](https://github.com/valhalla/valhalla/pull/3205)
    * FIXED: Modified approach for retrieving signs from a directed edge #3166 [#3208](https://github.com/valhalla/valhalla/pull/3208)
    * FIXED: Improve turn channel classification: detect slip lanes [#3196](https://github.com/valhalla/valhalla/pull/3196)
+   * FIXED: Compatibility with older boost::optional versions [#3219](https://github.com/valhalla/valhalla/pull/3219)
 
 * **Enhancement**
    * CHANGED: Refactor base costing options parsing to handle more common stuff in a one place [#3125](https://github.com/valhalla/valhalla/pull/3125)

--- a/src/mjolnir/linkclassification.cc
+++ b/src/mjolnir/linkclassification.cc
@@ -656,7 +656,7 @@ bool IsSlipLane(Data& data, SlipLaneInput input, double traverse_threshold) {
                                            *intersection_node));
   }
 
-  return intersection_node.has_value();
+  return intersection_node.is_initialized();
 }
 
 SlipLaneInput GetSlipLaneInput(Data& data, const std::vector<uint32_t>& link_edges) {


### PR DESCRIPTION
also discovered during building with boost 1.62. has_value() was introduce in 1.68: https://www.boost.org/doc/libs/1_69_0/libs/optional/doc/html/boost_optional/relnotes.html#boost_optional.relnotes.boost_release_1_68

`has_value()` is just an alias for `is_initialized()` which has more compatibility: https://github.com/boostorg/optional/commit/5182f7f30fad87023ae5e5a4e1f660fb513fb469#diff-39c347130088a3259b9ba81c9aa6f72ed620fb23ff0cc52484c6088dc8ed6661R1336