### PR TITLE
Fix Broken Trivial Unidirectional Routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
    * FIXED: TransitionCostReverse fix: revert internal_turn change [#3271](https://github.com/valhalla/valhalla/issues/3271)
    * FIXED: Optimize tiles usage in reach-based pruning [#3294](https://github.com/valhalla/valhalla/pull/3294)
    * FIXED: Fix distance value in a 0-length road [#3185](https://github.com/valhalla/valhalla/pull/3185)
+   * FIXED: Trivial routes were broken when origin was node snapped and destnation was not and vice-versa for reverse astar [#3299](https://github.com/valhalla/valhalla/pull/3299)
+
 * **Enhancement**
    * CHANGED: Favor turn channels more [#3222](https://github.com/valhalla/valhalla/pull/3222)
    * CHANGED: Rename `valhalla::midgard::logging::LogLevel` enumerators to avoid clash with common macros [#3236](https://github.com/valhalla/valhalla/pull/3236)

--- a/test/gurka/test_route.cc
+++ b/test/gurka/test_route.cc
@@ -916,7 +916,16 @@ TEST(AlgorithmTestTrivial, unidirectional_regression) {
   };
   const auto layout = gurka::detail::map_to_coordinates(ascii_map, gridsize_metres, {0.00, 0.00});
   auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_trivial_regression");
+
+  // the code used to remove one of the origin edge candidates which then forced a uturn
   auto result = gurka::do_action(valhalla::Options::route, map, {"A", "3"}, "auto");
-  // the route should simply be one little piece of AB
+  gurka::assert::raw::expect_path(result, {"AB"});
+
+  // again with reverse a* search direction
+  result = gurka::do_action(valhalla::Options::route, map, {"3", "A"}, "auto",
+                            {
+                                {"/date_time/type", "2"},
+                                {"/date_time/value", "2111-11-11T11:11"},
+                            });
   gurka::assert::raw::expect_path(result, {"AB"});
 }

--- a/test/gurka/test_route.cc
+++ b/test/gurka/test_route.cc
@@ -906,3 +906,17 @@ TEST(AlgorithmTestDest, TestAlgoSwapAndDestOnly) {
   }
   ASSERT_EQ(expected_path_edge_sizes, actual_path_edge_sizes);
 }
+
+TEST(AlgorithmTestTrivial, unidirectional_regression) {
+  constexpr double gridsize_metres = 10;
+  const std::string ascii_map = R"(A1234B5678C)";
+  const gurka::ways ways = {
+      {"AB", {{"highway", "primary"}}},
+      {"BC", {{"highway", "primary"}}},
+  };
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, gridsize_metres, {0.00, 0.00});
+  auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_trivial_regression");
+  auto result = gurka::do_action(valhalla::Options::route, map, {"A", "3"}, "auto");
+  // the route should simply be one little piece of AB
+  gurka::assert::raw::expect_path(result, {"AB"});
+}


### PR DESCRIPTION
While I was lending a hand over in #3274 i added a simple test that relied on the results of unidirecitonal path finding (in the forward direction). The route in question is a single edge starting at the beginning of the edge and going 2/3rds along it. The algorithm currently (for this specific ordering of the input data) returns a two edge route starting at the end of the opposing edge and then making its way to the correct edge and ending 2/3rds along. at least from my quick debug session that is what looked like happened.

i thought we removed node snap edge candidates  that were the full distance along...