### PR TITLE
fixes #3465 #3466

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
    * FIXED: Use midgard::unaligned_read in GraphTileBuilder::AddSigns [#3456](https://github.com/valhalla/valhalla/pull/3456)
    * FIXED: Relax test margin for time dependent traffic test [#3467](https://github.com/valhalla/valhalla/pull/3467)
    * FIXED: Fixed missed intersection heading [#3463](https://github.com/valhalla/valhalla/pull/3463)
+   * FIXED: Stopped putting binary bytes into a string field of the protobuf TaggedValue since proto3 protects against that for cross language support [#3468](https://github.com/valhalla/valhalla/pull/3468)
 
 * **Enhancement**
    * CHANGED: Pronunciation for names and destinations [#3132](https://github.com/valhalla/valhalla/pull/3132)

--- a/proto/tripcommon.proto
+++ b/proto/tripcommon.proto
@@ -368,17 +368,17 @@ enum RoadClass {
 }
 
 message TaggedValue {
+  // dont renumber these they match the c++ definitions
   enum Type {
     kNone = 0;
     kLayer = 1;
+    kPronunciation = 2;
     kBssInfo = 3;
-    // we used to have bug when we encoded 1 and 2 as their ASCII codes, but not actual 1 and 2 values
-    // see https://github.com/valhalla/valhalla/issues/3262
-    kTunnel = 49; // static_cast<uint8_t>('1')
-    kBridge = 50; // static_cast<uint8_t>('2')
+    kTunnel = 49;
+    kBridge = 50;    
   }
   oneof has_value {
-    string value = 1;   // The actual tagged name value, examples: Ted Williams Tunnel
+    bytes value = 1;    // The actual tagged name value, examples: Ted Williams Tunnel
   }
   oneof has_type {
     Type type = 2;      // The type of tagged name (tunnel or bridge)


### PR DESCRIPTION
# what was going wrong?

so when going from proto2 to proto3 we get a new scalar type called `bytes`. this is useful in languages like java and python which want to make assertions about the type of data that is in a string vs a byte array. in c++ we roll our own so the apis are exactly the same regardless.

we have this concept of tagged values which are arbitrary data which we can attach to any edge via its edge info. the tag usually refers to the tag in osm and the value is any payload we want to attach. the first types of these were strings and were additional names for things like tunnels and bridges. but then we added other stuff like `layer` which is an integer and `pronunciation` which is a custom c++ struct and finally also bike share stations which are actually serialized protobufs.

because proto3 doesnt want c++ to send non utf8 binary stuff as a pythong `str` or java `String` and have the person on the other end in those languages get screwed over, they have implemented checks in serialization/deserialization to check that even if we dont differentiate in c++.

# how to fix

there were two ways to fix this. the first way would be to not put any non textual things in the tagged value. indeed we are currently only using tunnels for the osrm serializer. so in `triplegbuilder` we could have filtered the binary ones out. the thing is though that then if you called trace attributes and you wanted all that data you would only get the filtered list. so instead of that i've just changed the type to bytes so we can keep putting all the values in there and the consumer on the other end can know how and whether or not they want to use the data.