### PR TITLE
add directions_type from directions_options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
    * FIXED: Add string for Use:kPedestrianCrossing to fix null output in to_string(Use). [#3416](https://github.com/valhalla/valhalla/pull/3416)
    * FIXED: Remove simple restrictions check for pedestrian cost calculation. [#3423](https://github.com/valhalla/valhalla/pull/3423)
    * FIXED: Parse "highway=busway" OSM tag: https://wiki.openstreetmap.org/wiki/Tag:highway%3Dbusway [#3413](https://github.com/valhalla/valhalla/pull/3413)
+   * FIXED: add directions_type from directions_options [#3431](https://github.com/valhalla/valhalla/pull/3431)
 
 * **Enhancement**
    * CHANGED: Pronunciation for names and destinations [#3132](https://github.com/valhalla/valhalla/pull/3132)

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -481,7 +481,7 @@ void from_json(rapidjson::Document& doc, Options& options) {
   auto deprecated = get_child_optional(doc, "/directions_options");
   auto& allocator = doc.GetAllocator();
   if (deprecated) {
-    for (const auto& key : {"/units", "/narrative", "/format", "/language"}) {
+    for (const auto& key : {"/units", "/narrative", "/format", "/language", "/directions_type"}) {
       auto child = rapidjson::get_child_optional(*deprecated, key);
       if (child) {
         doc.AddMember(rapidjson::Value(&key[1], allocator), *child, allocator);


### PR DESCRIPTION
# Issue

Fix bug - there's a mismatch between [doc](https://valhalla.readthedocs.io/en/latest/api/turn-by-turn/api-reference/) and code. In the [doc](https://valhalla.readthedocs.io/en/latest/api/turn-by-turn/api-reference/), `directions_type` is listed as an option inside `directions_options`, and I'm adding it back.  

Options | Description
-- | --
directions_type | An enum with 3 values.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
