### PR TITLE
Reach-based pruning for bidirectional astar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
    * ADDED: Added info to /status endpoint [#3008](https://github.com/valhalla/valhalla/pull/3008)
    * ADDED: Added stop and give_way/yield signs to the data and traffic signal fixes [#3251](https://github.com/valhalla/valhalla/pull/3251)
    * ADDED: use_hills for pedestrian costing, which also affects the walking speed [#3234](https://github.com/valhalla/valhalla/pull/3234)
+   * CHANGED: Fixed cost threshold fot bidirectional astar. Implemented reach-based pruning for suboptimal branches [#3257](https://github.com/valhalla/valhalla/pull/3257)
 
 ## Release Date: 2021-07-20 Valhalla 3.1.3
 * **Removed**

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -714,23 +714,22 @@ bool BidirectionalAStar::SetForwardConnection(GraphReader& graphreader, const BD
     c = pred.cost().cost + oppcost + opp_pred.transition_cost().cost;
   }
 
+  // Set thresholds to extend search
+  if (cost_threshold_ == std::numeric_limits<float>::max() || c < best_connections_.front().cost) {
+    if (desired_paths_count_ == 1) {
+      cost_threshold_ = c + kThresholdDelta;
+    } else {
+      cost_threshold_ = (1.f + kAlternativeCostExtend) * c + kThresholdDelta;
+      iterations_threshold_ =
+          edgelabels_forward_.size() + edgelabels_reverse_.size() + kAlternativeIterationsDelta;
+    }
+  }
+
   // Keep the best ones at the front all others to the back
   best_connections_.emplace_back(CandidateConnection{pred.edgeid(), oppedge, c});
 
   if (c < best_connections_.front().cost)
     std::swap(best_connections_.front(), best_connections_.back());
-
-  // Set thresholds to extend search
-  if (cost_threshold_ == std::numeric_limits<float>::max()) {
-    float sortcost = std::max(pred.sortcost() + cost_diff_, opp_pred.sortcost());
-    if (desired_paths_count_ == 1) {
-      cost_threshold_ = sortcost + kThresholdDelta;
-    } else {
-      cost_threshold_ = sortcost + std::max(kAlternativeCostExtend * sortcost, kThresholdDelta);
-      iterations_threshold_ =
-          edgelabels_forward_.size() + edgelabels_reverse_.size() + kAlternativeIterationsDelta;
-    }
-  }
 
   // setting this edge as connected
   if (expansion_callback_) {
@@ -780,23 +779,22 @@ bool BidirectionalAStar::SetReverseConnection(GraphReader& graphreader, const BD
     c = rev_pred.cost().cost + oppcost + fwd_pred.transition_cost().cost;
   }
 
+  // Set thresholds to extend search
+  if (cost_threshold_ == std::numeric_limits<float>::max() || c < best_connections_.front().cost) {
+    if (desired_paths_count_ == 1) {
+      cost_threshold_ = c + kThresholdDelta;
+    } else {
+      cost_threshold_ = (1.f + kAlternativeCostExtend) * c + kThresholdDelta;
+      iterations_threshold_ =
+          edgelabels_forward_.size() + edgelabels_reverse_.size() + kAlternativeIterationsDelta;
+    }
+  }
+
   // Keep the best ones at the front all others to the back
   best_connections_.emplace_back(CandidateConnection{fwd_edge_id, rev_pred.edgeid(), c});
 
   if (c < best_connections_.front().cost)
     std::swap(best_connections_.front(), best_connections_.back());
-
-  // Set thresholds to extend search
-  if (cost_threshold_ == std::numeric_limits<float>::max()) {
-    float sortcost = std::max(rev_pred.sortcost(), fwd_pred.sortcost() + cost_diff_);
-    if (desired_paths_count_ == 1) {
-      cost_threshold_ = sortcost + kThresholdDelta;
-    } else {
-      cost_threshold_ = sortcost + std::max(kAlternativeCostExtend * sortcost, kThresholdDelta);
-      iterations_threshold_ =
-          edgelabels_forward_.size() + edgelabels_reverse_.size() + kAlternativeIterationsDelta;
-    }
-  }
 
   // setting this edge as connected, sending the opposing because this is the reverse tree
   if (expansion_callback_) {

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -547,9 +547,14 @@ BidirectionalAStar::GetBestPath(valhalla::Location& origin,
 
         // Check if the edge on the forward search connects to a settled edge on the
         // reverse search tree. Do not expand further past this edge since it will just
-        // result in other connections.
-        if (edgestatus_reverse_.Get(fwd_pred.opp_edgeid()).set() == EdgeSet::kPermanent) {
-          if (SetForwardConnection(graphreader, fwd_pred)) {
+        // result in other connections. Handle special edge case when we encountered the
+        // destination edge that wasn't still pulled out of the queue.
+        const auto opp_status = edgestatus_reverse_.Get(fwd_pred.opp_edgeid());
+        if (opp_status.set() == EdgeSet::kPermanent ||
+            (opp_status.set() == EdgeSet::kTemporary &&
+             edgelabels_reverse_[opp_status.index()].predecessor() == kInvalidLabel)) {
+          if (SetForwardConnection(graphreader, fwd_pred) &&
+              opp_status.set() == EdgeSet::kPermanent) {
             continue;
           }
         }
@@ -592,9 +597,14 @@ BidirectionalAStar::GetBestPath(valhalla::Location& origin,
 
         // Check if the edge on the reverse search connects to a settled edge on the
         // forward search tree. Do not expand further past this edge since it will just
-        // result in other connections.
-        if (edgestatus_forward_.Get(rev_pred.opp_edgeid()).set() == EdgeSet::kPermanent) {
-          if (SetReverseConnection(graphreader, rev_pred)) {
+        // result in other connections. Handle special edge case when we encountered the
+        // destination edge that wasn't still pulled out of the queue.
+        const auto opp_status = edgestatus_forward_.Get(rev_pred.opp_edgeid());
+        if (opp_status.set() == EdgeSet::kPermanent ||
+            (opp_status.set() == EdgeSet::kTemporary &&
+             edgelabels_forward_[opp_status.index()].predecessor() == kInvalidLabel)) {
+          if (SetReverseConnection(graphreader, rev_pred) &&
+              opp_status.set() == EdgeSet::kPermanent) {
             continue;
           }
         }

--- a/valhalla/thor/bidirectional_astar.h
+++ b/valhalla/thor/bidirectional_astar.h
@@ -100,6 +100,7 @@ protected:
   // Hierarchy limits
   std::vector<sif::HierarchyLimits> hierarchy_limits_forward_;
   std::vector<sif::HierarchyLimits> hierarchy_limits_reverse_;
+  bool ignore_hierarchy_limits_;
 
   // A* heuristic
   float cost_diff_;

--- a/valhalla/thor/edgestatus.h
+++ b/valhalla/thor/edgestatus.h
@@ -16,9 +16,11 @@ enum class EdgeSet : uint8_t {
                          // reset due to encountering a complex restriction:
                          // https://github.com/valhalla/valhalla/issues/2103
   kPermanent = 1,        // Permanent - shortest path to this edge has been found
-  kTemporary = 2         // Temporary - edge has been encountered but there could
+  kTemporary = 2,        // Temporary - edge has been encountered but there could
                          //   still be a shorter path to this edge. This edge will
                          //   be "adjacent" to an edge that is permanently labeled.
+  kSkipped = 3           // Skipped - edge has been encountered but was thrown out
+                         // of consideration.
 };
 
 // Store the edge label status and its index in the EdgeLabels list


### PR DESCRIPTION
# Issue

This PR fixes the "bug" described here https://github.com/valhalla/valhalla/issues/2928 (incorrect stop criterion in the bidirectional astar algorithm). 

There are following changes were made.
- Fixed **cost threshold** in bidirectional astar: use full route cost instead of sortcost.
- Implemented **reach-based pruning** technique described in the article from the comment https://github.com/valhalla/valhalla/issues/2884#issuecomment-785277797 . The main idea is to estimate lower bound cost for the path that goes through the current edge using min sortcost in the queue of the opposing search.
- Added logic that **exhausts hierarchy limits** more or less **simultaneously** for both directions (if we reached the limit in the forward/reverse direction - wait until the opposing direction also will expand this hierarchy level). The main intention of this logic is to provide (almost) valid conditions for the reach-based pruning.
- "**Synchronize**" shortcuts usage. Apply the same behavior for the same shortcut in both directions, i.e., if the shortcut was skipped by the forward/reverse search - it will be also skipped by the opposing search. And, if the shortcut was used by the forward/reverse search - it will be also used by the opposing search. This logic also helps to avoid false positive prunings.


## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
