### PR TITLE
Only log errors on azure for win builds, no warnings

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -118,7 +118,7 @@ jobs:
           for /f "delims=" %%x in ('.\vswhere.exe -latest -property InstallationPath') do set VSPATH=%%x
           popd
           call "%VSPATH%\VC\Auxiliary\Build\vcvars64.bat"
-          cmake --build %BUILD_DIR% --config %BUILD_CFG%
+          cmake --build %BUILD_DIR% --config %BUILD_CFG% -- /clp:ErrorsOnly
         displayName: 'Run CMake to build'
 
       - script: |

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -118,7 +118,7 @@ jobs:
           for /f "delims=" %%x in ('.\vswhere.exe -latest -property InstallationPath') do set VSPATH=%%x
           popd
           call "%VSPATH%\VC\Auxiliary\Build\vcvars64.bat"
-          cmake --build %BUILD_DIR% --config %BUILD_CFG% -- -clp:ErrorsOnly
+          cmd /C "cmake --build %BUILD_DIR% --config %BUILD_CFG% -- /clp:ErrorsOnly"
         displayName: 'Run CMake to build'
 
       - script: |

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -118,7 +118,7 @@ jobs:
           for /f "delims=" %%x in ('.\vswhere.exe -latest -property InstallationPath') do set VSPATH=%%x
           popd
           call "%VSPATH%\VC\Auxiliary\Build\vcvars64.bat"
-          cmake --build %BUILD_DIR% --config %BUILD_CFG% -- /clp:ErrorsOnly
+          cmake --build %BUILD_DIR% --config %BUILD_CFG% -- -clp:ErrorsOnly
         displayName: 'Run CMake to build'
 
       - script: |


### PR DESCRIPTION
was driving me crazy debugging #3206 with those ridiculously verbose msbuild logs.. now it's only logging errors, no more warnings. guess that's ok, we're (read I'm ;)) not really interested optimizing win builds.