### PR TITLE
CostMatrix fixes in SetSources and SetTargets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
    * FIXED: Add missing service road case from GetTripLegUse method. [#3763](https://github.com/valhalla/valhalla/pull/3763)
    * FIXED: Fix TimeDistanceMatrix results sequence [#3738](https://github.com/valhalla/valhalla/pull/3738)
    * FIXED: Fix status endpoint not reporting that the service is shutting down [#3785](https://github.com/valhalla/valhalla/pull/3785)
+   * FIXED: Fix TimdDistanceMatrix SetSources and SetTargets [#3792](https://github.com/valhalla/valhalla/pull/3792)
 
 * **Enhancement**
    * CHANGED: Pronunciation for names and destinations [#3132](https://github.com/valhalla/valhalla/pull/3132)

--- a/src/thor/costmatrix.cc
+++ b/src/thor/costmatrix.cc
@@ -737,9 +737,9 @@ void CostMatrix::SetSources(GraphReader& graphreader,
     // Only skip inbound edges if we have other options
     bool has_other_edges = false;
     std::for_each(origin.correlation().edges().begin(), origin.correlation().edges().end(),
-                [&has_other_edges](const valhalla::PathEdge& e) {
-                  has_other_edges = has_other_edges || !e.end_node();
-                });
+                  [&has_other_edges](const valhalla::PathEdge& e) {
+                    has_other_edges = has_other_edges || !e.end_node();
+                  });
 
     // Iterate through edges and add to adjacency list
     for (const auto& edge : origin.correlation().edges()) {
@@ -818,9 +818,9 @@ void CostMatrix::SetTargets(baldr::GraphReader& graphreader,
     // Only skip outbound edges if we have other options
     bool has_other_edges = false;
     std::for_each(dest.correlation().edges().begin(), dest.correlation().edges().end(),
-                [&has_other_edges](const valhalla::PathEdge& e) {
-                  has_other_edges = has_other_edges || !e.begin_node();
-                });
+                  [&has_other_edges](const valhalla::PathEdge& e) {
+                    has_other_edges = has_other_edges || !e.begin_node();
+                  });
 
     // Iterate through edges and add to adjacency list
     for (const auto& edge : dest.correlation().edges()) {

--- a/src/thor/costmatrix.cc
+++ b/src/thor/costmatrix.cc
@@ -423,6 +423,7 @@ void CostMatrix::ForwardSearch(const uint32_t index, const uint32_t n, GraphRead
 void CostMatrix::CheckForwardConnections(const uint32_t source,
                                          const BDEdgeLabel& pred,
                                          const uint32_t n) {
+
   // Disallow connections that are part of an uturn on an internal edge
   if (pred.internal_turn() != InternalTurn::kNoTurn) {
     return;

--- a/src/thor/costmatrix.cc
+++ b/src/thor/costmatrix.cc
@@ -423,7 +423,6 @@ void CostMatrix::ForwardSearch(const uint32_t index, const uint32_t n, GraphRead
 void CostMatrix::CheckForwardConnections(const uint32_t source,
                                          const BDEdgeLabel& pred,
                                          const uint32_t n) {
-
   // Disallow connections that are part of an uturn on an internal edge
   if (pred.internal_turn() != InternalTurn::kNoTurn) {
     return;
@@ -734,10 +733,17 @@ void CostMatrix::SetSources(GraphReader& graphreader,
                                                                   &source_edgelabel_[index]));
     source_hierarchy_limits_[index] = costing_->GetHierarchyLimits();
 
+    // Only skip inbound edges if we have other options
+    bool has_other_edges = false;
+    std::for_each(origin.correlation().edges().begin(), origin.correlation().edges().end(),
+                [&has_other_edges](const valhalla::PathEdge& e) {
+                  has_other_edges = has_other_edges || !e.end_node();
+                });
+
     // Iterate through edges and add to adjacency list
     for (const auto& edge : origin.correlation().edges()) {
       // If origin is at a node - skip any inbound edge (dist = 1)
-      if (edge.end_node()) {
+      if (has_other_edges && edge.end_node()) {
         continue;
       }
 
@@ -808,11 +814,18 @@ void CostMatrix::SetTargets(baldr::GraphReader& graphreader,
                                                                   &target_edgelabel_[index]));
     target_hierarchy_limits_[index] = costing_->GetHierarchyLimits();
 
+    // Only skip outbound edges if we have other options
+    bool has_other_edges = false;
+    std::for_each(dest.correlation().edges().begin(), dest.correlation().edges().end(),
+                [&has_other_edges](const valhalla::PathEdge& e) {
+                  has_other_edges = has_other_edges || !e.begin_node();
+                });
+
     // Iterate through edges and add to adjacency list
     for (const auto& edge : dest.correlation().edges()) {
       // If the destination is at a node, skip any outbound edges (so any
       // opposing inbound edges are not considered)
-      if (edge.begin_node()) {
+      if (has_other_edges && edge.begin_node()) {
         continue;
       }
 


### PR DESCRIPTION
In SetSources, only exclude inbound edges if other edges exist. Similarly, in SetTargets only exclude inbound edges if other edges exist. It was possible to not add any edges for a source or target when the only correlated edge was inbound/ outbound.

fixes #3790

# Issue

What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
