### PR TITLE
Use a small snap to node distance when Projecting candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
    * FIXED: DateTime::is_conditional_active(...) incorrect end week handling [#3655](https://github.com/valhalla/valhalla/pull/3655)
    * FIXED: TimeDistanceBSSMatrix: incorrect initialization for destinations[#3659](https://github.com/valhalla/valhalla/pull/3659)
    * FIXED: Some interpolated points had invalid edge_index in trace_attributes response [#3646](https://github.com/valhalla/valhalla/pull/3670)
+   * FIXED: Use a small node snap distance in map-matching. FIxes issue with incorrect turn followed by Uturn. [#3677](https://github.com/valhalla/valhalla/pull/3677)
 
 * **Enhancement**
    * CHANGED: Pronunciation for names and destinations [#3132](https://github.com/valhalla/valhalla/pull/3132)

--- a/src/meili/candidate_search.cc
+++ b/src/meili/candidate_search.cc
@@ -6,6 +6,10 @@ using namespace valhalla::midgard;
 
 namespace valhalla {
 
+// Use a short snap to node distance in Project helper methods. This seems to fix
+// a bug where an incorrect turn + immediate Uturn exists when this distance = 0.
+constexpr double kSnapToNodeDistance = 1.0; // meters
+
 namespace meili {
 
 struct CandidateCollector {
@@ -78,7 +82,8 @@ CandidateCollector::WithinSquaredDistance(const midgard::PointLL& location,
     const bool edge_included = !costing || costing->Allowed(edge, tile, sif::kDisallowShortcut);
 
     if (edge_included) {
-      std::tie(point, sq_distance, segment, offset) = helpers::Project(projector, shape);
+      std::tie(point, sq_distance, segment, offset) =
+          helpers::Project(projector, shape, kSnapToNodeDistance);
 
       if (sq_distance <= sq_search_radius) {
         const double dist = edge->forward() ? offset : 1.0 - offset;
@@ -97,7 +102,8 @@ CandidateCollector::WithinSquaredDistance(const midgard::PointLL& location,
     if (oppedge_included) {
       // No need to project again if we already did it above
       if (!edge_included) {
-        std::tie(point, sq_distance, segment, offset) = helpers::Project(projector, shape);
+        std::tie(point, sq_distance, segment, offset) =
+            helpers::Project(projector, shape, kSnapToNodeDistance);
       }
       if (sq_distance <= sq_search_radius) {
         const double dist = opp_edge->forward() ? offset : 1.0 - offset;


### PR DESCRIPTION
# Issue

fixes #3230

Use a node snapping distance of 1 meter in calls to helpers::Project. This fixes an issue where an incorrect turn followed by immediate Uturn occurs at the node.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
