### PR TITLE
Install python3-distutils for valhalla_build_config in Docker

### DIFF
--- a/docker/Dockerfile-run
+++ b/docker/Dockerfile-run
@@ -45,7 +45,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt update && \
     apt install -y \
       libboost-program-options1.71.0 libcurl4 libczmq4 libluajit-5.1-2 \
       libprotobuf-lite17 libsqlite3-0 libsqlite3-mod-spatialite libzmq5 zlib1g \
-      curl gdb locales parallel python3.8-minimal python-is-python3 \
+      curl gdb locales parallel python3.8-minimal python3-distutils python-is-python3 \
       spatialite-bin unzip wget && \
     cat /usr/local/src/valhalla_locales | xargs -d '\n' -n1 locale-gen && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
# Issue

valhalla_build_config throws an error: 
```
Traceback (most recent call last):
File "/usr/local/bin/valhalla_build_config", line 3, in <module>
    from distutils.util import strtobool
ModuleNotFoundError: No module named 'distutils.util'
```
ubuntu:20.04 image doesn't have this package installed by default, so it has to be installed manually.
