### PR TITLE
fix graphreader instantiations while setting up the workers

### DIFF
--- a/src/loki/worker.cc
+++ b/src/loki/worker.cc
@@ -149,9 +149,11 @@ void loki_worker_t::parse_costing(Api& api, bool allow_none) {
 
 loki_worker_t::loki_worker_t(const boost::property_tree::ptree& config,
                              const std::shared_ptr<baldr::GraphReader>& graph_reader)
-    : service_worker_t(config), config(config), reader(graph_reader),
+    : service_worker_t(config), config(config),
+      reader(graph_reader ? graph_reader
+                          : std::make_shared<baldr::GraphReader>(config.get_child("mjolnir"))),
       connectivity_map(config.get<bool>("loki.use_connectivity", true)
-                           ? new connectivity_map_t(config.get_child("mjolnir"), graph_reader)
+                           ? new connectivity_map_t(config.get_child("mjolnir"), reader)
                            : nullptr),
       max_contours(config.get<size_t>("service_limits.isochrone.max_contours")),
       max_contour_min(config.get<size_t>("service_limits.isochrone.max_time_contour")),
@@ -160,9 +162,6 @@ loki_worker_t::loki_worker_t(const boost::property_tree::ptree& config,
       sample(config.get<std::string>("additional_data.elevation", "")),
       max_elevation_shape(config.get<size_t>("service_limits.skadi.max_shape")),
       min_resample(config.get<float>("service_limits.skadi.min_resample")) {
-  // If we weren't provided with a graph reader make our own
-  if (!reader)
-    reader.reset(new baldr::GraphReader(config.get_child("mjolnir")));
 
   // Keep a string noting which actions we support, throw if one isnt supported
   Options::Action action;

--- a/src/thor/worker.cc
+++ b/src/thor/worker.cc
@@ -70,10 +70,9 @@ thor_worker_t::thor_worker_t(const boost::property_tree::ptree& config,
       bidir_astar(config.get_child("thor")), bss_astar(config.get_child("thor")),
       multi_modal_astar(config.get_child("thor")), timedep_forward(config.get_child("thor")),
       timedep_reverse(config.get_child("thor")), isochrone_gen(config.get_child("thor")),
-      matcher_factory(config, graph_reader), reader(graph_reader), controller{} {
-  // If we weren't provided with a graph reader make our own
-  if (!reader)
-    reader = matcher_factory.graphreader();
+      reader(graph_reader ? graph_reader
+                          : std::make_shared<baldr::GraphReader>(config.get_child("mjolnir"))),
+      matcher_factory(config, reader), controller{} {
 
   // Select the matrix algorithm based on the conf file (defaults to
   // select_optimal if not present)

--- a/valhalla/thor/worker.h
+++ b/valhalla/thor/worker.h
@@ -127,8 +127,8 @@ protected:
   float max_timedep_distance;
   std::unordered_map<std::string, float> max_matrix_distance;
   SOURCE_TO_TARGET_ALGORITHM source_to_target_algorithm;
-  meili::MapMatcherFactory matcher_factory;
   std::shared_ptr<baldr::GraphReader> reader;
+  meili::MapMatcherFactory matcher_factory;
   AttributesController controller;
   Centroid centroid_gen;
 


### PR DESCRIPTION
As discussed with @kevinkreiser, we found that the workers are setting up quite a few graphreader instances where they shouldn't have to, see https://github.com/valhalla/valhalla/pull/3281#issuecomment-913354775.

I think this PR should fix that. does it need testing?