### PR TITLE
Do not create statsd client in workers if it is not configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
    * CHANGED: de-singleton tile_extract by introducing an optional index.bin file created by valhalla_build_extract [#3281](https://github.com/valhalla/valhalla/pull/3281)
    * CHANGED: implement valhalla_build_elevation in python and add more --from-geojson & --from-graph options [#3318](https://github.com/valhalla/valhalla/pull/3318)
    * ADDED: Add boolean parameter to clear memory for edge labels from thor. [#2789](https://github.com/valhalla/valhalla/pull/2789)
+   * CHANGED: Do not create statsd client in workers if it is not configured [#3394](https://github.com/valhalla/valhalla/pull/3394)
 
 ## Release Date: 2021-10-07 Valhalla 3.1.4
 * **Removed**


### PR DESCRIPTION
# Issue

Right now the statsd client is created all the time.
If there is no configuration, the defaults are used.
However, under some conditions we noticed unwanted side effects.

For example, the use of `getaddrinfo` during initialization may cause DNS requests under the hood.
In the case of the bogus network at the start, it may cause uncontrollable hangs.

The idea here is not to pay for what is not used.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

