### PR TITLE
Fix PointXY::ClosestPoint to compile on GCC 12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
    * FIXED: Conan error when building Docker image. [#3689](https://github.com/valhalla/valhalla/pull/3689)
    * FIXED: CostMatrix incorrect tile usage with oppedge. [#3719](https://github.com/valhalla/valhalla/pull/3719)
    * FIXED: Fix elevation serializing [#3735](https://github.com/valhalla/valhalla/pull/3735)
+   * FIXED: Fix returning a potentially uninitialized value in PointXY::ClosestPoint [#3737](https://github.com/valhalla/valhalla/pull/3737)
 
 * **Enhancement**
    * CHANGED: Pronunciation for names and destinations [#3132](https://github.com/valhalla/valhalla/pull/3132)

--- a/src/midgard/point2.cc
+++ b/src/midgard/point2.cc
@@ -33,7 +33,7 @@ PointXY<PrecisionT>::ClosestPoint(const std::vector<PointXY<PrecisionT>>& pts) c
 
   // Iterate through the pts
   bool beyond_end = true;     // Need to test past the end point?
-  int idx;                    // Index of closest segment so far
+  int idx = 0;                // Index of closest segment so far
   VectorXY<PrecisionT> v1;    // Segment vector (v1)
   VectorXY<PrecisionT> v2;    // Vector from origin to target (v2)
   PointXY<PrecisionT> projpt; // Projected point along v1
@@ -47,8 +47,9 @@ PointXY<PrecisionT>::ClosestPoint(const std::vector<PointXY<PrecisionT>>& pts) c
     const PointXY<PrecisionT>& p1 = pts[index + 1];
 
     // Construct vector v1 - represents the segment.  Skip 0 length segments
+    // that are not at the end of the line.
     v1.Set(p0, p1);
-    if (v1.x() == 0.0f && v1.y() == 0.0f) {
+    if (v1.x() == 0.0f && v1.y() == 0.0f && index < pts.size() - 2) {
       continue;
     }
 


### PR DESCRIPTION
# Issue

Fixes #3727.

I solved the actual uninitialized value problem that @kevinkreiser mentioned and initialized `idx` to 0 so that GCC 12.2 won't error anymore.

I think it's fine to initialize `idx` to 0 to make GCC stop erroring because the `closest` variable already starts with an initial value and always gets assigned a new value at the same time as `idx`... in the case that the for loop completes without changing `idx` from 0, it also won't have changed `closest` from its initial value. The function would have already been returning a potentially wrong result by using this initial value for `closest`. In other words, the assumptions made by this updated version of the function are no different than before.

## Tasklist

 - [ ] Add tests
 - [x] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
