### PR TITLE
Fix crash in DoubleBucketQueue

### DIFF
--- a/valhalla/baldr/double_bucket_queue.h
+++ b/valhalla/baldr/double_bucket_queue.h
@@ -140,7 +140,7 @@ public:
     if (prevbucket != newbucket) {
       // Add label to newbucket and remove from previous bucket
       newbucket.push_back(label);
-      prevbucket.erase(std::remove(prevbucket.begin(), prevbucket.end(), label));
+      std::remove(prevbucket.begin(), prevbucket.end(), label);
     }
   }
 


### PR DESCRIPTION
When decreasing label costs, std::remove already removes the label from prevbucket. And since std::remove returns a past-the-end iterator, feeding it to erase() is illegal and caused crashes for us.