### PR TITLE
Allow up to 32 outgoing link edges on a node when reclassifying links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
    * CHANGED: remove boost from dependencies and add conan as prep for #3346 [#3459](https://github.com/valhalla/valhalla/pull/3459)
    * CHANGED: Remove boost.program_options in favor of cxxopts header-only lib and use conan to install header-only boost. [#3346](https://github.com/valhalla/valhalla/pull/3346)
    * CHANGED: Moved all protos to proto3 for internal request/response handling [#3457)(https://github.com/valhalla/valhalla/pull/3457)
+   * CHANGED: Allow up to 32 outgoing link edges on a node when reclassifying links [#3483)(https://github.com/valhalla/valhalla/pull/3483)
 
 ## Release Date: 2021-10-07 Valhalla 3.1.4
 * **Removed**

--- a/src/mjolnir/linkclassification.cc
+++ b/src/mjolnir/linkclassification.cc
@@ -18,7 +18,7 @@ namespace valhalla {
 namespace mjolnir {
 
 constexpr uint32_t kMaxClassification = 8;
-constexpr uint32_t kMaxLinkEdges = 16;
+constexpr uint32_t kMaxLinkEdges = 32;
 constexpr uint32_t kServiceClass = static_cast<uint32_t>(RoadClass::kServiceOther);
 using nodelist_t = std::vector<std::vector<sequence<Node>::iterator>>;
 


### PR DESCRIPTION
fixes #3473 

I dug into the code enough to not understand why there was a limit of 16 children for a node in the link graph (during link reclassification). the code is pretty old but maybe you remember @dnesbitt61 ? 

I naively increased the limit to 32 which built the planet again. not sure what value you'd like to see there. the code builds a proper acyclic graph, not sure why that check is needed in the first place. maybe we can remove it entirely?