### PR TITLE
BSS: refine edge type on which bss will be projected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@
    * ADDED: Shorten down the request delay, when some sources/targets searches are early aborted [#3611](https://github.com/valhalla/valhalla/pull/3611)
    * ADDED: add `pre-commit` hook for running the `format.sh` script [#3637](https://github.com/valhalla/valhalla/pull/3637)
    * CHANGED: upgrade pybind11 to v2.9.2 to remove cmake warning [#3658](https://github.com/valhalla/valhalla/pull/3658)
+   * CHANGED: Precise definition of types of edges on which BSS could be projected [#3658](https://github.com/valhalla/valhalla/pull/3663)
 
 ## Release Date: 2021-10-07 Valhalla 3.1.4
 * **Removed**

--- a/src/mjolnir/bssbuilder.cc
+++ b/src/mjolnir/bssbuilder.cc
@@ -148,8 +148,9 @@ void compute_and_fill_shape(const BestProjection& best,
 }
 
 const static auto VALID_EDGE_USES = std::unordered_set<Use>{
-    Use::kRoad,    Use::kLivingStreet, Use::kCycleway,   Use::kSidewalk,
-    Use::kFootway, Use::kPath,         Use::kPedestrian,
+    Use::kRoad, Use::kLivingStreet, Use::kCycleway, Use::kSidewalk,    Use::kFootway,
+    Use::kPath, Use::kPedestrian,   Use::kAlley,    Use::kServiceRoad,
+
 };
 
 std::vector<BSSConnection> project(const GraphTile& local_tile, const std::vector<OSMNode>& osm_bss) {

--- a/test/astar_bss.cc
+++ b/test/astar_bss.cc
@@ -283,10 +283,10 @@ TEST(AstarBss, test_Truck) {
   std::string request =
       R"({"locations":[{"lat":48.859895,"lon":2.3610976338},{"lat":48.86271911,"lon":2.367111146}],"costing":"truck"})";
   std::vector<TravelMode> expected_travel_modes{TravelMode::kDrive};
-  std::vector<std::string> expected_route{"Rue de la Perle",        "Rue des Archives",
-                                          "Rue Pastourelle",        "Rue du Temple",
-                                          "Place de la République", "Boulevard du Temple",
-                                          "Rue Oberkampf",          "Rue Amelot"};
+  std::vector<std::string>
+      expected_route{"Rue de la Perle",     "Rue des Archives",       "Rue Pastourelle",
+                     "Rue du Temple",       "Place de la République", "Place de la République",
+                     "Boulevard du Temple", "Rue Oberkampf",          "Rue Amelot"};
   // There shouldn't be any bss maneuvers
   const std::map<size_t, BssManeuverType>& expected_bss_maneuver{};
 


### PR DESCRIPTION
# Issue

In the previous PR, we didn't define precisely the types(the so-called `USE`) of edges on which a bike share station could be projected. As we bring Valhalla into production gradually, some weird projections have been detected. 

In this PR, we'd like to exclude the types of edges on which a bike share station **must NOT** be projected.

The reason why these type are excluded are purely empirical, but most of them are quite logical and obvious.  
```
  // Road specific uses
  kRoad = 0,            // Yes
  kRamp = 1,            // No: Link - exits/entrance ramps.
  kTurnChannel = 2,     // No: Link - turn lane.
  kTrack = 3,           // No: Agricultural use, forest tracks
  kDriveway = 4,        // No: Driveway/private service
  kAlley = 5,           // Yes: Service road - limited route use
  kParkingAisle = 6,    // No: Access roads in parking areas
  kEmergencyAccess = 7, // No: Emergency vehicles only
  kDriveThru = 8,       // No: Commercial drive-thru (banks/fast-food)
  kCuldesac = 9,        // No: Cul-de-sac (edge that forms a loop and is only
                        // connected at one node to another edge.
  kLivingStreet = 10,   // Yes: Streets with preference towards bicyclists and pedestrians
  kServiceRoad = 11,    // Yes: Generic service road (not driveway, alley, parking aisle, etc.)

  // Bicycle specific uses
  kCycleway = 20,     // Yes: Dedicated bicycle path
  kMountainBike = 21, // No: Mountain bike trail

  kSidewalk = 24,  // Yes

  // Pedestrian specific uses
  kFootway = 25,      // Yes
  kSteps = 26,        // No: Stairs
  kPath = 27,        // Yes(???? not sure at all)
  kPedestrian = 28,    // Yes
  kBridleway = 29, // No
  kPedestrianCrossing = 32, // No: cross walks
  kElevator = 33, // No 
  kEscalator = 34, // No 

  // Rest/Service Areas
  kRestArea = 30,        // No 
  kServiceArea = 31,    // No 

  // Other...
  kOther = 40, // No 

  // Ferry and rail ferry
  kFerry = 41, // No 
  kRailFerry = 42, // No 

  kConstruction = 43, // No  Road under construction

  // Transit specific uses. Must be last in the list
  kRail = 50,               // No:  Rail line
  kBus = 51,                // No:  Bus line
  kEgressConnection = 52,   // No: Connection to a egress node
  kPlatformConnection = 53, // No: Connection to a platform node
  kTransitConnection = 54,  // No: Connection to multi-use transit stop
```

## Tasklist

 - [x] Update the [changelog](CHANGELOG.md)
 - [x] fix tests