### PR TITLE
fix more protobuf unstable 3.x API problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
    * CHANGED: Reuse sample::get implementation [#3471](https://github.com/valhalla/valhalla/pull/3471)
    * ADDED: Beta support for interacting with the http/bindings/library via serialized and pbf objects respectively [#3464](https://github.com/valhalla/valhalla/pull/3464)
    * CHANGED: Update xcode to 12.4.0 [#3492](https://github.com/valhalla/valhalla/pull/3492)
+   * CHANGED: fix more protobuf unstable 3.x API [#3494](https://github.com/valhalla/valhalla/pull/3494)
 
 ## Release Date: 2021-10-07 Valhalla 3.1.4
 * **Removed**

--- a/src/mjolnir/valhalla_query_transit.cc
+++ b/src/mjolnir/valhalla_query_transit.cc
@@ -38,7 +38,7 @@ Transit read_pbf(const std::string& file_name) {
   google::protobuf::io::CodedInputStream cs(
       static_cast<google::protobuf::io::ZeroCopyInputStream*>(&as));
   auto limit = std::max(static_cast<size_t>(1), buffer.size() * 2);
-#if GOOGLE_PROTOBUF_VERSION >= 3018000
+#if GOOGLE_PROTOBUF_VERSION >= 3006000
   cs.SetTotalBytesLimit(limit);
 #else
   cs.SetTotalBytesLimit(limit, limit);

--- a/valhalla/mjolnir/transitpbf.h
+++ b/valhalla/mjolnir/transitpbf.h
@@ -138,7 +138,7 @@ void write_pbf(const Transit& tile, const filesystem::path& transit_tile) {
 #if GOOGLE_PROTOBUF_VERSION >= 3001000
   auto size = tile.ByteSizeLong();
 #else
-  auto size = tile.ByteSize()
+  auto size = tile.ByteSize();
 #endif
   valhalla::midgard::mem_map<char> buffer;
   buffer.create(transit_tile.string(), size);

--- a/valhalla/mjolnir/transitpbf.h
+++ b/valhalla/mjolnir/transitpbf.h
@@ -80,7 +80,7 @@ Transit read_pbf(const std::string& file_name, std::mutex& lock) {
   google::protobuf::io::CodedInputStream cs(
       static_cast<google::protobuf::io::ZeroCopyInputStream*>(&as));
   auto limit = std::max(static_cast<size_t>(1), buffer.size() * 2);
-#if GOOGLE_PROTOBUF_VERSION >= 3018000
+#if GOOGLE_PROTOBUF_VERSION >= 3006000
   cs.SetTotalBytesLimit(limit);
 #else
   cs.SetTotalBytesLimit(limit, limit);
@@ -102,7 +102,7 @@ Transit read_pbf(const std::string& file_name) {
   google::protobuf::io::CodedInputStream cs(
       static_cast<google::protobuf::io::ZeroCopyInputStream*>(&as));
   auto limit = std::max(static_cast<size_t>(1), buffer.size() * 2);
-#if GOOGLE_PROTOBUF_VERSION >= 3018000
+#if GOOGLE_PROTOBUF_VERSION >= 3006000
   cs.SetTotalBytesLimit(limit);
 #else
   cs.SetTotalBytesLimit(limit, limit);
@@ -135,7 +135,11 @@ void write_pbf(const Transit& tile, const filesystem::path& transit_tile) {
   if (!filesystem::exists(transit_tile.parent_path())) {
     filesystem::create_directories(transit_tile.parent_path());
   }
+#if GOOGLE_PROTOBUF_VERSION >= 3001000
   auto size = tile.ByteSizeLong();
+#else
+  auto size = tile.ByteSize()
+#endif
   valhalla::midgard::mem_map<char> buffer;
   buffer.create(transit_tile.string(), size);
   if (!tile.SerializeToArray(buffer.get(), size)) {


### PR DESCRIPTION
ref https://github.com/valhalla/valhalla/pull/3346#discussion_r778861950: pbf just kicked ByteSize for ByteSizeLong from v3.0.0 to v3.1.0 :exploding_head: 
ref #3418: lower the pbf version check in previous ifdefs