### PR TITLE
Cost matrix early abort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,9 +83,9 @@
    * CHANGED: modernized spatialite syntax [#3580](https://github.com/valhalla/valhalla/pull/3580)
    * ADDED: Options to generate partial results for time distance matrix when there is one source (one to many) or one target (many to one). [#3181](https://github.com/valhalla/valhalla/pull/3181)
    * ADDED: Enhance valhalla_build_elevation with LZ4 recompression support [#3607](https://github.com/valhalla/valhalla/pull/3607)
-   * ADDED: Shorten down the request delay, when some sources/targets searches are early aborted [#3611](https://github.com/valhalla/valhalla/pull/3611)
    * CHANGED: removed UK admin and upgraded its constituents to countries [#3619](https://github.com/valhalla/valhalla/pull/3619)
    * CHANGED: expansion service: only track requested max time/distance [#3532](https://github.com/valhalla/valhalla/pull/3509)
+   * ADDED: Shorten down the request delay, when some sources/targets searches are early aborted [#3611](https://github.com/valhalla/valhalla/pull/3611)
 
 ## Release Date: 2021-10-07 Valhalla 3.1.4
 * **Removed**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
    * CHANGED: modernized spatialite syntax [#3580](https://github.com/valhalla/valhalla/pull/3580)
    * ADDED: Options to generate partial results for time distance matrix when there is one source (one to many) or one target (many to one). [#3181](https://github.com/valhalla/valhalla/pull/3181)
    * ADDED: Enhance valhalla_build_elevation with LZ4 recompression support [#3607](https://github.com/valhalla/valhalla/pull/3607) 
+   * ADDED: Shorten down the request delay, when some sources/targets searches are early aborted [#3611](https://github.com/valhalla/valhalla/pull/3611)
 
 ## Release Date: 2021-10-07 Valhalla 3.1.4
 * **Removed**

--- a/src/thor/costmatrix.cc
+++ b/src/thor/costmatrix.cc
@@ -172,13 +172,12 @@ std::vector<TimeDistance> CostMatrix::SourceToTarget(
             //  Get all sources remaining for the destination
             auto& sources = target_status_[target].remaining_locations;
             auto it = sources.find(i);
-            if (it != sources.end()) {
+            if (it != sources.end())
               sources.erase(it);
-              if (sources.empty() && target_status_[target].threshold > 0) {
-                target_status_[i].threshold = -1;
-                if (remaining_targets_ > 0) {
-                  remaining_targets_--;
-                }
+            if (sources.empty() && target_status_[target].threshold > 0) {
+              target_status_[i].threshold = -1;
+              if (remaining_targets_ > 0) {
+                remaining_targets_--;
               }
             }
           }

--- a/src/thor/costmatrix.cc
+++ b/src/thor/costmatrix.cc
@@ -145,12 +145,13 @@ std::vector<TimeDistance> CostMatrix::SourceToTarget(
             //  Get all targets remaining for the origin
             auto& targets = source_status_[source].remaining_locations;
             auto it = targets.find(i);
-            if (it != targets.end())
+            if (it != targets.end()) {
               targets.erase(it);
-            if (targets.empty() && source_status_[source].threshold > 0) {
-              source_status_[i].threshold = -1;
-              if (remaining_sources_ > 0) {
-                remaining_sources_--;
+              if (targets.empty() && source_status_[source].threshold > 0) {
+                source_status_[i].threshold = -1;
+                if (remaining_sources_ > 0) {
+                  remaining_sources_--;
+                }
               }
             }
           }
@@ -172,12 +173,13 @@ std::vector<TimeDistance> CostMatrix::SourceToTarget(
             //  Get all sources remaining for the destination
             auto& sources = target_status_[target].remaining_locations;
             auto it = sources.find(i);
-            if (it != sources.end())
+            if (it != sources.end()) {
               sources.erase(it);
-            if (sources.empty() && target_status_[target].threshold > 0) {
-              target_status_[i].threshold = -1;
-              if (remaining_targets_ > 0) {
-                remaining_targets_--;
+              if (sources.empty() && target_status_[target].threshold > 0) {
+                target_status_[i].threshold = -1;
+                if (remaining_targets_ > 0) {
+                  remaining_targets_--;
+                }
               }
             }
           }

--- a/src/thor/costmatrix.cc
+++ b/src/thor/costmatrix.cc
@@ -141,6 +141,19 @@ std::vector<TimeDistance> CostMatrix::SourceToTarget(
         target_status_[i].threshold--;
         BackwardSearch(i, graphreader);
         if (target_status_[i].threshold == 0) {
+          for (uint32_t source = 0; source < source_count_; source++) {
+            //  Get all targets remaining for the origin
+            auto& targets = source_status_[source].remaining_locations;
+            auto it = targets.find(i);
+            if (it != targets.end())
+              targets.erase(it);
+            if (targets.empty() && source_status_[source].threshold > 0) {
+              source_status_[i].threshold = -1;
+              if (remaining_sources_ > 0) {
+                remaining_sources_--;
+              }
+            }
+          }
           target_status_[i].threshold = -1;
           if (remaining_targets_ > 0) {
             remaining_targets_--;
@@ -155,6 +168,20 @@ std::vector<TimeDistance> CostMatrix::SourceToTarget(
         source_status_[i].threshold--;
         ForwardSearch(i, n, graphreader);
         if (source_status_[i].threshold == 0) {
+          for (uint32_t target = 0; target < target_count_; target++) {
+            //  Get all sources remaining for the destination
+            auto& sources = target_status_[target].remaining_locations;
+            auto it = sources.find(i);
+            if (it != sources.end()) {
+              sources.erase(it);
+              if (sources.empty() && target_status_[target].threshold > 0) {
+                target_status_[i].threshold = -1;
+                if (remaining_targets_ > 0) {
+                  remaining_targets_--;
+                }
+              }
+            }
+          }
           source_status_[i].threshold = -1;
           if (remaining_sources_ > 0) {
             remaining_sources_--;

--- a/test/matrix.cc
+++ b/test/matrix.cc
@@ -244,6 +244,30 @@ TEST(Matrix, test_matrix) {
                " to expected value for CostMatrix";
   }
 
+  CostMatrix cost_matrix_abort_source;
+  results = cost_matrix_abort_source.SourceToTarget(request.options().sources(), request.options().targets(), reader,
+                                   mode_costing, sif::TravelMode::kDrive, 100000.0);
+
+  uint32_t found = 0;
+  for (uint32_t i = 0; i < results.size(); ++i) {
+    if (results[i].dist < kMaxCost) {
+      ++found;
+    }
+  }
+  EXPECT_EQ(found, 15) << " not the number of results as expected";
+
+  CostMatrix cost_matrix_abort_target;
+  results = cost_matrix_abort_target.SourceToTarget(request.options().sources(), request.options().targets(), reader,
+                                    mode_costing, sif::TravelMode::kDrive, 50000.0);
+
+  found = 0;
+  for (uint32_t i = 0; i < results.size(); ++i) {
+    if (results[i].dist < kMaxCost) {
+      ++found;
+    }
+  }
+  EXPECT_EQ(found, 10) << " not the number of results as expected";
+
   TimeDistanceMatrix timedist_matrix;
   results = timedist_matrix.SourceToTarget(request.options().sources(), request.options().targets(),
                                            reader, mode_costing, sif::TravelMode::kDrive, 400000.0);

--- a/test/matrix.cc
+++ b/test/matrix.cc
@@ -245,8 +245,9 @@ TEST(Matrix, test_matrix) {
   }
 
   CostMatrix cost_matrix_abort_source;
-  results = cost_matrix_abort_source.SourceToTarget(request.options().sources(), request.options().targets(), reader,
-                                   mode_costing, sif::TravelMode::kDrive, 100000.0);
+  results = cost_matrix_abort_source.SourceToTarget(request.options().sources(),
+                                                    request.options().targets(), reader, mode_costing,
+                                                    sif::TravelMode::kDrive, 100000.0);
 
   uint32_t found = 0;
   for (uint32_t i = 0; i < results.size(); ++i) {
@@ -257,8 +258,9 @@ TEST(Matrix, test_matrix) {
   EXPECT_EQ(found, 15) << " not the number of results as expected";
 
   CostMatrix cost_matrix_abort_target;
-  results = cost_matrix_abort_target.SourceToTarget(request.options().sources(), request.options().targets(), reader,
-                                    mode_costing, sif::TravelMode::kDrive, 50000.0);
+  results = cost_matrix_abort_target.SourceToTarget(request.options().sources(),
+                                                    request.options().targets(), reader, mode_costing,
+                                                    sif::TravelMode::kDrive, 50000.0);
 
   found = 0;
   for (uint32_t i = 0; i < results.size(); ++i) {


### PR DESCRIPTION
Shorten down the request delay, when some sources/targets searches are early aborted.
* Decrease remaining_sources_ for all targets when a source search is aborted due to overpassing the threshold
* Decrease remaining_targets_ for all sources when a target search is aborted due to overpassing the threshold

## Issue
#3610
