### PR TITLE
Run elevation builder after restrictions builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
    * FIXED: Fix distance value in a 0-length road [#3185](https://github.com/valhalla/valhalla/pull/3185)
    * FIXED: Trivial routes were broken when origin was node snapped and destnation was not and vice-versa for reverse astar [#3299](https://github.com/valhalla/valhalla/pull/3299)
    * FIXED: Tweaked TestAvoids map to get TestAvoidShortcutsTruck working [#3301](https://github.com/valhalla/valhalla/pull/3301)
+   * FIXED: Run elevation builder after restriction builder, as expected [#3304](https://github.com/valhalla/valhalla/pull/3304)
 
 * **Enhancement**
    * CHANGED: Favor turn channels more [#3222](https://github.com/valhalla/valhalla/pull/3222)

--- a/src/mjolnir/util.cc
+++ b/src/mjolnir/util.cc
@@ -363,17 +363,17 @@ bool build_tile_set(const boost::property_tree::ptree& original_config,
     LOG_INFO("Skipping hierarchy builder and shortcut builder");
   }
 
-  // Add elevation to the tiles
-  if (start_stage <= BuildStage::kElevation && BuildStage::kElevation <= end_stage) {
-    ElevationBuilder::Build(config);
-  }
-
   // Build the Complex Restrictions
   // ComplexRestrictions must be done after elevation. The reason is that building
   // elevation into the tiles reads each tile and serializes the data to "builders"
   // within the tile. However, there is no serialization currently available for complex restrictions.
   if (start_stage <= BuildStage::kRestrictions && BuildStage::kRestrictions <= end_stage) {
     RestrictionBuilder::Build(config, cr_from_bin, cr_to_bin);
+  }
+
+  // Add elevation to the tiles
+  if (start_stage <= BuildStage::kElevation && BuildStage::kElevation <= end_stage) {
+    ElevationBuilder::Build(config);
   }
 
   // Validate the graph and add information that cannot be added until full graph is formed.


### PR DESCRIPTION
Just wanted to re-run a graph build from restrictions builder which then started by building elevation. This fixes it by building elevation after restrictions.