### PR TITLE
Use std::multimap for admin and timezone polygon results

### DIFF
--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -470,7 +470,7 @@ void BuildTileSet(const std::string& ways_file,
       // Get the admin polygons. If only one exists for the tile check if the
       // tile is entirely inside the polygon
       bool tile_within_one_admin = false;
-      std::unordered_multimap<uint32_t, multi_polygon_type> admin_polys;
+      std::multimap<uint32_t, multi_polygon_type> admin_polys;
       std::unordered_map<uint32_t, bool> drive_on_right;
       std::unordered_map<uint32_t, bool> allow_intersection_names;
 
@@ -484,7 +484,7 @@ void BuildTileSet(const std::string& ways_file,
       }
 
       bool tile_within_one_tz = false;
-      std::unordered_multimap<uint32_t, multi_polygon_type> tz_polys;
+      std::multimap<uint32_t, multi_polygon_type> tz_polys;
       if (tz_db_handle) {
         tz_polys = GetTimeZones(tz_db_handle, tiling.TileBounds(id));
         if (tz_polys.size() == 1) {

--- a/src/mjolnir/valhalla_convert_transit.cc
+++ b/src/mjolnir/valhalla_convert_transit.cc
@@ -490,7 +490,7 @@ void AddToGraph(GraphTileBuilder& tilebuilder_transit,
                 const std::vector<float>& distances,
                 const std::vector<uint32_t>& route_types,
                 bool tile_within_one_tz,
-                const std::unordered_multimap<uint32_t, multi_polygon_type>& tz_polys,
+                const std::multimap<uint32_t, multi_polygon_type>& tz_polys,
                 uint32_t& no_dir_edge_count) {
   auto t1 = std::chrono::high_resolution_clock::now();
 
@@ -1148,7 +1148,7 @@ void build_tiles(const boost::property_tree::ptree& pt,
     std::vector<uint32_t> route_types = AddRoutes(transit, tilebuilder_transit);
     auto filter = tiles.TileBounds(tile_id.tileid());
     bool tile_within_one_tz = false;
-    std::unordered_multimap<uint32_t, multi_polygon_type> tz_polys;
+    std::multimap<uint32_t, multi_polygon_type> tz_polys;
     if (tz_db_handle) {
       tz_polys = GetTimeZones(tz_db_handle, filter);
       if (tz_polys.size() == 1) {

--- a/src/mjolnir/valhalla_fetch_transit.cc
+++ b/src/mjolnir/valhalla_fetch_transit.cc
@@ -287,7 +287,7 @@ void get_stop_stations(Transit& tile,
                        const ptree& response,
                        const AABB2<PointLL>& filter/*,
                        bool tile_within_one_tz,
-                       const std::unordered_multimap<uint32_t, multi_polygon_type>& tz_polys*/) {
+                       const std::multimap<uint32_t, multi_polygon_type>& tz_polys*/) {
 
   for (const auto& station_pt : response.get_child("stop_stations")) {
 
@@ -774,7 +774,7 @@ void fetch_tiles(const ptree& pt,
     LOG_INFO("Fetching " + transit_tile.string());
 
     bool tile_within_one_tz = false;
-    std::unordered_multimap<uint32_t, multi_polygon_type> tz_polys;
+    std::multimap<uint32_t, multi_polygon_type> tz_polys;
     if (tz_db_handle) {
       tz_polys = GetTimeZones(tz_db_handle, filter);
       if (tz_polys.size() == 1) {

--- a/valhalla/mjolnir/admin.h
+++ b/valhalla/mjolnir/admin.h
@@ -39,7 +39,7 @@ sqlite3* GetDBHandle(const std::string& database);
  * @param  ll         point that needs to be checked.
  * @param  graphtile  graphtilebuilder that is used to determine if we are a country poly or not.
  */
-uint32_t GetMultiPolyId(const std::unordered_multimap<uint32_t, multi_polygon_type>& polys,
+uint32_t GetMultiPolyId(const std::multimap<uint32_t, multi_polygon_type>& polys,
                         const PointLL& ll,
                         GraphTileBuilder& graphtile);
 
@@ -49,7 +49,7 @@ uint32_t GetMultiPolyId(const std::unordered_multimap<uint32_t, multi_polygon_ty
  * @param  polys      unordered map of polys.
  * @param  ll         point that needs to be checked.
  */
-uint32_t GetMultiPolyId(const std::unordered_multimap<uint32_t, multi_polygon_type>& polys,
+uint32_t GetMultiPolyId(const std::multimap<uint32_t, multi_polygon_type>& polys,
                         const PointLL& ll);
 
 /**
@@ -57,8 +57,8 @@ uint32_t GetMultiPolyId(const std::unordered_multimap<uint32_t, multi_polygon_ty
  * @param  db_handle    sqlite3 db handle
  * @param  aabb         bb of the tile
  */
-std::unordered_multimap<uint32_t, multi_polygon_type> GetTimeZones(sqlite3* db_handle,
-                                                                   const AABB2<PointLL>& aabb);
+std::multimap<uint32_t, multi_polygon_type> GetTimeZones(sqlite3* db_handle,
+                                                         const AABB2<PointLL>& aabb);
 /**
  * Get the admin data from the spatialite db given an SQL statement
  * @param  db_handle        sqlite3 db handle
@@ -73,7 +73,7 @@ void GetData(sqlite3* db_handle,
              sqlite3_stmt* stmt,
              const std::string& sql,
              GraphTileBuilder& tilebuilder,
-             std::unordered_multimap<uint32_t, multi_polygon_type>& polys,
+             std::multimap<uint32_t, multi_polygon_type>& polys,
              std::unordered_map<uint32_t, bool>& drive_on_right);
 
 /**
@@ -86,7 +86,7 @@ void GetData(sqlite3* db_handle,
  * @param  aabb             bb of the tile
  * @param  tilebuilder      Graph tile builder
  */
-std::unordered_multimap<uint32_t, multi_polygon_type>
+std::multimap<uint32_t, multi_polygon_type>
 GetAdminInfo(sqlite3* db_handle,
              std::unordered_map<uint32_t, bool>& drive_on_right,
              std::unordered_map<uint32_t, bool>& allow_intersection_names,


### PR DESCRIPTION
Admin polygon lookup previously was using std::unordered_multimap for the polygon set returned when querying the admin database. This results in a polygon set that is unordered. It was found that often the country polygon was tested before state polygons in GetMultiPolyId. Since we always want to find a state polygon first (if one exists) this unordered list of results is sub-optimal.

this PR changes to using std::multimap for the resulting polygon list. This can now be checked in the proper order and if a state polygon is found as the first case where the lat,lng is within the admin polygon we can avoid testing the (usually) larger country polygon.

I tested this on North America OSM data. The build stage was done with 8 threads (set concurrency=8 in the config) with the following performance:

master: 2:57:55
branch: 1:32:36

The total size of tiles matches between master and the branch (which I take to mean it is likely the admin results are consistent).

# Issue

What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
