### PR TITLE
Potentially unsafe CSV serialization in report generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
    * FIXED: Setting statsd tags in config via valhalla_build_config [#3225](https://github.com/valhalla/valhalla/pull/3225)
    * FIXED: Cache for gzipped elevation tiles [#3120](https://github.com/valhalla/valhalla/pull/3120)
    * FIXED: Current time conversion regression introduced in unidirectional algorithm refractor [#3278](https://github.com/valhalla/valhalla/issues/3278)
+   * FIXED: Make combine_route_stats.py properly quote CSV output (best practice improvement) [#3328](https://github.com/valhalla/valhalla/pull/3328)
 
 * **Enhancement**
    * CHANGED: Favor turn channels more [#3222](https://github.com/valhalla/valhalla/pull/3222)

--- a/run_route_scripts/results/combine_route_stats.py
+++ b/run_route_scripts/results/combine_route_stats.py
@@ -39,7 +39,7 @@ def main(old_stats_file, new_stats_file, output_file):
             stats_diff_fieldnames.append('{}_diff'.format(col))
             stats_diff_fieldnames.append('{}_%diff'.format(col))
 
-        csv_writer = csv.writer(output_csv)
+        csv_writer = csv.writer(output_csv,quoting=csv.QUOTE_ALL)
         csv_writer.writerow(stats_diff_fieldnames)
 
         route_num = 1


### PR DESCRIPTION
# Issue

A security reviewer was scanning for "unsafe practices" and spotted this usage in the `combine_route_stats.py` script.

Honestly, chances of this ever being exploited for anything are effectively zero, but I'm going to keep getting nagged unless it's no longer present, so here's the trivial PR to always quote CSV output.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
