### PR TITLE
add more options to valhalla_build_extract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
    * ADDED: Add time info to sources_to_targets [#3795](https://github.com/valhalla/valhalla/pull/3795)
    * ADDED: "available_actions" to the /status response [#3836](https://github.com/valhalla/valhalla/pull/3836)
    * ADDED: "waiting" field on input/output intermediate break(_through) locations to respect services times [#3849](https://github.com/valhalla/valhalla/pull/3849)
-   * ADDED: --bbox option to valhalla_build_extract to only archive a subset of tiles [#3856](https://github.com/valhalla/valhalla/pull/3856)
+   * ADDED: --bbox & --geojson-dir options to valhalla_build_extract to only archive a subset of tiles [#3856](https://github.com/valhalla/valhalla/pull/3856)
 
 ## Release Date: 2022-10-26 Valhalla 3.2.0
 * **Removed**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
    * ADDED: Add time info to sources_to_targets [#3795](https://github.com/valhalla/valhalla/pull/3795)
    * ADDED: "available_actions" to the /status response [#3836](https://github.com/valhalla/valhalla/pull/3836)
    * ADDED: "waiting" field on input/output intermediate break(_through) locations to respect services times [#3849](https://github.com/valhalla/valhalla/pull/3849)
+   * ADDED: --bbox option to valhalla_build_extract to only archive a subset of tiles [#3856](https://github.com/valhalla/valhalla/pull/3856)
 
 ## Release Date: 2022-10-26 Valhalla 3.2.0
 * **Removed**

--- a/scripts/valhalla_build_extract
+++ b/scripts/valhalla_build_extract
@@ -7,14 +7,13 @@ from io import BytesIO
 import json
 from math import floor
 import logging
-import os
 from pathlib import Path
 import struct
 import sys
 import tarfile
 from tarfile import BLOCKSIZE
 from time import time
-from typing import List, Tuple, Optional
+from typing import List, Tuple, Union, Set
 
 # "<" prefix means little-endian and no alignment
 # order is important! if uint64_t is not first, c++ will use padding bytes to unpack
@@ -28,6 +27,14 @@ TRAFFIC_SPEED_SIZE = struct.calcsize('<Q')
 
 Bbox = namedtuple("Bbox", "min_x min_y max_x max_y")
 TILE_SIZES = {0: 4, 1: 1, 2: 0.25}
+
+# hack so ArgumentParser can accept negative numbers
+# see https://github.com/valhalla/valhalla/issues/3426
+for i, arg in enumerate(sys.argv):
+    if not len(arg) > 1:
+        continue
+    if (arg[0] == '-') and arg[1].isdigit():
+        sys.argv[i] = ' ' + arg
 
 
 class TileHeader(ctypes.Structure):
@@ -45,6 +52,7 @@ class TileHeader(ctypes.Structure):
 
 
 description = "Builds a tar extract from the tiles in mjolnir.tile_dir to the path specified in mjolnir.tile_extract."
+
 parser = argparse.ArgumentParser(description=description)
 parser.add_argument(
     "-c", "--config", help="Absolute or relative path to the Valhalla config JSON.", type=Path
@@ -59,12 +67,20 @@ parser.add_argument(
 parser.add_argument(
     "-t", "--with-traffic", help="Flag to add a traffic.tar skeleton", action="store_true", default=False
 )
-parser.add_argument(
+geom_type = parser.add_mutually_exclusive_group()
+geom_type.add_argument(
     "-b",
     "--bbox",
     help="If specified, will only archive tiles which are intersecting this bbox. In 'minx,miny,maxx,maxy' format.",
     type=str,
     default="",
+)
+geom_type.add_argument(
+    "-g",
+    "--geojson-dir",
+    help="Absolute or relative path to directory with .geojson files used "
+    "as input to tile intersection. Requires shapely.",
+    type=Path,
 )
 parser.add_argument(
     "-v",
@@ -81,12 +97,9 @@ handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)5s: %(message)s"
 LOGGER.addHandler(handler)
 
 
-def tile_intersects_bbox(tile_path: str, in_bounds: Optional[Bbox]) -> bool:
-    """Check if a tile intersects the bbox"""
-    if not in_bounds:
-        return True
-
-    level, tile_idx = [int(x.replace("/", "")) for x in get_tile_level_id(tile_path)]
+def get_tile_bbox(tile_path: Path) -> Tuple[float, float, float, float]:
+    """Returns a tile's bounding box in minx,miny,maxx,maxy format"""
+    level, tile_idx = [int(x.replace("/", "")) for x in get_tile_level_id(str(tile_path))]
 
     tile_size = TILE_SIZES[level]
     row = floor(tile_idx / (360 / tile_size))
@@ -94,36 +107,83 @@ def tile_intersects_bbox(tile_path: str, in_bounds: Optional[Bbox]) -> bool:
 
     tile_base_y = (row * tile_size) - 90
     tile_base_x = (col * tile_size) - 180
-    tile_bbox = Bbox(
-        tile_base_x,
-        tile_base_y,
-        tile_base_x + tile_size,
-        tile_base_y + tile_size,
-    )
 
-    # check if tile_bbox is outside of in_bounds
-    return not any(
-        [
-            tile_bbox.min_x < in_bounds.min_x
-            and tile_bbox.max_x < in_bounds.min_x,  # bbox1 left of bbox2
-            tile_bbox.min_y < in_bounds.min_y and tile_bbox.max_y < in_bounds.min_y,  # bbox1 below bbox2
-            tile_bbox.min_x > in_bounds.max_x
-            and tile_bbox.max_x > in_bounds.max_x,  # bbox1 right of bbox2
-            tile_bbox.min_y > in_bounds.max_y and tile_bbox.max_y > in_bounds.max_y,  # bbox1 above bbox2
-        ]
-    )
+    return tile_base_x, tile_base_y, tile_base_x + tile_size, tile_base_y + tile_size
 
 
-def get_tile_count(in_path: Path) -> int:
-    """Iterates over the full tree and returns the count of all tiles it found."""
-    count = 0
-    for _, _, files in os.walk(in_path):
-        count += len(list(filter(lambda f: f.endswith('.gph'), files)))
+def get_tiles_with_geojson(all_tile_paths: List[Path], geojson_dir: Path) -> Set[Path]:
+    """Returns all tile paths intersecting with the GeoJSON (multi)polygons"""
+    try:
+        from shapely.geometry import Polygon, box
+    except ImportError:
+        LOGGER.critical(
+            "Could not import shapely. Please install shapely or use another download method instead."
+        )
+        sys.exit(1)
 
-    return count
+    if not geojson_dir.is_dir() or not len(list(geojson_dir.glob('*.geojson'))) > 0:
+        LOGGER.critical(
+            f"Geojson directory does not exist or contains no GeoJSON files: {geojson_dir.resolve()}"
+        )
+        sys.exit(1)
+
+    def get_outer_rings(input_dir: Path) -> List[Polygon]:
+        polygons = list()
+        for file in input_dir.glob("*.geojson"):
+            with open(file) as gj_f:
+                geojson = json.load(gj_f)
+            for feature in geojson["features"]:
+                if feature["geometry"]["type"] == "Polygon":
+                    polygons.append(Polygon(feature["geometry"]["coordinates"][0]))
+                if feature["geometry"]["type"] == "MultiPolygon":
+                    for single_polygon in feature["geometry"]["coordinates"]:
+                        polygons.append(Polygon(single_polygon[0]))
+        return polygons
+
+    tile_paths_ = set()
+    geojson_polys = get_outer_rings(geojson_dir)
+    for tile_path in all_tile_paths:
+        tile_bbox = box(*get_tile_bbox(tile_path))
+        for poly in geojson_polys:
+            if poly.intersects(tile_bbox):
+                tile_paths_.add(tile_path)
+
+    return tile_paths_
 
 
-def get_tile_level_id(path: str) -> Tuple[int, int]:
+def get_tiles_with_bbox(all_tile_paths: List[Path], bbox_str: str) -> Set[Path]:
+    """Returns all tile paths intersecting with the bbox"""
+    try:
+        bbox = Bbox(*[float(x) for x in bbox_str.split(",")])
+    except ValueError:
+        LOGGER.critical(f"BBOX {bbox_str} is not a comma-separated string of coordinates.")
+        sys.exit(1)
+
+    # validate bbox
+    if (bbox.min_x >= bbox.max_x or bbox.min_x < -180 or bbox.max_x > 180) or (
+        bbox.min_y >= bbox.max_y or bbox.min_y < -90 or bbox.max_y > 90
+    ):
+        LOGGER.critical(f"Bbox invalid: {list(bbox)}")
+        sys.exit(1)
+
+    tile_paths_ = set()
+    for tile_path in all_tile_paths:
+        tile_bbox = Bbox(*get_tile_bbox(tile_path))
+        # check if tile_bbox is outside of bbox
+        if not any(
+            [
+                tile_bbox.min_x < bbox.min_x and tile_bbox.max_x < bbox.min_x,  # left of bbox
+                tile_bbox.min_y < bbox.min_y and tile_bbox.max_y < bbox.min_y,  # below bbox
+                tile_bbox.min_x > bbox.max_x and tile_bbox.max_x > bbox.max_x,  # right of bbox
+                tile_bbox.min_y > bbox.max_y and tile_bbox.max_y > bbox.max_y,  # above bbox
+            ]
+        ):
+            tile_paths_.add(tile_path)
+
+    return tile_paths_
+
+
+def get_tile_level_id(path: str) -> List[str]:
     """Returns both level and tile ID"""
     return path[:-4].split('/', 1)
 
@@ -166,7 +226,7 @@ def write_index_to_tar(tar_fp_: Path):
             tar.write(struct.pack(INDEX_BIN_FORMAT, *entry))
 
 
-def create_extracts(config_: dict, do_traffic: bool, bbox: Optional[Bbox] = None):
+def create_extracts(config_: dict, do_traffic: bool, tile_paths_: Union[Set[Path], List[Path]]):
     """Actually creates the tar ball. Break out of main function for testability."""
     tiles_fp: Path = Path(config_["mjolnir"].get("tile_dir", '/dev/null'))
     extract_fp: Path = Path(
@@ -176,15 +236,9 @@ def create_extracts(config_: dict, do_traffic: bool, bbox: Optional[Bbox] = None
         config_["mjolnir"].get("traffic_extract") or tiles_fp.parent.joinpath('traffic.tar')
     )
 
-    if not tiles_fp.is_dir():
-        LOGGER.critical(
-            f"Directory 'mjolnir.tile_dir': {tiles_fp.resolve()} was not found on the filesystem."
-        )
-        sys.exit(1)
-
-    tiles_count = get_tile_count(tiles_fp)
+    tiles_count = len(tile_paths_)
     if not tiles_count:
-        LOGGER.critical(f"Directory {tiles_fp} does not contain any usable graph tiles.")
+        LOGGER.critical(f"Directory {tiles_fp.resolve()} does not contain any usable graph tiles.")
         sys.exit(1)
 
     # write the in-memory index file
@@ -196,12 +250,8 @@ def create_extracts(config_: dict, do_traffic: bool, bbox: Optional[Bbox] = None
     # TODO: come up with a smarter strategy to cluster the tiles in the tar
     with tarfile.open(extract_fp, 'w') as tar:
         tar.addfile(get_tar_info(INDEX_FILE, index_size), index_fd)
-        for t in sorted(tiles_fp.rglob('*.gph')):
-            # only include the tiles falling inside the bbox
+        for t in tile_paths_:
             rel_path = str(t.relative_to(tiles_fp))
-            if not tile_intersects_bbox(rel_path, bbox):
-                LOGGER.debug(f"Tile {rel_path} is outside {tuple(bbox)}.")
-                continue
             LOGGER.debug(f"Adding tile {rel_path} to the path")
             tar.add(str(t.resolve()), arcname=rel_path)
 
@@ -268,21 +318,20 @@ if __name__ == '__main__':
     # override with inline-config
     config.update(**json.loads(args.inline_config))
 
-    # see if there's a bbox to limit the tiles archived
-    bbox = None
-    if args.bbox:
-        try:
-            bbox = Bbox(*[float(x) for x in args.bbox.split(",")])
-        except ValueError:
-            LOGGER.critical(f"BBOX {args.bbox} is not a comma-separated string of coordinates.")
-            sys.exit(1)
+    # get and validate the tiles directory
+    tiles_dir: Path = Path(config["mjolnir"].get("tile_dir", '/dev/null'))
+    if not tiles_dir.is_dir():
+        LOGGER.critical(
+            f"Directory 'mjolnir.tile_dir': {tiles_dir.resolve()} was not found on the filesystem."
+        )
+        sys.exit(1)
 
-        # validate bbox
-        if (bbox.min_x >= bbox.max_x or bbox.min_x < -180 or bbox.max_x > 180) or (
-            bbox.min_y >= bbox.max_y or bbox.min_y < -90 or bbox.max_y > 90
-        ):
-            LOGGER.critical(f"Bbox invalid: {list(bbox)}")
-            sys.exit(1)
+    # get the tile paths which intersect with the geom, if any
+    tile_paths: Union[Set[Path], List[Path]] = sorted(tiles_dir.rglob('*.gph'))
+    if args.bbox:
+        tile_paths = get_tiles_with_bbox(tile_paths, args.bbox)
+    elif args.geojson_dir:
+        tile_paths = get_tiles_with_geojson(tile_paths, args.geojson_dir)
 
     # set the right logger level
     if args.verbosity == 0:
@@ -292,4 +341,4 @@ if __name__ == '__main__':
     elif args.verbosity >= 2:
         LOGGER.setLevel(logging.DEBUG)
 
-    create_extracts(config, args.with_traffic, bbox)
+    create_extracts(config, args.with_traffic, tile_paths)

--- a/scripts/valhalla_build_extract
+++ b/scripts/valhalla_build_extract
@@ -14,7 +14,7 @@ import sys
 import tarfile
 from tarfile import BLOCKSIZE
 from time import time
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 
 # "<" prefix means little-endian and no alignment
 # order is important! if uint64_t is not first, c++ will use padding bytes to unpack
@@ -81,7 +81,7 @@ handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)5s: %(message)s"
 LOGGER.addHandler(handler)
 
 
-def tile_intersects_bbox(tile_path: str, in_bounds: Bbox) -> bool:
+def tile_intersects_bbox(tile_path: str, in_bounds: Optional[Bbox]) -> bool:
     """Check if a tile intersects the bbox"""
     if not in_bounds:
         return True
@@ -166,7 +166,7 @@ def write_index_to_tar(tar_fp_: Path):
             tar.write(struct.pack(INDEX_BIN_FORMAT, *entry))
 
 
-def create_extracts(config_: dict, do_traffic: bool, bbox: Bbox):
+def create_extracts(config_: dict, do_traffic: bool, bbox: Optional[Bbox] = None):
     """Actually creates the tar ball. Break out of main function for testability."""
     tiles_fp: Path = Path(config_["mjolnir"].get("tile_dir", '/dev/null'))
     extract_fp: Path = Path(
@@ -269,7 +269,7 @@ if __name__ == '__main__':
     config.update(**json.loads(args.inline_config))
 
     # see if there's a bbox to limit the tiles archived
-    bbox = []
+    bbox = None
     if args.bbox:
         try:
             bbox = Bbox(*[float(x) for x in args.bbox.split(",")])

--- a/scripts/valhalla_build_extract
+++ b/scripts/valhalla_build_extract
@@ -198,12 +198,12 @@ def create_extracts(config_: dict, do_traffic: bool, bbox: Bbox):
         tar.addfile(get_tar_info(INDEX_FILE, index_size), index_fd)
         for t in sorted(tiles_fp.rglob('*.gph')):
             # only include the tiles falling inside the bbox
-            rel_path = t.relative_to(tiles_fp)
+            rel_path = str(t.relative_to(tiles_fp))
             if not tile_intersects_bbox(rel_path, bbox):
                 LOGGER.debug(f"Tile {rel_path} is outside {tuple(bbox)}.")
                 continue
             LOGGER.debug(f"Adding tile {rel_path} to the path")
-            tar.add(str(t.resolve()), arcname=str(rel_path))
+            tar.add(str(t.resolve()), arcname=rel_path)
 
     write_index_to_tar(extract_fp)
 

--- a/scripts/valhalla_build_extract
+++ b/scripts/valhalla_build_extract
@@ -101,14 +101,17 @@ def tile_intersects_bbox(tile_path: str, in_bounds: Bbox) -> bool:
         tile_base_y + tile_size,
     )
 
-    result = [
-        tile_bbox.min_x < in_bounds.min_x and tile_bbox.max_x < in_bounds.min_x,  # bbox1 left of bbox2
-        tile_bbox.min_y < in_bounds.min_y and tile_bbox.max_y < in_bounds.min_y,  # bbox1 below bbox2
-        tile_bbox.min_x > in_bounds.max_x and tile_bbox.max_x > in_bounds.max_x,  # bbox1 right of bbox2
-        tile_bbox.min_y > in_bounds.max_y and tile_bbox.max_y > in_bounds.max_y,  # bbox1 above bbox2
-    ]
-
-    return not any(result)
+    # check if tile_bbox is outside of in_bounds
+    return not any(
+        [
+            tile_bbox.min_x < in_bounds.min_x
+            and tile_bbox.max_x < in_bounds.min_x,  # bbox1 left of bbox2
+            tile_bbox.min_y < in_bounds.min_y and tile_bbox.max_y < in_bounds.min_y,  # bbox1 below bbox2
+            tile_bbox.min_x > in_bounds.max_x
+            and tile_bbox.max_x > in_bounds.max_x,  # bbox1 right of bbox2
+            tile_bbox.min_y > in_bounds.max_y and tile_bbox.max_y > in_bounds.max_y,  # bbox1 above bbox2
+        ]
+    )
 
 
 def get_tile_count(in_path: Path) -> int:
@@ -197,6 +200,7 @@ def create_extracts(config_: dict, do_traffic: bool, bbox: Bbox):
             # only include the tiles falling inside the bbox
             rel_path = t.relative_to(tiles_fp)
             if not tile_intersects_bbox(rel_path, bbox):
+                LOGGER.debug(f"Tile {rel_path} is outside {tuple(bbox)}.")
                 continue
             LOGGER.debug(f"Adding tile {rel_path} to the path")
             tar.add(str(t.resolve()), arcname=str(rel_path))

--- a/scripts/valhalla_build_extract
+++ b/scripts/valhalla_build_extract
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 
 import argparse
+from collections import namedtuple
 import ctypes
 from io import BytesIO
 import json
+from math import floor
 import logging
 import os
 from pathlib import Path
@@ -23,6 +25,9 @@ INDEX_FILE = "index.bin"
 GRAPHTILE_SKIP_BYTES = struct.calcsize('<Q2f16cQ')
 TRAFFIC_HEADER_SIZE = struct.calcsize('<2Q4I')
 TRAFFIC_SPEED_SIZE = struct.calcsize('<Q')
+
+Bbox = namedtuple("Bbox", "min_x min_y max_x max_y")
+TILE_SIZES = {0: 4, 1: 1, 2: 0.25}
 
 
 class TileHeader(ctypes.Structure):
@@ -55,6 +60,13 @@ parser.add_argument(
     "-t", "--with-traffic", help="Flag to add a traffic.tar skeleton", action="store_true", default=False
 )
 parser.add_argument(
+    "-b",
+    "--bbox",
+    help="If specified, will only archive tiles which are intersecting this bbox. In 'minx,miny,maxx,maxy' format.",
+    type=str,
+    default="",
+)
+parser.add_argument(
     "-v",
     "--verbosity",
     help="Accumulative verbosity flags; -v: INFO, -vv: DEBUG",
@@ -69,6 +81,36 @@ handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)5s: %(message)s"
 LOGGER.addHandler(handler)
 
 
+def tile_intersects_bbox(tile_path: str, in_bounds: Bbox) -> bool:
+    """Check if a tile intersects the bbox"""
+    if not in_bounds:
+        return True
+
+    level, tile_idx = [int(x.replace("/", "")) for x in get_tile_level_id(tile_path)]
+
+    tile_size = TILE_SIZES[level]
+    row = floor(tile_idx / (360 / tile_size))
+    col = tile_idx % (360 / tile_size)
+
+    tile_base_y = (row * tile_size) - 90
+    tile_base_x = (col * tile_size) - 180
+    tile_bbox = Bbox(
+        tile_base_x,
+        tile_base_y,
+        tile_base_x + tile_size,
+        tile_base_y + tile_size,
+    )
+
+    result = [
+        tile_bbox.min_x < in_bounds.min_x and tile_bbox.max_x < in_bounds.min_x,  # bbox1 left of bbox2
+        tile_bbox.min_y < in_bounds.min_y and tile_bbox.max_y < in_bounds.min_y,  # bbox1 below bbox2
+        tile_bbox.min_x > in_bounds.max_x and tile_bbox.max_x > in_bounds.max_x,  # bbox1 right of bbox2
+        tile_bbox.min_y > in_bounds.max_y and tile_bbox.max_y > in_bounds.max_y,  # bbox1 above bbox2
+    ]
+
+    return not any(result)
+
+
 def get_tile_count(in_path: Path) -> int:
     """Iterates over the full tree and returns the count of all tiles it found."""
     count = 0
@@ -78,9 +120,14 @@ def get_tile_count(in_path: Path) -> int:
     return count
 
 
+def get_tile_level_id(path: str) -> Tuple[int, int]:
+    """Returns both level and tile ID"""
+    return path[:-4].split('/', 1)
+
+
 def get_tile_id(path: str) -> int:
-    """Turns a tile path into a numeric GraphId"""
-    level, idx = path[:-4].split('/', 1)
+    """Turns a tile path into a numeric GraphId, including the level"""
+    level, idx = get_tile_level_id(path)
 
     return int(level) | (int(idx.replace('/', '')) << 3)
 
@@ -116,7 +163,7 @@ def write_index_to_tar(tar_fp_: Path):
             tar.write(struct.pack(INDEX_BIN_FORMAT, *entry))
 
 
-def create_extracts(config_: dict, do_traffic: bool):
+def create_extracts(config_: dict, do_traffic: bool, bbox: Bbox):
     """Actually creates the tar ball. Break out of main function for testability."""
     tiles_fp: Path = Path(config_["mjolnir"].get("tile_dir", '/dev/null'))
     extract_fp: Path = Path(
@@ -147,7 +194,12 @@ def create_extracts(config_: dict, do_traffic: bool):
     with tarfile.open(extract_fp, 'w') as tar:
         tar.addfile(get_tar_info(INDEX_FILE, index_size), index_fd)
         for t in sorted(tiles_fp.rglob('*.gph')):
-            tar.add(str(t.resolve()), arcname=str(t.relative_to(tiles_fp)))
+            # only include the tiles falling inside the bbox
+            rel_path = t.relative_to(tiles_fp)
+            if not tile_intersects_bbox(rel_path, bbox):
+                continue
+            LOGGER.debug(f"Adding tile {rel_path} to the path")
+            tar.add(str(t.resolve()), arcname=str(rel_path))
 
     write_index_to_tar(extract_fp)
 
@@ -212,6 +264,22 @@ if __name__ == '__main__':
     # override with inline-config
     config.update(**json.loads(args.inline_config))
 
+    # see if there's a bbox to limit the tiles archived
+    bbox = []
+    if args.bbox:
+        try:
+            bbox = Bbox(*[float(x) for x in args.bbox.split(",")])
+        except ValueError:
+            LOGGER.critical(f"BBOX {args.bbox} is not a comma-separated string of coordinates.")
+            sys.exit(1)
+
+        # validate bbox
+        if (bbox.min_x >= bbox.max_x or bbox.min_x < -180 or bbox.max_x > 180) or (
+            bbox.min_y >= bbox.max_y or bbox.min_y < -90 or bbox.max_y > 90
+        ):
+            LOGGER.critical(f"Bbox invalid: {list(bbox)}")
+            sys.exit(1)
+
     # set the right logger level
     if args.verbosity == 0:
         LOGGER.setLevel(logging.CRITICAL)
@@ -220,4 +288,4 @@ if __name__ == '__main__':
     elif args.verbosity >= 2:
         LOGGER.setLevel(logging.DEBUG)
 
-    create_extracts(config, args.with_traffic)
+    create_extracts(config, args.with_traffic, bbox)

--- a/test/scripts/test_valhalla_build_elevation.py
+++ b/test/scripts/test_valhalla_build_elevation.py
@@ -41,15 +41,18 @@ class TestBuildElevation(unittest.TestCase):
                  }
             ]
         }
-        gj_fp = TILE_DIR.joinpath('test.geojson')
+        gj_dir = TILE_DIR.joinpath("test_build_elevation")
+        gj_dir.mkdir()
+        gj_fp = gj_dir.joinpath('test_build_elevation.geojson')
         with open(gj_fp, 'w') as f:
             json.dump(gj, f)
 
-        tiles = valhalla_build_elevation.get_tiles_with_geojson(gj_fp.parent)
+        tiles = valhalla_build_elevation.get_tiles_with_geojson(gj_dir)
         self.assertEqual(len(tiles), 8)
         self.assertNotIn(Tile("N03E003.hgt", "N03"), tiles)
 
         gj_fp.unlink()
+        gj_dir.rmdir()
 
     def test_get_tiles_with_bbox(self):
         bbox = "0.90,0.12,3.56,3.12"

--- a/test/scripts/test_valhalla_build_extract.py
+++ b/test/scripts/test_valhalla_build_extract.py
@@ -25,7 +25,7 @@ def tile_base_to_path(base_x: int, base_y: int, level: int) -> str:
     tile_size = TILE_SIZES[level]
 
     # assert we got no bogus tile base..
-    assert (base_x + 180) % tile_size == 0 and (base_y + 90) % tile_size == 0
+    assert (base_x + 180) % tile_size == 0 and (base_y + 90) % tile_size == 0, f"{base_x}, {base_y} failed"
 
     row = floor((base_y + 90) / tile_size)
     col = floor((base_x + 180) / tile_size)
@@ -60,11 +60,10 @@ class TestBuildExtract(unittest.TestCase):
             self.assertTrue(valhalla_build_extract.tile_intersects_bbox(tile_path, bbox), f"Tile {input_tuple} is failing.")
 
         # don't find the ones not intersecting
-        bbox = Bbox(0, 10, 2, 12)
+        bbox = Bbox(0, 10, 4, 14)
         for input_tuple in (
-            (2, 12, 0),   # base at the upper right corner
-            (-1, 9, 1),  # contained in bbox
-            (-0.25, 9.75, 2),  # barely intersecting in the upper right
+            (8, 14, 0),
+            (-0.50, 9.75, 2)
         ):
             tile_path = tile_base_to_path(*input_tuple)
             self.assertFalse(valhalla_build_extract.tile_intersects_bbox(tile_path, bbox), f"Tile {input_tuple} shouldn't be found.")

--- a/test/scripts/test_valhalla_build_extract.py
+++ b/test/scripts/test_valhalla_build_extract.py
@@ -48,7 +48,7 @@ class TestBuildExtract(unittest.TestCase):
             (20, 59, 2),  # barely intersecting in the upper right
         ):
             tile_path = tile_base_to_path(*input_tuple)
-            self.assertTrue(valhalla_build_extract.tile_intersects_bbox(tile_path, bbox), f"Tuple {input_tuple} is failing.")
+            self.assertTrue(valhalla_build_extract.tile_intersects_bbox(tile_path, bbox), f"Tile {input_tuple} is failing.")
 
         bbox = Bbox(-20, -59.2, -10.2, -53.9)
         for input_tuple in (
@@ -57,14 +57,24 @@ class TestBuildExtract(unittest.TestCase):
             (-12, -62, 0),
         ):
             tile_path = tile_base_to_path(*input_tuple)
-            self.assertTrue(valhalla_build_extract.tile_intersects_bbox(tile_path, bbox), f"Tuple {input_tuple} is failing.")
+            self.assertTrue(valhalla_build_extract.tile_intersects_bbox(tile_path, bbox), f"Tile {input_tuple} is failing.")
+
+        # don't find the ones not intersecting
+        bbox = Bbox(0, 10, 2, 12)
+        for input_tuple in (
+            (2, 12, 0),   # base at the upper right corner
+            (-1, 9, 1),  # contained in bbox
+            (-0.25, 9.75, 2),  # barely intersecting in the upper right
+        ):
+            tile_path = tile_base_to_path(*input_tuple)
+            self.assertFalse(valhalla_build_extract.tile_intersects_bbox(tile_path, bbox), f"Tile {input_tuple} shouldn't be found.")
 
 
     def test_create_extracts(self):
         config = {"mjolnir": {"tile_dir": str(TILE_PATH), "tile_extract": str(EXTRACT_PATH), "traffic_extract": str(TRAFFIC_PATH)}}
 
         # it will open the tars in write mode, so other test output can't interfere
-        valhalla_build_extract.create_extracts(config, True, "")
+        valhalla_build_extract.create_extracts(config, True)
         tile_count = valhalla_build_extract.get_tile_count(TILE_PATH)
 
         # test that the index has the right offsets/sizes

--- a/test/scripts/test_valhalla_build_extract.py
+++ b/test/scripts/test_valhalla_build_extract.py
@@ -1,3 +1,4 @@
+import json
 from math import floor
 import tarfile
 import unittest
@@ -25,15 +26,18 @@ def tile_base_to_path(base_x: int, base_y: int, level: int) -> str:
     tile_size = TILE_SIZES[level]
 
     # assert we got no bogus tile base..
-    assert (base_x + 180) % tile_size == 0 and (base_y + 90) % tile_size == 0, f"{base_x}, {base_y} failed"
+    assert (base_x + 180) % tile_size == 0 and (
+                base_y + 90) % tile_size == 0, f"{base_x}, {base_y} on level {level} failed"
 
     row = floor((base_y + 90) / tile_size)
     col = floor((base_x + 180) / tile_size)
 
     tile_id = int((row * 360 / tile_size) + col)
 
+    print("row/col: ", row, ", ", col)
+
     level_tile_id = level | (tile_id << 3)
-    path = str(level)+ "{:,}".format(int(pow(10, TAR_PATH_LENGTHS[level])) + tile_id).replace(",", os.sep)[1:]
+    path = str(level) + "{:,}".format(int(pow(10, TAR_PATH_LENGTHS[level])) + tile_id).replace(",", os.sep)[1:]
 
     return path + ".gph"
 
@@ -41,40 +45,93 @@ def tile_base_to_path(base_x: int, base_y: int, level: int) -> str:
 class TestBuildExtract(unittest.TestCase):
     def test_tile_intersects_bbox(self):
         # bbox with which to filter the tile paths
-        bbox = Bbox(10.2, 53.9, 20, 59.2)
-        for input_tuple in (
-            (8, 50, 0),   # barely intersecting in the lower left
+        bbox = "10.2,53.9,20,59.2"
+        input_paths = set([tile_base_to_path(*input_tuple) for input_tuple in (
+            (8, 50, 0),  # barely intersecting in the lower left
             (12, 54, 1),  # contained in bbox
             (20, 59, 2),  # barely intersecting in the upper right
-        ):
-            tile_path = tile_base_to_path(*input_tuple)
-            self.assertTrue(valhalla_build_extract.tile_intersects_bbox(tile_path, bbox), f"Tile {input_tuple} is failing.")
+        )])
+        out_paths = valhalla_build_extract.get_tiles_with_bbox(input_paths, bbox)
+        self.assertSetEqual(input_paths, out_paths)
 
-        bbox = Bbox(-20, -59.2, -10.2, -53.9)
-        for input_tuple in (
+        bbox = "-20,-59.2,-10.2,-53.9"
+        input_paths = set([tile_base_to_path(*input_tuple) for input_tuple in (
             (-20, -59, 2),  # barely intersecting in the lower left
             (-12, -54, 1),  # contained in bbox
             (-12, -62, 0),
-        ):
-            tile_path = tile_base_to_path(*input_tuple)
-            self.assertTrue(valhalla_build_extract.tile_intersects_bbox(tile_path, bbox), f"Tile {input_tuple} is failing.")
+        )])
+        out_paths = valhalla_build_extract.get_tiles_with_bbox(input_paths, bbox)
+        self.assertSetEqual(input_paths, out_paths)
 
         # don't find the ones not intersecting
-        bbox = Bbox(0, 10, 4, 14)
-        for input_tuple in (
+        bbox = "0,10,4,14"
+        input_paths = set([tile_base_to_path(*input_tuple) for input_tuple in (
             (8, 14, 0),
             (-0.50, 9.75, 2)
-        ):
-            tile_path = tile_base_to_path(*input_tuple)
-            self.assertFalse(valhalla_build_extract.tile_intersects_bbox(tile_path, bbox), f"Tile {input_tuple} shouldn't be found.")
+        )])
+        out_paths = valhalla_build_extract.get_tiles_with_bbox(input_paths, bbox)
+        self.assertSetEqual(out_paths, set())
 
+    def test_tile_intersects_geojson(self):
+        # create 1 polygon with 2 height & width, should leave out e.g. tile (2,2)
+        #  __
+        # | |__
+        # |___|
+
+        gj = {
+            "type": "FeatureCollection",
+            "properties": {},
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [[0, 2], [0, 3.99], [0.99, 3.99], [0.99, 2.99], [1.99, 2.99], [1.99, 2], [0, 2]]]
+                    }
+                }
+            ]
+        }
+        gj_dir = TILE_PATH.joinpath("test_build_extract")
+        gj_dir.mkdir()
+        gj_fp = gj_dir.joinpath('test_build_extract.geojson')
+        with open(gj_fp, 'w') as f:
+            json.dump(gj, f)
+
+        input_paths = set([tile_base_to_path(*input_tuple) for input_tuple in (
+            (0, 2, 0),
+            (0, 2, 1),
+            (0, 3, 1),
+            (1, 2, 1),
+            (0, 2, 2),
+            (1.75, 2.75, 2),
+            (0.75, 3.25, 2)
+        )])
+        out_paths = valhalla_build_extract.get_tiles_with_geojson(input_paths, gj_dir)
+        print(input_paths, out_paths)
+        self.assertSetEqual(input_paths, out_paths)
+
+        # don't find the ones not intersecting
+        input_paths = set([tile_base_to_path(*input_tuple) for input_tuple in (
+            (4, 2, 0),
+            (1, 3, 1),
+            (1, 4.75, 2),
+            (1, 3, 2),
+        )])
+        out_paths = valhalla_build_extract.get_tiles_with_geojson(input_paths, gj_dir)
+        self.assertSetEqual(out_paths, set())
+
+        gj_fp.unlink()
+        gj_dir.rmdir()
 
     def test_create_extracts(self):
-        config = {"mjolnir": {"tile_dir": str(TILE_PATH), "tile_extract": str(EXTRACT_PATH), "traffic_extract": str(TRAFFIC_PATH)}}
+        config = {"mjolnir": {"tile_dir": str(TILE_PATH), "tile_extract": str(EXTRACT_PATH),
+                              "traffic_extract": str(TRAFFIC_PATH)}}
 
         # it will open the tars in write mode, so other test output can't interfere
-        valhalla_build_extract.create_extracts(config, True)
-        tile_count = valhalla_build_extract.get_tile_count(TILE_PATH)
+        tile_paths = sorted(TILE_PATH.rglob('*.gph'))
+        valhalla_build_extract.create_extracts(config, True, tile_paths)
+        tile_count = len(tile_paths)
 
         # test that the index has the right offsets/sizes
         exp_tuples = ((2560, 25568, 291912), (296448, 410441, 662496), (960512, 6549282, 6059792))

--- a/test/scripts/test_valhalla_build_extract.py
+++ b/test/scripts/test_valhalla_build_extract.py
@@ -1,9 +1,14 @@
+from math import floor
 import tarfile
 import unittest
 from pathlib import Path
 import struct
+from typing import List, Tuple
+import sys
+import os
 
 import valhalla_build_extract
+from valhalla_build_extract import TILE_SIZES, Bbox
 
 INDEX_BIN_SIZE = valhalla_build_extract.INDEX_BIN_SIZE
 INDEX_BIN_FORMAT = valhalla_build_extract.INDEX_BIN_FORMAT
@@ -12,13 +17,54 @@ TILE_PATH = Path('test/data/utrecht_tiles')
 EXTRACT_PATH = TILE_PATH.joinpath('tiles.tar')
 TRAFFIC_PATH = TILE_PATH.joinpath('traffic.tar')
 
+TAR_PATH_LENGTHS = [6, 6, 9]  # how many leading 0's do we need as tar file name?
+
+
+def tile_base_to_path(base_x: int, base_y: int, level: int) -> str:
+    """Convert a tile's base lat/lon to a relative tile path."""
+    tile_size = TILE_SIZES[level]
+
+    # assert we got no bogus tile base..
+    assert (base_x + 180) % tile_size == 0 and (base_y + 90) % tile_size == 0
+
+    row = floor((base_y + 90) / tile_size)
+    col = floor((base_x + 180) / tile_size)
+
+    tile_id = int((row * 360 / tile_size) + col)
+
+    level_tile_id = level | (tile_id << 3)
+    path = str(level)+ "{:,}".format(int(pow(10, TAR_PATH_LENGTHS[level])) + tile_id).replace(",", os.sep)[1:]
+
+    return path + ".gph"
+
 
 class TestBuildExtract(unittest.TestCase):
+    def test_tile_intersects_bbox(self):
+        # bbox with which to filter the tile paths
+        bbox = Bbox(10.2, 53.9, 20, 59.2)
+        for input_tuple in (
+            (8, 50, 0),   # barely intersecting in the lower left
+            (12, 54, 1),  # contained in bbox
+            (20, 59, 2),  # barely intersecting in the upper right
+        ):
+            tile_path = tile_base_to_path(*input_tuple)
+            self.assertTrue(valhalla_build_extract.tile_intersects_bbox(tile_path, bbox), f"Tuple {input_tuple} is failing.")
+
+        bbox = Bbox(-20, -59.2, -10.2, -53.9)
+        for input_tuple in (
+            (-20, -59, 2),  # barely intersecting in the lower left
+            (-12, -54, 1),  # contained in bbox
+            (-12, -62, 0),
+        ):
+            tile_path = tile_base_to_path(*input_tuple)
+            self.assertTrue(valhalla_build_extract.tile_intersects_bbox(tile_path, bbox), f"Tuple {input_tuple} is failing.")
+
+
     def test_create_extracts(self):
         config = {"mjolnir": {"tile_dir": str(TILE_PATH), "tile_extract": str(EXTRACT_PATH), "traffic_extract": str(TRAFFIC_PATH)}}
 
         # it will open the tars in write mode, so other test output can't interfere
-        valhalla_build_extract.create_extracts(config, True)
+        valhalla_build_extract.create_extracts(config, True, "")
         tile_count = valhalla_build_extract.get_tile_count(TILE_PATH)
 
         # test that the index has the right offsets/sizes


### PR DESCRIPTION
So we can archive a subset of tiles from a directory giving either:
- bbox string or
- directory path with `.geojson` files (analogous to `valhalla_build_elevation`, fixes #3858)