### PR TITLE
Only consider a road hov-only if both hov:designated and hov:minimum are correctly set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Release Date: 2021-??-?? Valhalla 3.1.5
 * **Removed**
 * **Bug Fix**
+   * FIXED: Both `hov:designated` and `hov:minimum` have to be correctly set for the way to be considered hov-only
    * FIXED: Fix precision losses while encoding-decoding distance parameter in openlr [#3374](https://github.com/valhalla/valhalla/pull/3374)
    * FIXED: Fix bearing calculation for openlr records [#3379](https://github.com/valhalla/valhalla/pull/3379)
    * FIXED: Some refactoring that was proposed for the PR 3379 [3381](https://github.com/valhalla/valhalla/pull/3381)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Release Date: 2021-??-?? Valhalla 3.1.5
 * **Removed**
 * **Bug Fix**
-   * FIXED: Both `hov:designated` and `hov:minimum` have to be correctly set for the way to be considered hov-only
+   * FIXED: Both `hov:designated` and `hov:minimum` have to be correctly set for the way to be considered hov-only [#3526](https://github.com/valhalla/valhalla/pull/3526)
    * FIXED: Fix precision losses while encoding-decoding distance parameter in openlr [#3374](https://github.com/valhalla/valhalla/pull/3374)
    * FIXED: Fix bearing calculation for openlr records [#3379](https://github.com/valhalla/valhalla/pull/3379)
    * FIXED: Some refactoring that was proposed for the PR 3379 [3381](https://github.com/valhalla/valhalla/pull/3381)

--- a/test/gurka/test_hov.cc
+++ b/test/gurka/test_hov.cc
@@ -103,6 +103,7 @@ TEST(HOVTest, mistagged_hov) {
     auto edge_tuple = gurka::findEdgeByNodes(*reader, layout, "A", "B");
     const baldr::DirectedEdge* edge = std::get<1>(edge_tuple);
     ASSERT_EQ(edge->is_hov_only(), false);
+    ASSERT_TRUE(edge->forwardaccess() & kAutoAccess);
   }
 }
 


### PR DESCRIPTION
# Issue

An issue was found where a `way` was tagged with `hov:designated` but was missing `hov:minimum`.  This exposed an issue that prevented all routing on the oddly tagged way.

Now both `hov:designated` and `hov:minimum` have to be correctly set for the way to be considered hov-only.

I was able to modify an existing test to prove correctness. 

## Tasklist

 - [x] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
