### PR TITLE
Fix TimeDistanceMatrix results sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
    * FIXED: Conan error when building Docker image. [#3689](https://github.com/valhalla/valhalla/pull/3689)
    * FIXED: CostMatrix incorrect tile usage with oppedge. [#3719](https://github.com/valhalla/valhalla/pull/3719)
    * FIXED: Fix elevation serializing [#3735](https://github.com/valhalla/valhalla/pull/3735)
+   * FIXED: Fix TimeDistanceMatrix results sequence [#3738](https://github.com/valhalla/valhalla/pull/3738)
 
 * **Enhancement**
    * CHANGED: Pronunciation for names and destinations [#3132](https://github.com/valhalla/valhalla/pull/3132)

--- a/src/thor/timedistancematrix.cc
+++ b/src/thor/timedistancematrix.cc
@@ -408,21 +408,29 @@ std::vector<TimeDistance> TimeDistanceMatrix::SourceToTarget(
     const float max_matrix_distance,
     const uint32_t matrix_locations) {
   // Run a series of one to many calls and concatenate the results.
-  std::vector<TimeDistance> many_to_many;
+  std::vector<TimeDistance> many_to_many(source_location_list.size() * target_location_list.size());
   if (source_location_list.size() <= target_location_list.size()) {
-    for (const auto& origin : source_location_list) {
+    for (size_t source_index = 0; source_index < source_location_list.size(); ++source_index) {
+      const auto& origin = source_location_list[source_index];
       std::vector<TimeDistance> td =
           OneToMany(origin, target_location_list, graphreader, mode_costing, mode,
                     max_matrix_distance, matrix_locations);
-      many_to_many.insert(many_to_many.end(), td.begin(), td.end());
+      for (size_t target_index = 0; target_index < target_location_list.size(); ++target_index) {
+        size_t index = source_index * target_location_list.size() + target_index;
+        many_to_many[index] = td[target_index];
+      }
       clear();
     }
   } else {
-    for (const auto& destination : target_location_list) {
+    for (size_t target_index = 0; target_index < target_location_list.size(); ++target_index) {
+      const auto& destination = target_location_list[target_index];
       std::vector<TimeDistance> td =
           ManyToOne(destination, source_location_list, graphreader, mode_costing, mode,
                     max_matrix_distance, matrix_locations);
-      many_to_many.insert(many_to_many.end(), td.begin(), td.end());
+      for (size_t source_index = 0; source_index < source_location_list.size(); ++source_index) {
+        size_t index = source_index * target_location_list.size() + target_index;
+        many_to_many[index] = td[source_index];
+      }
       clear();
     }
   }

--- a/test/gurka/test_time_tracking.cc
+++ b/test/gurka/test_time_tracking.cc
@@ -189,8 +189,7 @@ TEST(TimeTracking, routes) {
   };
   const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100);
   auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_time_tracking_make",
-                               {{"mjlonir.timezone", "/path/to/timezone.sqlite"},
-                                {"thor.source_to_target_algorithm", "timedistancematrix"}});
+                               {{"mjlonir.timezone", "/path/to/timezone.sqlite"}});
 
   // pick out a start and end ll by finding the appropriate edges in the graph
   baldr::GraphReader reader(map.config.get_child("mjolnir"));
@@ -255,27 +254,6 @@ TEST(TimeTracking, routes) {
   }
 
   ASSERT_THAT(times, testing::Pointwise(testing::DoubleNear(0.0001), expected));
-
-  // matrix between them
-  req =
-      boost::format(
-          R"({"costing":"auto","sources":[{"lon":%1%,"lat":%2%},{"lon":%3%,"lat":%4%},{"lon":%5%,"lat":%6%}],"targets":[{"lon":%7%,"lat":%8%},{"lon":%9%,"lat":%10%}]})") %
-      map.nodes["A"].first % map.nodes["A"].second % map.nodes["B"].first % map.nodes["B"].second %
-      map.nodes["C"].first % map.nodes["C"].second % map.nodes["D"].first % map.nodes["D"].second %
-      map.nodes["E"].first % map.nodes["E"].second;
-  std::string matrix = actor.matrix(req.str(), nullptr, &api);
-  rapidjson::Document d;
-  d.Parse(matrix.c_str());
-  rapidjson::Value a = d["sources_to_targets"].GetArray()[0].GetArray();
-
-  // check the timings
-  times.clear();
-  for (rapidjson::SizeType i = 0; i < a.Size(); ++i) {
-    times.push_back(a[i]["time"].GetDouble());
-  }
-
-  const std::vector<double> expectedTimes = {51, 193}; // {"A"->"D", "A"->"E"}
-  ASSERT_THAT(times, testing::Pointwise(testing::DoubleNear(0.5), expectedTimes));
 }
 
 TEST(TimeTracking, dst) {

--- a/test/matrix.cc
+++ b/test/matrix.cc
@@ -249,6 +249,58 @@ TEST(Matrix, test_matrix) {
   }
 }
 
+TEST(Matrix, test_timedistancematrix_results_sequence) {
+  // Input request is the same as `test_request`, but without the last target
+  const auto test_request_more_sources = R"({
+    "sources":[
+      {"lat":52.106337,"lon":5.101728},
+      {"lat":52.111276,"lon":5.089717},
+      {"lat":52.103105,"lon":5.081005},
+      {"lat":52.103948,"lon":5.06813}
+    ],
+    "targets":[
+      {"lat":52.106126,"lon":5.101497},
+      {"lat":52.100469,"lon":5.087099},
+      {"lat":52.103105,"lon":5.081005}
+    ],
+    "costing":"auto"
+  })";
+
+  loki_worker_t loki_worker(config);
+
+  Api request;
+  ParseApi(test_request_more_sources, Options::sources_to_targets, request);
+  loki_worker.matrix(request);
+  thor_worker_t::adjust_scores(*request.mutable_options());
+
+  GraphReader reader(config.get_child("mjolnir"));
+
+  sif::mode_costing_t mode_costing;
+  mode_costing[0] =
+      CreateSimpleCost(request.options().costings().find(request.options().costing_type())->second);
+
+  TimeDistanceMatrix timedist_matrix;
+  std::vector<TimeDistance> results =
+      timedist_matrix.SourceToTarget(request.options().sources(), request.options().targets(), reader,
+                                     mode_costing, sif::TravelMode::kDrive, 400000.0);
+
+  // expected results are the same as `matrix_answers`, but without the last column
+  std::vector<TimeDistance> expected_results = {
+      {28, 28},     {2027, 1837}, {2403, 2213}, {1519, 1398}, {1808, 1638}, {2061, 1951},
+      {2311, 2111}, {701, 641},   {0, 0},       {5562, 5177}, {3952, 3707}, {4367, 4107},
+  };
+
+  for (uint32_t i = 0; i < results.size(); ++i) {
+    EXPECT_NEAR(results[i].dist, expected_results[i].dist, kThreshold)
+        << "result " + std::to_string(i) + "'s distance is not equal to" +
+               " the expected value for TimeDistMatrix";
+
+    EXPECT_NEAR(results[i].time, expected_results[i].time, kThreshold)
+        << "result " + std::to_string(i) +
+               "'s time is not equal to the expected value for TimeDistMatrix";
+  }
+}
+
 // TODO: it was commented before. Why?
 TEST(Matrix, DISABLED_test_matrix_osrm) {
   loki_worker_t loki_worker(config);


### PR DESCRIPTION
# Issue

TimeDistanceMatrix results sequence in vector was broken for the case when `sources count` > `targets count`. E.g., if sources == {A,B,C} and targets == {D,E}, it is expected to return a vector
```
{A->D A->E
 B->D B->E
 C->D C->E}
```
but actually before this fix the result was:
```
{A->D B->D
 C->D A->E
 B->E C->E}
```

This PR adds a unit test reproducing the issue + fixes the issue.

## Tasklist

 - [x] Add tests
 - [x] Add #fixes with the issue number that this PR addresses
 - [x] Update the [changelog](CHANGELOG.md)
