### PR TITLE
Fix TransitionReverseCost usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
    * FIXED: Revert default speed boost for turn channels [#3232](https://github.com/valhalla/valhalla/pull/3232)
    * FIXED: Use the right tile to get country for incident [#3235](https://github.com/valhalla/valhalla/pull/3235)
    * FIXED: Fix factors passed to `RelaxHierarchyLimits` [#3253](https://github.com/valhalla/valhalla/pull/3253)
+   * FIXED: Fix TransitionCostReverse usage [#3260](https://github.com/valhalla/valhalla/pull/3260)
 * **Enhancement**
    * CHANGED: Favor turn channels more [#3222](https://github.com/valhalla/valhalla/pull/3222)
    * CHANGED: Rename `valhalla::midgard::logging::LogLevel` enumerators to avoid clash with common macros [#3236](https://github.com/valhalla/valhalla/pull/3236)

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -230,17 +230,26 @@ inline bool BidirectionalAStar::ExpandInner(baldr::GraphReader& graphreader,
     }
   }
 
-  // Get cost. Separate out transition cost.
-  sif::Cost transition_cost =
-      FORWARD ? costing_->TransitionCost(meta.edge, nodeinfo, pred)
-              : costing_->TransitionCostReverse(meta.edge->localedgeidx(), nodeinfo, opp_edge,
-                                                opp_pred_edge, pred.has_measured_speed(),
-                                                pred.internal_turn());
+  // Get cost
   uint8_t flow_sources;
   sif::Cost newcost =
-      pred.cost() + transition_cost +
-      (FORWARD ? costing_->EdgeCost(meta.edge, tile, time_info.second_of_week, flow_sources)
-               : costing_->EdgeCost(opp_edge, t2, time_info.second_of_week, flow_sources));
+      pred.cost() + (FORWARD
+                         ? costing_->EdgeCost(meta.edge, tile, time_info.second_of_week, flow_sources)
+                         : costing_->EdgeCost(opp_edge, t2, time_info.second_of_week, flow_sources));
+
+  // Separate out transition cost.
+  InternalTurn internal_turn;
+  sif::Cost transition_cost;
+  if (FORWARD) {
+    transition_cost = costing_->TransitionCost(meta.edge, nodeinfo, pred);
+  } else {
+    internal_turn = costing_->TurnType(meta.edge->localedgeidx(), nodeinfo, opp_edge, opp_pred_edge);
+    transition_cost =
+        costing_->TransitionCostReverse(meta.edge->localedgeidx(), nodeinfo, opp_edge, opp_pred_edge,
+                                        static_cast<bool>(flow_sources & kDefaultFlowMask),
+                                        internal_turn);
+  }
+  newcost += transition_cost;
 
   // Check if edge is temporarily labeled and this path has less cost. If
   // less cost the predecessor is updated and the sort cost is decremented
@@ -308,9 +317,7 @@ inline bool BidirectionalAStar::ExpandInner(baldr::GraphReader& graphreader,
                                      sortcost, dist, mode_, transition_cost, thru,
                                      (pred.closure_pruning() || !costing_->IsClosed(meta.edge, tile)),
                                      static_cast<bool>(flow_sources & kDefaultFlowMask),
-                                     costing_->TurnType(meta.edge->localedgeidx(), nodeinfo, opp_edge,
-                                                        opp_pred_edge),
-                                     restriction_idx);
+                                     internal_turn, restriction_idx);
     adjacencylist_reverse_.add(idx);
   }
 

--- a/src/thor/unidirectional_astar.cc
+++ b/src/thor/unidirectional_astar.cc
@@ -234,11 +234,17 @@ inline bool UnidirectionalAStar<expansion_direction, FORWARD>::ExpandInner(
                        ? costing_->EdgeCost(meta.edge, tile, time_info.second_of_week, flow_sources)
                        : costing_->EdgeCost(opp_edge, t2, time_info.second_of_week, flow_sources);
 
-  auto transition_cost =
-      FORWARD ? costing_->TransitionCost(meta.edge, nodeinfo, pred)
-              : costing_->TransitionCostReverse(meta.edge->localedgeidx(), nodeinfo, opp_edge,
-                                                opp_pred_edge, pred.has_measured_speed(),
-                                                pred.internal_turn());
+  InternalTurn internal_turn;
+  sif::Cost transition_cost;
+  if (FORWARD) {
+    transition_cost = costing_->TransitionCost(meta.edge, nodeinfo, pred);
+  } else {
+    internal_turn = costing_->TurnType(meta.edge->localedgeidx(), nodeinfo, opp_edge, opp_pred_edge);
+    transition_cost =
+        costing_->TransitionCostReverse(meta.edge->localedgeidx(), nodeinfo, opp_edge, opp_pred_edge,
+                                        static_cast<bool>(flow_sources & kDefaultFlowMask),
+                                        internal_turn);
+  }
   Cost newcost = pred.cost() + edge_cost;
   newcost += transition_cost;
 
@@ -316,9 +322,7 @@ inline bool UnidirectionalAStar<expansion_direction, FORWARD>::ExpandInner(
                              mode_, transition_cost,
                              (pred.not_thru_pruning() || !meta.edge->not_thru()),
                              (pred.closure_pruning() || !(costing_->IsClosed(meta.edge, tile))),
-                             static_cast<bool>(flow_sources & kDefaultFlowMask),
-                             costing_->TurnType(meta.edge->localedgeidx(), nodeinfo, opp_edge,
-                                                opp_pred_edge),
+                             static_cast<bool>(flow_sources & kDefaultFlowMask), internal_turn,
                              restriction_idx);
     *meta.edge_status = {EdgeSet::kTemporary, idx};
     adjacencylist_.add(idx);


### PR DESCRIPTION
# Issue

https://github.com/valhalla/valhalla/issues/2524
https://github.com/valhalla/valhalla/issues/2524#issuecomment-889152247

The original issue is that in some cases main route cost can be greater than alternative cost. This happens because of the bug in the `TransitionCostReverse` usage, i.e we pass parameters of the wrong edge. So what happens is
1. Main route gets less cost before recosting(i.e when connections are found)
2. After recosting main route gets **greater** cost because `TransitionCost` function is used now for cost calculation
![image](https://user-images.githubusercontent.com/14297128/128988968-106dfba3-ce38-437f-9c27-3e4595e71128.png)


The picture after the fix
![Screenshot 2021-08-11 at 10 28 01](https://user-images.githubusercontent.com/14297128/128989263-0949f908-9233-403e-9527-19a251be0918.png)



## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
