### PR TITLE
WIP: Output data quality issues to log instead of duplicateways.txt

### DIFF
--- a/src/mjolnir/dataquality.cc
+++ b/src/mjolnir/dataquality.cc
@@ -81,14 +81,13 @@ void DataQuality::LogIssues() const {
   }
 
   // Sort by edgecount and write to separate file
-  std::ofstream dupfile;
-  std::sort(dups.begin(), dups.end());
-  dupfile.open("duplicateways.txt", std::ofstream::out | std::ofstream::app);
-  dupfile << "WayID1   WayID2    DuplicateEdges" << std::endl;
-  for (const auto& dupway : dups) {
-    dupfile << dupway.wayid1 << "," << dupway.wayid2 << "," << dupway.edgecount << std::endl;
+  if (duplicateways_.size() > 0) {
+    LOG_WARN("WayID1   WayID2    DuplicateEdges");
+    for (const auto& dupway : dups) {
+      LOG_WARN(std::to_string(dupway.wayid1) + "," + std::to_string(dupway.wayid2) + "," +
+               std::to_string(dupway.edgecount));
+    }
   }
-  dupfile.close();
 
   // Log the unconnected link edges
   if (unconnectedlinks_.size() > 0) {


### PR DESCRIPTION
# Issue

The duplicateways.txt is created in 'random' location which can not
be controlled by a user.

Alternatively, if there was a way to access "mjolnir.logging.file_name"
we could create the duplicateways.txt inside the same older as the log file.

## Tasklist

 - ~[ ] Add tests~
 - ~[ ] Add #fixes with the issue number that this PR addresses~
 - ~[ ] Update the docs with any new request parameters or changes to behavior described~
 - [ ] Update the [changelog](CHANGELOG.md)
 - ~[ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.~

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
