### PR TITLE
GraphReader with write-access to traffic extract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
    * ADDED: "waiting" field on input/output intermediate break(_through) locations to respect services times [#3849](https://github.com/valhalla/valhalla/pull/3849)
    * ADDED: --bbox & --geojson-dir options to valhalla_build_extract to only archive a subset of tiles [#3856](https://github.com/valhalla/valhalla/pull/3856)
    * CHANGED: Replace unstable c++ geos API with a mix of geos' c api and boost::geometry for admin building [#3683](https://github.com/valhalla/valhalla/pull/3683)
+   * ADDED: optional write-access to traffic extract from GraphReader [#3876](https://github.com/valhalla/valhalla/pull/3876)
 
 ## Release Date: 2022-10-26 Valhalla 3.2.0
 * **Removed**

--- a/valhalla/baldr/graphreader.h
+++ b/valhalla/baldr/graphreader.h
@@ -439,9 +439,12 @@ public:
    * @param pt  Property tree listing the configuration for the tile storage
    * @param tile_getter Object responsible for getting tiles by url. If nullptr default implementation
    * is in use.
+   * @param traffic_readonly Flag to indicate if memory-mapped traffic extract should be writeable or
+   * read-only (default).
    */
   explicit GraphReader(const boost::property_tree::ptree& pt,
-                       std::unique_ptr<tile_getter_t>&& tile_getter = nullptr);
+                       std::unique_ptr<tile_getter_t>&& tile_getter = nullptr,
+                       bool traffic_readonly = true);
 
   virtual ~GraphReader() = default;
 
@@ -940,7 +943,7 @@ public:
 protected:
   // (Tar) extract of tiles - the contents are empty if not being used
   struct tile_extract_t {
-    tile_extract_t(const boost::property_tree::ptree& pt);
+    tile_extract_t(const boost::property_tree::ptree& pt, bool traffic_readonly = true);
     // TODO: dont remove constness, and actually make graphtile read only?
     std::unordered_map<uint64_t, std::pair<char*, size_t>> tiles;
     std::unordered_map<uint64_t, std::pair<char*, size_t>> traffic_tiles;

--- a/valhalla/midgard/sequence.h
+++ b/valhalla/midgard/sequence.h
@@ -669,6 +669,7 @@ struct tar {
   size_t corrupt_blocks;
 
   tar(const std::string& tar_file,
+      bool readonly = true,
       bool regular_files_only = true,
       const std::function<decltype(contents)(const std::string&, const char*, const char*, size_t)>&
           from_index = nullptr)
@@ -684,7 +685,7 @@ struct tar {
     }
 
     // map the file
-    mm.map_readonly(tar_file, s.st_size);
+    mm.map(tar_file, s.st_size, POSIX_MADV_NORMAL, readonly);
 
     // determine opposite of preferred path separator (needed to update OS-specific path separator)
     const char opp_sep = filesystem::path::preferred_separator == '/' ? '\\' : '/';


### PR DESCRIPTION
For the purpose of live-traffic updates, write-access to traffic tiles is required. Instead of relying on a completely separate implementation, the traffic update mechanism could benefit from all the optimizations available in GraphReader by allowing read-only mode to be disabled.

The approach was working well for our use case, I would be interested to hear your thoughts on this and potential problems this might lead to. Thanks!

Philipp Voigt (<philipp.voigt@mercedes-benz.com>), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)

Licensed under MIT
