### PR TITLE
fix graphbuilder's elevation initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # editor temporary / backup files
 *~
+.venv
 
 # built objects
 valhalla_run_map_match

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
    * FIXED: Wrong predecessor opposing edge in dijkstra's expansion [#3528](https://github.com/valhalla/valhalla/pull/3528)
    * FIXED: exit and exit_verbal in Russian locale should be same [#3545](https://github.com/valhalla/valhalla/pull/3545)
    * FIXED: Skip transit tiles in hierarchy builder [#3559](https://github.com/valhalla/valhalla/pull/3559)
+   * FIXED: Fix "no elevation" values and /locate elevation response [#3571](https://github.com/valhalla/valhalla/pull/3571)
    
 * **Enhancement**
    * CHANGED: Pronunciation for names and destinations [#3132](https://github.com/valhalla/valhalla/pull/3132)

--- a/src/baldr/edgeinfo.cc
+++ b/src/baldr/edgeinfo.cc
@@ -313,11 +313,17 @@ std::string EdgeInfo::level_ref() const {
 json::MapPtr EdgeInfo::json() const {
   json::MapPtr edge_info = json::map({
       {"way_id", static_cast<uint64_t>(wayid())},
-      {"mean_elevation", static_cast<uint64_t>(mean_elevation())},
       {"bike_network", bike_network_json(bike_network())},
       {"names", names_json(GetNames())},
       {"shape", midgard::encode(shape())},
   });
+  // add the mean_elevation depending on its validity
+  const auto elev = mean_elevation();
+  if (elev == kNoElevationData) {
+    edge_info->emplace("mean_elevation", nullptr);
+  } else {
+    edge_info->emplace("mean_elevation", static_cast<int64_t>(elev));
+  }
 
   if (speed_limit() == kUnlimitedSpeedLimit) {
     edge_info->emplace("speed_limit", std::string("unlimited"));

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -732,10 +732,9 @@ void BuildTileSet(const std::string& ways_file,
               bike_network = w.bike_network();
             }
 
-            // Add edge info. Mean elevation is set to 1234 as a placeholder, set later if we have it.
             edge_info_offset =
                 graphtile.AddEdgeInfo(edge_pair.second, (*nodes[source]).graph_id,
-                                      (*nodes[target]).graph_id, w.way_id(), 1234, bike_network,
+                                      (*nodes[target]).graph_id, w.way_id(), 0, bike_network,
                                       speed_limit, shape, names, tagged_values, pronunciations, types,
                                       added, dual_refs);
             if (added) {

--- a/src/tyr/trace_serializer.cc
+++ b/src/tyr/trace_serializer.cc
@@ -111,10 +111,18 @@ json::ArrayPtr serialize_edges(const AttributesController& controller,
         edge_map->emplace("lane_connectivity", lane_connectivity);
       }
       if (controller(kEdgeMaxDownwardGrade)) {
-        edge_map->emplace("max_downward_grade", static_cast<int64_t>(edge.max_downward_grade()));
+        if (edge.max_downward_grade() == kNoElevationData) {
+          edge_map->emplace("max_downward_grade", static_cast<int64_t>(edge.max_downward_grade()));
+        } else {
+          edge_map->emplace("max_downward_grade", nullptr);
+        }
       }
       if (controller(kEdgeMaxUpwardGrade)) {
-        edge_map->emplace("max_upward_grade", static_cast<int64_t>(edge.max_upward_grade()));
+        if (edge.max_downward_grade() == kNoElevationData) {
+          edge_map->emplace("max_upward_grade", static_cast<int64_t>(edge.max_upward_grade()));
+        } else {
+          edge_map->emplace("max_upward_grade", nullptr);
+        }
       }
       if (controller(kEdgeWeightedGrade)) {
         edge_map->emplace("weighted_grade", json::fixed_t{edge.weighted_grade(), 3});
@@ -122,10 +130,13 @@ json::ArrayPtr serialize_edges(const AttributesController& controller,
       if (controller(kEdgeMeanElevation)) {
         // Convert to feet if a valid elevation and units are miles
         float mean = edge.mean_elevation();
-        if (mean != kNoElevationData && options.units() == Options::miles) {
-          mean *= kFeetPerMeter;
+        if (mean == kNoElevationData) {
+          edge_map->emplace("mean_elevation", nullptr);
+        } else {
+          edge_map->emplace("mean_elevation", static_cast<int64_t>(options.units() == Options::miles
+                                                                       ? mean
+                                                                       : mean * kFeetPerMeter));
         }
-        edge_map->emplace("mean_elevation", static_cast<int64_t>(mean));
       }
       if (controller(kEdgeWayId)) {
         edge_map->emplace("way_id", static_cast<uint64_t>(edge.way_id()));

--- a/valhalla/baldr/graphconstants.h
+++ b/valhalla/baldr/graphconstants.h
@@ -198,7 +198,8 @@ constexpr uint32_t kMaxCurvatureFactor = 15;
 constexpr uint32_t kMaxAddedTime = 255;
 
 // Elevation constants
-constexpr float kNoElevationData = 32768.0f;
+// this is the minimum we support, i.e. -500 m would result in "no elevation"
+constexpr float kNoElevationData = -500;
 
 // Node types.
 enum class NodeType : uint8_t {


### PR DESCRIPTION
fixes https://github.com/valhalla/valhalla/issues/3258

finally getting some time to fix some of my old issues.. 

mostly fixes returning `"mean_elevation": null` when there is none, instead of `1234`. also some others:

`EdgeInfo::json` was casting elevation to an unsigned integer, leading to bogus values for the (admittedly few) roads which are sub sea level, e.g. next to dead sea:
```
curl --request POST \
  --url https://valhalla1.openstreetmap.de/locate \
  --header 'Content-Type: application/json' \
  --data '{
	"costing": "auto",
	"verbose": true,
	"id": 1,
	"locations": [
		{
			"lon": 35.408936,
			"lat": 31.591404
		}
	]
}'
```
leads to `"mean_elevation": 18446744073709551254`. with this PR it's `"mean_elevation": -362`.