### PR TITLE
Speed up nearest-neighbor searches when large search cutoff is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
    * ADDED: Added traffic signal and stop sign check for stop impact. These traffic signals and stop sign are located on edges. [#3279](https://github.com/valhalla/valhalla/pull/3279)
    * CHANGED: Improved sharing criterion to obtain more reasonable alternatives; extended alternatives search [#3302](https://github.com/valhalla/valhalla/pull/3302)
    * ADDED: pull ubuntu:20.04 base image before building [#3233](https://github.com/valhalla/valhalla/pull/3223)
+   * CHANGED: Improve Loki nearest-neighbour performance for large radius searches in open space [#3233](https://github.com/valhalla/valhalla/pull/3324)
 
 ## Release Date: 2021-07-20 Valhalla 3.1.3
 * **Removed**

--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -213,11 +213,11 @@ struct projector_wrapper {
       // we have something AND cant find more in the search radius AND
       // cant find anything better in general than what we have
       int32_t tile_index;
-      double distance;
-      std::tie(tile_index, bin_index, distance) = binner();
-      if (distance > location.search_cutoff_ ||
-          (reachable.size() && distance > location.radius_ &&
-           distance > std::sqrt(reachable.back().sq_distance))) {
+      double distance_squared;
+      std::tie(tile_index, bin_index, distance_squared) = binner();
+      if (distance_squared > location.search_cutoff_ * location.search_cutoff_ ||
+          (reachable.size() && distance_squared > location.radius_ * location.radius_ &&
+           distance_squared > reachable.back().sq_distance)) {
         cur_tile = nullptr;
         break;
       }

--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -213,11 +213,11 @@ struct projector_wrapper {
       // we have something AND cant find more in the search radius AND
       // cant find anything better in general than what we have
       int32_t tile_index;
-      double distance_squared;
-      std::tie(tile_index, bin_index, distance_squared) = binner();
-      if (distance_squared > location.search_cutoff_ * location.search_cutoff_ ||
-          (reachable.size() && distance_squared > location.radius_ * location.radius_ &&
-           distance_squared > reachable.back().sq_distance)) {
+      double distance;
+      std::tie(tile_index, bin_index, distance) = binner();
+      if (distance > location.search_cutoff_ ||
+          (reachable.size() && distance > location.radius_ &&
+           distance > std::sqrt(reachable.back().sq_distance))) {
         cur_tile = nullptr;
         break;
       }

--- a/src/midgard/CMakeLists.txt
+++ b/src/midgard/CMakeLists.txt
@@ -28,4 +28,5 @@ valhalla_module(NAME midgard
       ${VALHALLA_SOURCE_DIR}/valhalla
       $<$<BOOL:${WIN32}>:${VALHALLA_SOURCE_DIR}/third_party/dirent/include>
   DEPENDS
-    Boost::boost)
+    Boost::boost
+    robin_hood::robin_hood)

--- a/src/midgard/tiles.cc
+++ b/src/midgard/tiles.cc
@@ -55,7 +55,8 @@ template <class coord_t> struct closest_first_generator_t {
   robin_hood::unordered_set<int32_t> queued;
   int32_t subcols, subrows;
   using best_t = std::pair<double, int32_t>;
-  std::priority_queue<best_t, std::vector<best_t>, std::function<bool(const best_t&, const best_t&)>> queue;
+  std::priority_queue<best_t, std::vector<best_t>, std::function<bool(const best_t&, const best_t&)>>
+      queue;
 
   // re-usable, pre-allocated vector used by dist
   std::vector<coord_t> corners;

--- a/src/midgard/tiles.cc
+++ b/src/midgard/tiles.cc
@@ -1,7 +1,6 @@
 #include <array>
 #include <cmath>
 #include <queue>
-#include <set>
 #include <unordered_set>
 #include <vector>
 
@@ -56,7 +55,7 @@ template <class coord_t> struct closest_first_generator_t {
   robin_hood::unordered_set<int32_t> queued;
   int32_t subcols, subrows;
   using best_t = std::pair<double, int32_t>;
-  std::set<best_t, std::function<bool(const best_t&, const best_t&)>> queue;
+  std::priority_queue<best_t, std::vector<best_t>, std::function<bool(const best_t&, const best_t&)>> queue;
 
   // re-usable, pre-allocated vector used by dist
   std::vector<coord_t> corners;
@@ -145,8 +144,8 @@ template <class coord_t> struct closest_first_generator_t {
     if (!queue.size()) {
       throw std::runtime_error("Subdivisions were exhausted");
     }
-    auto best = *queue.cbegin();
-    queue.erase(queue.cbegin());
+    auto best = queue.top();
+    queue.pop();
     // add its neighbors
     neighbors(best.second);
     // return it

--- a/src/midgard/tiles.cc
+++ b/src/midgard/tiles.cc
@@ -62,7 +62,7 @@ template <class coord_t> struct closest_first_generator_t {
 
   closest_first_generator_t(const valhalla::midgard::Tiles<coord_t>& tiles, const coord_t& seed)
       : tiles(tiles), seed(seed), queued(100), queue([](const best_t& a, const best_t& b) {
-          return a.first == b.first ? a.second < b.second : a.first < b.first;
+          return a.first == b.first ? b.second < a.second : b.first < a.first;
         }) {
     // what global subdivision are we starting in
     // TODO: worry about wrapping around valid range

--- a/src/midgard/tiles.cc
+++ b/src/midgard/tiles.cc
@@ -57,9 +57,6 @@ template <class coord_t> struct closest_first_generator_t {
   using best_t = std::pair<double, int32_t>;
   std::priority_queue<best_t, std::vector<best_t>, std::function<bool(const best_t&, const best_t&)>> queue;
 
-  // re-usable, pre-allocated vector used by dist
-  std::vector<coord_t> corners;
-
   closest_first_generator_t(const valhalla::midgard::Tiles<coord_t>& tiles, const coord_t& seed)
       : tiles(tiles), seed(seed), queued(100), queue([](const best_t& a, const best_t& b) {
           return a.first == b.first ? b.second < a.second : b.first < a.first;
@@ -78,35 +75,13 @@ template <class coord_t> struct closest_first_generator_t {
     corners.reserve(max_tested_corners);
   }
 
-  // something to measure the closest possible point of a subdivision from the given seed point
+  // Measure the distance to the midpoint of each subdivision for distance sorting purposes
   double dist(int32_t sub) {
     auto x = sub % subcols;
-    auto x0 = tiles.TileBounds().minx() + x * tiles.SubdivisionSize();
-    auto x1 = tiles.TileBounds().minx() + (x + 1) * tiles.SubdivisionSize();
+    auto mid_x = tiles.TileBounds().minx() + (x + 0.5) * tiles.SubdivisionSize();
     auto y = sub / subcols;
-    auto y0 = tiles.TileBounds().miny() + y * tiles.SubdivisionSize();
-    auto y1 = tiles.TileBounds().miny() + (y + 1) * tiles.SubdivisionSize();
-    auto distance = std::numeric_limits<double>::max();
-    corners.clear();
-    corners.emplace_back(x0, y0);
-    corners.emplace_back(x1, y0);
-    corners.emplace_back(x0, y1);
-    corners.emplace_back(x1, y1);
-    if (x0 < seed.first && x1 > seed.first) {
-      corners.emplace_back(seed.first, y0);
-      corners.emplace_back(seed.first, y1);
-    }
-    if (y0 < seed.second && y1 > seed.second) {
-      corners.emplace_back(x0, seed.second);
-      corners.emplace_back(x1, seed.second);
-    }
-    for (const auto& c : corners) {
-      auto d = seed.DistanceSquared(c);
-      if (d < distance) {
-        distance = d;
-      }
-    }
-    return distance;
+    auto mid_y = tiles.TileBounds().miny() + (y + 0.5) * tiles.SubdivisionSize();
+    return seed.DistanceSquared({mid_x, mid_y});
   }
 
   // something to add the neighbors of a given subdivision

--- a/src/midgard/tiles.cc
+++ b/src/midgard/tiles.cc
@@ -102,7 +102,7 @@ template <class coord_t> struct closest_first_generator_t {
       corners.emplace_back(x1, seed.second);
     }
     for (const auto& c : corners) {
-      auto d = seed.DistanceSquared(c);
+      auto d = seed.Distance(c);
       if (d < distance) {
         distance = d;
       }


### PR DESCRIPTION
# Issue

If "someone" (could be anyone, definitely not me) happened to want to use a very large search cutoff with Loki, and placed a coordinate a long way from any actual edge, it can take Loki quite a while to snap to the nearest edge.

Doing some basic work with a profiler, it looks like there were a lot of small allocations/deallocations, and some unnecessary floating point math.

Performance improvements will be negligible for most requests.  However, the problem can be highlighted by making a request with `search_cutoff: 21000000` (approx half the planet), and using Point Nemo (-123.45,-48.89, furthest point from land) against OSM data:

## Before
```
$ time curl -d '{"locations":[{"lon":-123.45,"lat":-48.89,"radius":0,"search_cutoff":21000000},{"lon":-123.45,"lat":-48.89,"radius":0,"search_cutoff":21000000}],"costing":"auto"}' http://localhost:8002/route
real	0m4.073s
user	0m0.003s
sys	0m0.007s
```

## After
```
$ time curl -s -d '{"locations":[{"lon":-123.45,"lat":-48.89,"radius":0,"search_cutoff":21000000},{"lon":-123.45,"lat":-48.89,"radius":0,"search_cutoff":21000000}],"costing":"auto"}' http://localhost:8002/route
real	0m1.238s
user	0m0.004s
sys	0m0.006s
```

## Tasklist

 - [x] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
