### PR TITLE
Fix: missing heading for intersections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
    * FIXED: Undefined behaviour on some platforms due to unaligned reads [#3447](https://github.com/valhalla/valhalla/pull/3447)
    * FIXED: Fixed undefined behavior due to invalid shift exponent when getting edge's heading [#3450](https://github.com/valhalla/valhalla/pull/3450)
    * FIXED: Use midgard::unaligned_read in GraphTileBuilder::AddSigns [#3456](https://github.com/valhalla/valhalla/pull/3456)
+   * FIXED: Fixed missed intersection heading [#3463](https://github.com/valhalla/valhalla/pull/3463)
 
 * **Enhancement**
    * CHANGED: Pronunciation for names and destinations [#3132](https://github.com/valhalla/valhalla/pull/3132)

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -439,13 +439,11 @@ json::ArrayPtr intersections(const valhalla::DirectionsLeg::Maneuver& maneuver,
   auto intersections = json::array({});
   uint32_t n = arrive_maneuver ? maneuver.end_path_index() + 1 : maneuver.end_path_index();
   EnhancedTripLeg_Node* prev_node = nullptr;
-
   for (uint32_t i = maneuver.begin_path_index(); i < n; i++) {
     auto intersection = json::map({});
 
     // Get the node and current edge from the enhanced trip path
     // NOTE: curr_edge does not exist for the arrive maneuver
-
     auto node = etp->GetEnhancedNode(i);
     auto curr_edge = etp->GetCurrEdge(i);
     auto prev_edge = etp->GetPrevEdge(i);
@@ -545,7 +543,6 @@ json::ArrayPtr intersections(const valhalla::DirectionsLeg::Maneuver& maneuver,
     // Add the incoming edge except for the first depart intersection.
     // Set routeable to false except for arrive.
     // TODO - what if a true U-turn - need to set it to routeable.
-
     if (i > 0) {
       bool entry = (arrive_maneuver) ? true : false;
       uint32_t prior_heading = prev_edge->end_heading();
@@ -1257,6 +1254,8 @@ std::string get_mode(const valhalla::DirectionsLeg::Maneuver& maneuver,
     case TravelMode::kTransit: {
       return "transit";
     }
+    default:
+      return {};
   }
   auto num = static_cast<int>(maneuver.travel_mode());
   throw std::runtime_error(std::string(__FILE__) + ":" + std::to_string(__LINE__) +

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -532,29 +532,28 @@ json::ArrayPtr intersections(const valhalla::DirectionsLeg::Maneuver& maneuver,
 
     // Get bearings and access to outgoing intersecting edges. Do not add
     // any intersecting edges for the first depart intersection and for
-    // the arrive step.
+    // the arrival step.
     std::vector<IntersectionEdges> edges;
 
     // Add the edge departing the node
     if (!arrive_maneuver) {
       edges.emplace_back(curr_edge->begin_heading(), true, false, true);
+      if (i > 0) {
+        for (uint32_t m = 0; m < node->intersecting_edge_size(); m++) {
+          auto intersecting_edge = node->GetIntersectingEdge(m);
+          bool routable = intersecting_edge->IsTraversableOutbound(curr_edge->travel_mode());
+          edges.emplace_back(intersecting_edge->begin_heading(), routable, false, true);
+        }
+      }
     }
 
     // Add the incoming edge except for the first depart intersection.
-    // Set routeable to false except for arrive.
+    // Set routable to false except for arrive.
     // TODO - what if a true U-turn - need to set it to routeable.
     if (i > 0) {
       bool entry = (arrive_maneuver) ? true : false;
       uint32_t prior_heading = prev_edge->end_heading();
       edges.emplace_back(((prior_heading + 180) % 360), entry, true, false);
-    }
-
-    if (i > 0 && !arrive_maneuver) {
-      bool entry = (arrive_maneuver) ? true : false;
-      for (uint32_t m = 0; m < node->intersecting_edge_size(); m++) {
-        auto intersecting_edge = node->GetIntersectingEdge(m);
-        edges.emplace_back(intersecting_edge->begin_heading(), entry, true, false);
-      }
     }
 
     // Create bearing and entry output

--- a/test/gurka/test_osrm_serializer.cc
+++ b/test/gurka/test_osrm_serializer.cc
@@ -31,3 +31,182 @@ TEST(Standalone, OsrmSerializerShape) {
   json = gurka::convert_to_json(result, Options::Format::Options_Format_osrm);
   EXPECT_EQ(json["routes"][0]["geometry"]["coordinates"].GetArray().Size(), 3);
 }
+
+TEST(Standalone, HeadingNumberTurnLeft) {
+  const std::string ascii_map = R"(
+    B---D
+    |
+    A
+  )";
+
+  const gurka::ways ways = {
+      {"AB", {{"highway", "primary"}}},
+      {"BD", {{"highway", "primary"}}},
+  };
+
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100, {40.7351162, -73.985719});
+  auto map =
+      gurka::buildtiles(layout, ways, {}, {}, "test/data/osrm_serializer_route_turnleft_heading");
+
+  // Test that full shape is returned by default
+  auto result = gurka::do_action(valhalla::Options::route, map, {"A", "D"}, "pedestrian",
+                                 {{"/shape_format", "geojson"}});
+  //
+  auto json = gurka::convert_to_json(result, Options::Format::Options_Format_osrm);
+  auto heading_number{1};
+  for (int i = 0; i < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++i)
+    ASSERT_EQ(heading_number, json["routes"][0]["legs"][0]["steps"][0]["intersections"][0]["bearings"]
+                                  .GetArray()
+                                  .Size());
+}
+
+TEST(Standalone, HeadingNumberTRoute) {
+  const std::string ascii_map = R"(
+    C----B---F
+         |
+         A
+  )";
+
+  const gurka::ways ways = {
+      {"AB", {{"highway", "primary"}}},
+      {"BC", {{"highway", "primary"}}},
+      {"BF", {{"highway", "primary"}}},
+  };
+
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100, {40.7351162, -73.985719});
+  auto map =
+      gurka::buildtiles(layout, ways, {}, {}, "test/data/osrm_serializer_route_troute_heading");
+
+  auto result = gurka::do_action(valhalla::Options::route, map, {"A", "F"}, "pedestrian");
+
+  auto json = gurka::convert_to_json(result, Options::Format::Options_Format_osrm);
+  std::vector<int> expected_headings{1, 3, 1};
+  for (int i = 0; i < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++i) {
+    for (int j = 0; j < json["routes"][0]["legs"][0]["steps"][i]["intersections"].GetArray().Size();
+         ++j) {
+      ASSERT_EQ(expected_headings[i],
+                json["routes"][0]["legs"][0]["steps"][i]["intersections"][j]["bearings"]
+                    .GetArray()
+                    .Size());
+    }
+  }
+}
+
+TEST(Standalone, HeadingNumberForkRoute) {
+
+  const std::string ascii_map = R"(A---B----------C-----D
+                                          \        /
+                                           E------F)";
+
+  const gurka::ways ways = {{"ABCD", {{"highway", "primary"}}},
+                            {"BE", {{"highway", "primary"}}},
+                            {"FC", {{"highway", "primary"}}},
+                            {"EF", {{"highway", "primary"}}}};
+
+  const double gridsize = 100;
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, gridsize);
+  auto map =
+      gurka::buildtiles(layout, ways, {}, {}, "test/data/osrm_serializer_route_forkroad_heading");
+  auto result = gurka::do_action(valhalla::Options::route, map, {"A", "D"}, "pedestrian");
+
+  auto json = gurka::convert_to_json(result, valhalla::Options_Format_osrm);
+  std::vector<int> expected_headings{1, 3, 3, 1};
+  for (int i = 0; i < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++i) {
+    for (int j = 0; j < json["routes"][0]["legs"][0]["steps"][i]["intersections"].GetArray().Size();
+         ++j) {
+      ASSERT_EQ(expected_headings[i],
+                json["routes"][0]["legs"][0]["steps"][i]["intersections"][j]["bearings"]
+                    .GetArray()
+                    .Size());
+    }
+  }
+}
+
+TEST(Standalone, HeadingNumberCrossRoad) {
+  const std::string ascii_map = R"(
+         E
+         |
+    C----B---F
+         |
+         A
+  )";
+
+  const gurka::ways ways = {
+      {"AB", {{"highway", "primary"}}},
+      {"BC", {{"highway", "primary"}}},
+      {"BF", {{"highway", "primary"}}},
+      {"BE", {{"highway", "primary"}}},
+  };
+
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100, {40.7351162, -73.985719});
+  auto map =
+      gurka::buildtiles(layout, ways, {}, {}, "test/data/osrm_serializer_route_crossroad_heading");
+
+  auto result = gurka::do_action(valhalla::Options::route, map, {"A", "F"}, "pedestrian");
+
+  auto json = gurka::convert_to_json(result, Options::Format::Options_Format_osrm);
+  std::vector<int> expected_headings{1, 4, 1};
+  for (int i = 0; i < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++i) {
+    for (int j = 0; j < json["routes"][0]["legs"][0]["steps"][i]["intersections"].GetArray().Size();
+         ++j) {
+      ASSERT_EQ(expected_headings[i],
+                json["routes"][0]["legs"][0]["steps"][i]["intersections"][j]["bearings"]
+                    .GetArray()
+                    .Size());
+    }
+  }
+}
+
+TEST(Standalone, HeadingNumber2CrossRoad) {
+  const std::string ascii_map = R"(
+         E   I
+         |   |
+    C----B---F----G
+         |   |
+         A   D
+  )";
+
+  const gurka::ways ways = {
+      {"AB", {{"highway", "secondary"}}}, {"BE", {{"highway", "secondary"}}},
+      {"BC", {{"highway", "primary"}}},   {"BF", {{"highway", "primary"}}},
+      {"FG", {{"highway", "primary"}}},   {"FI", {{"highway", "service"}}},
+      {"FD", {{"highway", "service"}}},
+  };
+
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100, {40.7351162, -73.985719});
+  auto map =
+      gurka::buildtiles(layout, ways, {}, {}, "test/data/osrm_serializer_route_2crossroad_heading");
+
+  auto result = gurka::do_action(valhalla::Options::route, map, {"C", "G"}, "pedestrian");
+
+  auto json = gurka::convert_to_json(result, Options::Format::Options_Format_osrm);
+  std::vector<int> expected_headings{1, 4, 4, 1};
+  int index{0};
+  for (int i = 0; i < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++i) {
+    for (int j = 0; j < json["routes"][0]["legs"][0]["steps"][i]["intersections"].GetArray().Size();
+         ++j) {
+      ASSERT_EQ(expected_headings[index++],
+                json["routes"][0]["legs"][0]["steps"][i]["intersections"][j]["bearings"]
+                    .GetArray()
+                    .Size());
+    }
+  }
+
+  result = gurka::do_action(valhalla::Options::route, map, {"A", "G"}, "pedestrian");
+  json = gurka::convert_to_json(result, Options::Format::Options_Format_osrm);
+  index = 0;
+  for (int i = 0; i < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++i) {
+    for (int j = 0; j < json["routes"][0]["legs"][0]["steps"][i]["intersections"].GetArray().Size();
+         ++j) {
+      std::cout << "heading --> "
+                << json["routes"][0]["legs"][0]["steps"][i]["intersections"][j]["bearings"]
+                       .GetArray()
+                       .Size()
+                << std::endl;
+      ASSERT_EQ(expected_headings[index++],
+                json["routes"][0]["legs"][0]["steps"][i]["intersections"][j]["bearings"]
+                    .GetArray()
+                    .Size());
+    }
+  }
+}


### PR DESCRIPTION

Originally only 2 edges were added along the route after the fix any possible number of intersecting edges are added to the final route.