### PR TITLE
Overflow in sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
    * FIXED: Fix distance value in a 0-length road [#3185](https://github.com/valhalla/valhalla/pull/3185)
    * FIXED: Trivial routes were broken when origin was node snapped and destnation was not and vice-versa for reverse astar [#3299](https://github.com/valhalla/valhalla/pull/3299)
    * FIXED: Tweaked TestAvoids map to get TestAvoidShortcutsTruck working [#3301](https://github.com/valhalla/valhalla/pull/3301)
+   * FIXED: Overflow in sequence sort [#3303](https://github.com/valhalla/valhalla/pull/3303)
 
 * **Enhancement**
    * CHANGED: Favor turn channels more [#3222](https://github.com/valhalla/valhalla/pull/3222)

--- a/valhalla/midgard/sequence.h
+++ b/valhalla/midgard/sequence.h
@@ -355,7 +355,8 @@ public:
       auto cmp = [&predicate](const std::pair<T, size_t>& a, std::pair<T, size_t>& b) {
         return predicate(b.first, a.first);
       };
-      std::priority_queue<std::pair<T, size_t>, std::vector<std::pair<T, size_t>>, decltype(cmp)> pq(cmp);
+      std::priority_queue<std::pair<T, size_t>, std::vector<std::pair<T, size_t>>, decltype(cmp)> pq(
+          cmp);
 
       // Sort the subsections
       for (size_t i = 0; i < memmap.size(); i += buffer_size) {

--- a/valhalla/midgard/sequence.h
+++ b/valhalla/midgard/sequence.h
@@ -352,10 +352,10 @@ public:
 
       // Comparator needs to be inverted for pq to provide constant time *smallest* lookup
       // Pq keeps track of element and its index.
-      auto cmp = [&predicate](const std::pair<T, int>& a, std::pair<T, int>& b) {
+      auto cmp = [&predicate](const std::pair<T, size_t>& a, std::pair<T, size_t>& b) {
         return predicate(b.first, a.first);
       };
-      std::priority_queue<std::pair<T, int>, std::vector<std::pair<T, int>>, decltype(cmp)> pq(cmp);
+      std::priority_queue<std::pair<T, size_t>, std::vector<std::pair<T, size_t>>, decltype(cmp)> pq(cmp);
 
       // Sort the subsections
       for (size_t i = 0; i < memmap.size(); i += buffer_size) {

--- a/valhalla/mjolnir/osmnode.h
+++ b/valhalla/mjolnir/osmnode.h
@@ -90,12 +90,13 @@ struct OSMNode {
    * @param  lat  Latitude of the node.
    *
    */
-  void set_latlng(const double lng, double lat) {
-    lng7_ = lat7_ = std::numeric_limits<uint32_t>::max();
-    if (lng >= -180 && lng <= 180)
-      lng7_ = std::round((lng + 180) * 1e7);
-    if (lat >= -90 && lat <= 90)
-      lat7_ = std::round((lat + 90) * 1e7);
+  void set_latlng(const double lng, const double lat) {
+    lng7_ = std::round((lng + 180) * 1e7);
+    lat7_ = std::round((lat + 90) * 1e7);
+    if (std::abs(lng7_) > 360 * 1e7)
+      lng7_ = std::numeric_limits<uint32_t>::max();
+    if (std::abs(lat7_) > 180 * 1e7)
+      lat7_ = std::numeric_limits<uint32_t>::max();
   }
 
   /**

--- a/valhalla/mjolnir/osmnode.h
+++ b/valhalla/mjolnir/osmnode.h
@@ -90,13 +90,12 @@ struct OSMNode {
    * @param  lat  Latitude of the node.
    *
    */
-  void set_latlng(const double lng, const double lat) {
-    lng7_ = std::round((lng + 180) * 1e7);
-    lat7_ = std::round((lat + 90) * 1e7);
-    if (lng7_ > 360 * 1e7)
-      lng7_ = std::numeric_limits<uint32_t>::max();
-    if (lat7_ > 180 * 1e7)
-      lat7_ = std::numeric_limits<uint32_t>::max();
+  void set_latlng(double lng, double lat) {
+    lng = std::round((lng + 180) * 1e7);
+    lng7_ = (lng >= 0 && lng <= 360 * 1e7) ? lng : std::numeric_limits<uint32_t>::max();
+
+    lat = std::round((lat + 90) * 1e7);
+    lat7_ = (lat >= 0 && lat <= 180 * 1e7) ? lat : std::numeric_limits<uint32_t>::max();
   }
 
   /**

--- a/valhalla/mjolnir/osmnode.h
+++ b/valhalla/mjolnir/osmnode.h
@@ -93,9 +93,9 @@ struct OSMNode {
   void set_latlng(const double lng, const double lat) {
     lng7_ = std::round((lng + 180) * 1e7);
     lat7_ = std::round((lat + 90) * 1e7);
-    if (std::abs(lng7_) > 360 * 1e7)
+    if (lng7_ > 360 * 1e7)
       lng7_ = std::numeric_limits<uint32_t>::max();
-    if (std::abs(lat7_) > 180 * 1e7)
+    if (lat7_ > 180 * 1e7)
       lat7_ = std::numeric_limits<uint32_t>::max();
   }
 


### PR DESCRIPTION
Priority_queue holds indexes to the elements. And after node insert to the output sequence index is incremented and put back to the priority_queue. When we have more than INT_MAX elements it overflows and drops part of points.

Discussed in https://github.com/valhalla/valhalla/issues/3286