### PR TITLE
Reuse sample::get implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
    * CHANGED: remove boost from dependencies and add conan as prep for #3346 [#3459](https://github.com/valhalla/valhalla/pull/3459)
    * CHANGED: Remove boost.program_options in favor of cxxopts header-only lib and use conan to install header-only boost. [#3346](https://github.com/valhalla/valhalla/pull/3346)
    * CHANGED: Moved all protos to proto3 for internal request/response handling [#3457)(https://github.com/valhalla/valhalla/pull/3457)
+   * CHANGED: Reuse sample::get implementation [#3471)(https://github.com/valhalla/valhalla/pull/3471)
 
 ## Release Date: 2021-10-07 Valhalla 3.1.4
 * **Removed**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,8 @@
    * ADDED: isochrone action for /expansion endpoint to track dijkstra expansion [#3215](https://github.com/valhalla/valhalla/pull/3215)
    * CHANGED: remove boost from dependencies and add conan as prep for #3346 [#3459](https://github.com/valhalla/valhalla/pull/3459)
    * CHANGED: Remove boost.program_options in favor of cxxopts header-only lib and use conan to install header-only boost. [#3346](https://github.com/valhalla/valhalla/pull/3346)
-   * CHANGED: Moved all protos to proto3 for internal request/response handling [#3457)(https://github.com/valhalla/valhalla/pull/3457)
-   * CHANGED: Reuse sample::get implementation [#3471)(https://github.com/valhalla/valhalla/pull/3471)
+   * CHANGED: Moved all protos to proto3 for internal request/response handling [#3457](https://github.com/valhalla/valhalla/pull/3457)
+   * CHANGED: Reuse sample::get implementation [#3471](https://github.com/valhalla/valhalla/pull/3471)
 
 ## Release Date: 2021-10-07 Valhalla 3.1.4
 * **Removed**

--- a/src/skadi/sample.cc
+++ b/src/skadi/sample.cc
@@ -458,6 +458,7 @@ template <class coord_t> double sample::get(const coord_t& coord, tile_data& til
   auto lat = std::floor(coord.second);
   auto index = static_cast<uint16_t>(lat + 90) * 360 + static_cast<uint16_t>(lon + 180);
 
+  // the caller can pass a cached tile, so we only fetch one if its not the one they already have
   if (index != tile.get_index()) {
     // get the proper source of the data
     tile = cache_->source(index);

--- a/valhalla/skadi/sample.h
+++ b/valhalla/skadi/sample.h
@@ -8,6 +8,7 @@ namespace valhalla {
 namespace skadi {
 
 struct cache_t;
+class tile_data;
 
 class sample {
 public:
@@ -43,6 +44,16 @@ public:
   static double get_no_data_value();
 
 protected:
+  /**
+   * Get a single sample from the datasource
+   * supplies the current tile - so if the same tile is requested in succession it does not have to
+   * look up the tile in the cache.
+   * @param coord  the single posting at which to sample the datasource
+   * @param tile the tile pointer that may already contain a tile, output value
+   * @return a single sample
+   */
+  template <class coord_t> double get(const coord_t& coord, tile_data& tile);
+
   /**
    * @return A tile index value from a coordinate
    */


### PR DESCRIPTION
# Issue

Previously we had duplicated logic for `sample::get` and `sample::get_all`. The PR
- removes the duplication by adding helper method `get(coord, tile&)`(like we have in [GraphReader](https://github.com/valhalla/valhalla/blob/ba50b993cc02be4e610f0231a71a40b3153b936c/valhalla/baldr/graphreader.h#L482))
- minor: sets default `tile_data` index to invalid value(i.e `TILE_COUNT` instead of 0)

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
