### PR TITLE
Bump vcpkg

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -37,7 +37,7 @@ jobs:
       BUILD_CFG: 'Release'
       BUILD_DIR: '$(Agent.WorkFolder)\build'
       VCPKG_DIR: '$(Build.SourcesDirectory)\vcpkg'
-      VCPKG_REF: 'f4bd6423'
+      VCPKG_REF: '2022.08.15'
       TRIPLET: 'x64'
       CONAN_HOME: '$(Build.SourcesDirectory)/conan'
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -37,6 +37,8 @@ jobs:
       BUILD_CFG: 'Release'
       BUILD_DIR: '$(Agent.WorkFolder)\build'
       VCPKG_DIR: '$(Build.SourcesDirectory)\vcpkg'
+      VCPKG_ROOT: '$(Build.SourcesDirectory)\vcpkg'
+      VCPKG_INSTALLATION_ROOT: '$(Build.SourcesDirectory)\vcpkg'
       VCPKG_REF: '2022.08.15'
       TRIPLET: 'x64'
       CONAN_HOME: '$(Build.SourcesDirectory)/conan'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@
    * ADDED: Ferry support for HGV [#3710](https://github.com/valhalla/valhalla/issues/3710)
    * ADDED: Linting & formatting checks for Python code [#3713](https://github.com/valhalla/valhalla/pull/3713)
    * CHANGED: rename Turkey admin to Türkiye [#3720](https://github.com/valhalla/valhalla/pull/3713)
+   * CHANGED: bumped vcpkg version to "2022.08.15" [#3754](https://github.com/valhalla/valhalla/pull/3754)
 
 ## Release Date: 2021-10-07 Valhalla 3.1.4
 * **Removed**


### PR DESCRIPTION
Trying to bump vcpkg version to the latest ["release"](https://github.com/microsoft/vcpkg/releases/tag/2022.08.15) (whatever that means with vpkg..), see discussion at https://github.com/valhalla/valhalla/pull/3588#issuecomment-1254111359.

We could also switch to VS 2022 while we're at it. No idea if it's best practice with VS or we'd have to run both 2019 & 2022 for a while. Back when we switched from 2017 to 2019 we did a hard switch.