### PR TITLE
Change sharing criterion to avoid artificial detours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
    * ADDED: Add `preferred_layer` as a parameter of loki requests. [#3270](https://github.com/valhalla/valhalla/pull/3270)
    * ADDED: Exposing service area names in passive maneuvers. [#3277](https://github.com/valhalla/valhalla/pull/3277)
    * ADDED: Added traffic signal and stop sign check for stop impact. These traffic signals and stop sign are located on edges. [#3279](https://github.com/valhalla/valhalla/pull/3279)
+   * CHANGED: Improved sharing criterion to obtain more reasonable alternatives; extended alternatives search [#3302](https://github.com/valhalla/valhalla/pull/3302)
 
 ## Release Date: 2021-07-20 Valhalla 3.1.3
 * **Removed**

--- a/src/thor/alternates.cc
+++ b/src/thor/alternates.cc
@@ -180,8 +180,7 @@ bool validate_alternate_by_sharing(std::vector<std::unordered_set<GraphId>>& sha
     }
 
     // throw this alternate away if any of the chosen paths shares more than at_most_shared with it
-    assert(paths[i].back().path_distance > 0);
-    if ((shared_length / paths[i].back().path_distance) > at_most_shared) {
+    if (shared_length > at_most_shared * paths[i].back().path_distance) {
       LOG_DEBUG("Candidate alternate rejected by sharing");
       return false;
     }

--- a/src/thor/alternates.cc
+++ b/src/thor/alternates.cc
@@ -169,20 +169,19 @@ bool validate_alternate_by_sharing(std::vector<std::unordered_set<GraphId>>& sha
 
     // if an edge on the candidate_path is encountered that is also on one of the existing paths,
     // we count it as a "shared" edge
-    float shared_length = 0.f, total_length = 0.f;
+    float shared_length = 0.f;
     for (const auto& cpi : candidate_path) {
       const auto length = &cpi == &candidate_path.front()
                               ? cpi.path_distance
                               : cpi.path_distance - (&cpi - 1)->path_distance;
-      total_length += length;
       if (shared.find(cpi.edgeid) != shared.end()) {
         shared_length += length;
       }
     }
 
-    // throw this alternate away if it shares more than at_most_shared with any of the chosen paths
-    assert(total_length > 0);
-    if ((shared_length / total_length) > at_most_shared) {
+    // throw this alternate away if any of the chosen paths shares more than at_most_shared with it
+    assert(paths[i].back().path_distance > 0);
+    if ((shared_length / paths[i].back().path_distance) > at_most_shared) {
       LOG_DEBUG("Candidate alternate rejected by sharing");
       return false;
     }

--- a/src/thor/alternates.cc
+++ b/src/thor/alternates.cc
@@ -28,24 +28,18 @@ namespace thor {
 float get_max_sharing(const valhalla::Location& origin, const valhalla::Location& destination) {
   PointLL from(origin.path_edges(0).ll().lng(), origin.path_edges(0).ll().lat());
   PointLL to(destination.path_edges(0).ll().lng(), destination.path_edges(0).ll().lat());
-  auto distance = from.Distance(to);
+  float distance = from.Distance(to);
 
   // 10km
-  if (distance < 10000.) {
-    return 0.50;
-  }
-  // 20km
-  else if (distance < 20000.) {
-    return 0.60;
-  }
-  // 50km
-  else if (distance < 50000.) {
-    return 0.65;
-  }
+  if (distance < 10000.f)
+    return 0.6f;
   // 100km
-  else if (distance < 100000.) {
-    return 0.70;
+  if (distance < 100000.f) {
+    // Uniformly increase 'at_most_shared' value from 0.6 to 0.75 for routes
+    // from 10km to 100km
+    return 0.6f + (kAtMostShared - 0.6f) * (distance - 10000.f) / (100000.f - 10000.f);
   }
+  // > 100km
   return kAtMostShared;
 }
 

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -28,7 +28,7 @@ constexpr float kThresholdDelta = 420.0f;
 // an upper bound value cost for alternative routes we're looking for. Due to the fact that
 // we can't estimate route cost that goes through some particular edge very precisely, we
 // can find alternatives with costs greater than the threshold.
-constexpr float kAlternativeCostExtend = 1.1f;
+constexpr float kAlternativeCostExtend = 1.2f;
 // Maximum number of additional iterations allowed once the first connection has been found.
 // For alternative routes we use bigger cost extension than in the case with one route. This
 // may lead to a significant increase in the number of iterations (~time). So, we should limit


### PR DESCRIPTION
Changes:
- use continuous function to calculate sharing coefficient (instead of piecewise constant function);
- change definition of "sharing": it was modified  from "part of edges that a candidate shares" to "part of edges that already chosen path shares with alternative";
- extend alternatives search.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
