### PR TITLE
fix docker image valhalla/valhalla:run-latest: conan error + python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
    * FIXED: Fixed missed intersection heading [#3463](https://github.com/valhalla/valhalla/pull/3463)
    * FIXED: Stopped putting binary bytes into a string field of the protobuf TaggedValue since proto3 protects against that for cross language support [#3468](https://github.com/valhalla/valhalla/pull/3468)
    * FIXED: valhalla_service uses now loki logging config instead of deprecated tyr logging [#3481](https://github.com/valhalla/valhalla/pull/3481)
+   * FIXED: Docker image `valhalla/valhalla:run-latest`: conan error + python integration [#3485](https://github.com/valhalla/valhalla/pull/3485)
 
 * **Enhancement**
    * CHANGED: Pronunciation for names and destinations [#3132](https://github.com/valhalla/valhalla/pull/3132)

--- a/docker/Dockerfile-run
+++ b/docker/Dockerfile-run
@@ -12,7 +12,7 @@ RUN mkdir build
 
 # configure the build with symbols turned on so that crashes can be triaged
 WORKDIR /usr/local/src/valhalla/build
-RUN cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo
+RUN cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER=gcc
 RUN make all -j$(nproc)
 RUN make install
 

--- a/docker/Dockerfile-run
+++ b/docker/Dockerfile-run
@@ -38,6 +38,7 @@ MAINTAINER Kevin Kreiser <kevinkreiser@gmail.com>
 COPY --from=builder /usr/local /usr/local
 COPY --from=builder /usr/bin/prime_* /usr/bin/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libprime* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/python3/dist-packages/valhalla/* /usr/lib/python3/dist-packages/valhalla/
 
 # we need to add back some runtime dependencies for binaries and scripts
 # install all the posix locales that we support
@@ -48,4 +49,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt update && \
       curl gdb locales parallel python3.8-minimal python3-distutils python-is-python3 \
       spatialite-bin unzip wget && \
     cat /usr/local/src/valhalla_locales | xargs -d '\n' -n1 locale-gen && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    \
+    # python smoke test
+    python3 -c "import valhalla,sys; print (sys.version, valhalla)"


### PR DESCRIPTION
## Issue https://github.com/valhalla/valhalla/issues/3484

fix docker image: valhalla/valhalla:run-latest:
1.) Conan error in the docker build log. "ERROR: Unable to find a working compiler"
   * fix credit: https://github.com/conan-io/conan/issues/4322#issuecomment-966817920
   
2.) The valhalla-python integration is missing in the final docker image.

## Tasklist

 - [x] Add #fixes with the issue number that this PR addresses
 - [x] Update the [changelog](CHANGELOG.md)
