### PR TITLE
Fixed CostMatrix incorrect tile usage with oppedge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
    * FIXED: Some interpolated points had invalid edge_index in trace_attributes response [#3646](https://github.com/valhalla/valhalla/pull/3670)
    * FIXED: Use a small node snap distance in map-matching. FIxes issue with incorrect turn followed by Uturn. [#3677](https://github.com/valhalla/valhalla/pull/3677)
    * FIXED: Conan error when building Docker image. [#3689](https://github.com/valhalla/valhalla/pull/3689)
+   * FIXED: CostMatrix incorrect tile usage with oppedge. [#3719](https://github.com/valhalla/valhalla/pull/3719)
 
 * **Enhancement**
    * CHANGED: Pronunciation for names and destinations [#3132](https://github.com/valhalla/valhalla/pull/3132)

--- a/src/thor/costmatrix.cc
+++ b/src/thor/costmatrix.cc
@@ -635,7 +635,7 @@ void CostMatrix::BackwardSearch(const uint32_t index, GraphReader& graphreader) 
       // we can properly recover elapsed time on the reverse path.
       uint8_t flow_sources;
       Cost newcost =
-          pred.cost() + costing_->EdgeCost(opp_edge, tile, TimeInfo::invalid(), flow_sources);
+          pred.cost() + costing_->EdgeCost(opp_edge, t2, TimeInfo::invalid(), flow_sources);
 
       Cost tc = costing_->TransitionCostReverse(directededge->localedgeidx(), nodeinfo, opp_edge,
                                                 opp_pred_edge,


### PR DESCRIPTION
# Issue

Fix an issue in `costmatrix.cc`: 
`opp_edge` is stored in `t2` tile, but its cost is requested with another `tile` specified:
https://github.com/valhalla/valhalla/blob/2f40cee436b38af682754f701158b9201de03218/src/thor/costmatrix.cc#L626
https://github.com/valhalla/valhalla/blob/2f40cee436b38af682754f701158b9201de03218/src/thor/costmatrix.cc#L638

## Tasklist

 - [x] Update the [changelog](CHANGELOG.md)
 