### PR TITLE
Avoid shortcuts truck fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
    * FIXED: Optimize tiles usage in reach-based pruning [#3294](https://github.com/valhalla/valhalla/pull/3294)
    * FIXED: Fix distance value in a 0-length road [#3185](https://github.com/valhalla/valhalla/pull/3185)
    * FIXED: Trivial routes were broken when origin was node snapped and destnation was not and vice-versa for reverse astar [#3299](https://github.com/valhalla/valhalla/pull/3299)
+   * FIXED: Tweaked TestAvoids map to get TestAvoidShortcutsTruck working [#3301](https://github.com/valhalla/valhalla/pull/3301)
 
 * **Enhancement**
    * CHANGED: Favor turn channels more [#3222](https://github.com/valhalla/valhalla/pull/3222)

--- a/test/gurka/test_avoids.cc
+++ b/test/gurka/test_avoids.cc
@@ -104,7 +104,7 @@ protected:
                               {"BD", {{"highway", "tertiary"}, {"name", "2nd"}}},
                               {"DE", {{"highway", "tertiary"}, {"name", "2nd"}}},
                               {"EF", {{"highway", "tertiary"}, {"name", "2nd"}}}};
-    const auto layout = gurka::detail::map_to_coordinates(ascii_map, 10);
+    const auto layout = gurka::detail::map_to_coordinates(ascii_map, 10, {1.0, 1.0});
     // Add low length limit for exclude_polygons so it throws an error
     avoid_map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_avoids",
                                   {{"service_limits.max_exclude_polygons_length", "1000"}});


### PR DESCRIPTION
# Issue

The TestAvoidShortcutsTruck unit test always fails for me.  I did a little debugging... I'm not sure if this is a gurka  projection issue or if boost::geometry::intersect() is having trouble at the equator/prime-meridian. Either way, this is just a quick fix to get this test passing.

#fixes https://github.com/valhalla/valhalla/issues/3195

## Tasklist

 - [x] Add tests
 - [x] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
