### PR TITLE
fix logger issue introduced when migrating to cxxopts

### DIFF
--- a/src/mjolnir/valhalla_add_predicted_traffic.cc
+++ b/src/mjolnir/valhalla_add_predicted_traffic.cc
@@ -309,6 +309,16 @@ int main(int argc, char** argv) {
     return EXIT_FAILURE;
   }
 
+  // configure logging
+  boost::optional<boost::property_tree::ptree&> logging_subtree =
+      config.get_child_optional("mjolnir.logging");
+  if (logging_subtree) {
+    auto logging_config =
+        valhalla::midgard::ToMap<const boost::property_tree::ptree&,
+                                 std::unordered_map<std::string, std::string>>(logging_subtree.get());
+    valhalla::midgard::logging::Configure(logging_config);
+  }
+
   // queue up all the work we'll be doing
   std::unordered_map<GraphId, std::vector<std::string>> files_per_tile;
   for (filesystem::recursive_directory_iterator i(traffic_tile_dir), end; i != end; ++i) {
@@ -328,16 +338,6 @@ int main(int argc, char** argv) {
                                                                           files_per_tile.end());
   std::random_device rd;
   std::shuffle(traffic_tiles.begin(), traffic_tiles.end(), std::mt19937(rd()));
-
-  // configure logging
-  boost::optional<boost::property_tree::ptree&> logging_subtree =
-      config.get_child_optional("mjolnir.logging");
-  if (logging_subtree) {
-    auto logging_config =
-        valhalla::midgard::ToMap<const boost::property_tree::ptree&,
-                                 std::unordered_map<std::string, std::string>>(logging_subtree.get());
-    valhalla::midgard::logging::Configure(logging_config);
-  }
 
   LOG_INFO("Adding predicted traffic with " + std::to_string(num_threads) + " threads");
   std::vector<std::shared_ptr<std::thread>> threads(num_threads);

--- a/src/valhalla_expand_bounding_box.cc
+++ b/src/valhalla_expand_bounding_box.cc
@@ -42,7 +42,7 @@ int main(int argc, char** argv) {
       return EXIT_SUCCESS;
     }
 
-    // Read the config filegi
+    // Read the config file
     if (result.count("inline-config")) {
       std::stringstream ss;
       ss << result["inline-config"].as<std::string>();
@@ -54,6 +54,16 @@ int main(int argc, char** argv) {
       return EXIT_FAILURE;
     }
 
+    // configure logging
+    boost::optional<boost::property_tree::ptree&> logging_subtree =
+        pt.get_child_optional("mjolnir.logging");
+    if (logging_subtree) {
+      auto logging_config = valhalla::midgard::ToMap<const boost::property_tree::ptree&,
+                                                     std::unordered_map<std::string, std::string>>(
+          logging_subtree.get());
+      valhalla::midgard::logging::Configure(logging_config);
+    }
+
     if (!result.count("bounding-box")) {
       std::cerr << "You must provide a bounding box to expand.\n\n";
       std::cerr << options.help() << std::endl;
@@ -62,16 +72,6 @@ int main(int argc, char** argv) {
   } catch (const cxxopts::OptionException& e) {
     std::cout << "Unable to parse command line options because: " << e.what() << std::endl;
     return EXIT_FAILURE;
-  }
-
-  // configure logging
-  boost::optional<boost::property_tree::ptree&> logging_subtree =
-      pt.get_child_optional("mjolnir.logging");
-  if (logging_subtree) {
-    auto logging_config =
-        valhalla::midgard::ToMap<const boost::property_tree::ptree&,
-                                 std::unordered_map<std::string, std::string>>(logging_subtree.get());
-    valhalla::midgard::logging::Configure(logging_config);
   }
 
   std::stringstream ss(bbox);


### PR DESCRIPTION
in #3459 we migrated all exes to cxxopts lib and in the process it seems I messed up the logger configuration. in some exes that was done too late, after LOG_x was called which basically configures the static logger as `std_out` and ignores whatever was set in the config.

most notably this happened in `valhalla_build_tiles`: https://github.com/valhalla/valhalla/pull/3346#issuecomment-994053989. I checked all other exes and amended the ones which had similar issues.