### PR TITLE
FIX(android):Fix for build android.

### DIFF
--- a/src/midgard/logging.cc
+++ b/src/midgard/logging.cc
@@ -136,6 +136,7 @@ public:
   }
   virtual void Log(const std::string& message, const std::string& custom_directive = " [TRACE] ") {
 #ifdef __ANDROID__
+    std::string tmp = custom_directive; // to prevent -Wunused-parameter
     __android_log_print(ANDROID_LOG_INFO, "valhalla", "%s", message.c_str());
 #else
     std::string output;
@@ -165,6 +166,7 @@ class StdErrLogger : public StdOutLogger {
   using StdOutLogger::StdOutLogger;
   virtual void Log(const std::string& message, const std::string& custom_directive = " [TRACE] ") {
 #ifdef __ANDROID__
+    std::string tmp = custom_directive; // to prevent -Wunused-parameter
     __android_log_print(ANDROID_LOG_ERROR, "valhalla", "%s", message.c_str());
 #else
     std::string output;


### PR DESCRIPTION
When build android, `unused parameter` error.
So, Fix it with temp value

# Issue
when build with android NDK

`valhalla/src/midgard/logging.cc:137:67: error: unused parameter 'custom_directive' [-Werror,-Wunused-parameter]
  virtual void Log(const std::string& message, const std::string& custom_directive = " [TRACE] ") {
                                                                  ^
valhalla/src/midgard/logging.cc:166:67: error: unused parameter 'custom_directive' [-Werror,-Wunused-parameter]
  virtual void Log(const std::string& message, const std::string& custom_directive = " [TRACE] ") {
                                                                  ^`

It's from that code 

```
virtual void Log(const std::string& message, const std::string& custom_directive = " [TRACE] ") {
 #ifdef __ANDROID__
     __android_log_print(ANDROID_LOG_INFO, "valhalla", "%s", message.c_str());
 #else
```

cause, when android, does not use `custom_directive` so add to temp using hack. 

like it 

`
std::string tmp = custom_directive; //for prevent unused error
`

now we can build it.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
