### PR TITLE
Ensure target directory exists before creating log file

### DIFF
--- a/src/midgard/logging.cc
+++ b/src/midgard/logging.cc
@@ -249,7 +249,7 @@ protected:
         }
         file.open(file_name, std::ofstream::out | std::ofstream::app);
         if (file.fail()) {
-            throw std::runtime_error("Cannot create log file: " + file_name);
+          throw std::runtime_error("Cannot create log file: " + file_name);
         }
         last_reopen = std::chrono::system_clock::now();
       } catch (std::exception& e) {


### PR DESCRIPTION
# Issue

Otherwise, log file creation is silently skipped.
e.g. if "mjolnir.logging.file_name" points to location inside "mjolnir.tile_dir"

Throw error if we failed to create the log file.

## Tasklist

 - ~[ ] Add tests~
 - ~[ ] Add #fixes with the issue number that this PR addresses~
 - ~[ ] Update the docs with any new request parameters or changes to behavior described~
 - [ ] Update the [changelog](CHANGELOG.md)
 - ~[ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.~

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
