### PR TITLE
Add preferred_layer as a parameter of loki requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
    * ADDED: Added `exclude_unpaved` request parameter [#3240](https://github.com/valhalla/valhalla/pull/3240)
    * ADDED: Add Z-level field to `EdgeInfo`. [#3261](https://github.com/valhalla/valhalla/pull/3261)
    * CHANGED: Calculate stretch threshold for alternatives based on the optimal route cost [#3276](https://github.com/valhalla/valhalla/pull/3276)
+   * ADDED: Add `preferred_z_level` as a parameter of loki requests. [#3270](https://github.com/valhalla/valhalla/pull/3270)
 
 ## Release Date: 2021-07-20 Valhalla 3.1.3
 * **Removed**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
    * ADDED: Add Z-level field to `EdgeInfo`. [#3261](https://github.com/valhalla/valhalla/pull/3261)
    * CHANGED: Calculate stretch threshold for alternatives based on the optimal route cost [#3276](https://github.com/valhalla/valhalla/pull/3276)
    * ADDED: Add `preferred_z_level` as a parameter of loki requests. [#3270](https://github.com/valhalla/valhalla/pull/3270)
+   * ADDED: Add `preferred_layer` as a parameter of loki requests. [#3270](https://github.com/valhalla/valhalla/pull/3270)
 
 ## Release Date: 2021-07-20 Valhalla 3.1.3
 * **Removed**

--- a/proto/tripcommon.proto
+++ b/proto/tripcommon.proto
@@ -95,6 +95,7 @@ message Location {
   optional uint32 waypoint_index = 31;
   optional SearchFilter search_filter = 32;
   optional uint32 street_side_max_distance = 33;
+  optional int32 preferred_z_level = 34;
 }
 
 message TransitEgressInfo {

--- a/proto/tripcommon.proto
+++ b/proto/tripcommon.proto
@@ -95,7 +95,7 @@ message Location {
   optional uint32 waypoint_index = 31;
   optional SearchFilter search_filter = 32;
   optional uint32 street_side_max_distance = 33;
-  optional int32 preferred_z_level = 34;
+  optional int32 preferred_layer = 34;
 }
 
 message TransitEgressInfo {
@@ -156,7 +156,7 @@ enum RoadClass {
 
 message TaggedValue {
   enum Type {
-    kZLevel = 1;
+    kLayer = 1;
     // we used to have bug when we encoded 1 and 2 as their ASCII codes, but not actual 1 and 2 values
     // see https://github.com/valhalla/valhalla/issues/3262
     kTunnel = 49; // static_cast<uint8_t>('1')

--- a/src/baldr/edgeinfo.cc
+++ b/src/baldr/edgeinfo.cc
@@ -197,15 +197,15 @@ std::string EdgeInfo::encoded_shape() const {
                                    : std::string(encoded_shape_, ei_.encoded_shape_size_);
 }
 
-int8_t EdgeInfo::z_level() const {
+int8_t EdgeInfo::layer() const {
   const auto& tags = GetTags();
-  auto itr = tags.find(TaggedValue::kZLevel);
+  auto itr = tags.find(TaggedValue::kLayer);
   if (itr == tags.end()) {
     return 0;
   }
   const auto& value = itr->second;
   if (value.size() != 1) {
-    throw std::runtime_error("z-level must contain 1-byte value");
+    throw std::runtime_error("layer must contain 1-byte value");
   }
   return static_cast<int8_t>(value.front());
 }

--- a/src/baldr/location.cc
+++ b/src/baldr/location.cc
@@ -27,11 +27,13 @@ Location::Location(const midgard::PointLL& latlng,
                    unsigned int min_inbound_reach,
                    unsigned long radius,
                    const PreferredSide& side,
-                   const SearchFilter& search_filter)
+                   const SearchFilter& search_filter,
+                   boost::optional<int8_t> preferred_z_level)
     : latlng_(latlng), stoptype_(stoptype), min_outbound_reach_(min_outbound_reach),
       min_inbound_reach_(min_inbound_reach), radius_(radius), preferred_side_(side),
       node_snap_tolerance_(5), heading_tolerance_(60), search_cutoff_(35000),
-      street_side_tolerance_(5), street_side_max_distance_(1000), search_filter_(search_filter) {
+      street_side_tolerance_(5), street_side_max_distance_(1000), search_filter_(search_filter),
+      preferred_z_level_(std::move(preferred_z_level)) {
 }
 
 bool Location::operator==(const Location& o) const {
@@ -44,7 +46,7 @@ bool Location::operator==(const Location& o) const {
          street_side_max_distance_ == o.street_side_max_distance_ && way_id_ == o.way_id_ &&
          min_outbound_reach_ == o.min_outbound_reach_ && min_inbound_reach_ == o.min_inbound_reach_ &&
          radius_ == o.radius_ && preferred_side_ == o.preferred_side_ &&
-         display_latlng_ == o.display_latlng_;
+         display_latlng_ == o.display_latlng_ && preferred_z_level_ == o.preferred_z_level_;
 }
 
 } // namespace baldr

--- a/src/baldr/location.cc
+++ b/src/baldr/location.cc
@@ -28,12 +28,12 @@ Location::Location(const midgard::PointLL& latlng,
                    unsigned long radius,
                    const PreferredSide& side,
                    const SearchFilter& search_filter,
-                   boost::optional<int8_t> preferred_z_level)
+                   boost::optional<int8_t> preferred_layer)
     : latlng_(latlng), stoptype_(stoptype), min_outbound_reach_(min_outbound_reach),
       min_inbound_reach_(min_inbound_reach), radius_(radius), preferred_side_(side),
       node_snap_tolerance_(5), heading_tolerance_(60), search_cutoff_(35000),
       street_side_tolerance_(5), street_side_max_distance_(1000), search_filter_(search_filter),
-      preferred_z_level_(std::move(preferred_z_level)) {
+      preferred_layer_(std::move(preferred_layer)) {
 }
 
 bool Location::operator==(const Location& o) const {
@@ -46,7 +46,7 @@ bool Location::operator==(const Location& o) const {
          street_side_max_distance_ == o.street_side_max_distance_ && way_id_ == o.way_id_ &&
          min_outbound_reach_ == o.min_outbound_reach_ && min_inbound_reach_ == o.min_inbound_reach_ &&
          radius_ == o.radius_ && preferred_side_ == o.preferred_side_ &&
-         display_latlng_ == o.display_latlng_ && preferred_z_level_ == o.preferred_z_level_;
+         display_latlng_ == o.display_latlng_ && preferred_layer_ == o.preferred_layer_;
 }
 
 } // namespace baldr

--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -304,7 +304,8 @@ struct bin_handler_t {
         // get some info about this edge and the opposing
         GraphId id = tile->id();
         id.set_id(node->edge_index() + (edge - start_edge));
-        const auto& info = *candidate.edge_info;
+        auto info = tile->edgeinfo(edge);
+
         // calculate the heading of the snapped point to the shape for use in heading filter
         size_t index = edge->forward() ? 0 : info.shape().size() - 2;
         float angle =

--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -81,6 +81,15 @@ bool heading_filter(const Location& location, float angle) {
          location.heading_tolerance_;
 }
 
+bool z_level_filter(const Location& location, int8_t z_level) {
+  // no z-level - we do not filter
+  if (!location.preferred_z_level_) {
+    return false;
+  }
+
+  return *location.preferred_z_level_ != z_level;
+}
+
 PathLocation::SideOfStreet flip_side(const PathLocation::SideOfStreet side) {
   if (side != PathLocation::SideOfStreet::NONE) {
     return side == PathLocation::SideOfStreet::LEFT ? PathLocation::SideOfStreet::RIGHT
@@ -295,18 +304,19 @@ struct bin_handler_t {
         // get some info about this edge and the opposing
         GraphId id = tile->id();
         id.set_id(node->edge_index() + (edge - start_edge));
-        auto info = tile->edgeinfo(edge);
+        const auto& info = *candidate.edge_info;
         // calculate the heading of the snapped point to the shape for use in heading filter
         size_t index = edge->forward() ? 0 : info.shape().size() - 2;
         float angle =
             tangent_angle(index, candidate.point, info.shape(),
                           GetOffsetForHeading(edge->classification(), edge->use()), edge->forward());
+        auto z_level = info.z_level();
         // do we want this edge
         if (costing->Allowed(edge, tile, kDisallowShortcut)) {
           auto reach = get_reach(id, edge);
           PathLocation::PathEdge
               path_edge{id, 0, node_ll, distance, PathLocation::NONE, reach.outbound, reach.inbound};
-          if (heading_filter(location, angle)) {
+          if (heading_filter(location, angle) || z_level_filter(location, z_level)) {
             filtered.emplace_back(std::move(path_edge));
           } else if (correlated_edges.insert(path_edge.id).second) {
             correlated.edges.push_back(std::move(path_edge));
@@ -330,7 +340,8 @@ struct bin_handler_t {
                                            reach.outbound,
                                            reach.inbound};
           // angle is 180 degrees opposite direction of the one above
-          if (heading_filter(location, std::fmod(angle + 180.f, 360.f))) {
+          if (heading_filter(location, std::fmod(angle + 180.f, 360.f)) ||
+              z_level_filter(location, z_level)) {
             filtered.emplace_back(std::move(path_edge));
           } else if (correlated_edges.insert(path_edge.id).second) {
             correlated.edges.push_back(std::move(path_edge));
@@ -382,6 +393,7 @@ struct bin_handler_t {
           tangent_angle(candidate.index, candidate.point, candidate.edge_info->shape(),
                         GetOffsetForHeading(candidate.edge->classification(), candidate.edge->use()),
                         candidate.edge->forward());
+      auto z_level = candidate.edge_info->z_level();
       auto sq_tolerance = square(double(location.street_side_tolerance_));
       auto sq_max_distance = square(double(location.street_side_max_distance_));
       auto side =
@@ -396,7 +408,8 @@ struct bin_handler_t {
                                        distance,          side,         reach.outbound,
                                        reach.inbound};
       // correlate the edge we found
-      if (side_filter(path_edge, location, reader) || heading_filter(location, angle)) {
+      if (side_filter(path_edge, location, reader) || heading_filter(location, angle) ||
+          z_level_filter(location, z_level)) {
         filtered.push_back(std::move(path_edge));
       } else if (correlated_edges.insert(candidate.edge_id).second) {
         correlated.edges.push_back(std::move(path_edge));
@@ -413,7 +426,8 @@ struct bin_handler_t {
                                                reach.inbound};
         // angle is 180 degrees opposite of the one above
         if (side_filter(other_path_edge, location, reader) ||
-            heading_filter(location, std::fmod(angle + 180.f, 360.f))) {
+            heading_filter(location, std::fmod(angle + 180.f, 360.f)) ||
+            z_level_filter(location, z_level)) {
           filtered.push_back(std::move(other_path_edge));
         } else if (correlated_edges.insert(opposing_edge_id).second) {
           correlated.edges.push_back(std::move(other_path_edge));

--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -81,13 +81,13 @@ bool heading_filter(const Location& location, float angle) {
          location.heading_tolerance_;
 }
 
-bool z_level_filter(const Location& location, int8_t z_level) {
-  // no z-level - we do not filter
-  if (!location.preferred_z_level_) {
+bool layer_filter(const Location& location, int8_t layer) {
+  // no layer - we do not filter
+  if (!location.preferred_layer_) {
     return false;
   }
 
-  return *location.preferred_z_level_ != z_level;
+  return *location.preferred_layer_ != layer;
 }
 
 PathLocation::SideOfStreet flip_side(const PathLocation::SideOfStreet side) {
@@ -311,13 +311,13 @@ struct bin_handler_t {
         float angle =
             tangent_angle(index, candidate.point, info.shape(),
                           GetOffsetForHeading(edge->classification(), edge->use()), edge->forward());
-        auto z_level = info.z_level();
+        auto layer = info.layer();
         // do we want this edge
         if (costing->Allowed(edge, tile, kDisallowShortcut)) {
           auto reach = get_reach(id, edge);
           PathLocation::PathEdge
               path_edge{id, 0, node_ll, distance, PathLocation::NONE, reach.outbound, reach.inbound};
-          if (heading_filter(location, angle) || z_level_filter(location, z_level)) {
+          if (heading_filter(location, angle) || layer_filter(location, layer)) {
             filtered.emplace_back(std::move(path_edge));
           } else if (correlated_edges.insert(path_edge.id).second) {
             correlated.edges.push_back(std::move(path_edge));
@@ -342,7 +342,7 @@ struct bin_handler_t {
                                            reach.inbound};
           // angle is 180 degrees opposite direction of the one above
           if (heading_filter(location, std::fmod(angle + 180.f, 360.f)) ||
-              z_level_filter(location, z_level)) {
+              layer_filter(location, layer)) {
             filtered.emplace_back(std::move(path_edge));
           } else if (correlated_edges.insert(path_edge.id).second) {
             correlated.edges.push_back(std::move(path_edge));
@@ -394,7 +394,7 @@ struct bin_handler_t {
           tangent_angle(candidate.index, candidate.point, candidate.edge_info->shape(),
                         GetOffsetForHeading(candidate.edge->classification(), candidate.edge->use()),
                         candidate.edge->forward());
-      auto z_level = candidate.edge_info->z_level();
+      auto layer = candidate.edge_info->layer();
       auto sq_tolerance = square(double(location.street_side_tolerance_));
       auto sq_max_distance = square(double(location.street_side_max_distance_));
       auto side =
@@ -410,7 +410,7 @@ struct bin_handler_t {
                                        reach.inbound};
       // correlate the edge we found
       if (side_filter(path_edge, location, reader) || heading_filter(location, angle) ||
-          z_level_filter(location, z_level)) {
+          layer_filter(location, layer)) {
         filtered.push_back(std::move(path_edge));
       } else if (correlated_edges.insert(candidate.edge_id).second) {
         correlated.edges.push_back(std::move(path_edge));
@@ -428,7 +428,7 @@ struct bin_handler_t {
         // angle is 180 degrees opposite of the one above
         if (side_filter(other_path_edge, location, reader) ||
             heading_filter(location, std::fmod(angle + 180.f, 360.f)) ||
-            z_level_filter(location, z_level)) {
+            layer_filter(location, layer)) {
           filtered.push_back(std::move(other_path_edge));
         } else if (correlated_edges.insert(opposing_edge_id).second) {
           correlated.edges.push_back(std::move(other_path_edge));

--- a/src/mjolnir/osmway.cc
+++ b/src/mjolnir/osmway.cc
@@ -94,8 +94,8 @@ void OSMWay::set_forward_lanes(const uint32_t forward_lanes) {
   forward_lanes_ = (forward_lanes > kMaxLaneCount) ? kMaxLaneCount : forward_lanes;
 }
 
-void OSMWay::set_z_level(int8_t z_level) {
-  z_level_ = z_level;
+void OSMWay::set_layer(int8_t layer) {
+  layer_ = layer;
 }
 
 // Get the names for the edge info based on the road class.
@@ -189,8 +189,8 @@ std::vector<std::string> OSMWay::GetTaggedValues(const UniqueNames& name_offset_
     }
   }
 
-  if (z_level_ != 0) {
-    names.emplace_back(encode_tag(TaggedValue::kZLevel) + static_cast<char>(z_level_));
+  if (layer_ != 0) {
+    names.emplace_back(encode_tag(TaggedValue::kLayer) + static_cast<char>(layer_));
   }
 
   return names;

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -189,8 +189,8 @@ public:
     };
 
     tag_handlers_["layer"] = [this]() {
-      auto z_level = static_cast<int8_t>(std::stoi(tag_.second));
-      way_.set_z_level(z_level);
+      auto layer = static_cast<int8_t>(std::stoi(tag_.second));
+      way_.set_layer(layer);
     };
 
     tag_handlers_["road_class"] = [this]() {

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -305,9 +305,9 @@ void parse_locations(const rapidjson::Document& doc,
         if (heading_tolerance) {
           location->set_heading_tolerance(*heading_tolerance);
         }
-        auto preferred_z_level = rapidjson::get_optional<int>(r_loc, "/preferred_z_level");
-        if (preferred_z_level) {
-          location->set_preferred_z_level(*preferred_z_level);
+        auto preferred_layer = rapidjson::get_optional<int>(r_loc, "/preferred_layer");
+        if (preferred_layer) {
+          location->set_preferred_layer(*preferred_layer);
         }
         auto node_snap_tolerance = rapidjson::get_optional<float>(r_loc, "/node_snap_tolerance");
         if (node_snap_tolerance) {

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -305,6 +305,10 @@ void parse_locations(const rapidjson::Document& doc,
         if (heading_tolerance) {
           location->set_heading_tolerance(*heading_tolerance);
         }
+        auto preferred_z_level = rapidjson::get_optional<int>(r_loc, "/preferred_z_level");
+        if (preferred_z_level) {
+          location->set_preferred_z_level(*preferred_z_level);
+        }
         auto node_snap_tolerance = rapidjson::get_optional<float>(r_loc, "/node_snap_tolerance");
         if (node_snap_tolerance) {
           location->set_node_snap_tolerance(*node_snap_tolerance);

--- a/test/gurka/test_multi_level_loki.cc
+++ b/test/gurka/test_multi_level_loki.cc
@@ -1,0 +1,133 @@
+#include "gurka.h"
+#include "rapidjson/document.h"
+#include <boost/format.hpp>
+#include <boost/optional.hpp>
+#include <gtest/gtest.h>
+
+#if !defined(VALHALLA_SOURCE_DIR)
+#define VALHALLA_SOURCE_DIR
+#endif
+
+using namespace valhalla;
+const std::unordered_map<std::string, std::string> build_config{{}};
+
+namespace {
+struct Waypoint {
+  midgard::PointLL ll;
+  boost::optional<int8_t> preferred_z_level;
+};
+
+std::string ToString(const rapidjson::Document& doc) {
+  rapidjson::StringBuffer sb;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(sb);
+  doc.Accept(writer);
+  return sb.GetString();
+}
+
+std::vector<std::string> GetStepNames(const rapidjson::Document& doc) {
+  std::vector<std::string> names;
+  auto steps = doc["routes"][0]["legs"][0]["steps"].GetArray();
+  names.reserve(steps.Size());
+  for (const auto& step : steps) {
+    names.emplace_back(step["name"].GetString());
+  }
+  return names;
+}
+
+std::string BuildRequest(const std::vector<Waypoint>& waypoints) {
+  rapidjson::Document requestDoc;
+  requestDoc.SetObject();
+  auto& allocator = requestDoc.GetAllocator();
+  rapidjson::Value locations(rapidjson::kArrayType);
+  for (const auto& waypoint : waypoints) {
+    rapidjson::Value p(rapidjson::kObjectType);
+    p.AddMember("lon", waypoint.ll.lng(), allocator);
+    p.AddMember("lat", waypoint.ll.lat(), allocator);
+    if (waypoint.preferred_z_level) {
+      p.AddMember("preferred_z_level", *waypoint.preferred_z_level, allocator);
+      // `preferred_z_level` is only working correctly if radius is provided,
+      // because Z-level filtering is performed as last step in loki and if we don't provide
+      // radius we would have only single candidate on the last step in this case
+      p.AddMember("radius", 1, allocator);
+    }
+
+    locations.PushBack(p, allocator);
+  }
+  requestDoc.AddMember("locations", locations, allocator);
+  requestDoc.AddMember("costing", "auto", allocator);
+  requestDoc.AddMember("verbose", true, allocator);
+  requestDoc.AddMember("shape_match", "map_snap", allocator);
+
+  return ToString(requestDoc);
+}
+
+} // namespace
+
+class MultiLevelLoki : public ::testing::Test {
+protected:
+  static gurka::map map;
+  static std::string ascii_map;
+  static gurka::nodelayout layout;
+  static void SetUpTestSuite() {
+    constexpr double gridsize_metres = 100;
+
+    ascii_map = R"(
+                          A
+                          H
+                          |
+                          |
+                          B-------E        
+                          |       |
+                          |       |
+                          I       |
+                          C       |
+                          |       |
+                          |       |
+                          D-------F
+                          |
+                          |
+                          G
+    )";
+
+    const gurka::ways ways = {{"AB", {{"highway", "motorway"}}},
+                              {"BE", {{"highway", "motorway"}}},
+                              {"EF", {{"highway", "motorway"}}},
+                              {"FD", {{"highway", "motorway"}}},
+                              {"HI", {{"highway", "motorway"}, {"layer", "-1"}}},
+                              {"ID", {{"highway", "motorway"}, {"layer", "-1"}}},
+                              {"DG", {{"highway", "motorway"}}}
+
+    };
+
+    layout = gurka::detail::map_to_coordinates(ascii_map, gridsize_metres);
+    map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_multi_level_loki", build_config);
+  }
+
+  rapidjson::Document Route(const std::vector<Waypoint>& waypoints) {
+    auto result = gurka::do_action(valhalla::Options::route, map, BuildRequest(waypoints));
+    return gurka::convert_to_json(result, valhalla::Options_Format_osrm);
+  }
+};
+gurka::map MultiLevelLoki::map = {};
+std::string MultiLevelLoki::ascii_map = {};
+gurka::nodelayout MultiLevelLoki::layout = {};
+
+TEST_F(MultiLevelLoki, test_multilevel_loki) {
+  auto start = map.nodes["B"];
+  auto end = map.nodes["G"];
+
+  EXPECT_EQ(GetStepNames(Route({{start, -1}, {end}})), std::vector<std::string>({"HI", "HI"}));
+  EXPECT_EQ(GetStepNames(Route({{start, 0}, {end}})),
+            std::vector<std::string>({"BE", "EF", "FD", "DG", "DG"}));
+  EXPECT_EQ(GetStepNames(Route({{start}, {end}})), std::vector<std::string>({"HI", "HI"}));
+}
+
+TEST_F(MultiLevelLoki, test_no_matching_z_level) {
+  // we don't have Z-level equal to "-1" near the `E` node,
+  // we should return something anyway
+  auto start = map.nodes["E"];
+  auto end = map.nodes["G"];
+
+  EXPECT_EQ(GetStepNames(Route({{start, -1}, {end}})),
+            std::vector<std::string>({"EF", "FD", "DG", "DG"}));
+}

--- a/test/gurka/test_multi_level_loki.cc
+++ b/test/gurka/test_multi_level_loki.cc
@@ -15,7 +15,7 @@ const std::unordered_map<std::string, std::string> build_config{{}};
 namespace {
 struct Waypoint {
   std::string node;
-  boost::optional<int8_t> preferred_z_level;
+  boost::optional<int8_t> preferred_layer;
 };
 
 } // namespace
@@ -66,9 +66,9 @@ protected:
     for (size_t index = 0; index < waypoints.size(); ++index) {
       const auto& wp = waypoints[index];
       nodes.emplace_back(wp.node);
-      if (wp.preferred_z_level) {
-        options["/locations/" + std::to_string(index) + "/preferred_z_level"] =
-            std::to_string(*wp.preferred_z_level);
+      if (wp.preferred_layer) {
+        options["/locations/" + std::to_string(index) + "/preferred_layer"] =
+            std::to_string(*wp.preferred_layer);
         options["/locations/" + std::to_string(index) + "/radius"] = "1";
       }
     }
@@ -89,7 +89,7 @@ TEST_F(MultiLevelLoki, test_multilevel_loki) {
   gurka::assert::osrm::expect_steps(result, std::vector<std::string>({"HI"}));
 }
 
-TEST_F(MultiLevelLoki, test_no_matching_z_level) {
+TEST_F(MultiLevelLoki, test_no_matching_layer) {
   auto result = Route({{"E", -1}, {"G"}});
   gurka::assert::osrm::expect_steps(result, std::vector<std::string>({"EF", "FD", "DG"}));
 }

--- a/test/gurka/test_tagged_values.cc
+++ b/test/gurka/test_tagged_values.cc
@@ -64,18 +64,18 @@ rapidjson::Document d;
 
 /*************************************************************/
 
-TEST_F(TaggedValues, ZLevel) {
+TEST_F(TaggedValues, Layer) {
   baldr::GraphReader graphreader(map.config.get_child("mjolnir"));
 
-  auto get_z_level = [&](auto from, auto to) {
+  auto get_layer = [&](auto from, auto to) {
     auto edgeId = std::get<0>(gurka::findEdgeByNodes(graphreader, layout, from, to));
-    return graphreader.edgeinfo(edgeId).z_level();
+    return graphreader.edgeinfo(edgeId).layer();
   };
-  EXPECT_EQ(get_z_level("A", "B"), 0);
-  EXPECT_EQ(get_z_level("B", "C"), -3);
-  EXPECT_EQ(get_z_level("C", "D"), -2);
-  EXPECT_EQ(get_z_level("D", "E"), -1);
-  EXPECT_EQ(get_z_level("B", "G"), 2);
+  EXPECT_EQ(get_layer("A", "B"), 0);
+  EXPECT_EQ(get_layer("B", "C"), -3);
+  EXPECT_EQ(get_layer("C", "D"), -2);
+  EXPECT_EQ(get_layer("D", "E"), -1);
+  EXPECT_EQ(get_layer("B", "G"), 2);
 }
 
 TEST_F(TaggedValues, Tunnel) {
@@ -86,19 +86,19 @@ TEST_F(TaggedValues, Tunnel) {
   EXPECT_EQ(leg.node(0).edge().has_tunnel(), false);
 
   EXPECT_EQ(leg.node(1).edge().tunnel(), true);
-  EXPECT_EQ(leg.node(1).edge().tagged_value().Get(0).type(), TaggedValue_Type_kZLevel);
+  EXPECT_EQ(leg.node(1).edge().tagged_value().Get(0).type(), TaggedValue_Type_kLayer);
   EXPECT_EQ(leg.node(1).edge().tagged_value().Get(0).value(), std::string(1, char(-3)));
   EXPECT_EQ(leg.node(1).edge().tagged_value().Get(1).type(), TaggedValue_Type_kTunnel);
   EXPECT_EQ(leg.node(1).edge().tagged_value().Get(1).value(), "Fort McHenry Tunnel");
 
   EXPECT_EQ(leg.node(2).edge().tunnel(), true);
-  EXPECT_EQ(leg.node(2).edge().tagged_value().Get(0).type(), TaggedValue_Type_kZLevel);
+  EXPECT_EQ(leg.node(2).edge().tagged_value().Get(0).type(), TaggedValue_Type_kLayer);
   EXPECT_EQ(leg.node(2).edge().tagged_value().Get(0).value(), std::string(1, char(-2)));
   EXPECT_EQ(leg.node(2).edge().tagged_value().Get(1).type(), TaggedValue_Type_kTunnel);
   EXPECT_EQ(leg.node(2).edge().tagged_value().Get(1).value(), "Fort McHenry Tunnel");
 
   EXPECT_EQ(leg.node(3).edge().tunnel(), true);
-  EXPECT_EQ(leg.node(3).edge().tagged_value().Get(0).type(), TaggedValue_Type_kZLevel);
+  EXPECT_EQ(leg.node(3).edge().tagged_value().Get(0).type(), TaggedValue_Type_kLayer);
   EXPECT_EQ(leg.node(3).edge().tagged_value().Get(0).value(), std::string(1, char(-1)));
   EXPECT_TRUE(leg.node(3).edge().tagged_value().Get(1).type() == TaggedValue_Type_kTunnel);
   EXPECT_TRUE(leg.node(3).edge().tagged_value().Get(1).value() == "Fort McHenry Tunnel");

--- a/valhalla/baldr/edgeinfo.h
+++ b/valhalla/baldr/edgeinfo.h
@@ -188,11 +188,11 @@ public:
   std::string encoded_shape() const;
 
   /**
-   * Get Z-level of the edge relatively to other edges. Can be negative.
+   * Get layer index of the edge relatively to other edges(Z-level). Can be negative.
    * @see https://wiki.openstreetmap.org/wiki/Key:layer
-   * @return Z-level of the edge
+   * @return layer index of the edge
    */
-  int8_t z_level() const;
+  int8_t layer() const;
 
   /**
    * Returns json representing this object

--- a/valhalla/baldr/graphconstants.h
+++ b/valhalla/baldr/graphconstants.h
@@ -359,7 +359,7 @@ inline std::string to_string(Use u) {
 }
 
 enum class TaggedValue : uint8_t { // must start at 1 due to nulls
-  kZLevel = 1,
+  kLayer = 1,
   // we used to have bug when we encoded 1 and 2 as their ASCII codes, but not actual 1 and 2 values
   // see https://github.com/valhalla/valhalla/issues/3262
   kTunnel = static_cast<uint8_t>('1'),

--- a/valhalla/baldr/location.h
+++ b/valhalla/baldr/location.h
@@ -71,7 +71,7 @@ public:
            unsigned long radius = 0,
            const PreferredSide& side = PreferredSide::EITHER,
            const SearchFilter& search_filter = SearchFilter(),
-           boost::optional<int8_t> preferred_z_level = {});
+           boost::optional<int8_t> preferred_layer = {});
 
   /**
    * equality.
@@ -118,7 +118,7 @@ public:
   // coordinates of the location as used for altering the side of street
   boost::optional<midgard::PointLL> display_latlng_;
 
-  boost::optional<int8_t> preferred_z_level_;
+  boost::optional<int8_t> preferred_layer_;
 
 protected:
 };

--- a/valhalla/baldr/location.h
+++ b/valhalla/baldr/location.h
@@ -70,7 +70,8 @@ public:
            unsigned int min_inbound_reach = 0,
            unsigned long radius = 0,
            const PreferredSide& side = PreferredSide::EITHER,
-           const SearchFilter& search_filter = SearchFilter());
+           const SearchFilter& search_filter = SearchFilter(),
+           boost::optional<int8_t> preferred_z_level = {});
 
   /**
    * equality.
@@ -116,6 +117,8 @@ public:
 
   // coordinates of the location as used for altering the side of street
   boost::optional<midgard::PointLL> display_latlng_;
+
+  boost::optional<int8_t> preferred_z_level_;
 
 protected:
 };

--- a/valhalla/baldr/pathlocation.h
+++ b/valhalla/baldr/pathlocation.h
@@ -125,8 +125,8 @@ public:
     }
     l->set_heading_tolerance(pl.heading_tolerance_);
     l->set_node_snap_tolerance(pl.node_snap_tolerance_);
-    if (pl.preferred_z_level_) {
-      l->set_preferred_z_level(*pl.preferred_z_level_);
+    if (pl.preferred_layer_) {
+      l->set_preferred_layer(*pl.preferred_layer_);
     }
     if (pl.way_id_) {
       l->set_way_id(*pl.way_id_);
@@ -258,8 +258,8 @@ public:
     if (loc.has_display_ll()) {
       l.display_latlng_ = midgard::PointLL{loc.display_ll().lng(), loc.display_ll().lat()};
     }
-    if (loc.has_preferred_z_level()) {
-      l.preferred_z_level_ = loc.preferred_z_level();
+    if (loc.has_preferred_layer()) {
+      l.preferred_layer_ = loc.preferred_layer();
     }
     return l;
   }

--- a/valhalla/baldr/pathlocation.h
+++ b/valhalla/baldr/pathlocation.h
@@ -125,6 +125,9 @@ public:
     }
     l->set_heading_tolerance(pl.heading_tolerance_);
     l->set_node_snap_tolerance(pl.node_snap_tolerance_);
+    if (pl.preferred_z_level_) {
+      l->set_preferred_z_level(*pl.preferred_z_level_);
+    }
     if (pl.way_id_) {
       l->set_way_id(*pl.way_id_);
     }
@@ -254,6 +257,9 @@ public:
     }
     if (loc.has_display_ll()) {
       l.display_latlng_ = midgard::PointLL{loc.display_ll().lng(), loc.display_ll().lat()};
+    }
+    if (loc.has_preferred_z_level()) {
+      l.preferred_z_level_ = loc.preferred_z_level();
     }
     return l;
   }

--- a/valhalla/mjolnir/osmway.h
+++ b/valhalla/mjolnir/osmway.h
@@ -1579,17 +1579,17 @@ struct OSMWay {
   }
 
   /**
-   * Sets z-level of the way.
-   * @param z_level Z-level.
+   * Sets layer index(Z-level) of the way.
+   * @param layer
    */
-  void set_z_level(int8_t z_level);
+  void set_layer(int8_t layer);
 
   /**
-   * Get z-level, can be negative.
-   * @return returns z-level of the way relatively to other ways.
+   * Get layer(Z-level), can be negative.
+   * @return returns layer index of the way relatively to other ways.
    */
-  int8_t z_level() const {
-    return z_level_;
+  int8_t layer() const {
+    return layer_;
   }
 
   /**
@@ -1741,8 +1741,8 @@ struct OSMWay {
   // Truck speed in kilometers per hour
   uint8_t truck_speed_;
 
-  // Z-level of the way relatively to other levels
-  int8_t z_level_;
+  // layer index(Z-level) of the way relatively to other levels
+  int8_t layer_;
 };
 
 } // namespace mjolnir


### PR DESCRIPTION
# Issue
The idea is to give clients ability to provide current Z-level(if they know it) and use it as a hint for loki where it should snap location - it is the only way to have proper snapping in in the case of multilevel roads.

Some discussions can be found at https://github.com/valhalla/valhalla/pull/3261

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
