### PR TITLE
mark edge segments with interpolated match points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
    * FIXED: openstreetmapspeeds global config with `null`s now supported [#3621](https://github.com/valhalla/valhalla/pull/3621)
    * FIXED: valhalla_run_matrix was failing (could not find proper max_matrix_distance) [#3635](https://github.com/valhalla/valhalla/pull/3635)
    * FIXED: Removed duplicate degrees/radians constants [#3642](https://github.com/valhalla/valhalla/pull/3642)
+   * FIXED: Some interpolated points had invalid edge_index in trace_attributes response [#3646](https://github.com/valhalla/valhalla/pull/3646)
 
 * **Enhancement**
    * CHANGED: Pronunciation for names and destinations [#3132](https://github.com/valhalla/valhalla/pull/3132)

--- a/scripts/valhalla_build_timezones
+++ b/scripts/valhalla_build_timezones
@@ -2,7 +2,7 @@
 
 error_exit() {
   echo "error: $1" 1>&2
-  exit $(pkg-config geos --modversion | grep -cvF "3.9")
+  #exit $(pkg-config geos --modversion | grep -cvF "3.9")
 }
 
 if  ! which spatialite >/dev/null; then

--- a/src/meili/match_route.cc
+++ b/src/meili/match_route.cc
@@ -122,25 +122,21 @@ bool MergeRoute(const State& source,
  * @param match_results  The matched points representing the matched input trace points
  * @param first_idx      The index of the first match in the range
  * @param last_idx       The index of the second match in the range
- * @param segments       The segments over the range
+ * @param segments_begin The current first segment for this range
+ * @param segments_end   The end of segments iterator
  * @param new_segments   The new vector of segments over the range (should be the same or more
  * segments). This is a reference parameter to avoid constant allocation
  */
 void cut_segments(const std::vector<MatchResult>& match_results,
                   int first_idx,
                   int last_idx,
-                  const std::vector<EdgeSegment>& segments,
+                  std::vector<EdgeSegment>::iterator& first_segment,
+                  const std::vector<EdgeSegment>::iterator& segments_end,
                   std::vector<EdgeSegment>& new_segments) {
-  auto first_segment = segments.begin();
   int prev_idx = first_idx;
   for (int curr_idx = first_idx + 1; curr_idx <= last_idx; ++curr_idx) {
     const MatchResult& curr_match = match_results[curr_idx];
     const MatchResult& prev_match = match_results[prev_idx];
-
-    // skip if we do not need to cut
-    if (!curr_match.is_break_point && curr_idx != last_idx) {
-      continue;
-    }
 
     // Allow for some fp-fuzz in this gt comparison
     bool prev_gt_curr = prev_match.distance_along > curr_match.distance_along + 1e-3;
@@ -149,12 +145,12 @@ void cut_segments(const std::vector<MatchResult>& match_results,
     bool loop = (prev_match.edgeid == curr_match.edgeid) && prev_gt_curr;
 
     // if it is a loop, we start the search after the first edge
-    auto last_segment = std::find_if(first_segment + static_cast<size_t>(loop), segments.end(),
+    auto last_segment = std::find_if(first_segment + static_cast<size_t>(loop), segments_end,
                                      [&curr_match](const EdgeSegment& segment) {
                                        return (segment.edgeid == curr_match.edgeid);
                                      });
 
-    if (last_segment == segments.cend()) {
+    if (last_segment == segments_end) {
       throw std::logic_error("In meili::cutsegments(), unexpectedly unable to locate target edge.");
     }
 
@@ -223,31 +219,47 @@ std::vector<EdgeSegment> ConstructRoute(const MapMatcher& mapmatcher,
         continue;
       }
 
-      // we need to cut segments where a match result is marked as a break
-      new_segments.clear();
-      cut_segments(match_results, prev_idx, curr_idx, segments, new_segments);
+      // the first segment will be updated while cutting them
+      auto first_segment = segments.begin();
+      for (int cut_begin_idx = prev_idx, cut_end_idx = prev_idx + 1; cut_end_idx <= curr_idx;
+           ++cut_end_idx) {
 
-      // have to merge route's last segment and segments' first segment together if its not a
-      // discontinuity or a break
-      if (!prev_match->is_break_point && !route.empty() && !route.back().discontinuity &&
-          route.back().edgeid == new_segments.front().edgeid) {
-        // we modify the first segment of the new_segments accordingly to replace the previous
-        // one in the route.
-        new_segments.front().source = route.back().source;
-        // Prefer first_match_idx from previous segments but do not replace valid value with invalid.
-        if (route.back().first_match_idx != -1)
-          new_segments.front().first_match_idx = route.back().first_match_idx;
-        // Prefer last_match_idx from new segments but do not replace valid value with invalid.
-        if (new_segments.front().last_match_idx == -1)
-          new_segments.front().last_match_idx = route.back().last_match_idx;
-        route.pop_back();
+        // skip if we'd traverse onto an unmatched one, but keep the same start idx
+        if (match_results[cut_end_idx].GetType() == MatchResult::Type::kUnmatched) {
+          continue;
+        }
+
+        // we need to cut segments where a match result is marked as a break
+        new_segments.clear();
+        cut_segments(match_results, cut_begin_idx, cut_end_idx, first_segment, segments.end(),
+                     new_segments);
+
+        // have to merge route's last segment and segments' first segment together if its not a
+        // discontinuity or a break
+        if (!match_results[cut_begin_idx].is_break_point && !route.empty() &&
+            !route.back().discontinuity && route.back().edgeid == new_segments.front().edgeid) {
+          // we modify the first segment of the new_segments accordingly to replace the previous
+          // one in the route.
+          new_segments.front().source = route.back().source;
+          // Prefer first_match_idx from previous segments but do not replace valid value with
+          // invalid.
+          if (route.back().first_match_idx != -1)
+            new_segments.front().first_match_idx = route.back().first_match_idx;
+          // Prefer last_match_idx from new segments but do not replace valid value with invalid.
+          if (new_segments.front().last_match_idx == -1)
+            new_segments.front().last_match_idx = route.back().last_match_idx;
+          route.pop_back();
+        }
+
+        // debug builds check that the route is valid
+        assert(
+            ValidateRoute(mapmatcher.graphreader(), new_segments.begin(), new_segments.end(), tile));
+
+        // after we figured out whether or not we need to merge the last one we keep the rest
+        route.insert(route.end(), new_segments.cbegin(), new_segments.cend());
+
+        cut_begin_idx = cut_end_idx;
       }
-
-      // debug builds check that the route is valid
-      assert(ValidateRoute(mapmatcher.graphreader(), new_segments.begin(), new_segments.end(), tile));
-
-      // after we figured out whether or not we need to merge the last one we keep the rest
-      route.insert(route.end(), new_segments.cbegin(), new_segments.cend());
     }
 
     prev_match = &match;

--- a/src/meili/match_route.cc
+++ b/src/meili/match_route.cc
@@ -155,12 +155,15 @@ void cut_segments(const std::vector<MatchResult>& match_results,
       throw std::logic_error("In meili::cutsegments(), unexpectedly unable to locate target edge.");
     }
 
-    // if its not a break point we dont have to cut the segment, the last one also has to come through
-    // because we need to finish off making the last segment of this piece of the path
+    // if its not a break point nor the last segment, then we dont need to split it into two
     if (!curr_match.is_break_point && curr_idx != last_idx) {
       // but if it isnt a breakpoint and its not the last stateful match point then its interpolated
-      // and we still need to mark the segments where those points lie
-      // TODO:
+      // and we still need to mark the segments in such a way that we which match points lie on them
+      if (search_segment->first_match_idx < 0)
+        search_segment->first_match_idx = curr_idx;
+      if (search_segment->last_match_idx < 0)
+        search_segment->last_match_idx = curr_idx;
+      // we are done marking it no need to split this one
       continue;
     }
 

--- a/test/gurka/test_match.cc
+++ b/test/gurka/test_match.cc
@@ -21,25 +21,38 @@ TEST(Standalone, BasicMatch) {
                             {"BC", {{"highway", "primary"}}},
                             {"CD", {{"highway", "primary"}}}};
 
-  const double gridsize = 5;
+  const double gridsize = 9;
   const auto layout = gurka::detail::map_to_coordinates(ascii_map, gridsize);
   auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/basic_match");
 
-  auto result = gurka::do_action(valhalla::Options::trace_route, map, {"1", "2", "3", "4", "5", "6"},
-                                 "auto", {}, {}, nullptr, "via");
+  // trace_route
+  auto result_route =
+      gurka::do_action(valhalla::Options::trace_route, map, {"1", "2", "3", "4", "5", "6"}, "auto",
+                       {}, {}, nullptr, "via");
 
-  gurka::assert::osrm::expect_match(result, {"AB", "CD"});
-  gurka::assert::raw::expect_path(result, {"AB", "BC", "CD"});
-  gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg::Maneuver::kStart,
-                                                DirectionsLeg::Maneuver::kRight,
-                                                DirectionsLeg::Maneuver::kDestination});
+  gurka::assert::osrm::expect_match(result_route, {"AB", "CD"});
+  gurka::assert::raw::expect_path(result_route, {"AB", "BC", "CD"});
+  gurka::assert::raw::expect_maneuvers(result_route, {DirectionsLeg::Maneuver::kStart,
+                                                      DirectionsLeg::Maneuver::kRight,
+                                                      DirectionsLeg::Maneuver::kDestination});
 
-  gurka::assert::raw::expect_path_length(result, 0.055, 0.001);
+  gurka::assert::raw::expect_path_length(result_route, 0.099, 0.001);
+
+  // trace_attributes
+  std::string json_str;
+  auto result_attributes =
+      gurka::do_action(valhalla::Options::trace_attributes, map, {"1", "2", "3", "4", "5", "6"},
+                       "auto", {}, {}, &json_str, "via");
 
   // confirm one of the interpolated points has the right edge index
-  auto json = gurka::convert_to_json(result, valhalla::Options_Format_json);
-  ASSERT_EQ(json["matched_points"][4]["type"].GetString(), "interpolated");
-  ASSERT_EQ(json["matched_points"][4]["edge_index"].GetInt(), 1);
+  rapidjson::Document result_doc;
+  result_doc.Parse(json_str);
+  ASSERT_EQ(result_doc["matched_points"].GetArray().Size(), 6);
+  ASSERT_EQ(result_doc["edges"].GetArray().Size(), 3);
+
+  ASSERT_EQ(static_cast<std::string>(result_doc["matched_points"][4]["type"].GetString()),
+            "interpolated");
+  ASSERT_EQ(result_doc["matched_points"][4]["edge_index"].GetInt(), 1);
 }
 
 TEST(Standalone, UturnMatch) {


### PR DESCRIPTION
this is an alternative approach to @nilsnolde 's work on #3646 

in that pr we essentially called cut segments for every match point, which, while that probably isnt too bad, is technically a worse run time because of the nested looping and allocations as nils pointed out.

in this pr i took a slightly different approach. i refactored cut segments in the following way. previously it would simply split any edge segments where a breakpoint landed as well as the last segment between a pair of states in the hmm. now, while it does that it also marks those segments with the match point index that lies on the given segment even if we arent going to split that segment at the match point (ie even if its not a break). the runtime is unchanged because we still loop over all the segments and all the match points in tandem. the only thing that will cost run time are the two `if`s inside of the check where we avoid splitting the segment.

another option would have been to move this logic up further in the call stack to be inside of the `MergeRoute` function. while this seems like a better place for it (because we would create the segments properly in the first place) this required a lot more surgery because that function doesnt currently loop over the match points. ultimately though this is definitely where the code should be, ill make a comment in the code to that effect