### PR TITLE
Fix unaligned reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
    * FIXED: Add string for Use:kPedestrianCrossing to fix null output in to_string(Use). [#3416](https://github.com/valhalla/valhalla/pull/3416)
    * FIXED: Remove simple restrictions check for pedestrian cost calculation. [#3423](https://github.com/valhalla/valhalla/pull/3423)
    * FIXED: Parse "highway=busway" OSM tag: https://wiki.openstreetmap.org/wiki/Tag:highway%3Dbusway [#3413](https://github.com/valhalla/valhalla/pull/3413)
+   * FIXED: Undefined behaviour on some platforms due to unaligned reads [#3447](https://github.com/valhalla/valhalla/pull/3447)
 
 * **Enhancement**
    * CHANGED: Pronunciation for names and destinations [#3132](https://github.com/valhalla/valhalla/pull/3132)

--- a/src/baldr/edgeinfo.cc
+++ b/src/baldr/edgeinfo.cc
@@ -116,7 +116,7 @@ std::vector<std::string> EdgeInfo::GetTaggedValues(bool only_pronunciations) con
 
           size_t pos = 1;
           while (pos < strlen(name)) {
-            const auto& header = *reinterpret_cast<const linguistic_text_header_t*>(name + pos);
+            const auto header = midgard::unaligned_read<linguistic_text_header_t>(name + pos);
             pos += 3;
             names.emplace_back((std::string(reinterpret_cast<const char*>(&header), 3) +
                                 std::string((name + pos), header.length_)));
@@ -219,7 +219,7 @@ std::unordered_map<uint8_t, std::pair<uint8_t, std::string>> EdgeInfo::GetPronun
         if (tv == baldr::TaggedValue::kPronunciation) {
           size_t pos = 1;
           while (pos < strlen(name)) {
-            const auto& header = *reinterpret_cast<const linguistic_text_header_t*>(name + pos);
+            const auto header = midgard::unaligned_read<linguistic_text_header_t>(name + pos);
             pos += 3;
             std::unordered_map<uint8_t, std::pair<uint8_t, std::string>>::iterator iter =
                 index_pronunciation_map.find(header.name_index_);

--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -800,7 +800,7 @@ std::vector<SignInfo> GraphTile::GetSigns(
             (!signs_[found].is_route_num_type() && !signs_on_node)) {
           size_t pos = 0;
           while (pos < strlen(text)) {
-            const auto& header = *reinterpret_cast<const linguistic_text_header_t*>(text + pos);
+            const auto header = midgard::unaligned_read<linguistic_text_header_t>(text + pos);
             pos += 3;
 
             auto iter = index_pronunciation_map.insert(

--- a/test/names.cc
+++ b/test/names.cc
@@ -1,4 +1,5 @@
 #include "baldr/graphconstants.h"
+#include "midgard/util.h"
 #include "mjolnir/osmway.h"
 #include "mjolnir/uniquenames.h"
 #include <iostream>
@@ -6,6 +7,7 @@
 #include "test.h"
 
 using namespace std;
+using namespace valhalla::midgard;
 using namespace valhalla::mjolnir;
 using namespace valhalla::baldr;
 
@@ -20,7 +22,7 @@ void TestKeyTypeValue(const std::string& pronunciation,
 
   size_t pos = 0;
   while (pos < strlen(p)) {
-    const auto& header = *reinterpret_cast<const linguistic_text_header_t*>(p + pos);
+    const auto header = unaligned_read<linguistic_text_header_t>(p + pos);
     pos += 3;
     EXPECT_EQ(header.name_index_, expected_key);
     EXPECT_EQ(static_cast<PronunciationAlphabet>(header.phonetic_alphabet_), expected_type);

--- a/valhalla/midgard/util.h
+++ b/valhalla/midgard/util.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstring>
 #include <functional>
 #include <limits>
 #include <memory>
@@ -8,6 +9,7 @@
 #include <random>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -707,6 +709,14 @@ template <typename T> struct Finally {
 template <typename T> Finally<T> make_finally(T t) {
   return Finally<T>{t};
 };
+
+template <typename T>
+typename std::enable_if<std::is_trivially_copy_assignable<T>::value, T>::type
+unaligned_read(const void* ptr) {
+  T r;
+  std::memcpy(&r, ptr, sizeof(T));
+  return r;
+}
 
 } // namespace midgard
 } // namespace valhalla


### PR DESCRIPTION
# Issue

Read of unaligned structs that require alignment causes performance degradation or even UB on some platforms.

This fix introduces `unaligned_read()` function template to safely access unaligned structs and fixes the issue for `linguistic_text_header_t` struct.

See https://stackoverflow.com/questions/48312068/fast-memcpy-for-small-unaligned-data for more details.