### PR TITLE
Use right tile to get country for an incident

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * **Removed**
 * **Bug Fix**
    * FIXED: Revert default speed boost for turn channels [#3232](https://github.com/valhalla/valhalla/pull/3232)
+   * FIXED: Use the right tile to get node info [#3235](https://github.com/valhalla/valhalla/pull/3235)
 * **Enhancement**
    * CHANGED: Favor turn channels more [#3222](https://github.com/valhalla/valhalla/pull/3222)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 * **Removed**
 * **Bug Fix**
    * FIXED: Revert default speed boost for turn channels [#3232](https://github.com/valhalla/valhalla/pull/3232)
-   * FIXED: Use the right tile to get node info [#3235](https://github.com/valhalla/valhalla/pull/3235)
+   * FIXED: Use the right tile to get country for incident [#3235](https://github.com/valhalla/valhalla/pull/3235)
 * **Enhancement**
    * CHANGED: Favor turn channels more [#3222](https://github.com/valhalla/valhalla/pull/3222)
 

--- a/src/thor/triplegbuilder.cc
+++ b/src/thor/triplegbuilder.cc
@@ -113,7 +113,7 @@ void UpdateIncident(const std::shared_ptr<const valhalla::IncidentsTile>& incide
                     TripLeg& leg,
                     const valhalla::IncidentsTile::Location* incident_location,
                     uint32_t index,
-                    const graph_tile_ptr& tile,
+                    const graph_tile_ptr& end_node_tile,
                     const valhalla::baldr::DirectedEdge& de) {
   const uint64_t current_incident_id =
       valhalla::baldr::getIncidentMetadata(incidents_tile, *incident_location).id();
@@ -133,7 +133,7 @@ void UpdateIncident(const std::shared_ptr<const valhalla::IncidentsTile>& incide
     *new_incident->mutable_metadata() = meta;
 
     // Set iso country code (2 & 3 char codes) on the new incident obj created for this leg
-    std::string country_code_iso_2 = country_code_from_edge(tile, de);
+    std::string country_code_iso_2 = country_code_from_edge(end_node_tile, de);
     if (!country_code_iso_2.empty()) {
       new_incident->mutable_metadata()->set_iso_3166_1_alpha2(country_code_iso_2.c_str());
     }
@@ -176,6 +176,7 @@ valhalla::TripLeg_Closure* fetch_or_create_closure_annotation(TripLeg& leg) {
  */
 void SetShapeAttributes(const AttributesController& controller,
                         const graph_tile_ptr& tile,
+                        const graph_tile_ptr& end_node_tile,
                         const DirectedEdge* edge,
                         std::vector<PointLL>& shape,
                         size_t shape_begin,
@@ -265,7 +266,7 @@ void SetShapeAttributes(const AttributesController& controller,
       // if this is clipped at the beginning of the edge then its not a new cut but we still need to
       // attach the incidents information to the leg
       if (offset == src_pct) {
-        UpdateIncident(incidents.tile, leg, &incident, shape_begin, tile, *edge);
+        UpdateIncident(incidents.tile, leg, &incident, shape_begin, end_node_tile, *edge);
         continue;
       }
 
@@ -384,7 +385,7 @@ void SetShapeAttributes(const AttributesController& controller,
     // Set the incidents if we just cut or we are at the end
     if ((shift || i == shape.size() - 1) && !cut_itr->incidents.empty()) {
       for (const auto* incident : cut_itr->incidents) {
-        UpdateIncident(incidents.tile, leg, incident, i, tile, *edge);
+        UpdateIncident(incidents.tile, leg, incident, i, end_node_tile, *edge);
       }
     }
 
@@ -1642,8 +1643,10 @@ void TripLegBuilder::Build(
                          ? graphreader.GetIncidents(edge_itr->edgeid, graphtile)
                          : valhalla::baldr::IncidentResult{};
 
-    SetShapeAttributes(controller, graphtile, directededge, trip_shape, begin_index, trip_path,
-                       trim_start_pct, trim_end_pct, edge_seconds,
+    graph_tile_ptr end_node_tile = graphtile;
+    graphreader.GetGraphTile(directededge->endnode(), end_node_tile);
+    SetShapeAttributes(controller, graphtile, end_node_tile, directededge, trip_shape, begin_index,
+                       trip_path, trim_start_pct, trim_end_pct, edge_seconds,
                        costing->flow_mask() & kCurrentFlowMask, incidents);
 
     // Set begin shape index if requested


### PR DESCRIPTION
# Issue

Houston, we have typical invalid tile usage issue! End node tile is used to get admin info but we pass start node tile https://github.com/valhalla/valhalla/blob/953c36ea0d585b80db0d157b9fb1dec7a8532eab/src/thor/triplegbuilder.cc#L102

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
