### PR TITLE
Enhance valhalla_build_elevation with LZ4 recompression support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
    * CHANGED: Remove `max_matrix_locations` and introduce `max_matrix_location_pairs` to configure the allowed number of total routes for the matrix action for more flexible asymmetric matrices [#3569](https://github.com/valhalla/valhalla/pull/3569)
    * CHANGED: modernized spatialite syntax [#3580](https://github.com/valhalla/valhalla/pull/3580)
    * ADDED: Options to generate partial results for time distance matrix when there is one source (one to many) or one target (many to one). [#3181](https://github.com/valhalla/valhalla/pull/3181)
+   * ADDED: Enhance valhalla_build_elevation with LZ4 recompression support [#3607](https://github.com/valhalla/valhalla/pull/3607) 
 
 ## Release Date: 2021-10-07 Valhalla 3.1.4
 * **Removed**

--- a/scripts/valhalla_build_elevation
+++ b/scripts/valhalla_build_elevation
@@ -71,7 +71,7 @@ method.add_argument(
 method.add_argument(
     "-t",
     "--from-tiles",
-    help="Only download tiles covered by the Valhalla graph.",
+    help="Only download tiles covered by the Valhalla graph (requires a Valhalla config JSON file).",
     action="store_true"
 )
 parser.add_argument(
@@ -307,7 +307,11 @@ if __name__ == "__main__":
     elif args.from_bbox:
         tiles = get_tiles_with_bbox(args.from_bbox)
     elif args.from_tiles:
-        tiles = get_tiles_with_graph(Path(config["mjolnir"]["tile_dir"]))
+        if config is not None:
+            tiles = get_tiles_with_graph(Path(config["mjolnir"]["tile_dir"]))
+        else:
+            LOGGER.critical("--from-tiles requires a config to be specified.")
+            sys.exit(1)
     else:
         LOGGER.critical("No download method specified.")
         sys.exit(1)

--- a/scripts/valhalla_build_elevation
+++ b/scripts/valhalla_build_elevation
@@ -307,11 +307,10 @@ if __name__ == "__main__":
     elif args.from_bbox:
         tiles = get_tiles_with_bbox(args.from_bbox)
     elif args.from_tiles:
-        if config is not None:
-            tiles = get_tiles_with_graph(Path(config["mjolnir"]["tile_dir"]))
-        else:
+        if config is None:
             LOGGER.critical("--from-tiles requires a config to be specified.")
             sys.exit(1)
+        tiles = get_tiles_with_graph(Path(config["mjolnir"]["tile_dir"]))
     else:
         LOGGER.critical("No download method specified.")
         sys.exit(1)

--- a/scripts/valhalla_build_elevation
+++ b/scripts/valhalla_build_elevation
@@ -2,27 +2,29 @@
 
 import argparse
 import os
-from collections import namedtuple
-from functools import partial
 import gzip
 import json
 import logging
+import sys
+
+from collections import namedtuple
+from enum import Enum, unique
+from functools import partial
 from math import ceil, floor
 from multiprocessing import cpu_count
 from multiprocessing.dummy import Pool as ThreadPool
 from pathlib import Path
-import sys
 from typing import List, Iterable, Set
 from urllib import request
 from urllib.error import URLError
-
 
 # hack so ArgumentParser can accept negative numbers
 # see https://github.com/valhalla/valhalla/issues/3426
 for i, arg in enumerate(sys.argv):
     if not len(arg) > 1:
         continue
-    if (arg[0] == '-') and arg[1].isdigit(): sys.argv[i] = ' ' + arg
+    if (arg[0] == '-') and arg[1].isdigit():
+        sys.argv[i] = ' ' + arg
 
 description = """Downloads Tilezen's elevation tiles that either intersect with features in all .geojson files in
               --input-geojson-dir or that intersect with --bbox. NOTE: geojson method requires shapely.
@@ -34,13 +36,31 @@ handler = logging.StreamHandler()
 handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)5s: %(message)s"))
 LOGGER.addHandler(handler)
 
+
+# Argument parser
+@unique
+class TileCompression(Enum):
+    UNCOMPRESSED = 1
+    GZIP = 2
+    LZ4 = 3
+
+    @property
+    def extension(self):
+        if self is TileCompression.UNCOMPRESSED:
+            return ""
+        elif self is TileCompression.GZIP:
+            return ".gz"
+        elif self is TileCompression.LZ4:
+            return ".lz4"
+
+
 parser = argparse.ArgumentParser(description=description)
 method = parser.add_mutually_exclusive_group()
 method.add_argument(
     "-g",
     "--from-geojson",
     help="Absolute or relative path to directory with .geojson files used "
-    "as input to tile intersection. Requires shapely.",
+         "as input to tile intersection. Requires shapely.",
     type=Path,
 )
 method.add_argument(
@@ -58,7 +78,14 @@ method.add_argument(
 parser.add_argument(
     "-c",
     "--config",
-    help="Absolute or relative path to the Valhalla config JSON.",
+    help="Absolute or relative path to the Valhalla config JSON. "
+         "If present, can be used for download location and bbox.",
+    type=Path,
+)
+parser.add_argument(
+    "-o",
+    "--outdir",
+    help="Absolute or relative path to the directory where the tiles will be saved. Overrides config JSON.",
     type=Path,
 )
 parser.add_argument(
@@ -68,17 +95,27 @@ parser.add_argument(
     default=cpu_count()
 )
 parser.add_argument(
-    "-d",
-    "--decompress",
-    help="If set, downloaded files will be decompressed.",
-    action="store_true",
-)
-parser.add_argument(
     "-v",
     "--verbosity",
     help="Accumulative verbosity flags; -v: INFO, -vv: DEBUG",
     action="count",
     default=0,
+)
+
+group = parser.add_mutually_exclusive_group()
+group.add_argument(
+    "-d",
+    "--decompress",
+    help="If set, downloaded files will be decompressed (default format is gzip).",
+    action="store_true",
+)
+group.add_argument(
+    "-z",
+    "--lz4",
+    help="If set, downloaded files will be recompressed with LZ4. Requires lz4. "
+         "Requires ~12% more disk space (216GB total) vs gzip. While you pay upfront in extra CPU and space on the "
+         "initial download, tiles will be several times faster to decompress vz gzip.",
+    action="store_true",
 )
 
 Tile = namedtuple("Tile", ["name", "dir"])
@@ -193,12 +230,13 @@ def get_tiles_with_graph(graph_dir: Path) -> Set[Tile]:
     return tile_infos
 
 
-def download(tile: Tile, output_dir, decompress):
+def download(tile: Tile, output_dir, compression: TileCompression):
     dest_directory = Path(output_dir, tile.dir)
     dest_directory.mkdir(parents=True, exist_ok=True)
 
-    filepath = dest_directory.joinpath(tile.name + (".gz" if not decompress else ""))
+    filepath = dest_directory.joinpath(tile.name + compression.extension)
     if filepath.is_file():
+        # Skip if the file already exists
         return False
 
     url = (
@@ -208,24 +246,45 @@ def download(tile: Tile, output_dir, decompress):
     LOGGER.info(f"Downloading tile {tile.name}")
     try:
         with request.urlopen(url) as res, open(filepath, "wb") as f:
-            if decompress:
-                with gzip.GzipFile(fileobj=res, mode="rb") as gz:
-                    f.write(gz.read())
-            else:
+            if compression is TileCompression.GZIP:
                 f.write(res.read())
+            else:
+                with gzip.GzipFile(fileobj=res, mode="rb") as gz:
+                    uncompressed = gz.read()
+                    if compression is TileCompression.UNCOMPRESSED:
+                        f.write(uncompressed)
+                    elif compression is TileCompression.LZ4:
+                        # Local imports are yuck, even though it only takes effect once. the alternative is
+                        # requiring everyone to have the LZ4 package available, regardless of whether the user needs it.
+                        # Compression level 6 was chosen after some benchmarking as having a reasonable balance between
+                        # compression time and space savings. The end result will be larger than the maximally gzipped
+                        # tiles from AWS, but only by around 12%. To narrow the gap to ~10% requires compression level
+                        # 9, and more than double the compression time, so this is the approximate efficient frontier.
+                        # for our purposes. Note that in general LZ4 decompression cost does not vary much with
+                        # compression level, unless using extremely high compression levels.
+                        import lz4.frame
+                        with lz4.frame.LZ4FrameCompressor(block_size=lz4.frame.BLOCKSIZE_MAX4MB,
+                                                          compression_level=6) as compressor:
+                            # Optimization: we know the exact size of every uncompressed hgt file
+                            f.write(compressor.begin(25934402))
+                            f.write(compressor.compress(uncompressed))
+                            f.write(compressor.flush())
+
             LOGGER.debug(f"Successfully downloaded tile {tile.name}")
 
         return True
     except URLError as e:
         LOGGER.critical(f"Download failed of elevation tile {tile.dir}/{tile.name}: {e.reason}")
         return False
+    except ImportError:
+        LOGGER.critical(
+            "Could not import lz4. Please install lz4 or use another compression format."
+        )
+        sys.exit(1)
 
 
 if __name__ == "__main__":
     args = parser.parse_args()
-    with open(args.config) as f:
-        config = json.load(f)
-    elevation_fp = Path(config["additional_data"]["elevation"] or "elevation")
 
     # set the right logger level
     if args.verbosity == 0:
@@ -234,6 +293,19 @@ if __name__ == "__main__":
         LOGGER.setLevel(logging.INFO)
     elif args.verbosity >= 2:
         LOGGER.setLevel(logging.DEBUG)
+
+    config = None
+    if args.config:
+        with open(args.config) as f:
+            config = json.load(f)
+
+    if args.outdir:
+        elevation_fp = args.outdir
+    elif config is not None:
+        elevation_fp = Path(config["additional_data"]["elevation"] or "elevation")
+    else:
+        LOGGER.critical("Either config or outdir is required.")
+        sys.exit(1)
 
     if args.from_geojson:
         tiles = get_tiles_with_geojson(args.from_geojson)
@@ -245,12 +317,18 @@ if __name__ == "__main__":
         LOGGER.critical("No download method specified.")
         sys.exit(1)
 
+    tile_compression = TileCompression.GZIP
+    if args.decompress:
+        tile_compression = TileCompression.UNCOMPRESSED
+    elif args.lz4:
+        tile_compression = TileCompression.LZ4
+
     LOGGER.debug(sorted(tiles, key=lambda x: x.name))
 
     # create the threadpool and download
     pool = ThreadPool(args.parallelism)
     results = pool.imap_unordered(
-        partial(download, output_dir=elevation_fp, decompress=args.decompress), tiles
+        partial(download, output_dir=elevation_fp, compression=tile_compression), tiles
     )
 
     sum_downloaded = list(filter(lambda res: res is True, results))

--- a/scripts/valhalla_build_elevation
+++ b/scripts/valhalla_build_elevation
@@ -1,19 +1,18 @@
 #!/usr/bin/env python3
 
 import argparse
-import os
-import gzip
-import json
-import logging
-import sys
-
 from collections import namedtuple
 from enum import Enum, unique
 from functools import partial
+import gzip
+import json
+import logging
 from math import ceil, floor
 from multiprocessing import cpu_count
 from multiprocessing.dummy import Pool as ThreadPool
+import os
 from pathlib import Path
+import sys
 from typing import List, Iterable, Set
 from urllib import request
 from urllib.error import URLError

--- a/scripts/valhalla_build_elevation
+++ b/scripts/valhalla_build_elevation
@@ -253,14 +253,10 @@ def download(tile: Tile, output_dir, compression: TileCompression):
                     if compression is TileCompression.UNCOMPRESSED:
                         f.write(uncompressed)
                     elif compression is TileCompression.LZ4:
-                        # Local imports are yuck, even though it only takes effect once. the alternative is
-                        # requiring everyone to have the LZ4 package available, regardless of whether the user needs it.
-                        # Compression level 6 was chosen after some benchmarking as having a reasonable balance between
-                        # compression time and space savings. The end result will be larger than the maximally gzipped
-                        # tiles from AWS, but only by around 12%. To narrow the gap to ~10% requires compression level
-                        # 9, and more than double the compression time, so this is the approximate efficient frontier.
-                        # for our purposes. Note that in general LZ4 decompression cost does not vary much with
-                        # compression level, unless using extremely high compression levels.
+                        # Compression level 6 was chosen after some benchmarking as the approx efficient frontier
+                        # between compression time and space savings (decompression time is roughly constant regardless
+                        # of level). The end result is larger than the maximally gzipped tiles from AWS, but only
+                        # by around 12%.
                         import lz4.frame
                         with lz4.frame.LZ4FrameCompressor(block_size=lz4.frame.BLOCKSIZE_MAX4MB,
                                                           compression_level=6) as compressor:


### PR DESCRIPTION
# Issue

Closes #3606.

## Tasklist

 - [ ] Add tests - **I don't see applicable tests for similar download portions of the script; let me know if you want a test**
 - [x] Add #fixes with the issue number that this PR addresses
 - [x] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too. - **N/A**

## Requirements / Relations

Complementary to #3401.

# Commentary

The main goal of this PR is to add support for re-compressing downloaded elevation tiles as LZ4. LZ4 comes at a slight space cost (roughly 12% larger than gzip for the planet) and of course the upfront CPU cost of recompressing. In real-world request loads, we have observed significant reductions in p95 and higher response times after switching from gzip to LZ4 elevation tiles.

Secondarily, this PR makes a subtle type change from a boolean decompress flag to explicitly supporting multiple compression types in case something better comes along later. This also ensures the added cases are cleanly handled. It also removes the requirement for a JSON config file. While a JSON config file is probably the more typical usage pattern, it's also useful to be able to specify a bbox and output directory on the command line directly when downloading the whole world to a local file server or similar applications (and it technically doesn't even have to be Valhalla-specific).