### PR TITLE
Fix ubsan error due to possible invalid shift exponent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
    * FIXED: Parse "highway=busway" OSM tag: https://wiki.openstreetmap.org/wiki/Tag:highway%3Dbusway [#3413](https://github.com/valhalla/valhalla/pull/3413)
    * FIXED: workaround python's ArgumentParser bug to not accept negative numbers as arguments [#3443](https://github.com/valhalla/valhalla/pull/3443)
    * FIXED: Undefined behaviour on some platforms due to unaligned reads [#3447](https://github.com/valhalla/valhalla/pull/3447)
+   * FIXED: Fixed undefined behavior due to invalid shift exponent when getting edge's heading [#3450](https://github.com/valhalla/valhalla/pull/3450)
 
 * **Enhancement**
    * CHANGED: Pronunciation for names and destinations [#3132](https://github.com/valhalla/valhalla/pull/3132)

--- a/valhalla/baldr/nodeinfo.h
+++ b/valhalla/baldr/nodeinfo.h
@@ -379,6 +379,11 @@ public:
    * @return Returns heading relative to N (0-360 degrees).
    */
   inline uint32_t heading(const uint32_t localidx) const {
+    if (localidx > kMaxLocalEdgeIndex) {
+      LOG_WARN("Local index " + std::to_string(localidx) + " exceeds max value of " +
+               std::to_string(kMaxLocalEdgeIndex) + ", returning heading of 0");
+      return 0;
+    }
     // Make sure everything is 64 bit!
     uint64_t shift = localidx * 8; // 8 bits per index
     return static_cast<uint32_t>(std::round(


### PR DESCRIPTION
ubsan complained about the shift exponent in NodeInfo::heading() being
possibly too large under some conditions.

Fixed by checking for valid localidx. If invalid index is passed in, we
log a warning and return a heading of 0.