### PR TITLE
feat: add `pre-commit` hook for running the `format.sh` script

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  # Autoformat: Docker files
+  - repo: local
+    hooks:
+      - id: hadolint
+        name: hadolint
+        language: docker_image
+        types:
+          - dockerfile
+        entry: hadolint/hadolint:v2.8.0-alpine hadolint ./docker/Dockerfile-*
+
+  # Autoformat: Shell files
+  - repo: local
+    hooks:
+    - id: format
+      name: format
+      entry: bash ./scripts/format.sh
+      language: system


### PR DESCRIPTION
- [x] Added the `pre-commit` hook as per discussion in #3613 & https://github.com/valhalla/valhalla/pull/3622#issuecomment-1122694251

Example:
<img width="686" alt="Screenshot 2022-05-18 at 8 18 48 PM" src="https://user-images.githubusercontent.com/19776877/169070669-14b118ef-d301-4336-84a6-f5e6196e7f24.png">

PS. This also lints the Dockerfiles using Hadolint :)

PPS. Thanks for this amazing open-source software ❤️