### PR TITLE
add some more goodies to mkdocs navigation

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -4,6 +4,11 @@ theme:
   name: material
   logo: images/valhalla.png
   favicon: images/valhalla.png
+  features:
+    - navigation.instant
+    - navigation.sections
+    - navigation.top
+    - toc.follow
   palette:
     - scheme: default
       toggle:


### PR DESCRIPTION
Only for UX:
- Show sub-sections of top-level leafs in the sidebar
- show "Back to Top" button when scrolling up further down in the document
- TOC follows down in the page, if the TOC would be really long

~~It's already live on https://valhalla.github.io/valhalla/ in case you wanna have a look.~~ new commits in `master` overwrote that.