### PR TITLE
Add support for LZ4 compressed elevation tiles.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,3 +37,6 @@
 [submodule "third_party/cpp-statsd-client"]
 	path = third_party/cpp-statsd-client
 	url = https://github.com/vthiery/cpp-statsd-client
+[submodule "third_party/lz4"]
+	path = third_party/lz4
+	url = https://github.com/lz4/lz4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
    * CHANGED: Minor fix for headers  [#3436](https://github.com/valhalla/valhalla/pull/3436)
    * CHANGED: Use std::multimap for polygons returned for admin and timezone queries. Improves performance when building tiles. [#3427](https://github.com/valhalla/valhalla/pull/3427)
    * CHANGED: Refactored GraphBuilder::CreateSignInfoList [#3438](https://github.com/valhalla/valhalla/pull/3438)
+   * ADDED: Add support for LZ4 compressed elevation tiles [#3401](https://github.com/valhalla/valhalla/pull/3401)
 
 ## Release Date: 2021-10-07 Valhalla 3.1.4
 * **Removed**

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,7 +316,7 @@ if(ENABLE_DATA_TOOLS)
     install(TARGETS ${program} DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT runtime)
   endforeach()
 
-  # Target-specific depedencies
+  # Target-specific dependencies
   find_package(GEOS)
   target_link_libraries(valhalla_build_admins GEOS::GEOS)
   target_sources(valhalla_build_statistics

--- a/src/skadi/CMakeLists.txt
+++ b/src/skadi/CMakeLists.txt
@@ -4,6 +4,10 @@ valhalla_module(NAME skadi
   SOURCES
     sample.cc
     util.cc
+    ${VALHALLA_SOURCE_DIR}/third_party/lz4/lib/lz4.c
+    ${VALHALLA_SOURCE_DIR}/third_party/lz4/lib/lz4hc.c
+    ${VALHALLA_SOURCE_DIR}/third_party/lz4/lib/lz4frame.c
+    ${VALHALLA_SOURCE_DIR}/third_party/lz4/lib/xxhash.c
   HEADERS
     ${headers}
   INCLUDE_DIRECTORIES
@@ -11,6 +15,8 @@ valhalla_module(NAME skadi
       ${VALHALLA_SOURCE_DIR}
       ${VALHALLA_SOURCE_DIR}/valhalla
       $<$<BOOL:${WIN32}>:${VALHALLA_SOURCE_DIR}/third_party/dirent/include>
+    PRIVATE
+      ${VALHALLA_SOURCE_DIR}/third_party/lz4/lib
   DEPENDS
     valhalla::baldr
     Boost::boost

--- a/src/skadi/sample.cc
+++ b/src/skadi/sample.cc
@@ -14,8 +14,8 @@
 #include <unordered_set>
 
 #include <boost/optional.hpp>
-#include <sys/stat.h>
 #include <lz4frame.h>
+#include <sys/stat.h>
 
 #include "baldr/compression_utils.h"
 #include "filesystem.h"
@@ -62,7 +62,7 @@ int16_t flip(int16_t value) {
 
 uint64_t file_size(const std::string& file_name) {
   // TODO: detect gzip and actually validate the uncompressed size?
-  struct stat s{};
+  struct stat s {};
   int rc = stat(file_name.c_str(), &s);
   return rc == 0 ? s.st_size : -1;
 }
@@ -160,7 +160,7 @@ public:
           format = format_t::UNKNOWN;
           return false;
         }
-      } while (result != 0 );
+      } while (result != 0);
     } else {
       LOG_WARN("Corrupt elevation data of unknown type");
       format = format_t::UNKNOWN;
@@ -358,7 +358,7 @@ tile_data cache_t::source(uint16_t index) {
 
   // we have it raw or we don't
   if (item.get_format() == format_t::RAW) {
-      return {this, index, false, (const int16_t*)item.get_data()};
+    return {this, index, false, (const int16_t*)item.get_data()};
   }
 
   // we were able to load it but the format wasn't RAW, which only leaves compressed formats

--- a/src/skadi/sample.cc
+++ b/src/skadi/sample.cc
@@ -376,7 +376,7 @@ tile_data cache_t::source(uint16_t index) {
   }
 
   // item in cache is already unpacked
-  auto unpacked = item.get_unpacked();
+  const char* unpacked = item.get_unpacked();
   if (unpacked) {
     auto rv = tile_data(this, index, true, (const int16_t*)unpacked);
     mutex.unlock();

--- a/src/skadi/sample.cc
+++ b/src/skadi/sample.cc
@@ -153,15 +153,19 @@ public:
       size_t src_size = data.size();
       size_t dest_size = HGT_BYTES;
       size_t result;
+
       do {
         result = LZ4F_decompress(decode, const_cast<char*>(this->unpacked), &dest_size, data.get(),
                                  &src_size, &options);
         if (LZ4F_isError(result)) {
+          LZ4F_freeDecompressionContext(decode);
           LOG_WARN("Corrupt lz4 elevation data");
           format = format_t::UNKNOWN;
           return false;
         }
       } while (result != 0);
+
+      LZ4F_freeDecompressionContext(decode);
     } else {
       LOG_WARN("Corrupt elevation data of unknown type");
       format = format_t::UNKNOWN;

--- a/src/skadi/sample.cc
+++ b/src/skadi/sample.cc
@@ -15,6 +15,7 @@
 
 #include <boost/optional.hpp>
 #include <sys/stat.h>
+#include <lz4frame.h>
 
 #include "baldr/compression_utils.h"
 #include "filesystem.h"
@@ -61,7 +62,7 @@ int16_t flip(int16_t value) {
 
 uint64_t file_size(const std::string& file_name) {
   // TODO: detect gzip and actually validate the uncompressed size?
-  struct stat s;
+  struct stat s{};
   int rc = stat(file_name.c_str(), &s);
   return rc == 0 ? s.st_size : -1;
 }
@@ -71,14 +72,14 @@ uint64_t file_size(const std::string& file_name) {
 namespace valhalla {
 namespace skadi {
 
-enum class format_t { UNKNOWN = 0, RAW = 1, GZIP = 2 };
+enum class format_t { UNKNOWN = 0, RAW = 1, GZIP = 2, LZ4 = 3 };
 
 class cache_item_t {
 private:
   format_t format;
   valhalla::midgard::mem_map<char> data;
   int usages;
-  const char* unpacked;
+  char* unpacked;
 
 public:
   cache_item_t() : format(format_t::UNKNOWN), usages(0), unpacked(nullptr) {
@@ -94,7 +95,7 @@ public:
       return false;
     }
     this->format = format;
-    data.map(path, size, POSIX_MADV_SEQUENTIAL);
+    data.map(path, size, POSIX_MADV_SEQUENTIAL, true);
     return true;
   }
 
@@ -110,47 +111,83 @@ public:
     return usages;
   }
 
-  inline const char* get_unpacked() {
+  inline char* get_unpacked() {
     return unpacked;
   }
 
-  inline const char* detach_unpacked() {
+  inline char* detach_unpacked() {
     auto rv = unpacked;
     unpacked = nullptr;
     return rv;
   }
 
-  bool unpack(const char* unpacked) {
+  bool unpack(char* unpacked) {
     this->unpacked = unpacked;
-    // for setting where to read compressed data from
-    auto src_func = [this](z_stream& s) -> void {
-      s.next_in = static_cast<Byte*>(static_cast<void*>(data.get()));
-      s.avail_in = static_cast<unsigned int>(data.size());
-    };
 
-    // for setting where to write the uncompressed data to
-    auto dst_func = [this](z_stream& s) -> int {
-      s.next_out = (Byte*)(this->unpacked);
-      s.avail_out = HGT_BYTES;
-      return Z_FINISH; // we know the output will hold all the input
-    };
+    if (format == format_t::GZIP) {
+      // for setting where to read compressed data from
+      auto src_func = [this](z_stream& s) -> void {
+        s.next_in = static_cast<Byte*>(static_cast<void*>(data.get()));
+        s.avail_in = static_cast<unsigned int>(data.size());
+      };
 
-    // we have to unzip it
-    if (!baldr::inflate(src_func, dst_func)) {
-      LOG_WARN("Corrupt compressed elevation data");
+      // for setting where to write the uncompressed data to
+      auto dst_func = [this](z_stream& s) -> int {
+        s.next_out = (Byte*)(this->unpacked);
+        s.avail_out = HGT_BYTES;
+        return Z_FINISH; // we know the output will hold all the input
+      };
+
+      // we have to unzip it
+      if (!baldr::inflate(src_func, dst_func)) {
+        LOG_WARN("Corrupt gzip elevation data");
+        format = format_t::UNKNOWN;
+        return false;
+      }
+    } else if (format == format_t::LZ4) {
+      LZ4F_decompressionContext_t decode;
+      LZ4F_decompressOptions_t options;
+      LZ4F_createDecompressionContext(&decode, LZ4F_VERSION);
+
+      // Take these two values locally, since LZ4F_decompress expects pointers...
+      size_t src_size = data.size();
+      size_t dest_size = HGT_BYTES;
+      size_t result;
+      do {
+        result = LZ4F_decompress(decode, this->unpacked, &dest_size, data.get(), &src_size, &options);
+        if (LZ4F_isError(result)) {
+          LOG_WARN("Corrupt lz4 elevation data");
+          format = format_t::UNKNOWN;
+          return false;
+        }
+      } while (result != 0 );
+    } else {
+      LOG_WARN("Corrupt elevation data of unknown type");
       format = format_t::UNKNOWN;
       return false;
     }
+
     return true;
   }
 
   static boost::optional<std::pair<uint16_t, format_t>> parse_hgt_name(const std::string& name) {
     std::smatch m;
-    std::regex e(".*/([NS])([0-9]{2})([WE])([0-9]{3})\\.hgt(\\.gz)?$");
+    std::regex e(".*/([NS])([0-9]{2})([WE])([0-9]{3})\\.hgt(\\.(gz|lz4))?$");
     if (std::regex_search(name, m, e)) {
-      // enum class format_t{ UNKNOWN = 0, GZIP = 1, RAW = 3 };
-      format_t fmt =
-          m[5].length() ? (m[5] == ".gz" ? format_t::GZIP : format_t::UNKNOWN) : format_t::RAW;
+      // enum class format_t{ UNKNOWN = 0, GZIP = 1, RAW = 3, LZ4 = 4 };
+      format_t fmt;
+      if (m[5].matched) {
+        if (m[5] == ".gz") {
+          fmt = format_t::GZIP;
+        } else if (m[5] == ".lz4") {
+          fmt = format_t::LZ4;
+        } else {
+          fmt = format_t::UNKNOWN;
+        }
+      } else {
+        fmt = format_t::RAW;
+      }
+
       auto lon = std::stoi(m[4]) * (m[3] == "E" ? 1 : -1) + 180;
       auto lat = std::stoi(m[2]) * (m[1] == "N" ? 1 : -1) + 90;
       if (lon >= 0 && lon < 360 && lat >= 0 && lat < 180) {
@@ -190,7 +227,7 @@ public:
     return *this;
   }
 
-  inline operator bool() const {
+  inline explicit operator bool() const {
     return data != nullptr;
   }
 
@@ -302,29 +339,29 @@ tile_data& tile_data::operator=(const tile_data& other) {
 }
 
 tile_data cache_t::source(uint16_t index) {
-  // bail if its out of bounds
+  // bail if it's out of bounds
   if (index >= TILE_COUNT) {
-    return tile_data();
+    return {};
   }
 
-  // if we dont have anything maybe its lazy loaded
+  // if we don't have anything maybe it's lazy loaded
   auto& item = cache[index];
   if (item.get_data() == nullptr) {
     auto f = data_source + sample::get_hgt_file_name(index);
     item.init(f, format_t::RAW);
   }
 
-  // it wasnt in cache and when we tried to load it the file was of unknown type
+  // it wasn't in cache and when we tried to load it the file was of unknown type
   if (item.get_format() == format_t::UNKNOWN) {
-    return tile_data();
+    return {};
   }
 
-  // we have it raw or we dont
+  // we have it raw or we don't
   if (item.get_format() == format_t::RAW) {
-    return tile_data(this, index, false, (const int16_t*)item.get_data());
+      return {this, index, false, (const int16_t*)item.get_data()};
   }
 
-  // we were able to load it but the format wasnt RAW, which only leaves the GZIP format
+  // we were able to load it but the format wasn't RAW, which only leaves compressed formats
   mutex.lock();
   auto it = pending_tiles.find(index);
   if (it != pending_tiles.end()) {
@@ -334,7 +371,7 @@ tile_data cache_t::source(uint16_t index) {
   }
 
   // item in cache is already unpacked
-  const char* unpacked = item.get_unpacked();
+  auto unpacked = item.get_unpacked();
   if (unpacked) {
     auto rv = tile_data(this, index, true, (const int16_t*)unpacked);
     mutex.unlock();
@@ -353,6 +390,7 @@ tile_data cache_t::source(uint16_t index) {
       }
     }
   }
+
   if (!unpacked) {
     unpacked = (char*)malloc(HGT_BYTES);
   }
@@ -376,7 +414,7 @@ sample::sample(const std::string& data_source) {
   cache_->data_source = data_source;
 
   // messy but needed
-  while (cache_->data_source.size() &&
+  while (!cache_->data_source.empty() &&
          cache_->data_source.back() == filesystem::path::preferred_separator) {
     cache_->data_source.pop_back();
   }

--- a/src/skadi/sample.cc
+++ b/src/skadi/sample.cc
@@ -79,7 +79,7 @@ private:
   format_t format;
   valhalla::midgard::mem_map<char> data;
   int usages;
-  char* unpacked;
+  const char* unpacked;
 
 public:
   cache_item_t() : format(format_t::UNKNOWN), usages(0), unpacked(nullptr) {
@@ -111,17 +111,17 @@ public:
     return usages;
   }
 
-  inline char* get_unpacked() {
+  inline const char* get_unpacked() {
     return unpacked;
   }
 
-  inline char* detach_unpacked() {
+  inline const char* detach_unpacked() {
     auto rv = unpacked;
     unpacked = nullptr;
     return rv;
   }
 
-  bool unpack(char* unpacked) {
+  bool unpack(const char* unpacked) {
     this->unpacked = unpacked;
 
     if (format == format_t::GZIP) {
@@ -154,7 +154,8 @@ public:
       size_t dest_size = HGT_BYTES;
       size_t result;
       do {
-        result = LZ4F_decompress(decode, this->unpacked, &dest_size, data.get(), &src_size, &options);
+        result = LZ4F_decompress(decode, const_cast<char*>(this->unpacked), &dest_size, data.get(),
+                                 &src_size, &options);
         if (LZ4F_isError(result)) {
           LOG_WARN("Corrupt lz4 elevation data");
           format = format_t::UNKNOWN;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,10 +12,16 @@ endif()
 add_library(valhalla_test
   ${TEST_SRCS}
   ${VALHALLA_SOURCE_DIR}/third_party/microtar/src/microtar.h
-  ${VALHALLA_SOURCE_DIR}/third_party/microtar/src/microtar.c)
+  ${VALHALLA_SOURCE_DIR}/third_party/microtar/src/microtar.c
+  ${VALHALLA_SOURCE_DIR}/third_party/lz4/lib/lz4.c
+  ${VALHALLA_SOURCE_DIR}/third_party/lz4/lib/lz4hc.c
+  ${VALHALLA_SOURCE_DIR}/third_party/lz4/lib/lz4frame.c
+  ${VALHALLA_SOURCE_DIR}/third_party/lz4/lib/xxhash.c
+  )
 target_include_directories(valhalla_test PUBLIC
   ${VALHALLA_SOURCE_DIR}/test
   ${VALHALLA_SOURCE_DIR}/test/gurka
+  ${VALHALLA_SOURCE_DIR}/third_party/lz4/lib
   ${VALHALLA_SOURCE_DIR}/third_party/protozero/include
   ${VALHALLA_SOURCE_DIR}/third_party/libosmium/include
   ${VALHALLA_SOURCE_DIR}/third_party/microtar/src)
@@ -24,6 +30,7 @@ target_link_libraries(valhalla_test valhalla gtest gtest_main gmock pthread)
 if(ENABLE_DATA_TOOLS)
   target_link_libraries(valhalla_test GEOS::GEOS)
 endif()
+
 
 ## Lists tests
 set(tests aabb2 access_restriction actor admin attributes_controller datetime directededge

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -265,7 +265,7 @@ add_custom_command(OUTPUT test/data/sample/N00
   COMMAND ${CMAKE_COMMAND} -E make_directory test/data/sample/N00
   COMMAND ${CMAKE_COMMAND} -E make_directory test/data/sample/N40
   COMMAND ${CMAKE_COMMAND} -E make_directory test/data/samplegz/N40
-  COMMAND ${CMAKE_COMMAND} -E make_directory test/data/samplelz/N40
+  COMMAND ${CMAKE_COMMAND} -E make_directory test/data/samplelz4/N40
   COMMAND ${CMAKE_COMMAND} -E make_directory test/data/service
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   COMMENT "Creating test directories")

--- a/test/sample.cc
+++ b/test/sample.cc
@@ -103,6 +103,10 @@ TEST(Sample, getgz) {
   _get("test/data/samplegz");
 };
 
+TEST(Sample, getlz4) {
+  _get("test/data/samplelz4");
+};
+
 struct testable_sample_t : public skadi::sample {
   testable_sample_t(const std::string& dir) : sample(dir) {
     {

--- a/test/sample.cc
+++ b/test/sample.cc
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <fstream>
 #include <list>
+#include <lz4.h>
 
 #include "test.h"
 
@@ -40,6 +41,7 @@ TEST(Sample, create_tile) {
   for (const auto& p : pixels) {
     tile[p.first] = p.second;
   }
+
   std::ofstream file("test/data/sample/N40/N40W077.hgt", std::ios::binary | std::ios::trunc);
   file.write(static_cast<const char*>(static_cast<void*>(tile.data())),
              sizeof(int16_t) * tile.size());
@@ -67,6 +69,11 @@ TEST(Sample, create_tile) {
 
   // gzip it
   EXPECT_TRUE(baldr::deflate(src_func, dst_func)) << "Can't write gzipped elevation tile";
+
+  // lz4 it
+  std::ofstream lzfile("test/data/samplelz4/N40/N40W077.hgt.lz4", std::ios::binary | std::ios::trunc);
+  LZ4_compress_fast(static_cast<const char*>(static_cast<void*>(tile.data())), dst_buffer.data(),
+                    sizeof(int16_t) * tile.size(), dst_buffer.size(), 0);
 }
 
 void _get(const std::string& location) {

--- a/test/sample.cc
+++ b/test/sample.cc
@@ -72,8 +72,9 @@ TEST(Sample, create_tile) {
 
   // lz4 it
   std::vector<char> lz4_buffer(tile.size() * sizeof(int16_t) * 2, 0);
-  size_t out_bytes = LZ4F_compressFrame(lz4_buffer.data(), lz4_buffer.size(), static_cast<const void*>(tile.data()),
-                    sizeof(int16_t) * tile.size(), NULL);
+  size_t out_bytes =
+      LZ4F_compressFrame(lz4_buffer.data(), lz4_buffer.size(), static_cast<const void*>(tile.data()),
+                         sizeof(int16_t) * tile.size(), NULL);
   EXPECT_TRUE(!LZ4F_isError(out_bytes) && out_bytes > 0) << "Can't write lz4 elevation tile";
 
   std::ofstream lzfile("test/data/samplelz4/N40/N40W077.hgt.lz4", std::ios::binary | std::ios::trunc);


### PR DESCRIPTION
~This is not fully baked, but since I'm by no means a CMake or C++ expert, I wanted to ensure this was a reasonable start.~

~I'll still need to add tests and some additional documentation.~

According to the tests, it does what it says on the cover. :smile: 

# Issue

Adds drop-in support for lz4 elevation tiles. Briefly discussed here: https://github.com/valhalla/valhalla/issues/3071#issuecomment-967591165

## Tasklist

 - [x] Add tests
 - [x] Add #fixes with the issue number that this PR addresses
 - [x] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [x] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
