### PR TITLE
switch to loki logging config for valhalla_service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
    * FIXED: Relax test margin for time dependent traffic test [#3467](https://github.com/valhalla/valhalla/pull/3467)
    * FIXED: Fixed missed intersection heading [#3463](https://github.com/valhalla/valhalla/pull/3463)
    * FIXED: Stopped putting binary bytes into a string field of the protobuf TaggedValue since proto3 protects against that for cross language support [#3468](https://github.com/valhalla/valhalla/pull/3468)
+   * FIXED: valhalla_service uses now loki logging config instead of deprecated tyr logging [#3481](https://github.com/valhalla/valhalla/pull/3481)
 
 * **Enhancement**
    * CHANGED: Pronunciation for names and destinations [#3132](https://github.com/valhalla/valhalla/pull/3132)

--- a/src/valhalla_service.cc
+++ b/src/valhalla_service.cc
@@ -166,7 +166,7 @@ int main(int argc, char** argv) {
 
   // configure logging
   boost::optional<boost::property_tree::ptree&> logging_subtree =
-      config.get_child_optional("tyr.logging");
+      config.get_child_optional("loki.logging");
   if (logging_subtree) {
     auto logging_config =
         valhalla::midgard::ToMap<const boost::property_tree::ptree&,


### PR DESCRIPTION
fixes #3479 

valhalla_service was using `tyr.logging` to configure logging, which is not being exported anymore by the config generator. switched to loki.logging instead.