### PR TITLE
Fix AABB2::Intersect() - y_intersect()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## Release Date: 2021-??-?? Valhalla 3.1.5
 * **Removed**
 * **Bug Fix**
-   * FIXED: Fix AABB2::Intersect(...) - horizontal line intersections y_intersect(...) returning NAN [#3654](https://github.com/valhalla/valhalla/pull/3654)
    * FIXED: Wrong out index in route intersections [#3541](https://github.com/valhalla/valhalla/pull/3541)
    * FIXED: Both `hov:designated` and `hov:minimum` have to be correctly set for the way to be considered hov-only [#3526](https://github.com/valhalla/valhalla/pull/3526)
    * FIXED: Fix precision losses while encoding-decoding distance parameter in openlr [#3374](https://github.com/valhalla/valhalla/pull/3374)
@@ -40,6 +39,7 @@
    * FIXED: valhalla_run_matrix was failing (could not find proper max_matrix_distance) [#3635](https://github.com/valhalla/valhalla/pull/3635)
    * FIXED: Removed duplicate degrees/radians constants [#3642](https://github.com/valhalla/valhalla/pull/3642)
    * FIXED: Forgot to adapt driving side and country access rules in [#3619](https://github.com/valhalla/valhalla/pull/3619) [#3652](https://github.com/valhalla/valhalla/pull/3652)
+   * FIXED: Fix AABB2::Intersect(...) - horizontal line intersections y_intersect(...) returning NAN [#3654](https://github.com/valhalla/valhalla/pull/3654)
 
 * **Enhancement**
    * CHANGED: Pronunciation for names and destinations [#3132](https://github.com/valhalla/valhalla/pull/3132)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Release Date: 2021-??-?? Valhalla 3.1.5
 * **Removed**
 * **Bug Fix**
+   * FIXED: Fix AABB2::Intersect(...) - horizontal line intersections y_intersect(...) returning NAN [#3654](https://github.com/valhalla/valhalla/pull/3654)
    * FIXED: Wrong out index in route intersections [#3541](https://github.com/valhalla/valhalla/pull/3541)
    * FIXED: Both `hov:designated` and `hov:minimum` have to be correctly set for the way to be considered hov-only [#3526](https://github.com/valhalla/valhalla/pull/3526)
    * FIXED: Fix precision losses while encoding-decoding distance parameter in openlr [#3374](https://github.com/valhalla/valhalla/pull/3374)

--- a/src/midgard/util.cc
+++ b/src/midgard/util.cc
@@ -552,7 +552,7 @@ y_intercept(const coord_t& u, const coord_t& v, const typename coord_t::second_t
   if (std::abs(u.first - v.first) < 1e-5) {
     return u.first;
   }
-  if (std::abs(u.second - u.second) < 1e-5) {
+  if (std::abs(u.second - v.second) < 1e-5) {
     return NAN;
   }
   auto m = (v.second - u.second) / (v.first - u.first);


### PR DESCRIPTION
# Issue

#3656 
Found during static code analyser running
The condition:
https://github.com/valhalla/valhalla/blob/de5e4a72332a0331099d26f8becfc95f9329d96b/src/midgard/util.cc#L555
is always `false`. `NAN` was returned mistakenly.

What is the best way to cover this code with tests?

## Tasklist

 - [ ] Add tests
 - [x] Update the [changelog](CHANGELOG.md)
