### PR TITLE
Added traffic signal and stop sign check for stop impact.  These traffic signals and stop sign are located on edges.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
    * ADDED: Add `preferred_z_level` as a parameter of loki requests. [#3270](https://github.com/valhalla/valhalla/pull/3270)
    * ADDED: Add `preferred_layer` as a parameter of loki requests. [#3270](https://github.com/valhalla/valhalla/pull/3270)
    * ADDED: Exposing service area names in passive maneuvers. [#3277](https://github.com/valhalla/valhalla/pull/3277)
+   * ADDED: Added traffic signal and stop sign check for stop impact. These traffic signals and stop sign are located on edges. [#3279](https://github.com/valhalla/valhalla/pull/3279)
 
 ## Release Date: 2021-07-20 Valhalla 3.1.3
 * **Removed**

--- a/src/mjolnir/graphenhancer.cc
+++ b/src/mjolnir/graphenhancer.cc
@@ -1136,7 +1136,7 @@ uint32_t GetStopImpact(uint32_t from,
   } else if (edges[from].use() == Use::kRamp && edges[to].use() == Use::kRamp &&
              bestrc < RoadClass::kUnclassified) {
     // Ramp may be crossing a road (not a path or service road)
-    if (nodeinfo.traffic_signal()) {
+    if (nodeinfo.traffic_signal() || edges[from].traffic_signal() || edges[from].stop_sign()) {
       stop_impact = 4;
     } else if (count > 3) {
       stop_impact += 2;
@@ -1174,7 +1174,7 @@ uint32_t GetStopImpact(uint32_t from,
            (turn_type == Turn::Type::kSharpLeft || turn_type == Turn::Type::kLeft) &&
            from_rc != edges[to].classification() && edges[to].use() != Use::kRamp &&
            edges[to].use() != Use::kTurnChannel) {
-    if (nodeinfo.traffic_signal()) {
+    if (nodeinfo.traffic_signal() || edges[from].traffic_signal() || edges[from].stop_sign()) {
       stop_impact += 2;
     } else if (abs(static_cast<int>(from_rc) - static_cast<int>(edges[to].classification())) > 1)
       stop_impact++;
@@ -1183,7 +1183,7 @@ uint32_t GetStopImpact(uint32_t from,
              (turn_type == Turn::Type::kSharpRight || turn_type == Turn::Type::kRight) &&
              from_rc != edges[to].classification() && edges[to].use() != Use::kRamp &&
              edges[to].use() != Use::kTurnChannel) {
-    if (nodeinfo.traffic_signal()) {
+    if (nodeinfo.traffic_signal() || edges[from].traffic_signal() || edges[from].stop_sign()) {
       stop_impact += 2;
     } else if (abs(static_cast<int>(from_rc) - static_cast<int>(edges[to].classification())) > 1)
       stop_impact++;


### PR DESCRIPTION
# Issue

With the fixes for traffic signals and stop sign updates in PR [#3251](https://github.com/valhalla/valhalla/pull/3251), I wanted to add a check for traffic signals and stop signs on the edge in the stop impact function.  Results look good and in most cases matching when you have traffic data.  RAD tested.

Red = Baseline
Blue = New result

![Screenshot from 2021-08-19 16-03-50](https://user-images.githubusercontent.com/2676277/130136420-4cc8fa53-7c43-448b-b23a-861c34bbbeee.png)

![Screenshot from 2021-08-19 16-03-20](https://user-images.githubusercontent.com/2676277/130136421-f1d6a2a2-234b-40bc-9eee-75a201a4057f.png)

![Screenshot from 2021-08-19 16-02-26](https://user-images.githubusercontent.com/2676277/130136422-8ea36649-0820-4571-b745-f6fa96bee6ac.png)

![Screenshot from 2021-08-19 16-01-54](https://user-images.githubusercontent.com/2676277/130136425-146f1606-2243-41ef-83a2-458fe6134b23.png)

![Screenshot from 2021-08-19 16-01-20](https://user-images.githubusercontent.com/2676277/130136427-ff83f8ed-bff0-480e-a785-a811d2c4fd4f.png)


## Tasklist

 - [x] Update the [changelog](CHANGELOG.md)

## Requirements / Relations
NA

 Link any requirements here. Other pull requests this PR is based on?
