### PR TITLE
bss trivial path doesnt use superfluous edge

### DIFF
--- a/test/gurka/test_route.cc
+++ b/test/gurka/test_route.cc
@@ -928,4 +928,8 @@ TEST(AlgorithmTestTrivial, unidirectional_regression) {
                                 {"/date_time/value", "2111-11-11T11:11"},
                             });
   gurka::assert::raw::expect_path(result, {"AB"});
+
+  // again with reverse a* search direction
+  result = gurka::do_action(valhalla::Options::route, map, {"A", "3"}, "bikeshare");
+  gurka::assert::raw::expect_path(result, {"AB"});
 }


### PR DESCRIPTION
over in #3299 we found a bug with unidirectional/timedep astar in which it favored a 2 edge route (with the first edge being 0 length) over a single edge trivial route. this was because of a bug in the code that proactively removes noded snapped candidate edges when they are superfluous.

that same bug, exists in astar bss however for some reason that algorithm does not prefer the path with the 0 length edge and returns the path with the single edge trivial route. this pr adds a test proving that the algorithm already worked, updates the algorithm to remove the bug and should (but doesnt yet) figure out what else is wrong with either astar or the bss flavor that makes it not suffer the same consequence given the same initial conditions