### PR TITLE
Get rid of typeid in statistics-related code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
    * ADDED: Introduced a new via_waypoints array on the leg in the osrm route serializer that describes where a particular waypoint from the root-level array matches to the route. [#3189](https://github.com/valhalla/valhalla/pull/3189)
    * ADDED: Added vehicle width and height as an option for auto (and derived: taxi, bus, hov) profile (https://github.com/valhalla/valhalla/pull/3179)
    * ADDED: Support for statsd integration for basic error and requests metrics [#3191](https://github.com/valhalla/valhalla/pull/3191)
+   * CHANGED: Get rid of typeid in statistics-related code. [#3227](https://github.com/valhalla/valhalla/pull/3227)
 
 ## Release Date: 2021-05-26 Valhalla 3.1.2
 * **Removed**

--- a/valhalla/loki/worker.h
+++ b/valhalla/loki/worker.h
@@ -101,6 +101,11 @@ protected:
   size_t max_elevation_shape;
   float min_resample;
   unsigned int max_alternates;
+
+private:
+  std::string service_name() const override {
+    return "loki";
+  }
 };
 } // namespace loki
 } // namespace valhalla

--- a/valhalla/odin/worker.h
+++ b/valhalla/odin/worker.h
@@ -28,6 +28,11 @@ public:
    */
   std::string narrate(Api& request) const;
   void status(Api& request) const;
+
+private:
+  std::string service_name() const override {
+    return "odin";
+  }
 };
 } // namespace odin
 } // namespace valhalla

--- a/valhalla/thor/worker.h
+++ b/valhalla/thor/worker.h
@@ -131,6 +131,11 @@ protected:
   std::shared_ptr<baldr::GraphReader> reader;
   AttributesController controller;
   Centroid centroid_gen;
+
+private:
+  std::string service_name() const override {
+    return "thor";
+  }
 };
 
 } // namespace thor

--- a/valhalla/worker.h
+++ b/valhalla/worker.h
@@ -121,6 +121,11 @@ protected:
   void enqueue_statistics(Api& api) const;
 
   /**
+   * Returns name of the service used in statistics
+   */
+  virtual std::string service_name() const = 0;
+
+  /**
    * Used to measure the time it takes to do an action in the current stage of the pipeline.
    * This should be called at the top of the scope in each major action of each worker
    *


### PR DESCRIPTION
# Issue

typeid requires RTTI, which is not acceptable for some projects using Valhalla. So this PR refactors it in order to not use RTTI.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
