### PR TITLE
Calculate stretch threshold based on the optimal route cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
    * CHANGED: Fixed cost threshold fot bidirectional astar. Implemented reach-based pruning for suboptimal branches [#3257](https://github.com/valhalla/valhalla/pull/3257)
    * ADDED: Added `exclude_unpaved` request parameter [#3240](https://github.com/valhalla/valhalla/pull/3240)
    * ADDED: Add Z-level field to `EdgeInfo`. [#3261](https://github.com/valhalla/valhalla/pull/3261)
+   * CHANGED: Calculate stretch threshold for alternatives based on the optimal route cost [#3276](https://github.com/valhalla/valhalla/pull/3276)
 
 ## Release Date: 2021-07-20 Valhalla 3.1.3
 * **Removed**


### PR DESCRIPTION
# Issue

closes https://github.com/valhalla/valhalla/issues/3239

What's done:
calculate stretch threshold for alternatives based on the optimal route cost. Approximately the following stretch thresholds we will get:
```
<= 10min -> 2.
20min -> 1.75
30min -> 1.5
1hour -> 1.4
2hours -> 1.3
>= 5hours -> 1.25
```
In order to approximate these value an quadratic hyperbolic function was chosen (because this is smooth monotonic function). 

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
