### PR TITLE
Update xcode up to 12.4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,14 +3,13 @@ version: 2.1
 executors:
   macos:
     macos:
-      xcode: 13.1.0
+      xcode: 12.5.1
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
 
 commands:
   install_macos_dependencies:
     steps:
-      - run: pip3 uninstall -y six
       - run: brew install protobuf cmake ccache libtool libspatialite pkg-config luajit curl wget czmq lz4 spatialite-tools unzip
       - run: pip3 install requests shapely conan
       - run: git clone https://github.com/kevinkreiser/prime_server --recurse-submodules && cd prime_server && ./autogen.sh && ./configure && make -j4 && make install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   macos:
     macos:
-      xcode: 12.5.1
+      xcode: 12.4.0
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ executors:
 commands:
   install_macos_dependencies:
     steps:
+      - run: pip3 uninstall six
       - run: brew install protobuf cmake ccache libtool libspatialite pkg-config luajit curl wget czmq lz4 spatialite-tools unzip
       - run: pip3 install requests shapely conan
       - run: git clone https://github.com/kevinkreiser/prime_server --recurse-submodules && cd prime_server && ./autogen.sh && ./configure && make -j4 && make install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 commands:
   install_macos_dependencies:
     steps:
-      - run: pip3 uninstall six
+      - run: pip3 uninstall -y six
       - run: brew install protobuf cmake ccache libtool libspatialite pkg-config luajit curl wget czmq lz4 spatialite-tools unzip
       - run: pip3 install requests shapely conan
       - run: git clone https://github.com/kevinkreiser/prime_server --recurse-submodules && cd prime_server && ./autogen.sh && ./configure && make -j4 && make install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   macos:
     macos:
-      xcode: 11.1.0
+      xcode: 13.1.0
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,8 @@
    * CHANGED: Moved all protos to proto3 for internal request/response handling [#3457](https://github.com/valhalla/valhalla/pull/3457)
    * CHANGED: Allow up to 32 outgoing link edges on a node when reclassifying links [#3483](https://github.com/valhalla/valhalla/pull/3483)
    * CHANGED: Reuse sample::get implementation [#3471](https://github.com/valhalla/valhalla/pull/3471)
-   * ADDED: Beta support for interacting with the http/bindings/library via serialized and pbf objects respectively [#3464](https:/     /github.com/valhalla/valhalla/pull/3464)
+   * ADDED: Beta support for interacting with the http/bindings/library via serialized and pbf objects respectively [#3464](https://github.com/valhalla/valhalla/pull/3464)
+   * CHANGED: Update xcode to 12.4.0 [#3492](https://github.com/valhalla/valhalla/pull/3492)
 
 ## Release Date: 2021-10-07 Valhalla 3.1.4
 * **Removed**


### PR DESCRIPTION
# Issue

Circle is deprecating xcode 11 so we need to upgrade(see https://circleci.com/docs/2.0/testing-ios/)

tldr: xcode 12.4.0 works out of the box without any other fixes, the newest xcode doesn't

# What about newest xcode version(13.12.1)
I tried different xcode versions. It looks like everything works smoothly on mac os 10.* while we need fixes for mac os 11(i.e xcode version >= 12.5.1)

## What fixes do we need for the newest xcode?
1. The first issue was `six` python package: six is installed by default and there's a conflict when you try to install protobuf via brew(six is a dependency of protobuf).
  - the fix is to remove default "six": `pip3 uninstall -y six`(see https://github.com/valhalla/valhalla/pull/3492/commits/e3fb8e924bcdd29c8d4b02553de0a0299003d7a5)

2. After that another issue popped up: prime server wasn't able to build successfully(see [build logs](https://app.circleci.com/pipelines/github/valhalla/valhalla/8732/workflows/f13cfdb5-7b71-4f2a-abd8-b3b350a7392f/jobs/51267))
```
m4/ax_pthread.m4:88: AX_PTHREAD is expanded from...
configure.ac:37: the top level
configure.ac:2: error: possibly undefined macro: m4_esyscmd
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
autoreconf: error: /usr/local/Cellar/autoconf/2.71/bin/autoconf failed with exit status: 1
```

At this moment I gave up and tried to decrease xcode version one more time. And it worked

fixes #3490