### PR TITLE
Fix PR number in release notes entry about renaming LogLevel enumerators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 
 * **Enhancement**
    * CHANGED: Favor turn channels more [#3222](https://github.com/valhalla/valhalla/pull/3222)
-   * CHANGED: Rename `valhalla::midgard::logging::LogLevel` enumerators to avoid clash with common macros [#3236](https://github.com/valhalla/valhalla/pull/3236)
+   * CHANGED: Rename `valhalla::midgard::logging::LogLevel` enumerators to avoid clash with common macros [#3237](https://github.com/valhalla/valhalla/pull/3237)
    * CHANGED: Move pre-defined algorithm-based factors inside `RelaxHierarchyLimits` [#3253](https://github.com/valhalla/valhalla/pull/3253)
    * ADDED: Reject alternatives with too long detours [#3238](https://github.com/valhalla/valhalla/pull/3238)
    * ADDED: Added info to /status endpoint [#3008](https://github.com/valhalla/valhalla/pull/3008)


### PR DESCRIPTION
# Issue

I have already edited, via "Edit release" button, the notes displayed at
https://github.com/valhalla/valhalla/releases/tag/3.1.4

## Tasklist

 - ~[ ] Add tests~
 - ~[ ] Add #fixes with the issue number that this PR addresses~
 - ~[ ] Update the docs with any new request parameters or changes to behavior described~
 - [x] Update the [changelog](CHANGELOG.md)
 - ~[ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.~

## Requirements / Relations

- https://github.com/valhalla/valhalla/pull/3237