### PR TITLE
Add "Proceed to route start." localized string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
    * ADDED: Beta support for interacting with the http/bindings/library via serialized and pbf objects respectively [#3464](https://github.com/valhalla/valhalla/pull/3464)
    * CHANGED: Update xcode to 12.4.0 [#3492](https://github.com/valhalla/valhalla/pull/3492)
    * CHANGED: fix more protobuf unstable 3.x API [#3494](https://github.com/valhalla/valhalla/pull/3494)
+   * ADDED: Added "Proceed to route start." localized string [#3500](https://github.com/valhalla/valhalla/pull/3500)
 
 ## Release Date: 2021-10-07 Valhalla 3.1.4
 * **Removed**

--- a/locales/bg-BG.json
+++ b/locales/bg-BG.json
@@ -2172,6 +2172,16 @@
           "In a quarter mile, Turn right onto North Gay Street."
         ]
       }
+    },
+    "proceed_to_route_start": {
+      "phrases": {
+        "0": "Proceed to route start."
+      },
+      "example_phrases": {
+        "0": [
+          "Proceed to route start."
+        ]
+      }
     }
   }
 }

--- a/locales/ca-ES.json
+++ b/locales/ca-ES.json
@@ -2172,6 +2172,16 @@
           "In a quarter mile, Turn right onto North Gay Street."
         ]
       }
+    },
+    "proceed_to_route_start": {
+      "phrases": {
+        "0": "Proceed to route start."
+      },
+      "example_phrases": {
+        "0": [
+          "Proceed to route start."
+        ]
+      }
     }
   }
 }

--- a/locales/cs-CZ.json
+++ b/locales/cs-CZ.json
@@ -2172,6 +2172,16 @@
           "In a quarter mile, Turn right onto North Gay Street."
         ]
       }
+    },
+    "proceed_to_route_start": {
+      "phrases": {
+        "0": "Proceed to route start."
+      },
+      "example_phrases": {
+        "0": [
+          "Proceed to route start."
+        ]
+      }
     }
   }
 }

--- a/locales/da-DK.json
+++ b/locales/da-DK.json
@@ -2172,6 +2172,16 @@
           "In a quarter mile, Turn right onto North Gay Street."
         ]
       }
+    },
+    "proceed_to_route_start": {
+      "phrases": {
+        "0": "Proceed to route start."
+      },
+      "example_phrases": {
+        "0": [
+          "Proceed to route start."
+        ]
+      }
     }
   }
 }

--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -2172,6 +2172,16 @@
           "In a quarter mile, Turn right onto North Gay Street."
         ]
       }
+    },
+    "proceed_to_route_start": {
+      "phrases": {
+        "0": "Proceed to route start."
+      },
+      "example_phrases": {
+        "0": [
+          "Proceed to route start."
+        ]
+      }
     }
   }
 }

--- a/locales/el-GR.json
+++ b/locales/el-GR.json
@@ -2172,6 +2172,16 @@
           "In a quarter mile, Turn right onto North Gay Street."
         ]
       }
+    },
+    "proceed_to_route_start": {
+      "phrases": {
+        "0": "Proceed to route start."
+      },
+      "example_phrases": {
+        "0": [
+          "Proceed to route start."
+        ]
+      }
     }
   }
 }

--- a/locales/en-GB.json
+++ b/locales/en-GB.json
@@ -2172,6 +2172,16 @@
           "In a quarter mile, Turn right onto North Gay Street."
         ]
       }
+    },
+    "proceed_to_route_start": {
+      "phrases": {
+        "0": "Proceed to route start."
+      },
+      "example_phrases": {
+        "0": [
+          "Proceed to route start."
+        ]
+      }
     }
   }
 }

--- a/locales/en-US-x-pirate.json
+++ b/locales/en-US-x-pirate.json
@@ -2172,6 +2172,16 @@
           "In a quarter mile, Turn right onto North Gay Street."
         ]
       }
+    },
+    "proceed_to_route_start": {
+      "phrases": {
+        "0": "Proceed to route start."
+      },
+      "example_phrases": {
+        "0": [
+          "Proceed to route start."
+        ]
+      }
     }
   }
 }

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -2172,6 +2172,16 @@
           "In a quarter mile, Turn right onto North Gay Street."
         ]
       }
+    },
+    "proceed_to_route_start": {
+      "phrases": {
+        "0": "Proceed to route start."
+      },
+      "example_phrases": {
+        "0": [
+          "Proceed to route start."
+        ]
+      }
     }
   }
 }

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -2172,6 +2172,16 @@
           "In a quarter mile, Turn right onto North Gay Street."
         ]
       }
+    },
+    "proceed_to_route_start": {
+      "phrases": {
+        "0": "Proceed to route start."
+      },
+      "example_phrases": {
+        "0": [
+          "Proceed to route start."
+        ]
+      }
     }
   }
 }

--- a/locales/et-EE.json
+++ b/locales/et-EE.json
@@ -2172,6 +2172,16 @@
           "In a quarter mile, Turn right onto North Gay Street."
         ]
       }
+    },
+    "proceed_to_route_start": {
+      "phrases": {
+        "0": "Proceed to route start."
+      },
+      "example_phrases": {
+        "0": [
+          "Proceed to route start."
+        ]
+      }
     }
   }
 }

--- a/locales/fi-FI.json
+++ b/locales/fi-FI.json
@@ -2172,6 +2172,16 @@
           "In a quarter mile, Turn right onto North Gay Street."
         ]
       }
+    },
+    "proceed_to_route_start": {
+      "phrases": {
+        "0": "Proceed to route start."
+      },
+      "example_phrases": {
+        "0": [
+          "Proceed to route start."
+        ]
+      }
     }
   }
 }

--- a/locales/fr-FR.json
+++ b/locales/fr-FR.json
@@ -2172,6 +2172,16 @@
           "In a quarter mile, Turn right onto North Gay Street."
         ]
       }
+    },
+    "proceed_to_route_start": {
+      "phrases": {
+        "0": "Proceed to route start."
+      },
+      "example_phrases": {
+        "0": [
+          "Proceed to route start."
+        ]
+      }
     }
   }
 }

--- a/locales/hi-IN.json
+++ b/locales/hi-IN.json
@@ -2172,6 +2172,16 @@
           "In a quarter mile, Turn right onto North Gay Street."
         ]
       }
+    },
+    "proceed_to_route_start": {
+      "phrases": {
+        "0": "Proceed to route start."
+      },
+      "example_phrases": {
+        "0": [
+          "Proceed to route start."
+        ]
+      }
     }
   }
 }

--- a/locales/hu-HU.json
+++ b/locales/hu-HU.json
@@ -2172,6 +2172,16 @@
           "In a quarter mile, Turn right onto North Gay Street."
         ]
       }
+    },
+    "proceed_to_route_start": {
+      "phrases": {
+        "0": "Proceed to route start."
+      },
+      "example_phrases": {
+        "0": [
+          "Proceed to route start."
+        ]
+      }
     }
   }
 }

--- a/locales/it-IT.json
+++ b/locales/it-IT.json
@@ -2172,6 +2172,16 @@
           "In a quarter mile, Turn right onto North Gay Street."
         ]
       }
+    },
+    "proceed_to_route_start": {
+      "phrases": {
+        "0": "Proceed to route start."
+      },
+      "example_phrases": {
+        "0": [
+          "Proceed to route start."
+        ]
+      }
     }
   }
 }

--- a/locales/ja-JP.json
+++ b/locales/ja-JP.json
@@ -2172,6 +2172,16 @@
           "In a quarter mile, Turn right onto North Gay Street."
         ]
       }
+    },
+    "proceed_to_route_start": {
+      "phrases": {
+        "0": "Proceed to route start."
+      },
+      "example_phrases": {
+        "0": [
+          "Proceed to route start."
+        ]
+      }
     }
   }
 }

--- a/locales/nb-NO.json
+++ b/locales/nb-NO.json
@@ -2172,6 +2172,16 @@
           "In a quarter mile, Turn right onto North Gay Street."
         ]
       }
+    },
+    "proceed_to_route_start": {
+      "phrases": {
+        "0": "Proceed to route start."
+      },
+      "example_phrases": {
+        "0": [
+          "Proceed to route start."
+        ]
+      }
     }
   }
 }

--- a/locales/nl-NL.json
+++ b/locales/nl-NL.json
@@ -2172,6 +2172,16 @@
           "In a quarter mile, Turn right onto North Gay Street."
         ]
       }
+    },
+    "proceed_to_route_start": {
+      "phrases": {
+        "0": "Proceed to route start."
+      },
+      "example_phrases": {
+        "0": [
+          "Proceed to route start."
+        ]
+      }
     }
   }
 }

--- a/locales/pl-PL.json
+++ b/locales/pl-PL.json
@@ -2172,6 +2172,16 @@
           "In a quarter mile, Turn right onto North Gay Street."
         ]
       }
+    },
+    "proceed_to_route_start": {
+      "phrases": {
+        "0": "Proceed to route start."
+      },
+      "example_phrases": {
+        "0": [
+          "Proceed to route start."
+        ]
+      }
     }
   }
 }

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -2172,6 +2172,16 @@
           "In a quarter mile, Turn right onto North Gay Street."
         ]
       }
+    },
+    "proceed_to_route_start": {
+      "phrases": {
+        "0": "Proceed to route start."
+      },
+      "example_phrases": {
+        "0": [
+          "Proceed to route start."
+        ]
+      }
     }
   }
 }

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -2172,6 +2172,16 @@
           "In a quarter mile, Turn right onto North Gay Street."
         ]
       }
+    },
+    "proceed_to_route_start": {
+      "phrases": {
+        "0": "Proceed to route start."
+      },
+      "example_phrases": {
+        "0": [
+          "Proceed to route start."
+        ]
+      }
     }
   }
 }

--- a/locales/ro-RO.json
+++ b/locales/ro-RO.json
@@ -2172,6 +2172,16 @@
           "In a quarter mile, Turn right onto North Gay Street."
         ]
       }
+    },
+    "proceed_to_route_start": {
+      "phrases": {
+        "0": "Proceed to route start."
+      },
+      "example_phrases": {
+        "0": [
+          "Proceed to route start."
+        ]
+      }
     }
   }
 }

--- a/locales/ru-RU.json
+++ b/locales/ru-RU.json
@@ -2172,6 +2172,16 @@
           "In a quarter mile, Turn right onto North Gay Street."
         ]
       }
+    },
+    "proceed_to_route_start": {
+      "phrases": {
+        "0": "Proceed to route start."
+      },
+      "example_phrases": {
+        "0": [
+          "Proceed to route start."
+        ]
+      }
     }
   }
 }

--- a/locales/sk-SK.json
+++ b/locales/sk-SK.json
@@ -2172,6 +2172,16 @@
           "Po štvrť míle, Odbočte vpravo na North Gay Street."
         ]
       }
+    },
+    "proceed_to_route_start": {
+      "phrases": {
+        "0": "Proceed to route start."
+      },
+      "example_phrases": {
+        "0": [
+          "Proceed to route start."
+        ]
+      }
     }
   }
 }

--- a/locales/sl-SI.json
+++ b/locales/sl-SI.json
@@ -2172,6 +2172,16 @@
           "In a quarter mile, Turn right onto North Gay Street."
         ]
       }
+    },
+    "proceed_to_route_start": {
+      "phrases": {
+        "0": "Proceed to route start."
+      },
+      "example_phrases": {
+        "0": [
+          "Proceed to route start."
+        ]
+      }
     }
   }
 }

--- a/locales/sv-SE.json
+++ b/locales/sv-SE.json
@@ -2172,6 +2172,16 @@
           "In a quarter mile, Turn right onto North Gay Street."
         ]
       }
+    },
+    "proceed_to_route_start": {
+      "phrases": {
+        "0": "Proceed to route start."
+      },
+      "example_phrases": {
+        "0": [
+          "Proceed to route start."
+        ]
+      }
     }
   }
 }

--- a/locales/tr-TR.json
+++ b/locales/tr-TR.json
@@ -2172,6 +2172,16 @@
           "In a quarter mile, Turn right onto North Gay Street."
         ]
       }
+    },
+    "proceed_to_route_start": {
+      "phrases": {
+        "0": "Proceed to route start."
+      },
+      "example_phrases": {
+        "0": [
+          "Proceed to route start."
+        ]
+      }
     }
   }
 }

--- a/locales/uk-UA.json
+++ b/locales/uk-UA.json
@@ -2172,6 +2172,16 @@
           "In a quarter mile, Turn right onto North Gay Street."
         ]
       }
+    },
+    "proceed_to_route_start": {
+      "phrases": {
+        "0": "Proceed to route start."
+      },
+      "example_phrases": {
+        "0": [
+          "Proceed to route start."
+        ]
+      }
     }
   }
 }

--- a/src/odin/narrative_dictionary.cc
+++ b/src/odin/narrative_dictionary.cc
@@ -314,6 +314,11 @@ void NarrativeDictionary::Load(const boost::property_tree::ptree& narrative_pt) 
   LOG_TRACE("Populate approach_verbal_alert_subset...");
   // Populate approach_verbal_alert_subset
   Load(approach_verbal_alert_subset, narrative_pt.get_child(kApproachVerbalAlertKey));
+
+  /////////////////////////////////////////////////////////////////////////////
+  LOG_TRACE("Populate proceed_to_route_start_subset...");
+  // Populate proceed_to_route_start_subset
+  Load(proceed_to_route_start_subset, narrative_pt.get_child(kProceedToRouteStartKey));
 }
 
 void NarrativeDictionary::Load(PhraseSet& phrase_handle,

--- a/test/narrative_dictionary.cc
+++ b/test/narrative_dictionary.cc
@@ -1339,10 +1339,10 @@ TEST(NarrativeDictionary, test_en_US_approach_verbal_alert) {
 }
 
 TEST(NarrativeDictionary, test_en_US_proceed_to_route_start) {
-    const NarrativeDictionary& dictionary = GetNarrativeDictionary("en-US");
+  const NarrativeDictionary& dictionary = GetNarrativeDictionary("en-US");
 
-    const auto& phrase_0 = dictionary.proceed_to_route_start_subset.phrases.at("0");
-    validate(phrase_0, "Proceed to route start.");
+  const auto& phrase_0 = dictionary.proceed_to_route_start_subset.phrases.at("0");
+  validate(phrase_0, "Proceed to route start.");
 }
 
 } // namespace

--- a/test/narrative_dictionary.cc
+++ b/test/narrative_dictionary.cc
@@ -1338,6 +1338,13 @@ TEST(NarrativeDictionary, test_en_US_approach_verbal_alert) {
   validate(us_customary_lengths, kExpectedUsCustomaryLengths);
 }
 
+TEST(NarrativeDictionary, test_en_US_proceed_to_route_start) {
+    const NarrativeDictionary& dictionary = GetNarrativeDictionary("en-US");
+
+    const auto& phrase_0 = dictionary.proceed_to_route_start_subset.phrases.at("0");
+    validate(phrase_0, "Proceed to route start.");
+}
+
 } // namespace
 
 int main(int argc, char* argv[]) {

--- a/valhalla/odin/narrative_dictionary.h
+++ b/valhalla/odin/narrative_dictionary.h
@@ -76,6 +76,7 @@ constexpr auto kPostTransitionVerbalKey = "instructions.post_transition_verbal";
 constexpr auto kPostTransitTransitionVerbalKey = "instructions.post_transition_transit_verbal";
 constexpr auto kVerbalMultiCueKey = "instructions.verbal_multi_cue";
 constexpr auto kApproachVerbalAlertKey = "instructions.approach_verbal_alert";
+constexpr auto kProceedToRouteStartKey = "instructions.proceed_to_route_start";
 constexpr auto kPosixLocaleKey = "posix_locale";
 
 // Variable keys
@@ -361,6 +362,9 @@ public:
 
   // Approach verbal alert
   ApproachVerbalAlertSubset approach_verbal_alert_subset;
+
+  // Proceed to route start
+  PhraseSet proceed_to_route_start_subset;
 
   // Posix locale
   std::string posix_locale;


### PR DESCRIPTION
# Issue

The "Proceed to route start." localized string was added.
It is still required to push the string to Transifex and wait for translations.

## Tasklist

 - [x] Add tests
 - [x] Update the [changelog](CHANGELOG.md)
 