### PR TITLE
fix invalid speed detection in GraphTile::GetSpeed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
    * FIXED: Fix status endpoint not reporting that the service is shutting down [#3785](https://github.com/valhalla/valhalla/pull/3785)
    * FIXED: Fix TimdDistanceMatrix SetSources and SetTargets [#3792](https://github.com/valhalla/valhalla/pull/3792)
    * FIXED: Added highway and surface factor in truckcost [#3590](https://github.com/valhalla/valhalla/pull/3590)
+   * FIXED: Fixed invalid time detection in GetSpeed [#3800](https://github.com/valhalla/valhalla/pull/3800)
 
 * **Enhancement**
    * CHANGED: Pronunciation for names and destinations [#3132](https://github.com/valhalla/valhalla/pull/3132)

--- a/test/gurka/test_time_tracking.cc
+++ b/test/gurka/test_time_tracking.cc
@@ -26,7 +26,7 @@ TEST(TimeTracking, make) {
   baldr::GraphReader reader(map.config.get_child("mjolnir"));
 
   // this is what the default should be, with constrained second of day
-  baldr::TimeInfo basic_ti{false, 0, 0, baldr::kConstrainedFlowSecondOfDay};
+  baldr::TimeInfo basic_ti{false, 0, 0, baldr::kInvalidSecondsOfWeek};
 
   // once without tz cache and once with
   for (auto* cache : std::vector<baldr::DateTime::tz_sys_info_cache_t*>{

--- a/valhalla/baldr/graphconstants.h
+++ b/valhalla/baldr/graphconstants.h
@@ -652,7 +652,8 @@ constexpr uint8_t kDefaultFlowMask =
     kFreeFlowMask | kConstrainedFlowMask | kPredictedFlowMask | kCurrentFlowMask;
 constexpr uint32_t kFreeFlowSecondOfDay = 60 * 60 * 0;         // midnight
 constexpr uint32_t kConstrainedFlowSecondOfDay = 60 * 60 * 12; // noon
-constexpr uint32_t kInvalidSecondsOfWeek = -1;
+constexpr uint64_t kInvalidSecondsOfWeek =
+    1048575; // invalid (20 bits - 1), Sunday 23:59:59 is 604799
 
 // There is only 1 bit to store these values, do not exceed the value 1.
 enum class HOVEdgeType : uint8_t { kHOV2 = 0, kHOV3 = 1 };

--- a/valhalla/baldr/graphconstants.h
+++ b/valhalla/baldr/graphconstants.h
@@ -652,8 +652,7 @@ constexpr uint8_t kDefaultFlowMask =
     kFreeFlowMask | kConstrainedFlowMask | kPredictedFlowMask | kCurrentFlowMask;
 constexpr uint32_t kFreeFlowSecondOfDay = 60 * 60 * 0;         // midnight
 constexpr uint32_t kConstrainedFlowSecondOfDay = 60 * 60 * 12; // noon
-constexpr uint32_t kInvalidSecondsOfWeek =
-    1048575; // invalid (20 bits - 1), Sunday 23:59:59 is 604799
+constexpr uint32_t kInvalidSecondsOfWeek = -1;
 
 // There is only 1 bit to store these values, do not exceed the value 1.
 enum class HOVEdgeType : uint8_t { kHOV2 = 0, kHOV3 = 1 };

--- a/valhalla/baldr/graphconstants.h
+++ b/valhalla/baldr/graphconstants.h
@@ -652,7 +652,8 @@ constexpr uint8_t kDefaultFlowMask =
     kFreeFlowMask | kConstrainedFlowMask | kPredictedFlowMask | kCurrentFlowMask;
 constexpr uint32_t kFreeFlowSecondOfDay = 60 * 60 * 0;         // midnight
 constexpr uint32_t kConstrainedFlowSecondOfDay = 60 * 60 * 12; // noon
-constexpr uint32_t kInvalidSecondsOfWeek = -1;                 // invalid
+constexpr uint32_t kInvalidSecondsOfWeek =
+    1048575; // invalid (20 bits - 1), Sunday 23:59:59 is 604799
 
 // There is only 1 bit to store these values, do not exceed the value 1.
 enum class HOVEdgeType : uint8_t { kHOV2 = 0, kHOV3 = 1 };

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -700,6 +700,7 @@ public:
 
     // fallback to constrained if time of week is within 7am to 7pm (or if no time was passed in) and
     // if the edge has constrained speed
+    // kInvalidSecondsOfWeek %= midgard::kSecondsPerDay = 12.1
     seconds %= midgard::kSecondsPerDay;
     auto is_daytime = (25200 < seconds && seconds < 68400);
     if ((invalid_time || is_daytime) && (flow_mask & kConstrainedFlowMask) &&

--- a/valhalla/baldr/graphtile.h
+++ b/valhalla/baldr/graphtile.h
@@ -624,7 +624,7 @@ public:
    */
   inline uint32_t GetSpeed(const DirectedEdge* de,
                            uint8_t flow_mask = kConstrainedFlowMask,
-                           uint32_t seconds = kInvalidSecondsOfWeek,
+                           uint64_t seconds = kInvalidSecondsOfWeek,
                            bool is_truck = false,
                            uint8_t* flow_sources = nullptr,
                            const uint64_t seconds_from_now = 0) const {

--- a/valhalla/baldr/time_info.h
+++ b/valhalla/baldr/time_info.h
@@ -46,7 +46,7 @@ struct TimeInfo {
    * @return    TimeInfo structure
    */
   static inline TimeInfo invalid() {
-    return {false, 0, 0, kConstrainedFlowSecondOfDay, 0, false, nullptr};
+    return {false, 0, 0, kInvalidSecondsOfWeek, 0, false, nullptr};
   }
 
   /**

--- a/valhalla/baldr/time_info.h
+++ b/valhalla/baldr/time_info.h
@@ -138,7 +138,7 @@ struct TimeInfo {
       parsed_date = dt::get_formatted_date(date_time, true);
     } catch (...) {
       LOG_ERROR("Could not parse provided date_time: " + date_time);
-      return {false, 0, 0, kConstrainedFlowSecondOfDay, 0, false, nullptr};
+      return {false, 0, 0, kInvalidSecondsOfWeek, 0, false, nullptr};
     }
     const auto then_date = date::make_zoned(tz, parsed_date, date::choose::latest);
     uint64_t local_time = date::to_utc_time(then_date.get_sys_time()).time_since_epoch().count();


### PR DESCRIPTION
While working on #3795 I came across the case where one matrix location has no `date_time` set but some other location does. Valhalla took the historical data anyways for that location and assumed a constant Monday noon. This PR fixes that, I tested it ~~(though not in code :innocent: )~~ it actually is tested in code 

I guess that wasn't really a problem so far. With routing we know at this point that we have a valid date time if the `flow_mask` says "please consider traffic". So it'd only be a bug once #3795 is merged;)