### PR TITLE
status endpoint should not answer queries if its shutting down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
    * FIXED: Fix for Mac OSx.  Small update for the workdir for the admin_sidewalk_override test.  [#3757](https://github.com/valhalla/valhalla/pull/3757)
    * FIXED: Add missing service road case from GetTripLegUse method. [#3763](https://github.com/valhalla/valhalla/pull/3763)
    * FIXED: Fix TimeDistanceMatrix results sequence [#3738](https://github.com/valhalla/valhalla/pull/3738)
+   * FIXED: Fix status endpoint not reporting that the service is shutting down [#3785](https://github.com/valhalla/valhalla/pull/3785)
 
 * **Enhancement**
    * CHANGED: Pronunciation for names and destinations [#3132](https://github.com/valhalla/valhalla/pull/3132)

--- a/src/loki/status_action.cc
+++ b/src/loki/status_action.cc
@@ -31,6 +31,14 @@ time_t get_tileset_last_modified(const std::shared_ptr<valhalla::baldr::GraphRea
 namespace valhalla {
 namespace loki {
 void loki_worker_t::status(Api& request) const {
+#ifdef HAVE_HTTP
+  // if we are in the process of shutting down we signal that here
+  // should react by draining traffic (though they are likely doing this as they are usually the ones
+  // who sent us the request to shutdown)
+  if (prime_server::draining() || prime_server::shutting_down()) {
+    throw valhalla_exception_t{102};
+  }
+#endif
 
   auto* status = request.mutable_status();
   status->set_version(VALHALLA_VERSION);
@@ -52,15 +60,6 @@ void loki_worker_t::status(Api& request) const {
   status->set_has_admins(tile && tile->header()->admincount() > 0);
   status->set_has_timezones(tile && tile->node(0)->timezone() > 0);
   status->set_has_live_traffic(reader->HasLiveTraffic());
-
-#ifdef HAVE_HTTP
-  // if we are in the process of shutting down we signal that here
-  // should react by draining traffic (though they are likely doing this as they are usually the ones
-  // who sent us the request to shutdown)
-  if (prime_server::draining() || prime_server::shutting_down()) {
-    throw valhalla_exception_t{102};
-  }
-#endif
 }
 } // namespace loki
 } // namespace valhalla


### PR DESCRIPTION
the point of the status endpoint is to not only give back the user some info about their running system but its also there to negotiate with external processes when a scaling event happens (ie when the process is being told to die with sigterm). back in #3008 we accidentally shifted the check down to the bottom of the function which essentially disables it. @dgearhart mentioned that @ktatterso noticed this, thanks guys for reporting it!