### PR TITLE
Fix int_ref processing when building ways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
    * FIXED: Add string for Use:kPedestrianCrossing to fix null output in to_string(Use). [#3416](https://github.com/valhalla/valhalla/pull/3416)
    * FIXED: Remove simple restrictions check for pedestrian cost calculation. [#3423](https://github.com/valhalla/valhalla/pull/3423)
    * FIXED: Parse "highway=busway" OSM tag: https://wiki.openstreetmap.org/wiki/Tag:highway%3Dbusway [#3413](https://github.com/valhalla/valhalla/pull/3413)
+   * FIXED: Process int_ref irrespective of `use_directions_on_ways_` [#3446](https://github.com/valhalla/valhalla/pull/3446)
 
 * **Enhancement**
    * CHANGED: Pronunciation for names and destinations [#3132](https://github.com/valhalla/valhalla/pull/3132)

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -1900,7 +1900,7 @@ public:
     }
 
     // add int_refs to the end of the refs for now.  makes sure that we don't add dups.
-    if (use_direction_on_ways_ && way_.int_ref_index()) {
+    if (way_.int_ref_index()) {
       std::string tmp = osmdata_.name_offset_map.name(way_.ref_index());
 
       std::vector<std::string> rs = GetTagTokens(tmp);
@@ -1931,9 +1931,7 @@ public:
 
     // add int_ref pronunciations to the end of the pronunciation refs for now.  makes sure that we
     // don't add dups.
-    if (use_direction_on_ways_) {
-      MergeRefPronunciations();
-    }
+    MergeRefPronunciations();
 
     // Process mtb tags.
     auto mtb_scale = results.find("mtb:scale");

--- a/test/gurka/test_phonemes.cc
+++ b/test/gurka/test_phonemes.cc
@@ -1286,7 +1286,7 @@ TEST(Standalone, PhonemesWithNoAltandDirection) {
     auto edgeinfo = tile->edgeinfo(AB_edge);
     std::vector<uint8_t> types;
     auto names_and_types = edgeinfo.GetNamesAndTypes(types, true);
-    ASSERT_EQ(names_and_types.size(), 5);
+    ASSERT_EQ(names_and_types.size(), 6);
 
     std::unordered_map<uint8_t, std::pair<uint8_t, std::string>> pronunciations =
         edgeinfo.GetPronunciationsMap();

--- a/test/gurka/test_route.cc
+++ b/test/gurka/test_route.cc
@@ -832,7 +832,7 @@ TEST(AlgorithmTestDest, TestAlgoSwapAndDestOnly) {
                             {"DA", {{"highway", "primary"}}},
                             {"AY", {{"highway", "primary"}}},
                             {"YZ", {{"highway", "primary"}}}};
-  gurka::map map = gurka::buildtiles(layout, ways, {}, {}, "test/data/search_filter");
+  gurka::map map = gurka::buildtiles(layout, ways, {}, {}, "test/data/algo_swap_dest_only");
 
   // Notes on this test:
   // * We want the first leg to choose bidir A*:

--- a/test/scripts/test_valhalla_build_extract.py
+++ b/test/scripts/test_valhalla_build_extract.py
@@ -22,7 +22,7 @@ class TestBuildExtract(unittest.TestCase):
         tile_count = valhalla_build_extract.get_tile_count(TILE_PATH)
 
         # test that the index has the right offsets/sizes
-        exp_tuples = ((2560, 25568, 289288), (293888, 410441, 658856), (954368, 6549282, 6051320))
+        exp_tuples = ((2560, 25568, 290368), (294912, 410441, 658856), (955392, 6549282, 6051320))
         self.check_tar(EXTRACT_PATH, exp_tuples, tile_count * INDEX_BIN_SIZE)
         # same for traffic.tar
         exp_tuples = ((1536, 25568, 26272), (28672, 410441, 65184), (94720, 6549282, 603808))


### PR DESCRIPTION
# Issue
`int_ref`s were not being processed when `use_direction_on_ways_` was not set. This is a bug as `int_ref` should always be processed irrespective of that setting.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
