### PR TITLE
fix setting the wrong edge candidates in shape walking map matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
    * FIXED: Current time conversion regression introduced in unidirectional algorithm refractor [#3278](https://github.com/valhalla/valhalla/issues/3278)
    * FIXED: Make combine_route_stats.py properly quote CSV output (best practice improvement) [#3328](https://github.com/valhalla/valhalla/pull/3328)
    * FIXED: Merge edge segment records in map matching properly so that resulting edge indices in trace_attributes are valid [#3280](https://github.com/valhalla/valhalla/pull/3280)
+   * FIXED: Shape walking map matcher now sets correct edge candidates used in the match for origin and destination location [#3329](https://github.com/valhalla/valhalla/pull/3329)
 
 * **Enhancement**
    * CHANGED: Favor turn channels more [#3222](https://github.com/valhalla/valhalla/pull/3222)

--- a/src/thor/route_matcher.cc
+++ b/src/thor/route_matcher.cc
@@ -60,10 +60,9 @@ float length_comparison(const float length, const bool exact_match) {
 //
 // Get a map of end edges and the start node
 // of each edge. This is used to terminate the edge walking method.
-end_node_t GetEndEdges(GraphReader& reader,
-                       const google::protobuf::RepeatedPtrField<valhalla::Location>& correlated) {
+end_node_t GetEndEdges(GraphReader& reader, const valhalla::Location& destination) {
   end_node_t end_nodes;
-  for (const auto& edge : correlated.rbegin()->path_edges()) {
+  for (const auto& edge : destination.path_edges()) {
     // If destination is at a node - skip any outbound edge
     GraphId graphid(edge.graph_id());
     if (edge.begin_node() || !graphid.Is_Valid()) {
@@ -328,7 +327,8 @@ bool RouteMatcher::FormPath(const sif::mode_costing_t& mode_costing,
   // Process and validate end edges (can be more than 1). Create a map of
   // the end edges' start nodes and the edge information.
   // TODO: when we want to do more than one leg we need to create correlated path_edges on the fly
-  auto end_nodes = GetEndEdges(reader, options.locations());
+  const auto& destination = *options.locations().rbegin();
+  auto end_nodes = GetEndEdges(reader, destination);
 
   // We support either the epoch timestamp that came with the trace point or
   // a local date time which we convert to epoch by finding the first timezone
@@ -427,20 +427,40 @@ bool RouteMatcher::FormPath(const sif::mode_costing_t& mode_costing,
         if (expand_from_node(mode_costing, mode, reader, options.shape(), distances, time_info,
                              options.use_timestamps(), index, end_node_tile, de->endnode(), end_nodes,
                              prev_edge_label, elapsed, path_infos, false, end_node, followed_edges)) {
-          // If node equals stop node then when are done expanding - get the matching end edge
+          // Find the edge we stopped on at the destination, if we didnt find it the greedy algorithm
+          // hit a local maximum (made the wrong choice), TODO: we could rollback and try more
           auto n = end_nodes.find(end_node);
           if (n == end_nodes.end()) {
             return false;
           }
 
+          // When the route ends at a node in the graph we have an ambiguous case. Multiple
+          // destination edge candidates could have ended at this node but we use an unordered_map
+          // instead of a multimap, which means when we go to insert the other candidates that end
+          // there, they dont get inserted, only the first one does. This is all we really need for
+          // finding the path but it means that once we do find the path to that node, the edge that
+          // was in the value portion of the map entry might be the wrong edge. So here we need to
+          // go find the edge candidate that was actually used in the path
+          auto found_edge = destination.path_edges().end();
+          if (n->second.first.end_node()) {
+            found_edge =
+                std::find_if(destination.path_edges().begin(), destination.path_edges().end(),
+                             [&path_infos](const auto& e) -> bool {
+                               return e.graph_id() == path_infos.back().edgeid;
+                             });
+            if (found_edge == destination.path_edges().end()) {
+              throw std::logic_error("Could not find destination candidate in shape-walked path");
+            }
+          }
+
           // TODO: when we actually have more than one leg, we have to do when we break legs
           // Store the matching edge candidates in the shapes locations
-          const auto& end_edge = n->second.first;
-          options.mutable_shape(0)->mutable_path_edges()->Add()->CopyFrom(end_edge);
+          const auto& end_edge =
+              found_edge == destination.path_edges().end() ? n->second.first : *found_edge;
+          options.mutable_shape(0)->mutable_path_edges()->Add()->CopyFrom(edge);
           options.mutable_shape()->rbegin()->mutable_path_edges()->Add()->CopyFrom(end_edge);
 
-          // If the end edge is at a node then we are done (no partial time
-          // along a destination edge)
+          // If the end edge is at a node then we are done (no partial time along a destination edge)
           if (end_edge.end_node()) {
             return true;
           }

--- a/src/thor/triplegbuilder.cc
+++ b/src/thor/triplegbuilder.cc
@@ -416,7 +416,7 @@ void RemovePathEdges(valhalla::Location* location, const GraphId& edge_id) {
                             return e.graph_id() == edge_id;
                           });
   if (pos == location->path_edges().end()) {
-    location->mutable_path_edges()->Clear();
+    location->mutable_path_edges()->Clear(); // should never happen
   } else if (location->path_edges_size() > 1) {
     location->mutable_path_edges()->SwapElements(0, pos - location->path_edges().begin());
     location->mutable_path_edges()->DeleteSubrange(1, location->path_edges_size() - 1);

--- a/test/mapmatch.cc
+++ b/test/mapmatch.cc
@@ -218,9 +218,13 @@ TEST(Mapmatch, test_matcher) {
     std::string walked_json;
 
     try {
+      Api api;
       walked_json = actor.trace_attributes(
           R"({"date_time":{"type":1,"value":"2019-10-31T18:30"},"costing":"auto","shape_match":"edge_walk","encoded_polyline":")" +
-          json_escape(encoded_shape) + "\"}");
+              json_escape(encoded_shape) + "\"}",
+          nullptr, &api);
+      EXPECT_NE(api.trip().routes(0).legs(0).location(0).path_edges_size(), 0);
+      EXPECT_NE(api.trip().routes(0).legs(0).location().rbegin()->path_edges_size(), 0);
       walked = test::json_to_pt(walked_json);
     } catch (...) {
       std::cout << test_case << std::endl;
@@ -946,7 +950,10 @@ TEST(Mapmatch, test_now_matches) {
   test_case =
       R"({"date_time":{"type":0},"shape_match":"edge_walk","costing":"auto","encoded_polyline":")" +
       json_escape(encoded_shape) + "\"}";
-  actor.trace_route(test_case);
+  Api api;
+  actor.trace_route(test_case, nullptr, &api);
+  EXPECT_NE(api.trip().routes(0).legs(0).location(0).path_edges_size(), 0);
+  EXPECT_NE(api.trip().routes(0).legs(0).location().rbegin()->path_edges_size(), 0);
 }
 
 TEST(Mapmatch, test_leg_duration_trimming) {


### PR DESCRIPTION
There were two bugs in the shape walking map matching algorithm both to do with setting the correct edge candidate that was used at both the origin and destination locations. This causes triplegbuilder to remove all the locations candidates which has negative side effects downstream mainly for serialization. We caught this bug as part of the work in #3274 where we strictly require that you do not send through locations with edge candidates not properly set (ie matching the routes path_infos)