### PR TITLE
Accommodate for API change in Protobuf 3.18+

### DIFF
--- a/src/mjolnir/valhalla_query_transit.cc
+++ b/src/mjolnir/valhalla_query_transit.cc
@@ -39,7 +39,11 @@ Transit read_pbf(const std::string& file_name) {
   google::protobuf::io::CodedInputStream cs(
       static_cast<google::protobuf::io::ZeroCopyInputStream*>(&as));
   auto limit = std::max(static_cast<size_t>(1), buffer.size() * 2);
+#if GOOGLE_PROTOBUF_VERSION >= 3018000
+  cs.SetTotalBytesLimit(limit);
+#else
   cs.SetTotalBytesLimit(limit, limit);
+#endif
   Transit transit;
   if (!transit.ParseFromCodedStream(&cs)) {
     throw std::runtime_error("Couldn't load " + file_name);

--- a/valhalla/mjolnir/transitpbf.h
+++ b/valhalla/mjolnir/transitpbf.h
@@ -80,7 +80,11 @@ Transit read_pbf(const std::string& file_name, std::mutex& lock) {
   google::protobuf::io::CodedInputStream cs(
       static_cast<google::protobuf::io::ZeroCopyInputStream*>(&as));
   auto limit = std::max(static_cast<size_t>(1), buffer.size() * 2);
+#if GOOGLE_PROTOBUF_VERSION >= 3018000
+  cs.SetTotalBytesLimit(limit);
+#else
   cs.SetTotalBytesLimit(limit, limit);
+#endif
   Transit transit;
   if (!transit.ParseFromCodedStream(&cs)) {
     throw std::runtime_error("Couldn't load " + file_name);
@@ -98,7 +102,11 @@ Transit read_pbf(const std::string& file_name) {
   google::protobuf::io::CodedInputStream cs(
       static_cast<google::protobuf::io::ZeroCopyInputStream*>(&as));
   auto limit = std::max(static_cast<size_t>(1), buffer.size() * 2);
+#if GOOGLE_PROTOBUF_VERSION >= 3018000
+  cs.SetTotalBytesLimit(limit);
+#else
   cs.SetTotalBytesLimit(limit, limit);
+#endif
   Transit transit;
   if (!transit.ParseFromCodedStream(&cs)) {
     throw std::runtime_error("Couldn't load " + file_name);


### PR DESCRIPTION
# Issue

Update related to this changes https://github.com/protocolbuffers/protobuf/commit/cda795437d00a15f375d3d5e2659adac715459c6

It should allow to build with older and newer Protobuf

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.
