### PR TITLE
support nulls in config-based speed assignment

### DIFF
--- a/test/gurka/test_config_speed.cc
+++ b/test/gurka/test_config_speed.cc
@@ -490,6 +490,7 @@ TEST(Standalone, AdminFallback) {
     ASSERT_EQ(edge.speed(), 11);
   }
 }
+
 TEST(Standalone, Malformed) {
   {
     std::ofstream speed_config("test/data/speed_config.json");
@@ -622,4 +623,33 @@ TEST(Standalone, Malformed) {
     testable_assigner assigner("test/data/speed_config.json");
     ASSERT_TRUE(assigner.tables.empty());
   }
+}
+
+TEST(Standalone, HandleNulls) {
+  DirectedEdge edge{};
+  edge.set_all_forward_access();
+
+  std::ofstream speed_config("test/data/speed_config.json");
+  speed_config << R"(
+    [{
+      "urban": {
+        "way": [null,null,null,null,null,null,null,null], "link_exiting": [null,null,null,null,null], "link_turning": [null,null,null,null,null],
+        "roundabout": [null,null,null,null,null,null,null,null], "driveway": null, "alley": null, "parking_aisle": null, "drive-through": null
+      },
+      "suburban": {
+        "way": [null,null,null,null,null,null,null,null], "link_exiting": [null,null,null,null,null], "link_turning": [null,null,null,null,null],
+        "roundabout": [null,null,null,null,null,null,null,null], "driveway": null, "alley": null, "parking_aisle": null, "drive-through": null
+      },
+      "rural": {
+        "way": [11,11,11,11,11,11,11,11], "link_exiting": [11,11,11,11,11], "link_turning": [11,11,11,11,11],
+        "roundabout": [11,11,11,11,11,11,11,11], "driveway": 11, "alley": 11, "parking_aisle": 11, "drive-through": 11
+      }
+    }]
+  )";
+  speed_config.close();
+  testable_assigner assigner("test/data/speed_config.json");
+  ASSERT_FALSE(assigner.tables.empty());
+  ASSERT_FALSE(assigner.UpdateSpeed(edge, 6, true, "foo", "bar"));
+  ASSERT_TRUE(assigner.UpdateSpeed(edge, 1, true, "foo", "bar"));
+  ASSERT_EQ(edge.speed(), 11);
 }


### PR DESCRIPTION
A while back we added support for configuring the default speeds of edges in the graph via data provided over in https://github.com/OpenStreetMapSpeeds/schema/blob/master/default_speeds.json

Semi-recently we were able to do a full planet build of that data but where there are holes in it we put nulls in the json. What we forgot to do was come back to the code here and make it robust certain entries being `null`. This PR does that.

I've added a unit test that shows a config with mixed `null` and non-`null` values properly do a partial speed assignment, setting those configured values to a given edge but not setting them when `null` is present.