### PR TITLE
Since we force 64-bit of stat for MSVC, call _fstat64 instead of fstat

### DIFF
--- a/test/test.cc
+++ b/test/test.cc
@@ -13,7 +13,9 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#ifndef _MSC_VER
 #include <sys/mman.h>
+#endif
 #include <sys/stat.h>
 
 #include <gmock/gmock.h>
@@ -61,7 +63,11 @@ struct MMap {
   MMap(const char* filename) {
     fd = open(filename, O_RDWR);
     struct stat s;
+#ifdef _MSC_VER
+    _fstat64(fd, &s);
+#else
     fstat(fd, &s);
+#endif
     data = mmap(0, s.st_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
     length = s.st_size;
   }

--- a/test/test.h
+++ b/test/test.h
@@ -13,7 +13,9 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#ifndef _MSC_VER
 #include <sys/mman.h>
+#endif
 #include <sys/stat.h>
 
 #include <gmock/gmock.h>


### PR DESCRIPTION
# Issue

Given 
https://github.com/valhalla/valhalla/blob/480cc790ea43f1da0415d85466af7697aeaac475/valhalla/midgard/sequence.h#L26-L29

this

https://github.com/valhalla/valhalla/blob/480cc790ea43f1da0415d85466af7697aeaac475/test/test.cc#L63-L64

evaluates to `fstat` taking pointer to `_stat64`, which simply does not compile.
At least, not with VS 2019 and 64-bit build targets.

There is also no `sys/mman.h` in MSVC++ libraries.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.
