### PR TITLE
Use midgard::unaligned_read in GraphTileBuilder::AddSigns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
    * FIXED: workaround python's ArgumentParser bug to not accept negative numbers as arguments [#3443](https://github.com/valhalla/valhalla/pull/3443)
    * FIXED: Undefined behaviour on some platforms due to unaligned reads [#3447](https://github.com/valhalla/valhalla/pull/3447)
    * FIXED: Fixed undefined behavior due to invalid shift exponent when getting edge's heading [#3450](https://github.com/valhalla/valhalla/pull/3450)
+   * FIXED: Use midgard::unaligned_read in GraphTileBuilder::AddSigns [#3456](https://github.com/valhalla/valhalla/pull/3456)
 
 * **Enhancement**
    * CHANGED: Pronunciation for names and destinations [#3132](https://github.com/valhalla/valhalla/pull/3132)

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -511,7 +511,8 @@ void GraphTileBuilder::AddSigns(const uint32_t idx,
           std::string updated_pronunciation;
 
           while (pos < strlen(p)) {
-            linguistic_text_header_t header = *reinterpret_cast<linguistic_text_header_t*>(p + pos);
+            linguistic_text_header_t header =
+                midgard::unaligned_read<linguistic_text_header_t>(p + pos);
             pos += 3;
             header.name_index_ = i;
             updated_pronunciation.append(std::string(reinterpret_cast<const char*>(&header), 3) +


### PR DESCRIPTION
Related to https://github.com/valhalla/valhalla/pull/3447 (the linguistic header should always be read using the util funciton)