### PR TITLE
Respect interpolated matches when building matched route

### DIFF
--- a/src/meili/match_route.cc
+++ b/src/meili/match_route.cc
@@ -122,25 +122,21 @@ bool MergeRoute(const State& source,
  * @param match_results  The matched points representing the matched input trace points
  * @param first_idx      The index of the first match in the range
  * @param last_idx       The index of the second match in the range
- * @param segments       The segments over the range
+ * @param segments_begin The current first segment for this range
+ * @param segments_end   The end of segments iterator
  * @param new_segments   The new vector of segments over the range (should be the same or more
  * segments). This is a reference parameter to avoid constant allocation
  */
 void cut_segments(const std::vector<MatchResult>& match_results,
                   int first_idx,
                   int last_idx,
-                  const std::vector<EdgeSegment>& segments,
+                  std::vector<EdgeSegment>::iterator& first_segment,
+                  const std::vector<EdgeSegment>::iterator& segments_end,
                   std::vector<EdgeSegment>& new_segments) {
-  auto first_segment = segments.begin();
   int prev_idx = first_idx;
   for (int curr_idx = first_idx + 1; curr_idx <= last_idx; ++curr_idx) {
     const MatchResult& curr_match = match_results[curr_idx];
     const MatchResult& prev_match = match_results[prev_idx];
-
-    // skip if we do not need to cut
-    if (!curr_match.is_break_point && curr_idx != last_idx) {
-      continue;
-    }
 
     // Allow for some fp-fuzz in this gt comparison
     bool prev_gt_curr = prev_match.distance_along > curr_match.distance_along + 1e-3;
@@ -149,12 +145,12 @@ void cut_segments(const std::vector<MatchResult>& match_results,
     bool loop = (prev_match.edgeid == curr_match.edgeid) && prev_gt_curr;
 
     // if it is a loop, we start the search after the first edge
-    auto last_segment = std::find_if(first_segment + static_cast<size_t>(loop), segments.end(),
+    auto last_segment = std::find_if(first_segment + static_cast<size_t>(loop), segments_end,
                                      [&curr_match](const EdgeSegment& segment) {
                                        return (segment.edgeid == curr_match.edgeid);
                                      });
 
-    if (last_segment == segments.cend()) {
+    if (last_segment == segments_end) {
       throw std::logic_error("In meili::cutsegments(), unexpectedly unable to locate target edge.");
     }
 
@@ -223,31 +219,47 @@ std::vector<EdgeSegment> ConstructRoute(const MapMatcher& mapmatcher,
         continue;
       }
 
-      // we need to cut segments where a match result is marked as a break
-      new_segments.clear();
-      cut_segments(match_results, prev_idx, curr_idx, segments, new_segments);
+      // the first segment will be updated while cutting them
+      auto first_segment = segments.begin();
+      for (int cut_begin_idx = prev_idx, cut_end_idx = prev_idx + 1; cut_end_idx <= curr_idx;
+           ++cut_end_idx) {
 
-      // have to merge route's last segment and segments' first segment together if its not a
-      // discontinuity or a break
-      if (!prev_match->is_break_point && !route.empty() && !route.back().discontinuity &&
-          route.back().edgeid == new_segments.front().edgeid) {
-        // we modify the first segment of the new_segments accordingly to replace the previous
-        // one in the route.
-        new_segments.front().source = route.back().source;
-        // Prefer first_match_idx from previous segments but do not replace valid value with invalid.
-        if (route.back().first_match_idx != -1)
-          new_segments.front().first_match_idx = route.back().first_match_idx;
-        // Prefer last_match_idx from new segments but do not replace valid value with invalid.
-        if (new_segments.front().last_match_idx == -1)
-          new_segments.front().last_match_idx = route.back().last_match_idx;
-        route.pop_back();
+        // skip if we'd traverse onto an unmatched one, but keep the same start idx
+        if (match_results[cut_end_idx].GetType() == MatchResult::Type::kUnmatched) {
+          continue;
+        }
+
+        // we need to cut segments where a match result is marked as a break
+        new_segments.clear();
+        cut_segments(match_results, cut_begin_idx, cut_end_idx, first_segment, segments.end(),
+                     new_segments);
+
+        // have to merge route's last segment and segments' first segment together if its not a
+        // discontinuity or a break
+        if (!match_results[cut_begin_idx].is_break_point && !route.empty() &&
+            !route.back().discontinuity && route.back().edgeid == new_segments.front().edgeid) {
+          // we modify the first segment of the new_segments accordingly to replace the previous
+          // one in the route.
+          new_segments.front().source = route.back().source;
+          // Prefer first_match_idx from previous segments but do not replace valid value with
+          // invalid.
+          if (route.back().first_match_idx != -1)
+            new_segments.front().first_match_idx = route.back().first_match_idx;
+          // Prefer last_match_idx from new segments but do not replace valid value with invalid.
+          if (new_segments.front().last_match_idx == -1)
+            new_segments.front().last_match_idx = route.back().last_match_idx;
+          route.pop_back();
+        }
+
+        // debug builds check that the route is valid
+        assert(
+            ValidateRoute(mapmatcher.graphreader(), new_segments.begin(), new_segments.end(), tile));
+
+        // after we figured out whether or not we need to merge the last one we keep the rest
+        route.insert(route.end(), new_segments.cbegin(), new_segments.cend());
+
+        cut_begin_idx = cut_end_idx;
       }
-
-      // debug builds check that the route is valid
-      assert(ValidateRoute(mapmatcher.graphreader(), new_segments.begin(), new_segments.end(), tile));
-
-      // after we figured out whether or not we need to merge the last one we keep the rest
-      route.insert(route.end(), new_segments.cbegin(), new_segments.cend());
     }
 
     prev_match = &match;


### PR DESCRIPTION
fixes #3371 

for more context see #3645 where I tried to change too much and it was very hard to keep the same results. now I just introduced one more nested loop more or less which fixes the problem and passes the tests