### PR TITLE
fix python's argumentparser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
    * FIXED: Add string for Use:kPedestrianCrossing to fix null output in to_string(Use). [#3416](https://github.com/valhalla/valhalla/pull/3416)
    * FIXED: Remove simple restrictions check for pedestrian cost calculation. [#3423](https://github.com/valhalla/valhalla/pull/3423)
    * FIXED: Parse "highway=busway" OSM tag: https://wiki.openstreetmap.org/wiki/Tag:highway%3Dbusway [#3413](https://github.com/valhalla/valhalla/pull/3413)
+   * FIXED: workaround python's ArgumentParser bug to not accept negative numbers as arguments [#3443](https://github.com/valhalla/valhalla/pull/3443)
 
 * **Enhancement**
    * CHANGED: Pronunciation for names and destinations [#3132](https://github.com/valhalla/valhalla/pull/3132)

--- a/scripts/valhalla_build_elevation
+++ b/scripts/valhalla_build_elevation
@@ -16,6 +16,12 @@ from typing import List, Iterable, Set
 from urllib import request
 from urllib.error import URLError
 
+
+# hack so ArgumentParser can accept negative numbers
+# see https://github.com/valhalla/valhalla/issues/3426
+for i, arg in enumerate(sys.argv):
+  if (arg[0] == '-') and arg[1].isdigit(): sys.argv[i] = ' ' + arg
+
 description = """Downloads Tilezen's elevation tiles that either intersect with features in all .geojson files in
               --input-geojson-dir or that intersect with --bbox. NOTE: geojson method requires shapely.
               """
@@ -39,7 +45,9 @@ method.add_argument(
     "-b",
     "--from-bbox",
     help="Bounding box coordinates in the format 'minX,minY,maxX,maxY'.",
-    type=str,
+    # type=bbox_parser,
+    action='store',
+    default=[-1, -2, -3, -4]
 )
 method.add_argument(
     "-t",

--- a/scripts/valhalla_build_elevation
+++ b/scripts/valhalla_build_elevation
@@ -47,9 +47,7 @@ method.add_argument(
     "-b",
     "--from-bbox",
     help="Bounding box coordinates in the format 'minX,minY,maxX,maxY'.",
-    # type=bbox_parser,
-    action='store',
-    default=[-1, -2, -3, -4]
+    type=str,
 )
 method.add_argument(
     "-t",

--- a/scripts/valhalla_build_elevation
+++ b/scripts/valhalla_build_elevation
@@ -20,7 +20,9 @@ from urllib.error import URLError
 # hack so ArgumentParser can accept negative numbers
 # see https://github.com/valhalla/valhalla/issues/3426
 for i, arg in enumerate(sys.argv):
-  if (arg[0] == '-') and arg[1].isdigit(): sys.argv[i] = ' ' + arg
+    if not len(arg) > 1:
+        continue
+    if (arg[0] == '-') and arg[1].isdigit(): sys.argv[i] = ' ' + arg
 
 description = """Downloads Tilezen's elevation tiles that either intersect with features in all .geojson files in
               --input-geojson-dir or that intersect with --bbox. NOTE: geojson method requires shapely.


### PR DESCRIPTION
fixes #3426 where python's argparse has a long-standing bug not being able to parse arguments which start with a negative number