### PR TITLE
remove unused methods from midgard

### DIFF
--- a/scripts/valhalla_build_timezones
+++ b/scripts/valhalla_build_timezones
@@ -2,7 +2,7 @@
 
 error_exit() {
   echo "error: $1" 1>&2
-  #exit $(pkg-config geos --modversion | grep -cvF "3.9")
+  exit $(pkg-config geos --modversion | grep -cvF "3.9")
 }
 
 if  ! which spatialite >/dev/null; then

--- a/scripts/valhalla_build_timezones
+++ b/scripts/valhalla_build_timezones
@@ -2,7 +2,7 @@
 
 error_exit() {
   echo "error: $1" 1>&2
-  exit $(pkg-config geos --modversion | grep -cvF "3.9")
+  #exit $(pkg-config geos --modversion | grep -cvF "3.9")
 }
 
 if  ! which spatialite >/dev/null; then

--- a/src/midgard/aabb2.cc
+++ b/src/midgard/aabb2.cc
@@ -107,54 +107,6 @@ template <class coord_t> bool AABB2<coord_t>::Intersects(const coord_t& c, float
          c.DistanceSquared(coord_t{vertical, maxy_}) <= r;     // intersects the top side
 }
 
-// Intersects the segment formed by u,v with the bounding box
-template <class coord_t> bool AABB2<coord_t>::Intersect(coord_t& u, coord_t& v) const {
-  // which do we need to move
-  bool need_u = u.first < minx_ || u.first > maxx_ || u.second < miny_ || u.second > maxy_;
-  bool need_v = v.first < minx_ || v.first > maxx_ || v.second < miny_ || v.second > maxy_;
-  if (!(need_u || need_v)) {
-    return true;
-  }
-  // find intercepts with each box edge
-  std::list<coord_t> intersections;
-  x_t x;
-  y_t y;
-  // intersect with each edge keeping it if its on this box and on the segment uv
-  if (!std::isnan(x = y_intercept(u, v, miny_)) && x >= minx_ && x <= maxx_ &&
-      between(x, u.first, v.first)) {
-    intersections.emplace_back(x, miny_);
-  }
-  if (!std::isnan(x = y_intercept(u, v, maxy_)) && x >= minx_ && x <= maxx_ &&
-      between(x, u.first, v.first)) {
-    intersections.emplace_back(x, maxy_);
-  }
-  if (!std::isnan(y = x_intercept(u, v, maxx_)) && y >= miny_ && y <= maxy_ &&
-      between(y, u.second, v.second)) {
-    intersections.emplace_back(maxx_, y);
-  }
-  if (!std::isnan(y = x_intercept(u, v, minx_)) && y >= miny_ && y <= maxy_ &&
-      between(y, u.second, v.second)) {
-    intersections.emplace_back(minx_, y);
-  }
-  // pick the best one for each that needs it
-  auto u_dist = std::numeric_limits<typename coord_t::value_type>::infinity();
-  auto v_dist = std::numeric_limits<typename coord_t::value_type>::infinity();
-  typename coord_t::value_type d;
-
-  for (const auto& intersection : intersections) {
-    if (need_u && (d = u.DistanceSquared(intersection)) < u_dist) {
-      u = intersection;
-      u_dist = d;
-    }
-    if (need_v && (d = v.DistanceSquared(intersection)) < v_dist) {
-      v = intersection;
-      v_dist = d;
-    }
-  }
-  // are we inside now?
-  return intersections.size();
-}
-
 // Clips the input set of vertices to the specified boundary.  Uses a
 // method where the shape is clipped against each edge in succession.
 template <class coord_t>

--- a/src/midgard/util.cc
+++ b/src/midgard/util.cc
@@ -545,62 +545,6 @@ template bool intersect<PointLL>(const PointLL& u,
 template bool
 intersect<Point2>(const Point2& u, const Point2& v, const Point2& a, const Point2& b, Point2& i);
 
-// Return the intercept of the line passing through uv with the horizontal line defined by y
-template <class coord_t>
-typename coord_t::first_type
-y_intercept(const coord_t& u, const coord_t& v, const typename coord_t::second_type y) {
-  if (std::abs(u.first - v.first) < 1e-5) {
-    return u.first;
-  }
-  if (std::abs(u.second - u.second) < 1e-5) {
-    return NAN;
-  }
-  auto m = (v.second - u.second) / (v.first - u.first);
-  auto b = u.second - (u.first * m);
-  return (y - b) / m;
-}
-template PointXY<float>::first_type y_intercept<PointXY<float>>(const PointXY<float>&,
-                                                                const PointXY<float>&,
-                                                                const PointXY<float>::first_type);
-template GeoPoint<float>::first_type y_intercept<GeoPoint<float>>(const GeoPoint<float>&,
-                                                                  const GeoPoint<float>&,
-                                                                  const GeoPoint<float>::first_type);
-template PointXY<double>::first_type y_intercept<PointXY<double>>(const PointXY<double>&,
-                                                                  const PointXY<double>&,
-                                                                  const PointXY<double>::first_type);
-template GeoPoint<double>::first_type
-y_intercept<GeoPoint<double>>(const GeoPoint<double>&,
-                              const GeoPoint<double>&,
-                              const GeoPoint<double>::first_type);
-
-// Return the intercept of the line passing through uv with the vertical line defined by x
-template <class coord_t>
-typename coord_t::first_type
-x_intercept(const coord_t& u, const coord_t& v, const typename coord_t::second_type x) {
-  if (std::abs(u.second - v.second) < 1e-5) {
-    return u.second;
-  }
-  if (std::abs(u.first - v.first) < 1e-5) {
-    return NAN;
-  }
-  auto m = (v.second - u.second) / (v.first - u.first);
-  auto b = u.second - (u.first * m);
-  return x * m + b;
-}
-template PointXY<float>::first_type x_intercept<PointXY<float>>(const PointXY<float>&,
-                                                                const PointXY<float>&,
-                                                                const PointXY<float>::first_type);
-template GeoPoint<float>::first_type x_intercept<GeoPoint<float>>(const GeoPoint<float>&,
-                                                                  const GeoPoint<float>&,
-                                                                  const GeoPoint<float>::first_type);
-template PointXY<double>::first_type x_intercept<PointXY<double>>(const PointXY<double>&,
-                                                                  const PointXY<double>&,
-                                                                  const PointXY<double>::first_type);
-template GeoPoint<double>::first_type
-x_intercept<GeoPoint<double>>(const GeoPoint<double>&,
-                              const GeoPoint<double>&,
-                              const GeoPoint<double>::first_type);
-
 template <class container_t>
 typename container_t::value_type::first_type polygon_area(const container_t& polygon) {
   // Shoelace formula

--- a/test/aabb2.cc
+++ b/test/aabb2.cc
@@ -199,43 +199,6 @@ TEST(AABB2, TestIntersectsCircle) {
 TEST(AABB2, TestIntersect) {
   // Test if bounding boxes intersect
   AABB2<Point2> box(-1, -1, 1, 1);
-  Point2 a, b;
-
-  EXPECT_TRUE(box.Intersect((a = {0, 0}), (b = {1, 1})));
-  EXPECT_EQ(a, Point2(0, 0));
-  EXPECT_EQ(b, Point2(1, 1));
-
-  EXPECT_TRUE(box.Intersect((a = {-2, 0}), (b = {2, 0})));
-  EXPECT_EQ(a, Point2(-1, 0));
-  EXPECT_EQ(b, Point2(1, 0));
-
-  EXPECT_TRUE(box.Intersect((a = {-2, -2}), (b = {2, 2})));
-  EXPECT_EQ(a, Point2(-1, -1));
-  EXPECT_EQ(b, Point2(1, 1));
-
-  EXPECT_TRUE(box.Intersect((a = {-2, -2}), (b = {0, 0})));
-  EXPECT_EQ(a, Point2(-1, -1));
-  EXPECT_EQ(b, Point2(0, 0));
-
-  EXPECT_TRUE(box.Intersect((a = {0, 0}), (b = {2, 2})));
-  EXPECT_EQ(a, Point2(0, 0));
-  EXPECT_EQ(b, Point2(1, 1));
-
-  EXPECT_TRUE(box.Intersect((a = {-1, 1}), (b = {1, -1})));
-  EXPECT_EQ(a, Point2(-1, 1));
-  EXPECT_EQ(b, Point2(1, -1));
-
-  EXPECT_TRUE(box.Intersect((a = {0, 2}), (b = {2, 0})));
-  EXPECT_EQ(a, Point2(1, 1));
-  EXPECT_EQ(b, Point2(1, 1));
-
-  LineSegment2<Point2> ab(a, b);
-  EXPECT_TRUE(box.Intersects(ab)) << "LineSegment intersects test failed";
-
-  EXPECT_FALSE(box.Intersect((a = {-2, -2}), (b = {-1, -1.001})));
-  EXPECT_FALSE(box.Intersect((a = {0, 2.1}), (b = {2.1, 0})));
-  EXPECT_FALSE(box.Intersect((a = {0, 1.1}), (b = {1, 1.1})));
-  EXPECT_FALSE(box.Intersect((a = {1.1, 0}), (b = {1, 1.1})));
 
   // Test intersection of bounding boxes
   // Case 1 - no intersection

--- a/valhalla/midgard/aabb2.h
+++ b/valhalla/midgard/aabb2.h
@@ -233,16 +233,6 @@ public:
   uint32_t Clip(std::vector<coord_t>& pts, const bool closed) const;
 
   /**
-   * Intersects the segment formed by u,v with the bounding box
-   *
-   * @param  u  the first point in the segment
-   * @param  v  the second point in the segment
-   * @return Returns true if the segment actually intersected the bounding box
-   *         and moves u and v to actually reflect the intersection points
-   */
-  bool Intersect(coord_t& u, coord_t& v) const;
-
-  /**
    * Expands (if necessary) the bounding box to include the specified
    * bounding box.
    * @param  r2  Bounding bounding box to "combine" with this bounding box.

--- a/valhalla/midgard/util.h
+++ b/valhalla/midgard/util.h
@@ -469,27 +469,6 @@ template <class coord_t>
 bool intersect(const coord_t& u, const coord_t& v, const coord_t& a, const coord_t& b, coord_t& i);
 
 /**
- * Return the intercept of the line passing through uv with the horizontal line defined by y
- * @param u  first point on line
- * @param v  second point on line
- * @param y  y component of horizontal line
- * @return x component (or NaN if parallel) of the intercept of uv with the horizontal line
- */
-template <class coord_t>
-typename coord_t::first_type
-y_intercept(const coord_t& u, const coord_t& v, const typename coord_t::second_type y = 0);
-/**
- * Return the intercept of the line passing through uv with the vertical line defined by x
- * @param u  first point on line
- * @param v  second point on line
- * @param x  x component of vertical line
- * @return y component (or NaN if parallel) of the intercept of uv with the vertical line
- */
-template <class coord_t>
-typename coord_t::first_type
-x_intercept(const coord_t& u, const coord_t& v, const typename coord_t::second_type x = 0);
-
-/**
  * Compute the area of a polygon. If your polygon is not twisted or self intersecting
  * this will return a positive value for counterclockwise wound polygons and negative otherwise.
  * Works with rings where the polygons first and last points are the same or not


### PR DESCRIPTION
in #3654 it was noticed that a pretty serious typo was breaking the intercept function. upon further inspection though, it turns out these methods arent even used anywhere (must have been at one time or came over with the initial code dump from @dnesbitt61) at any rate, im of the opinion that we should trim out as much unused code as possible since this reduces maintainance and increases readability (findability really i guess)