### PR TITLE
Resolve variable name before using it

### DIFF
--- a/scripts/needs_ci_run
+++ b/scripts/needs_ci_run
@@ -104,7 +104,7 @@ if not status:
     sys.exit(0)
 
 # if commit does not exist anymore, dont skip
-if subprocess.run(['git', 'cat-file', '-t', 'last_pr_gitsha'],
+if subprocess.run(['git', 'cat-file', '-t', f'{last_pr_gitsha}'],
                   capture_output=True,
                   text=True).stdout != 'commit':
     sys.exit(0)


### PR DESCRIPTION
The variable `last_pr_gitsha` used in scripts/needs_ci_run needs to be resolved before use in the `git cat-file` command.