### PR TITLE
Const graph tile memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
    * FIXED: Wrong predecessor opposing edge in dijkstra's expansion [#3528](https://github.com/valhalla/valhalla/pull/3528)
    * FIXED: exit and exit_verbal in Russian locale should be same [#3545](https://github.com/valhalla/valhalla/pull/3545)
    * FIXED: Skip transit tiles in hierarchy builder [#3559](https://github.com/valhalla/valhalla/pull/3559)
+   * FIXED: Const graph tile memory [#3575](https://github.com/valhalla/valhalla/pull/3575)
    
 * **Enhancement**
    * CHANGED: Pronunciation for names and destinations [#3132](https://github.com/valhalla/valhalla/pull/3132)

--- a/src/baldr/edgeinfo.cc
+++ b/src/baldr/edgeinfo.cc
@@ -37,14 +37,14 @@ json::ArrayPtr names_json(const std::vector<std::string>& names) {
 namespace valhalla {
 namespace baldr {
 
-EdgeInfo::EdgeInfo(char* ptr, const char* names_list, const size_t names_list_length)
+EdgeInfo::EdgeInfo(const char* ptr, const char* names_list, const size_t names_list_length)
     : names_list_(names_list), names_list_length_(names_list_length) {
 
-  ei_ = *reinterpret_cast<EdgeInfoInner*>(ptr);
+  ei_ = *reinterpret_cast<const EdgeInfoInner*>(ptr);
   ptr += sizeof(EdgeInfoInner);
 
   // Set name info list pointer
-  name_info_list_ = reinterpret_cast<NameInfo*>(ptr);
+  name_info_list_ = reinterpret_cast<const NameInfo*>(ptr);
   ptr += (name_count() * sizeof(NameInfo));
 
   // Set encoded_shape_ pointer

--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -257,7 +257,7 @@ void GraphTile::Initialize(const GraphId& graphid) {
     throw std::runtime_error("Missing tile data");
   }
 
-  const char *tile_ptr = memory_->data;
+  const char* tile_ptr = memory_->data;
   const size_t tile_size = memory_->size;
 
   if (tile_size < sizeof(GraphTileHeader)) {
@@ -265,7 +265,7 @@ void GraphTile::Initialize(const GraphId& graphid) {
                              ". Tile file might me corrupted");
   }
 
-  const char *ptr = tile_ptr;
+  const char* ptr = tile_ptr;
   header_ = reinterpret_cast<const GraphTileHeader*>(ptr);
   ptr += sizeof(GraphTileHeader);
 

--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -257,7 +257,7 @@ void GraphTile::Initialize(const GraphId& graphid) {
     throw std::runtime_error("Missing tile data");
   }
 
-  char* const tile_ptr = memory_->data;
+  const char *tile_ptr = memory_->data;
   const size_t tile_size = memory_->size;
 
   if (tile_size < sizeof(GraphTileHeader)) {
@@ -265,8 +265,8 @@ void GraphTile::Initialize(const GraphId& graphid) {
                              ". Tile file might me corrupted");
   }
 
-  char* ptr = tile_ptr;
-  header_ = reinterpret_cast<GraphTileHeader*>(ptr);
+  const char *ptr = tile_ptr;
+  header_ = reinterpret_cast<const GraphTileHeader*>(ptr);
   ptr += sizeof(GraphTileHeader);
 
   if (header_->end_offset() != tile_size)
@@ -277,61 +277,61 @@ void GraphTile::Initialize(const GraphId& graphid) {
   // TODO check version
 
   // Set a pointer to the node list
-  nodes_ = reinterpret_cast<NodeInfo*>(ptr);
+  nodes_ = reinterpret_cast<const NodeInfo*>(ptr);
   ptr += header_->nodecount() * sizeof(NodeInfo);
 
   // Set a pointer to the node transition list
-  transitions_ = reinterpret_cast<NodeTransition*>(ptr);
+  transitions_ = reinterpret_cast<const NodeTransition*>(ptr);
   ptr += header_->transitioncount() * sizeof(NodeTransition);
 
   // Set a pointer to the directed edge list
-  directededges_ = reinterpret_cast<DirectedEdge*>(ptr);
+  directededges_ = reinterpret_cast<const DirectedEdge*>(ptr);
   ptr += header_->directededgecount() * sizeof(DirectedEdge);
 
   // Extended directed edge attribution (if available).
   if (header_->has_ext_directededge()) {
-    ext_directededges_ = reinterpret_cast<DirectedEdgeExt*>(ptr);
+    ext_directededges_ = reinterpret_cast<const DirectedEdgeExt*>(ptr);
     ptr += header_->directededgecount() * sizeof(DirectedEdgeExt);
   }
 
   // Set a pointer access restriction list
-  access_restrictions_ = reinterpret_cast<AccessRestriction*>(ptr);
+  access_restrictions_ = reinterpret_cast<const AccessRestriction*>(ptr);
   ptr += header_->access_restriction_count() * sizeof(AccessRestriction);
 
   // Set a pointer to the transit departure list
-  departures_ = reinterpret_cast<TransitDeparture*>(ptr);
+  departures_ = reinterpret_cast<const TransitDeparture*>(ptr);
   ptr += header_->departurecount() * sizeof(TransitDeparture);
 
   // Set a pointer to the transit stop list
-  transit_stops_ = reinterpret_cast<TransitStop*>(ptr);
+  transit_stops_ = reinterpret_cast<const TransitStop*>(ptr);
   ptr += header_->stopcount() * sizeof(TransitStop);
 
   // Set a pointer to the transit route list
-  transit_routes_ = reinterpret_cast<TransitRoute*>(ptr);
+  transit_routes_ = reinterpret_cast<const TransitRoute*>(ptr);
   ptr += header_->routecount() * sizeof(TransitRoute);
 
   // Set a pointer to the transit schedule list
-  transit_schedules_ = reinterpret_cast<TransitSchedule*>(ptr);
+  transit_schedules_ = reinterpret_cast<const TransitSchedule*>(ptr);
   ptr += header_->schedulecount() * sizeof(TransitSchedule);
 
   // Set a pointer to the transit transfer list
-  transit_transfers_ = reinterpret_cast<TransitTransfer*>(ptr);
+  transit_transfers_ = reinterpret_cast<const TransitTransfer*>(ptr);
   ptr += header_->transfercount() * sizeof(TransitTransfer);
 
   // Set a pointer to the sign list
-  signs_ = reinterpret_cast<Sign*>(ptr);
+  signs_ = reinterpret_cast<const Sign*>(ptr);
   ptr += header_->signcount() * sizeof(Sign);
 
   // Start of turn lane data.
-  turnlanes_ = reinterpret_cast<TurnLanes*>(ptr);
+  turnlanes_ = reinterpret_cast<const TurnLanes*>(ptr);
   ptr += header_->turnlane_count() * sizeof(TurnLanes);
 
   // Set a pointer to the admininstrative information list
-  admins_ = reinterpret_cast<Admin*>(ptr);
+  admins_ = reinterpret_cast<const Admin*>(ptr);
   ptr += header_->admincount() * sizeof(Admin);
 
   // Set a pointer to the edge bin list
-  edge_bins_ = reinterpret_cast<GraphId*>(ptr);
+  edge_bins_ = reinterpret_cast<const GraphId*>(ptr);
 
   // Start of forward restriction information and its size
   complex_restriction_forward_ = tile_ptr + header_->complex_restriction_forward_offset();
@@ -353,15 +353,15 @@ void GraphTile::Initialize(const GraphId& graphid) {
 
   // Start of lane connections and their size
   lane_connectivity_ =
-      reinterpret_cast<LaneConnectivity*>(tile_ptr + header_->lane_connectivity_offset());
+      reinterpret_cast<const LaneConnectivity*>(tile_ptr + header_->lane_connectivity_offset());
   lane_connectivity_size_ = header_->predictedspeeds_offset() - header_->lane_connectivity_offset();
 
   // Start of predicted speed data.
   if (header_->predictedspeeds_count() > 0) {
-    char* ptr1 = tile_ptr + header_->predictedspeeds_offset();
-    char* ptr2 = ptr1 + (header_->directededgecount() * sizeof(int32_t));
-    predictedspeeds_.set_offset(reinterpret_cast<uint32_t*>(ptr1));
-    predictedspeeds_.set_profiles(reinterpret_cast<int16_t*>(ptr2));
+    auto ptr1 = tile_ptr + header_->predictedspeeds_offset();
+    auto ptr2 = ptr1 + (header_->directededgecount() * sizeof(int32_t));
+    predictedspeeds_.set_offset(reinterpret_cast<const uint32_t*>(ptr1));
+    predictedspeeds_.set_profiles(reinterpret_cast<const int16_t*>(ptr2));
 
     lane_connectivity_size_ = header_->predictedspeeds_offset() - header_->lane_connectivity_offset();
   } else {
@@ -632,14 +632,13 @@ EdgeInfo GraphTile::edgeinfo(const DirectedEdge* edge) const {
 
 // Get the complex restrictions in the forward or reverse order based on
 // the id and modes.
-std::vector<ComplexRestriction*>
+std::vector<const ComplexRestriction*>
 GraphTile::GetRestrictions(const bool forward, const GraphId id, const uint64_t modes) const {
   size_t offset = 0;
-  std::vector<ComplexRestriction*> cr_vector;
+  std::vector<const ComplexRestriction*> cr_vector;
   if (forward) {
     while (offset < complex_restriction_forward_size_) {
-      ComplexRestriction* cr =
-          reinterpret_cast<ComplexRestriction*>(complex_restriction_forward_ + offset);
+      auto cr = reinterpret_cast<const ComplexRestriction*>(complex_restriction_forward_ + offset);
       if (cr->to_graphid() == id && (cr->modes() & modes)) {
         cr_vector.push_back(cr);
       }
@@ -647,8 +646,7 @@ GraphTile::GetRestrictions(const bool forward, const GraphId id, const uint64_t 
     }
   } else {
     while (offset < complex_restriction_reverse_size_) {
-      ComplexRestriction* cr =
-          reinterpret_cast<ComplexRestriction*>(complex_restriction_reverse_ + offset);
+      auto cr = reinterpret_cast<const ComplexRestriction*>(complex_restriction_reverse_ + offset);
       if (cr->from_graphid() == id && (cr->modes() & modes)) {
         cr_vector.push_back(cr);
       }
@@ -1037,9 +1035,9 @@ const TransitDeparture* GraphTile::GetTransitDeparture(const uint32_t lineid,
 }
 
 // Get a map of departures based on lineid.  No dups exist in the map.
-std::unordered_map<uint32_t, TransitDeparture*> GraphTile::GetTransitDepartures() const {
+std::unordered_map<uint32_t, const TransitDeparture*> GraphTile::GetTransitDepartures() const {
 
-  std::unordered_map<uint32_t, TransitDeparture*> deps;
+  std::unordered_map<uint32_t, const TransitDeparture*> deps;
   deps.reserve(header_->departurecount());
 
   for (uint32_t i = 0; i < header_->departurecount(); i++) {
@@ -1146,14 +1144,14 @@ std::vector<AccessRestriction> GraphTile::GetAccessRestrictions(const uint32_t i
 }
 
 // Get the array of graphids for this bin
-midgard::iterable_t<GraphId> GraphTile::GetBin(size_t column, size_t row) const {
+midgard::iterable_t<const GraphId> GraphTile::GetBin(size_t column, size_t row) const {
   auto offsets = header_->bin_offset(column, row);
-  return iterable_t<GraphId>{edge_bins_ + offsets.first, edge_bins_ + offsets.second};
+  return iterable_t<const GraphId>{edge_bins_ + offsets.first, edge_bins_ + offsets.second};
 }
 
-midgard::iterable_t<GraphId> GraphTile::GetBin(size_t index) const {
+midgard::iterable_t<const GraphId> GraphTile::GetBin(size_t index) const {
   auto offsets = header_->bin_offset(index);
-  return iterable_t<GraphId>{edge_bins_ + offsets.first, edge_bins_ + offsets.second};
+  return iterable_t<const GraphId>{edge_bins_ + offsets.first, edge_bins_ + offsets.second};
 }
 
 // Get turn lanes for this edge.

--- a/valhalla/baldr/edgeinfo.h
+++ b/valhalla/baldr/edgeinfo.h
@@ -80,7 +80,7 @@ public:
    * @param  names_list  Pointer to the start of the text/names list.
    * @param  names_list_length  Length (bytes) of the text/names list.
    */
-  EdgeInfo(char* ptr, const char* names_list, const size_t names_list_length);
+  EdgeInfo(const char* ptr, const char* names_list, const size_t names_list_length);
 
   /**
    * Destructor

--- a/valhalla/baldr/graphmemory.h
+++ b/valhalla/baldr/graphmemory.h
@@ -11,7 +11,7 @@ protected:
 public:
   virtual ~GraphMemory() = default;
 
-  char* data;
+  const char* data;
   size_t size;
 };
 

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -332,7 +332,7 @@ public:
    * @return  Returns the vector of complex restrictions in the order requested
    *          based on the id and modes.
    */
-  std::vector<ComplexRestriction*>
+  std::vector<const ComplexRestriction*>
   GetRestrictions(const bool forward, const GraphId id, const uint64_t modes) const;
 
   /**
@@ -443,7 +443,7 @@ public:
    * Get the departures based on the line Id
    * @return  Returns a map of lineids to departures.
    */
-  std::unordered_map<uint32_t, TransitDeparture*> GetTransitDepartures() const;
+  std::unordered_map<uint32_t, const TransitDeparture*> GetTransitDepartures() const;
 
   /**
    * Get the stop onestop Ids in this tile.
@@ -506,14 +506,14 @@ public:
    * @param  row the bin's row
    * @return iterable container of graphids contained in the bin
    */
-  midgard::iterable_t<GraphId> GetBin(size_t column, size_t row) const;
+  midgard::iterable_t<const GraphId> GetBin(size_t column, size_t row) const;
 
   /**
    * Get an iteratable list of GraphIds given a bin in the tile
    * @param  index the bin's index in the row major array
    * @return iterable container of graphids contained in the bin
    */
-  midgard::iterable_t<GraphId> GetBin(size_t index) const;
+  midgard::iterable_t<const GraphId> GetBin(size_t index) const;
 
   /**
    * Get lane connections ending on this edge.
@@ -704,83 +704,83 @@ protected:
   std::unique_ptr<const GraphMemory> memory_;
 
   // Header information for the tile
-  GraphTileHeader* header_{};
+  const GraphTileHeader* header_{};
 
   // List of nodes. Fixed size structure, indexed by Id within the tile.
-  NodeInfo* nodes_{};
+  const NodeInfo* nodes_{};
 
   // List of transitions between nodes on different levels. NodeInfo contains
   // an index and count of transitions.
-  NodeTransition* transitions_{};
+  const NodeTransition* transitions_{};
 
   // List of directed edges. Fixed size structure indexed by Id within the tile.
-  DirectedEdge* directededges_{};
+  const DirectedEdge* directededges_{};
 
   // Extended directed edge records. For expansion. These are indexed by the same
   // Id as the directed edge.
-  DirectedEdgeExt* ext_directededges_{};
+  const DirectedEdgeExt* ext_directededges_{};
 
   // Access restrictions, 1 or more per edge id
-  AccessRestriction* access_restrictions_{};
+  const AccessRestriction* access_restrictions_{};
 
   // Transit departures, many per index (indexed by directed edge index and
   // sorted by departure time)
-  TransitDeparture* departures_{};
+  const TransitDeparture* departures_{};
 
   // Transit stops (indexed by stop index within the tile)
-  TransitStop* transit_stops_{};
+  const TransitStop* transit_stops_{};
 
   // Transit route (indexed by route index within the tile)
-  TransitRoute* transit_routes_{};
+  const TransitRoute* transit_routes_{};
 
   // Transit schedules (index by schedule index within the tile)
-  TransitSchedule* transit_schedules_{};
+  const TransitSchedule* transit_schedules_{};
 
   // Transit transfer records.
-  TransitTransfer* transit_transfers_{};
+  const TransitTransfer* transit_transfers_{};
 
   // Signs (indexed by directed edge index)
-  Sign* signs_{};
+  const Sign* signs_{};
 
   // Turn lanes (indexed by directed edge index)
-  TurnLanes* turnlanes_{};
+  const TurnLanes* turnlanes_{};
 
   // List of admins. This is a fixed size structure so it can be
   // indexed directly.
-  Admin* admins_{};
+  const Admin* admins_{};
 
   // List of complex_restrictions in the forward direction.
-  char* complex_restriction_forward_{};
+  const char* complex_restriction_forward_{};
 
   // Size of the complex restrictions in the forward direction
   std::size_t complex_restriction_forward_size_{};
 
   // List of complex_restrictions in the reverse direction.
-  char* complex_restriction_reverse_{};
+  const char* complex_restriction_reverse_{};
 
   // Size of the complex restrictions in the reverse direction
   std::size_t complex_restriction_reverse_size_{};
 
   // List of edge info structures. Since edgeinfo is not fixed size we
   // use offsets in directed edges.
-  char* edgeinfo_{};
+  const char* edgeinfo_{};
 
   // Size of the edgeinfo data
   std::size_t edgeinfo_size_{};
 
   // Street names as sets of null-terminated char arrays. Edge info has
   // offsets into this array.
-  char* textlist_{};
+  const char* textlist_{};
 
   // Number of bytes in the text/name list
   std::size_t textlist_size_{};
 
   // List of edge graph ids. The list is broken up in bins which have
   // indices in the tile header.
-  GraphId* edge_bins_{};
+  const GraphId* edge_bins_{};
 
   // Lane connectivity data.
-  LaneConnectivity* lane_connectivity_{};
+  const LaneConnectivity* lane_connectivity_{};
 
   // Number of bytes in lane connectivity data.
   std::size_t lane_connectivity_size_{};

--- a/valhalla/baldr/traffictile.h
+++ b/valhalla/baldr/traffictile.h
@@ -239,9 +239,10 @@ public:
 
   TrafficTile(std::unique_ptr<const GraphMemory> memory)
       : memory_(std::move(memory)),
-        header(memory_ ? reinterpret_cast<volatile const TrafficTileHeader*>(memory_->data) : nullptr),
+        header(memory_ ? reinterpret_cast<volatile const TrafficTileHeader*>(memory_->data)
+                       : nullptr),
         speeds(memory_ ? reinterpret_cast<volatile const TrafficSpeed*>(memory_->data +
-                                                                  sizeof(TrafficTileHeader))
+                                                                        sizeof(TrafficTileHeader))
                        : nullptr) {
   }
 

--- a/valhalla/baldr/traffictile.h
+++ b/valhalla/baldr/traffictile.h
@@ -239,8 +239,8 @@ public:
 
   TrafficTile(std::unique_ptr<const GraphMemory> memory)
       : memory_(std::move(memory)),
-        header(memory_ ? reinterpret_cast<volatile TrafficTileHeader*>(memory_->data) : nullptr),
-        speeds(memory_ ? reinterpret_cast<volatile TrafficSpeed*>(memory_->data +
+        header(memory_ ? reinterpret_cast<volatile const TrafficTileHeader*>(memory_->data) : nullptr),
+        speeds(memory_ ? reinterpret_cast<volatile const TrafficSpeed*>(memory_->data +
                                                                   sizeof(TrafficTileHeader))
                        : nullptr) {
   }
@@ -270,8 +270,8 @@ public:
   // the pointer values won't change.  The pointer targets are marked
   // as const volatile because they can be modified by code outside
   // our control (another process accessing a mmap'd file for example)
-  volatile TrafficTileHeader* header;
-  volatile TrafficSpeed* speeds;
+  volatile const TrafficTileHeader* header;
+  volatile const TrafficSpeed* speeds;
 };
 
 } // namespace baldr


### PR DESCRIPTION
# Issue

Tile data was loaded into memory without const modifiers and it was hard to trace if there was no erroneous modification of this memory somewhere. I set const for all objects that are loaded from this memory.