### PR TITLE
add "waiting time" to locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * **Enhancement**
    * ADDED: Add time info to sources_to_targets [#3795](https://github.com/valhalla/valhalla/pull/3795)
    * ADDED: "available_actions" to the /status response [#3836](https://github.com/valhalla/valhalla/pull/3836)
+   * ADDED: "waiting" field on input/output intermediate break(_through) locations to respect services times [#3849](https://github.com/valhalla/valhalla/pull/3849)
 
 ## Release Date: 2022-10-26 Valhalla 3.2.0
 * **Removed**

--- a/docs/api/turn-by-turn/api-reference.md
+++ b/docs/api/turn-by-turn/api-reference.md
@@ -56,8 +56,9 @@ Optionally, you can include the following location information without impacting
 * `country` = Country name.
 * `phone` = Telephone number.
 * `url` = URL for the place or location.
+* `waiting`: The waiting time in seconds at this location. E.g. when the route describes a pizza delivery tour, each location has a service time, which can be respected by setting `waiting` on the location, then the departure will be delayed by this amount in seconds. Only works for `break` or `break_through` types.
 * `side_of_street` = (response only) The side of street of a `break` `location` that is determined based on the actual route when the `location` is offset from the street. The possible values are `left` and `right`.
-* `date_time` = (response only) Expected date/time for the user to be at the location using the ISO 8601 format (YYYY-MM-DDThh:mm) in the local time zone of departure or arrival.  For example "2015-12-29T08:00".
+* `date_time` = (response only for `/route`) Expected date/time for the user to be at the location using the ISO 8601 format (YYYY-MM-DDThh:mm) in the local time zone of departure or arrival.  For example "2015-12-29T08:00". If `waiting` was set on this location in the request, and it's an intermediate location, the `date_time` will describe the departure time at this location.
 
 Future development work includes adding location options and information related to time at each location. This will allow routes to specify a start time or an arrive by time at each location. There is also ongoing work to improve support for `through` locations.
 

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -123,6 +123,7 @@ message Location {
   oneof has_preferred_layer {
     int32 preferred_layer = 28;
   }
+  float waiting_secs = 29;                   // waiting period before a new leg starts, e.g. for servicing/loading goods
 
   // This information will be ignored if provided in the request. Instead it will be filled in as the request is handled
   Correlation correlation = 90;

--- a/src/baldr/datetime.cc
+++ b/src/baldr/datetime.cc
@@ -126,10 +126,13 @@ std::string iso_date_time(const date::time_zone* time_zone) {
 
 // Get the seconds since epoch time is already adjusted based on TZ
 uint64_t seconds_since_epoch(const std::string& date_time, const date::time_zone* time_zone) {
-  if (date_time.empty() || !time_zone) {
+  if (date_time.empty()) {
     return 0;
   }
   const auto d = get_formatted_date(date_time);
+  if (!time_zone) {
+    return static_cast<uint64_t>(d.time_since_epoch().count());
+  }
   const auto utc = date::to_utc_time(get_ldt(d, time_zone).get_sys_time()); // supports leap sec.
   return static_cast<uint64_t>(utc.time_since_epoch().count());
 }
@@ -162,19 +165,22 @@ std::string
 seconds_to_date(const uint64_t seconds, const date::time_zone* time_zone, bool tz_format) {
 
   std::string iso_date;
-  if (seconds == 0 || !time_zone) {
+  if (seconds == 0) {
     return iso_date;
   }
 
+  std::ostringstream iso_date_time;
+  const char* format = tz_format ? "%FT%R%z" : "%FT%R";
   std::chrono::seconds dur(seconds);
   std::chrono::time_point<std::chrono::system_clock> tp(dur);
-  const auto date = date::make_zoned(time_zone, tp);
 
-  std::ostringstream iso_date_time;
-  if (tz_format)
-    iso_date_time << date::format("%FT%R%z", date);
-  else
-    iso_date_time << date::format("%FT%R", date);
+  if (time_zone) {
+    const auto date = date::make_zoned(time_zone, tp);
+    iso_date_time << date::format(format, date);
+  } else {
+    iso_date_time << date::format(format, tp);
+  }
+
   iso_date = iso_date_time.str();
   if (tz_format)
     iso_date.insert(19, 1, ':');

--- a/src/thor/route_action.cc
+++ b/src/thor/route_action.cc
@@ -481,11 +481,6 @@ void thor_worker_t::path_arrive_by(Api& api, const std::string& costing) {
   auto origin = ++correlated.rbegin();
   while (origin != correlated.rend()) {
     auto destination = std::prev(origin);
-
-    std::cerr << "Processing origin/destination " +
-                     std::to_string(std::distance(correlated.rend(), origin)) + " / " +
-                     std::to_string(std::distance(correlated.rend(), destination));
-
     if (!route_two_locations(origin, destination)) {
       // if routing failed because an intermediate waypoint was snapped to the low reachability road
       // (such road lies in a small connectivity component that is not connected to other locations)

--- a/src/tyr/route_serializer_valhalla.cc
+++ b/src/tyr/route_serializer_valhalla.cc
@@ -193,6 +193,10 @@ void locations(const valhalla::Api& api, int route_index, rapidjson::writer_wrap
         writer("date_time", location->date_time());
       }
 
+      if (location->waiting_secs()) {
+        writer("waiting", static_cast<uint64_t>(location->waiting_secs()));
+      }
+
       if (location->side_of_street() != valhalla::Location::kNone) {
         writer("side_of_street", Location_SideOfStreet_Enum_Name(location->side_of_street()));
       }

--- a/test/gurka/test_time_tracking.cc
+++ b/test/gurka/test_time_tracking.cc
@@ -187,12 +187,12 @@ TEST(TimeTracking, routes) {
       {"GH", {{"highway", "primary"}}},     {"DI", {{"highway", "residential"}}},
       {"IJ", {{"highway", "primary"}}},     {"JE", {{"highway", "primary"}}},
   };
-  const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100);
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100, {5.1079374, 52.0887174});
   auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_time_tracking_make",
-                               {{"mjlonir.timezone", "/path/to/timezone.sqlite"}});
+                               {{"mjlonir.timezone", "test/data/tz.sqlite"}});
 
-  const std::vector<double> expected = {0,       51.4286, 102.857, 154.286, 195.446, 0,
-                                        148.927, 169.104, 215.799, 239.817, 263.817, 287.817};
+  const std::vector<double> expected = {0,       31.5771, 63.1543, 94.7314, 120.052, 0,
+                                        91.6466, 105.024, 144.325, 159.079, 173.815, 188.551};
 
   auto test_result = [&expected](const std::vector<double>& actual_times, const Api& request) {
     ASSERT_THAT(actual_times, testing::Pointwise(testing::DoubleNear(0.001), expected));

--- a/test/gurka/test_time_tracking.cc
+++ b/test/gurka/test_time_tracking.cc
@@ -174,86 +174,82 @@ TEST(TimeTracking, reverse) {
 }
 
 TEST(TimeTracking, routes) {
-
   // build a very simple graph
-  const std::string ascii_map = R"(A----B----C----D
-                                                  |
-                                                  |
-                                                  |
-                                   H----G----F----E)";
+  const std::string ascii_map = R"(A----B----C----D---I
+                                                  |   |
+                                                  1   |
+                                                  |   |
+                                   H----G----F----E---J)";
   const gurka::ways ways = {
-      {"AB", {{"highway", "motorway"}}}, {"BC", {{"highway", "motorway"}}},
-      {"CD", {{"highway", "motorway"}}}, {"DE", {{"highway", "motorway_link"}}},
-      {"EF", {{"highway", "primary"}}},  {"FG", {{"highway", "primary"}}},
-      {"GH", {{"highway", "primary"}}},
+      {"AB", {{"highway", "residential"}}}, {"BC", {{"highway", "residential"}}},
+      {"CD", {{"highway", "residential"}}}, {"DE", {{"highway", "residential"}}},
+      {"EF", {{"highway", "primary"}}},     {"FG", {{"highway", "primary"}}},
+      {"GH", {{"highway", "primary"}}},     {"DI", {{"highway", "residential"}}},
+      {"IJ", {{"highway", "primary"}}},     {"JE", {{"highway", "primary"}}},
   };
   const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100);
   auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_time_tracking_make",
                                {{"mjlonir.timezone", "/path/to/timezone.sqlite"}});
 
-  // pick out a start and end ll by finding the appropriate edges in the graph
-  baldr::GraphReader reader(map.config.get_child("mjolnir"));
-  auto start = map.nodes["A"];
-  auto end = map.nodes["H"];
+  const std::vector<double> expected = {0,       51.4286, 102.857, 154.286, 195.446, 0,
+                                        148.927, 169.104, 215.799, 239.817, 263.817, 287.817};
 
-  // route between them with a current time
-  auto req =
-      boost::format(
-          R"({"costing":"auto","date_time":{"type":0},"locations":[{"lon":%1%,"lat":%2%},{"lon":%3%,"lat":%4%}]})") %
-      start.first % start.second % end.first % end.second;
-  valhalla::Api api;
-  tyr::actor_t actor(map.config, reader);
-  actor.route(req.str(), nullptr, &api);
+  auto test_result = [&expected](const std::vector<double>& actual_times, const Api& request) {
+    ASSERT_THAT(actual_times, testing::Pointwise(testing::DoubleNear(0.001), expected));
+    // first location has a waiting_time, second not since it was "through"
+    EXPECT_EQ(request.options().locations(1).waiting_secs(), 600.f);
+    EXPECT_EQ(request.options().locations(2).waiting_secs(), 0.f);
+    EXPECT_EQ(request.info().warnings(0).code(), 203);
+  };
 
-  // check the timings
   std::vector<double> times;
-  for (const auto& route : api.trip().routes()) {
+  auto result = gurka::do_action(Options::route, map, {"A", "I", "1", "H"}, "auto",
+                                 {{"/date_time/type", "0"},
+                                  {"/locations/1/waiting", "600"},
+                                  {"/locations/2/type", "through"},
+                                  {"/locations/2/waiting", "600"}});
+  for (const auto& route : result.trip().routes()) {
     for (const auto& leg : route.legs()) {
       for (const auto& node : leg.node()) {
         times.push_back(node.cost().elapsed_cost().seconds());
       }
     }
   }
-  const std::vector<double> expected = {0,        17.1429,  34.2857,  51.4286,
-                                        193.9319, 245.4273, 269.4273, 293.4273};
-  ASSERT_THAT(times, testing::Pointwise(testing::DoubleNear(0.0001), expected));
+  test_result(times, result);
 
   // route between them with a depart_at
-  req =
-      boost::format(
-          R"({"costing":"auto","date_time":{"type":1,"value":"1982-12-08T17:17"},"locations":[{"lon":%1%,"lat":%2%},{"lon":%3%,"lat":%4%}]})") %
-      start.first % start.second % end.first % end.second;
-  actor.route(req.str(), nullptr, &api);
-
-  // check the timings
+  result = gurka::do_action(Options::route, map, {"A", "I", "1", "H"}, "auto",
+                            {{"/date_time/type", "1"},
+                             {"/date_time/value", "1982-12-08T17:17"},
+                             {"/locations/1/waiting", "600"},
+                             {"/locations/2/type", "through"},
+                             {"/locations/2/waiting", "600"}});
   times.clear();
-  for (const auto& route : api.trip().routes()) {
+  for (const auto& route : result.trip().routes()) {
     for (const auto& leg : route.legs()) {
       for (const auto& node : leg.node()) {
         times.push_back(node.cost().elapsed_cost().seconds());
       }
     }
   }
-  ASSERT_THAT(times, testing::Pointwise(testing::DoubleNear(0.0001), expected));
+  test_result(times, result);
 
   // route between them with a arrive_by
-  req =
-      boost::format(
-          R"({"costing":"auto","date_time":{"type":2,"value":"1982-12-08T17:17"},"locations":[{"lon":%1%,"lat":%2%},{"lon":%3%,"lat":%4%}]})") %
-      start.first % start.second % end.first % end.second;
-  actor.route(req.str(), nullptr, &api);
-
-  // check the timings
+  result = gurka::do_action(Options::route, map, {"A", "I", "1", "H"}, "auto",
+                            {{"/date_time/type", "2"},
+                             {"/date_time/value", "1982-12-08T17:17"},
+                             {"/locations/1/waiting", "600"},
+                             {"/locations/2/type", "through"},
+                             {"/locations/2/waiting", "600"}});
   times.clear();
-  for (const auto& route : api.trip().routes()) {
+  for (const auto& route : result.trip().routes()) {
     for (const auto& leg : route.legs()) {
       for (const auto& node : leg.node()) {
         times.push_back(node.cost().elapsed_cost().seconds());
       }
     }
   }
-
-  ASSERT_THAT(times, testing::Pointwise(testing::DoubleNear(0.0001), expected));
+  test_result(times, result);
 }
 
 TEST(TimeTracking, dst) {


### PR DESCRIPTION
fixes #3832 

How it works:
- `waiting` input in seconds as `float`
- `src/worker.cc` checks if a location is intermediate **and** `break` when `waiting` is set, otherwise emits a warning
- `thor/route_action.cc` deals with juggling the logic for `depart_at` & `arrive_by`. We always add the waiting time after a leg is finished to the next origin's `date_time` object. 
- in the JSON output we add a `waiting` field to the `locations` mirroring the input and a location's `date_time` field of intermediate waypoints are adjusted for the `waiting` time, so it's understood as a `depart_at` time, I think that makes most sense.

`/optimized` should get it for free, but not sure it's so desirable.

What I wanna discuss:
- name.. `waiting`, `waiting_secs`, `waiting_time`?
- unit: seconds or minutes (then e.g. `waiting_mins`)
- currently in the response, an intermediate's `date_time` field is regarded as `depart_at` if it has a `waiting` time, i.e. we add that time to the `date_time`. I think that's fine. Or should we add another field to those locations, e.g. `date_time_depart` and have `date_time` as arrival? I think the way it is it's fine.
- currently the `summary.time` fields **do not** include the `waiting` time. Both is appealing somehow. I feel like it kind of belongs in the overall summary, but not in each leg's summary, but I can't convince my fingers to execute such an inconsistency.. What do you think @kevinkreiser ?

A request looks e.g. like this, adding 10 mins `waiting` time to the intermediate location:
```json
{
	"costing": "truck",
	"locations": [
		{
			"lon": 13.44350292,
			"lat": 52.46437987
		},
		{
			"lon": 13.44564241,
			"lat": 52.47644020,
			"waiting": 600
		},
		{
			"lon": 13.42095168,
			"lat": 52.48738710
		}
	],
	"date_time": {
		"value": "2022-11-25T09:00",
		"type": 1
	}
}
``` 

A response like this, where it actually arrives at the second location at `2022-11-25T09:09` but leaves at `2022-11-25T09:19`:
```json
{
	"trip": {
		"locations": [
			{
				"type": "break",
				"lat": 52.464379,
				"lon": 13.443502,
				"date_time": "2022-11-25T09:00",
				"original_index": 0
			},
			{
				"type": "break",
				"lat": 52.47644,
				"lon": 13.445642,
				"date_time": "2022-11-25T09:19",
				"waiting": 600,
				"original_index": 1
			},
			{
				"type": "break",
				"lat": 52.487387,
				"lon": 13.420951,
				"date_time": "2022-11-25T09:25",
				"original_index": 2
			}
		],
...
}
````