### PR TITLE
Add graph support for highway=busway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
    * FIXED: Some refactoring that was proposed for the PR 3379 [3381](https://github.com/valhalla/valhalla/pull/3381)
    * FIXED: Avoid calling out "keep left/right" when passing an exit [3349](https://github.com/valhalla/valhalla/pull/3349)
    * FIXED: Fix iterator decrement beyond begin() in GeoPoint::HeadingAtEndOfPolyline() method [#3393](https://github.com/valhalla/valhalla/pull/3393)
+   * FIXED: Parse "highway=busway" OSM tag: https://wiki.openstreetmap.org/wiki/Tag:highway%3Dbusway [#3413](https://github.com/valhalla/valhalla/pull/3413)
 
 * **Enhancement**
    * CHANGED: Pronunciation for names and destinations [#3132](https://github.com/valhalla/valhalla/pull/3132)

--- a/lua/graph.lua
+++ b/lua/graph.lua
@@ -29,7 +29,8 @@ highway = {
 ["construction"] =      {["auto_forward"] = "false", ["truck_forward"] = "false", ["bus_forward"] = "false", ["taxi_forward"] = "false", ["moped_forward"] = "false", ["motorcycle_forward"] = "false", ["pedestrian_forward"] = "false", ["bike_forward"] = "false"},
 ["cycleway"] =          {["auto_forward"] = "false", ["truck_forward"] = "false", ["bus_forward"] = "false", ["taxi_forward"] = "false", ["moped_forward"] = "false", ["motorcycle_forward"] = "false", ["pedestrian_forward"] = "false", ["bike_forward"] = "true"},
 ["path"] =              {["auto_forward"] = "false", ["truck_forward"] = "false", ["bus_forward"] = "false", ["taxi_forward"] = "false", ["moped_forward"] = "false", ["motorcycle_forward"] = "false", ["pedestrian_forward"] = "true",  ["bike_forward"] = "true"},
-["bus_guideway"] =      {["auto_forward"] = "false", ["truck_forward"] = "false", ["bus_forward"] = "true",  ["taxi_forward"] = "false", ["moped_forward"] = "false", ["motorcycle_forward"] = "false", ["pedestrian_forward"] = "false", ["bike_forward"] = "false"}
+["bus_guideway"] =      {["auto_forward"] = "false", ["truck_forward"] = "false", ["bus_forward"] = "true",  ["taxi_forward"] = "false", ["moped_forward"] = "false", ["motorcycle_forward"] = "false", ["pedestrian_forward"] = "false", ["bike_forward"] = "false"},
+["busway"] =            {["auto_forward"] = "false", ["truck_forward"] = "false", ["bus_forward"] = "true",  ["taxi_forward"] = "false", ["moped_forward"] = "false", ["motorcycle_forward"] = "false", ["pedestrian_forward"] = "false", ["bike_forward"] = "false"}
 }
 
 road_class = {

--- a/taginfo.json
+++ b/taginfo.json
@@ -2754,6 +2754,13 @@
     },
     {
       "key": "highway",
+      "value": "busway",
+      "object_types": [
+        "way"
+      ]
+    },
+    {
+      "key": "highway",
       "value": "crossing",
       "object_types": [
         "node"

--- a/test/gurka/test_access_psv.cc
+++ b/test/gurka/test_access_psv.cc
@@ -41,9 +41,9 @@ TEST(Standalone, AccessPsvWay) {
        }},
       {"FH", {{"highway", "primary"}}},
       {"EI", {{"highway", "bus_guideway"}}},
-      {"IJ", {{"highway", "primary"}}},
+      {"JI", {{"highway", "primary"}}},
       {"GK", {{"highway", "primary"}}},
-      {"JK", {{"highway", "primary"}}},
+      {"KJ", {{"highway", "primary"}}},
 
   };
 

--- a/test/gurka/test_access_psv.cc
+++ b/test/gurka/test_access_psv.cc
@@ -17,7 +17,9 @@ TEST(Standalone, AccessPsvWay) {
   constexpr double gridsize_metres = 10;
 
   const std::string ascii_map = R"(
-               
+                            L
+                            |
+                            |
         A---B---C---D---E---I---J
                 |       |       |
                 F-------G-------K
@@ -41,10 +43,10 @@ TEST(Standalone, AccessPsvWay) {
        }},
       {"FH", {{"highway", "primary"}}},
       {"EI", {{"highway", "bus_guideway"}}},
-      {"JI", {{"highway", "primary"}}},
+      {"JI", {{"highway", "busway"}}},
       {"GK", {{"highway", "primary"}}},
       {"KJ", {{"highway", "primary"}}},
-
+      {"LI", {{"highway", "primary"}}},
   };
 
   const auto layout =
@@ -58,13 +60,22 @@ TEST(Standalone, AccessPsvWay) {
     else
       gurka::assert::raw::expect_path(result, {"AB", "BC", "CD", "DE", "EG", "FG", "FH"});
   }
+
   for (auto& c : costing) {
-    auto result = gurka::do_action(valhalla::Options::route, map, {"A", "J"}, c);
+    auto result = gurka::do_action(valhalla::Options::route, map, {"D", "J"}, c);
 
     if (c == "bus")
-      gurka::assert::raw::expect_path(result, {"AB", "BC", "CD", "DE", "EI"});
+      gurka::assert::raw::expect_path(result, {"DE", "EI", "JI"});
     else
-      gurka::assert::raw::expect_path(result, {"AB", "BC", "CD", "DE", "EG", "GK", "KJ", "JI"});
+      gurka::assert::raw::expect_path(result, {"DE", "EG", "GK", "KJ"});
+  }
+
+  for (auto& c : costing) {
+    if (c == "bus")
+      EXPECT_NO_THROW(gurka::do_action(valhalla::Options::route, map, {"D", "L"}, c));
+    else
+      EXPECT_THROW(gurka::do_action(valhalla::Options::route, map, {"D", "L"}, c),
+                   std::runtime_error);
   }
 }
 

--- a/test/gurka/test_access_psv.cc
+++ b/test/gurka/test_access_psv.cc
@@ -18,9 +18,9 @@ TEST(Standalone, AccessPsvWay) {
 
   const std::string ascii_map = R"(
                
-        A---B---C---D---E
-                |       |
-                F-------G
+        A---B---C---D---E---I---J
+                |       |       |
+                F-------G-------K
                 |
                 H
     )";
@@ -40,6 +40,10 @@ TEST(Standalone, AccessPsvWay) {
            {"bus", "no"},
        }},
       {"FH", {{"highway", "primary"}}},
+      {"EI", {{"highway", "bus_guideway"}}},
+      {"IJ", {{"highway", "primary"}}},
+      {"GK", {{"highway", "primary"}}},
+      {"JK", {{"highway", "primary"}}},
 
   };
 
@@ -53,6 +57,14 @@ TEST(Standalone, AccessPsvWay) {
       gurka::assert::raw::expect_path(result, {"AB", "BC", "CF", "FH"});
     else
       gurka::assert::raw::expect_path(result, {"AB", "BC", "CD", "DE", "EG", "FG", "FH"});
+  }
+  for (auto& c : costing) {
+    auto result = gurka::do_action(valhalla::Options::route, map, {"A", "J"}, c);
+
+    if (c == "bus")
+      gurka::assert::raw::expect_path(result, {"AB", "BC", "CD", "DE", "EI"});
+    else
+      gurka::assert::raw::expect_path(result, {"AB", "BC", "CD", "DE", "EG", "GK", "KJ", "JI"});
   }
 }
 


### PR DESCRIPTION
# Issue

This PR targets #2574. While it may not handle all of the cases described in that issue, it aims to expand the routable bus-only ways for bus costing to include the OSM tag `highway=busway`, which according to [OSM docs](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dbusway) should imply `bus=designated`. This is specifically designed to support [some ways in the Brisbane area](https://overpass-turbo.eu/s/1cqh) that are correctly identified as `highway=busway`.

I'm not sure if this warrants a test, but am open to adding one if the maintainers think that would be helpful!

## Tasklist

 - N/A Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - N/A Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [x] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 N/A
