### PR TITLE
Add helpers for DirectedEdgeExt and save them to file in GraphTileBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
    * FIXED: Fix some country overrides in adminconstants and add a couple new countries. [#3578](https://github.com/valhalla/valhalla/pull/3578)
    
 * **Enhancement**
+   * ADDED: Add helpers for DirectedEdgeExt and save them to file in GraphTileBuilder [#3562](https://github.com/valhalla/valhalla/pull/3562)
    * CHANGED: Pronunciation for names and destinations [#3132](https://github.com/valhalla/valhalla/pull/3132)
    * CHANGED: Requested code clean up for phonemes PR [#3356](https://github.com/valhalla/valhalla/pull/3356)
    * CHANGED: Refactor Pronunciation class to struct [#3359](https://github.com/valhalla/valhalla/pull/3359)

--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -702,6 +702,15 @@ GraphTile::GetDirectedEdges(const uint32_t node_index, uint32_t& count, uint32_t
   return directededge(nodeinfo->edge_index());
 }
 
+// Get the directed edge extensions outbound from the specified node index.
+const DirectedEdgeExt*
+GraphTile::GetDirectedEdgeExts(const uint32_t node_index, uint32_t& count, uint32_t& edge_index) const {
+  const NodeInfo* nodeinfo = node(node_index);
+  count = nodeinfo->edge_count();
+  edge_index = nodeinfo->edge_index();
+  return ext_directededge(nodeinfo->edge_index());
+}
+
 // Convenience method to get the names for an edge
 std::vector<std::string> GraphTile::GetNames(const DirectedEdge* edge) const {
   return edgeinfo(edge).GetNames();

--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -626,6 +626,41 @@ iterable_t<const DirectedEdge> GraphTile::GetDirectedEdges(const size_t idx) con
   return iterable_t<const DirectedEdge>{edge, nodeinfo.edge_count()};
 }
 
+iterable_t<const DirectedEdgeExt> GraphTile::GetDirectedEdgeExts(const NodeInfo* node) const {
+  if (node < nodes_ || node >= nodes_ + header_->nodecount()) {
+    throw std::logic_error(
+        std::string(__FILE__) + ":" + std::to_string(__LINE__) +
+        " GraphTile NodeInfo out of bounds: " + std::to_string(header_->graphid()));
+  }
+  const auto* edge_ext = ext_directededges_ + node->edge_index();
+  return iterable_t<const DirectedEdgeExt>{edge_ext, node->edge_count()};
+}
+
+iterable_t<const DirectedEdgeExt> GraphTile::GetDirectedEdgeExts(const GraphId& node) const {
+  if (node.Tile_Base() != header_->graphid() || node.id() >= header_->nodecount()) {
+    throw std::logic_error(
+        std::string(__FILE__) + ":" + std::to_string(__LINE__) +
+        " GraphTile NodeInfo index out of bounds: " + std::to_string(node.tileid()) + "," +
+        std::to_string(node.level()) + "," + std::to_string(node.id()) +
+        " nodecount= " + std::to_string(header_->nodecount()));
+  }
+  const auto* nodeinfo = nodes_ + node.id();
+  return GetDirectedEdgeExts(nodeinfo);
+}
+
+iterable_t<const DirectedEdgeExt> GraphTile::GetDirectedEdgeExts(const size_t idx) const {
+  if (idx >= header_->nodecount()) {
+    throw std::logic_error(
+        std::string(__FILE__) + ":" + std::to_string(__LINE__) +
+        " GraphTile NodeInfo index out of bounds 5: " + std::to_string(header_->graphid().tileid()) +
+        "," + std::to_string(header_->graphid().level()) + "," + std::to_string(idx) +
+        " nodecount= " + std::to_string(header_->nodecount()));
+  }
+  const auto& nodeinfo = nodes_[idx];
+  const auto* edge_ext = ext_directededge(nodeinfo.edge_index());
+  return iterable_t<const DirectedEdgeExt>{edge_ext, nodeinfo.edge_count()};
+}
+
 EdgeInfo GraphTile::edgeinfo(const DirectedEdge* edge) const {
   return EdgeInfo(edgeinfo_ + edge->edgeinfo_offset(), textlist_, textlist_size_);
 }

--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -703,8 +703,9 @@ GraphTile::GetDirectedEdges(const uint32_t node_index, uint32_t& count, uint32_t
 }
 
 // Get the directed edge extensions outbound from the specified node index.
-const DirectedEdgeExt*
-GraphTile::GetDirectedEdgeExts(const uint32_t node_index, uint32_t& count, uint32_t& edge_index) const {
+const DirectedEdgeExt* GraphTile::GetDirectedEdgeExts(const uint32_t node_index,
+                                                      uint32_t& count,
+                                                      uint32_t& edge_index) const {
   const NodeInfo* nodeinfo = node(node_index);
   count = nodeinfo->edge_count();
   edge_index = nodeinfo->edge_index();

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -954,6 +954,14 @@ DirectedEdge& GraphTileBuilder::directededge_builder(const size_t idx) {
   throw std::runtime_error("GraphTile DirectedEdge id out of bounds");
 }
 
+// Get the directed edge extension builder at the specified index.
+DirectedEdgeExt& GraphTileBuilder::directededge_ext_builder(const size_t idx) {
+  if (idx < header_->directededgecount()) {
+    return directededges_ext_builder_[idx];
+  }
+  throw std::runtime_error("GraphTile DirectedEdgeExt id out of bounds");
+}
+
 // Gets a non-const access restriction from existing tile data.
 AccessRestriction& GraphTileBuilder::accessrestriction(const size_t idx) {
   if (idx < header_->access_restriction_count()) {

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -91,6 +91,13 @@ GraphTileBuilder::GraphTileBuilder(const std::string& tile_dir,
   std::copy(directededges_, directededges_ + n, std::back_inserter(directededges_builder_));
 
   // Add extended directededge attributes (if available)
+  if (header_->has_ext_directededge()) {
+    // Copy extended directed edges to the builder list
+    // NOTE: directed edge and directed edge extensions are assumed to have the
+    // same length
+    directededges_ext_builder_.reserve(n);
+    std::copy(ext_directededges_, ext_directededges_ + n, std::back_inserter(directededges_ext_builder_));
+  }
 
   // Create access restriction list
   for (uint32_t i = 0; i < header_->access_restriction_count(); i++) {

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -96,7 +96,8 @@ GraphTileBuilder::GraphTileBuilder(const std::string& tile_dir,
     // NOTE: directed edge and directed edge extensions are assumed to have the
     // same length
     directededges_ext_builder_.reserve(n);
-    std::copy(ext_directededges_, ext_directededges_ + n, std::back_inserter(directededges_ext_builder_));
+    std::copy(ext_directededges_, ext_directededges_ + n,
+              std::back_inserter(directededges_ext_builder_));
   }
 
   // Create access restriction list

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -922,6 +922,14 @@ DirectedEdge& GraphTileBuilder::directededge(const size_t idx) {
   throw std::runtime_error("GraphTile DirectedEdge id out of bounds");
 }
 
+// Gets a non-const directed edge extension from existing tile data.
+DirectedEdgeExt& GraphTileBuilder::directededge_ext(const size_t idx) {
+  if (idx < header_->directededgecount()) {
+    return ext_directededges_[idx];
+  }
+  throw std::runtime_error("GraphTile DirectedEdgeExt id out of bounds");
+}
+
 // Gets a pointer to directed edges within the list being built.
 const DirectedEdge* GraphTileBuilder::directededges(const size_t idx) const {
   if (idx < header_->directededgecount()) {

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -938,6 +938,14 @@ const DirectedEdge* GraphTileBuilder::directededges(const size_t idx) const {
   throw std::runtime_error("GraphTile DirectedEdge id out of bounds");
 }
 
+// Gets a pointer to directed edge extensions within the list being built.
+const DirectedEdgeExt* GraphTileBuilder::directededges_ext(const size_t idx) const {
+  if (idx < header_->directededgecount()) {
+    return &directededges_ext_builder_[idx];
+  }
+  throw std::runtime_error("GraphTile DirectedEdgeExt id out of bounds");
+}
+
 // Get the directed edge builder at the specified index.
 DirectedEdge& GraphTileBuilder::directededge_builder(const size_t idx) {
   if (idx < header_->directededgecount()) {

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -459,6 +459,11 @@ std::vector<DirectedEdge>& GraphTileBuilder::directededges() {
   return directededges_builder_;
 }
 
+// Gets the current list of directed edge extension (builders).
+std::vector<DirectedEdgeExt>& GraphTileBuilder::directededges_ext() {
+  return directededges_ext_builder_;
+}
+
 // Add a transit departure.
 void GraphTileBuilder::AddTransitDeparture(const TransitDeparture& departure) {
   departure_builder_.emplace_back(std::move(departure));

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -379,6 +379,14 @@ public:
   }
 
   /**
+   * Get an iterable set of edge extensions in this tile
+   * @return returns an iterable collection of edge extensions
+   */
+  midgard::iterable_t<const DirectedEdgeExt> GetDirectedEdgeExts() const {
+    return midgard::iterable_t<const DirectedEdgeExt>{ext_directededges_, header_->directededgecount()};
+  }
+
+  /**
    * Get a pointer to edge info.
    * @return  Returns edge info.
    */

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -245,7 +245,7 @@ public:
    * @param  idx  Index of the directed edge within the current tile.
    * @return  Returns a pointer to the edge.
    */
-  const DirectedEdge* directededge(const size_t idx) const {
+  const DirectedEdgeExt* ext_directededge(const size_t idx) const {
     // Testing against directededgecount since the number of directed edges
     // should be the same as the number of directed edge extensions
     if (idx < header_->directededgecount()) {
@@ -280,6 +280,30 @@ public:
    * @return returns an iterable collection of directed edges
    */
   midgard::iterable_t<const DirectedEdge> GetDirectedEdges(const size_t idx) const;
+
+  /**
+   * Get an iterable set of directed edges extensions from a node in this tile
+   * @param  node  Node from which the edges leave
+   * @return returns an iterable collection of directed edges extensions
+   */
+  midgard::iterable_t<const DirectedEdgeExt> GetDirectedEdgeExts(const NodeInfo* node) const;
+
+  /**
+   * Get an iterable set of directed edges extensions from a node in this tile
+   * @param  node  GraphId of the node from which the edges leave
+   * @return returns an iterable collection of directed edges extensions
+   */
+  midgard::iterable_t<const DirectedEdgeExt> GetDirectedEdgeExts(const GraphId& node) const;
+
+  /**
+   * Get an iterable set of directed edges extensions from a node in this tile
+   * WARNING: this only returns edge extensions in this tile, edges at this node on another level
+   *          will not be returned by this method, node transitions must be used
+   *
+   * @param  idx  Index of the node within the current tile
+   * @return returns an iterable collection of directed edges extensions
+   */
+  midgard::iterable_t<const DirectedEdgeExt> GetDirectedEdgeExts(const size_t idx) const;
 
   /**
    * Convenience method to get opposing edge Id given a directed edge.

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -414,6 +414,16 @@ public:
   GetDirectedEdges(const uint32_t node_index, uint32_t& count, uint32_t& edge_index) const;
 
   /**
+   * Convenience method to get the directed edge extensions originating at a node.
+   * @param  node_index  Node Id within this tile.
+   * @param  count       (OUT) Number of outbound edges
+   * @param  edge_index  (OUT) Index of the first outbound edge.
+   * @return  Returns a pointer to the first outbound directed edge extension.
+   */
+  const DirectedEdgeExt*
+  GetDirectedEdgeExts(const uint32_t node_index, uint32_t& count, uint32_t& edge_index) const;
+
+  /**
    * Convenience method to get the names for an edge
    * @param  edge  Directed edge
    *

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -241,6 +241,23 @@ public:
   }
 
   /**
+   * Get a pointer to an edge extension.
+   * @param  idx  Index of the directed edge within the current tile.
+   * @return  Returns a pointer to the edge.
+   */
+  const DirectedEdge* directededge(const size_t idx) const {
+    // Testing against directededgecount since the number of directed edges
+    // should be the same as the number of directed edge extensions
+    if (idx < header_->directededgecount()) {
+      return &ext_directededges_[idx];
+    }
+    throw std::runtime_error(
+        "GraphTile DirectedEdgeExt index out of bounds: " + std::to_string(header_->graphid().tileid()) +
+        "," + std::to_string(header_->graphid().level()) + "," + std::to_string(idx) +
+        " directededgecount= " + std::to_string(header_->directededgecount()));
+  }
+
+  /**
    * Get an iterable set of directed edges from a node in this tile
    * @param  node  Node from which the edges leave
    * @return returns an iterable collection of directed edges

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -234,10 +234,11 @@ public:
     if (edge.id() < header_->directededgecount()) {
       return &ext_directededges_[edge.id()];
     }
-    throw std::runtime_error(
-        "GraphTile DirectedEdgeExt index out of bounds: " + std::to_string(header_->graphid().tileid()) +
-        "," + std::to_string(header_->graphid().level()) + "," + std::to_string(edge.id()) +
-        " directededgecount= " + std::to_string(header_->directededgecount()));
+    throw std::runtime_error("GraphTile DirectedEdgeExt index out of bounds: " +
+                             std::to_string(header_->graphid().tileid()) + "," +
+                             std::to_string(header_->graphid().level()) + "," +
+                             std::to_string(edge.id()) +
+                             " directededgecount= " + std::to_string(header_->directededgecount()));
   }
 
   /**
@@ -251,10 +252,10 @@ public:
     if (idx < header_->directededgecount()) {
       return &ext_directededges_[idx];
     }
-    throw std::runtime_error(
-        "GraphTile DirectedEdgeExt index out of bounds: " + std::to_string(header_->graphid().tileid()) +
-        "," + std::to_string(header_->graphid().level()) + "," + std::to_string(idx) +
-        " directededgecount= " + std::to_string(header_->directededgecount()));
+    throw std::runtime_error("GraphTile DirectedEdgeExt index out of bounds: " +
+                             std::to_string(header_->graphid().tileid()) + "," +
+                             std::to_string(header_->graphid().level()) + "," + std::to_string(idx) +
+                             " directededgecount= " + std::to_string(header_->directededgecount()));
   }
 
   /**
@@ -383,7 +384,8 @@ public:
    * @return returns an iterable collection of edge extensions
    */
   midgard::iterable_t<const DirectedEdgeExt> GetDirectedEdgeExts() const {
-    return midgard::iterable_t<const DirectedEdgeExt>{ext_directededges_, header_->directededgecount()};
+    return midgard::iterable_t<const DirectedEdgeExt>{ext_directededges_,
+                                                      header_->directededgecount()};
   }
 
   /**

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -222,6 +222,25 @@ public:
   }
 
   /**
+   * Get a pointer to an edge extension .
+   * @param  edge  GraphId of the directed edge.
+   * @return  Returns a pointer to the edge extension.
+   */
+  const DirectedEdgeExt* ext_directededge(const GraphId& edge) const {
+    assert(edge.Tile_Base() == header_->graphid().Tile_Base());
+
+    // Testing against directededgecount since the number of directed edges
+    // should be the same as the number of directed edge extensions
+    if (edge.id() < header_->directededgecount()) {
+      return &ext_directededges_[edge.id()];
+    }
+    throw std::runtime_error(
+        "GraphTile DirectedEdgeExt index out of bounds: " + std::to_string(header_->graphid().tileid()) +
+        "," + std::to_string(header_->graphid().level()) + "," + std::to_string(edge.id()) +
+        " directededgecount= " + std::to_string(header_->directededgecount()));
+  }
+
+  /**
    * Get an iterable set of directed edges from a node in this tile
    * @param  node  Node from which the edges leave
    * @return returns an iterable collection of directed edges

--- a/valhalla/mjolnir/graphtilebuilder.h
+++ b/valhalla/mjolnir/graphtilebuilder.h
@@ -355,6 +355,14 @@ public:
   const DirectedEdge* directededges(const size_t idx) const;
 
   /**
+   * Gets a pointer to directed edge extensions within the list being built.
+   * @param  idx  Index of the directed edge within the tile.
+   * @return  Returns a pointer to the directed edge extension builder (allows
+   *          accessing all directed edge extensions from a node).
+   */
+  const DirectedEdgeExt* directededges_ext(const size_t idx) const;
+
+  /**
    * Get the directed edge builder at the specified index.
    * @param  idx  Index of the directed edge builder.
    * @return  Returns a reference to the directed edge builder.

--- a/valhalla/mjolnir/graphtilebuilder.h
+++ b/valhalla/mjolnir/graphtilebuilder.h
@@ -340,6 +340,13 @@ public:
   DirectedEdge& directededge(const size_t idx);
 
   /**
+   * Gets a directed edge extension from existing tile data.
+   * @param  idx  Index of the directed edge extension within the tile.
+   * @return  Returns a reference to the directed edge extension.
+   */
+  DirectedEdgeExt& directededge_ext(const size_t idx);
+
+  /**
    * Gets a pointer to directed edges within the list being built.
    * @param  idx  Index of the directed edge within the tile.
    * @return  Returns a pointer to the directed edge builder (allows

--- a/valhalla/mjolnir/graphtilebuilder.h
+++ b/valhalla/mjolnir/graphtilebuilder.h
@@ -88,6 +88,12 @@ public:
   std::vector<DirectedEdge>& directededges();
 
   /**
+   * Gets the current list of directed edge extension (builders).
+   * @return  Returns the directed edge extension builders.
+   */
+  std::vector<DirectedEdgeExt>& directededges_ext();
+
+  /**
    * Gets the current list of node transition (builders).
    * @return  Returns a reference to node transition builders.
    */

--- a/valhalla/mjolnir/graphtilebuilder.h
+++ b/valhalla/mjolnir/graphtilebuilder.h
@@ -369,8 +369,12 @@ public:
    */
   DirectedEdge& directededge_builder(const size_t idx);
 
-  // TODO - add access method to directededge_ext_builder if extended directed edge
-  // attributes are needed.
+  /**
+   * Get the directed edge extension builder at the specified index.
+   * @param  idx  Index of the directed edge extension builder.
+   * @return  Returns a reference to the directed edge extension builder.
+   */
+  DirectedEdgeExt& directededge_ext_builder(const size_t idx);
 
   /**
    * Gets a non-const access restriction from existing tile data.


### PR DESCRIPTION
# Issue

This PR adds helpers in `GraphTile` and `GraphTileBuilder` to manipulate `DirectedEdgeExt` lists as easily as with regular `DirectedEdge`.

It also writes the DirectedEdgeExt data to the tile if `header->has_ext_directededge_` is true.

**NOTE:** I didn't make changes to `GraphTileBuilder::Update` function as I was not sure whether to create two signatures, one that takes only a list of directed edges and assumes there are no new extensions and another that takes both edges and edge extensions and writes them together OR have an optional argument of the list of directed edge extensions...

I am not very familiar with the codebase and I haven't touched C++ in a long while so please be indulgent :)
 
## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.
