### PR TITLE
Parse lit tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * **Bug Fix**
 * **Enhancement**
    * CHANGED: replace boost::optional with C++17's std::optional where possible [#3890](https://github.com/valhalla/valhalla/pull/3890)
+   * ADDED: parse `lit` tag on ways and add it to graph [#3893](https://github.com/valhalla/valhalla/pull/3893)
 
 ## Release Date: 2022-01-03 Valhalla 3.3.0
 * **Removed**

--- a/lua/graph.lua
+++ b/lua/graph.lua
@@ -408,6 +408,17 @@ toll = {
 ["snowmobile"] = "true"
 }
 
+lit = {
+  ["yes"] = "true",
+  ["no"] = "false",
+  ["24/7"] = "true",
+  ["automatic"] = "true",
+  ["limited"] = "false",
+  ["disused"] = "false",
+  ["dusk-dawn"] = "true",
+  ["sunset-sunrise"] = "true"
+}
+
 --node proc needs the same info as above but in the form of a mask so duplicate..
 motor_vehicle_node = {
 ["yes"] = 1,
@@ -1429,6 +1440,8 @@ function filter_tags_generic(kv)
   if kv["service"] == "driveway" then
      kv["default_speed"] = math.floor(tonumber(kv["default_speed"]) * 0.5)
   end
+
+  kv["lit"] = lit[kv["lit"]]
 
   local use = use[kv["service"]]
 

--- a/src/baldr/directededge.cc
+++ b/src/baldr/directededge.cc
@@ -577,6 +577,10 @@ void DirectedEdge::set_bss_connection(const bool bss_connection) {
   bss_connection_ = bss_connection;
 }
 
+void DirectedEdge::set_lit(const bool lit) {
+  lit_ = lit;
+}
+
 // Json representation
 json::MapPtr DirectedEdge::json() const {
   json::MapPtr map = json::map({

--- a/src/mjolnir/directededgebuilder.cc
+++ b/src/mjolnir/directededgebuilder.cc
@@ -87,6 +87,8 @@ DirectedEdgeBuilder::DirectedEdgeBuilder(const OSMWay& way,
       (way.tagged_speed() || way.forward_tagged_speed() || way.backward_tagged_speed());
   set_speed_type(tagged_speed ? SpeedType::kTagged : SpeedType::kClassified);
 
+  set_lit(way.lit());
+
   // Set forward flag and access modes (based on direction)
   set_forward(forward);
   uint32_t forward_access = 0;

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -778,7 +778,7 @@ void BuildTileSet(const std::string& ways_file,
                                  truck_speed, use, static_cast<RoadClass>(edge.attributes.importance),
                                  n, has_signal, has_stop, has_yield,
                                  ((has_stop || has_yield) ? node.minor() : false), restrictions,
-                                 bike_network, edge.attributes.reclass_ferry);
+                                 bike_network, edge.attributes.reclass_ferry, w.lit());
           graphtile.directededges().emplace_back(de);
           DirectedEdge& directededge = graphtile.directededges().back();
           // temporarily set the leaves tile flag to indicate when we need to search the access.bin

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -778,7 +778,7 @@ void BuildTileSet(const std::string& ways_file,
                                  truck_speed, use, static_cast<RoadClass>(edge.attributes.importance),
                                  n, has_signal, has_stop, has_yield,
                                  ((has_stop || has_yield) ? node.minor() : false), restrictions,
-                                 bike_network, edge.attributes.reclass_ferry, w.lit());
+                                 bike_network, edge.attributes.reclass_ferry);
           graphtile.directededges().emplace_back(de);
           DirectedEdge& directededge = graphtile.directededges().back();
           // temporarily set the leaves tile flag to indicate when we need to search the access.bin

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -1408,6 +1408,7 @@ public:
     tag_handlers_["guidance_view:signboard:base:backward"] = [this]() {
       way_.set_bwd_signboard_base_index(osmdata_.name_offset_map.index(tag_.second));
     };
+    tag_handlers_["lit"] = [this]() { way_.set_lit(tag_.second == "true" ? true : false); };
   }
 
   static std::string get_lua(const boost::property_tree::ptree& pt) {

--- a/taginfo.json
+++ b/taginfo.json
@@ -7289,6 +7289,70 @@
         "way"
       ],
       "description": "Overrides access flags for wheelchair.  Wheelchair access allowed."
-    }
+    },
+    {
+      "key": "lit",
+      "value": "yes",
+      "object_types": [
+        "way"
+      ],
+      "description": "Considers the way lit"
+    },
+    {
+      "key": "lit",
+      "value": "no",
+      "object_types": [
+        "way"
+      ],
+      "description": "Considers the way unlit"
+    },
+    {
+      "key": "lit",
+      "value": "automatic",
+      "object_types": [
+        "way"
+      ],
+      "description": "Considers the way lit"
+    },
+    {
+      "key": "lit",
+      "value": "24/7",
+      "object_types": [
+        "way"
+      ],
+      "description": "Considers the way lit"
+    },
+    {
+      "key": "lit",
+      "value": "disused",
+      "object_types": [
+        "way"
+      ],
+      "description": "Considers the way unlit"
+    },
+    {
+      "key": "lit",
+      "value": "limited",
+      "object_types": [
+        "way"
+      ],
+      "description": "Considers the way unlit"
+    },
+    {
+      "key": "lit",
+      "value": "sunset-sunrise",
+      "object_types": [
+        "way"
+      ],
+      "description": "Considers the way lit"
+    },
+    {
+      "key": "lit",
+      "value": "dusk-dawn",
+      "object_types": [
+        "way"
+      ],
+      "description": "Considers the way lit"
+    },
   ]
 }

--- a/test/gurka/test_lit.cc
+++ b/test/gurka/test_lit.cc
@@ -24,7 +24,7 @@ gurka::nodelayout LitTest::layout = {};
 //=======================================================================================
 TEST_P(LitTest, tagged_lit) {
 
-  std::string lit_value = std::get<0>(GetParam());
+  const std::string lit_value = std::get<0>(GetParam());
 
   gurka::ways ways = {
       {"AB", {{"highway", "residential"}}},
@@ -37,9 +37,9 @@ TEST_P(LitTest, tagged_lit) {
   gurka::map map = gurka::buildtiles(layout, ways, {}, {}, "test/data/tagged_lit");
   std::shared_ptr<baldr::GraphReader> reader =
       test::make_clean_graphreader(map.config.get_child("mjolnir"));
-  auto edge_tuple = gurka::findEdgeByNodes(*reader, layout, "A", "B");
+  const auto edge_tuple = gurka::findEdgeByNodes(*reader, layout, "A", "B");
   const baldr::DirectedEdge* edge = std::get<1>(edge_tuple);
-  bool evaluates_to = std::get<1>(GetParam());
+  const bool evaluates_to = std::get<1>(GetParam());
   ASSERT_EQ(edge->lit(), evaluates_to);
 }
 

--- a/test/gurka/test_lit.cc
+++ b/test/gurka/test_lit.cc
@@ -24,7 +24,7 @@ gurka::nodelayout LitTest::layout = {};
 //=======================================================================================
 TEST_P(LitTest, tagged_lit) {
 
-  const std::string lit_value = std::get<0>(GetParam());
+  const std::string& lit_value = std::get<0>(GetParam());
 
   gurka::ways ways = {
       {"AB", {{"highway", "residential"}}},
@@ -34,12 +34,12 @@ TEST_P(LitTest, tagged_lit) {
     ways["AB"]["lit"] = lit_value;
   }
 
-  const gurka::map map = gurka::buildtiles(layout, ways, {}, {}, "test/data/tagged_lit");
+  const gurka::map& map = gurka::buildtiles(layout, ways, {}, {}, "test/data/tagged_lit");
   std::shared_ptr<baldr::GraphReader> reader =
       test::make_clean_graphreader(map.config.get_child("mjolnir"));
-  const auto edge_tuple = gurka::findEdgeByNodes(*reader, layout, "A", "B");
+  const auto& edge_tuple = gurka::findEdgeByNodes(*reader, layout, "A", "B");
   const baldr::DirectedEdge* edge = std::get<1>(edge_tuple);
-  const bool evaluates_to = std::get<1>(GetParam());
+  const bool& evaluates_to = std::get<1>(GetParam());
   ASSERT_EQ(edge->lit(), evaluates_to);
 }
 

--- a/test/gurka/test_lit.cc
+++ b/test/gurka/test_lit.cc
@@ -1,0 +1,57 @@
+#include "gurka.h"
+#include "test.h"
+#include <gtest/gtest.h>
+
+#if !defined(VALHALLA_SOURCE_DIR)
+#define VALHALLA_SOURCE_DIR
+#endif
+
+using namespace valhalla;
+
+class LitTest : public ::testing::TestWithParam<std::tuple<std::string, bool>> {
+protected:
+  static gurka::nodelayout layout;
+  static void SetUpTestSuite() {
+    const std::string ascii_map = R"(
+      A---------------------------B
+    )";
+    layout = gurka::detail::map_to_coordinates(ascii_map, 10);
+  }
+};
+
+gurka::nodelayout LitTest::layout = {};
+
+//=======================================================================================
+TEST_P(LitTest, tagged_lit) {
+
+  std::string lit_value = std::get<0>(GetParam());
+
+  gurka::ways ways = {
+      {"AB", {{"highway", "residential"}}},
+  };
+
+  if (!lit_value.empty()) {
+    ways["AB"]["lit"] = lit_value;
+  }
+
+  gurka::map map = gurka::buildtiles(layout, ways, {}, {}, "test/data/tagged_lit");
+  std::shared_ptr<baldr::GraphReader> reader =
+      test::make_clean_graphreader(map.config.get_child("mjolnir"));
+  auto edge_tuple = gurka::findEdgeByNodes(*reader, layout, "A", "B");
+  const baldr::DirectedEdge* edge = std::get<1>(edge_tuple);
+  bool evaluates_to = std::get<1>(GetParam());
+  ASSERT_EQ(edge->lit(), evaluates_to);
+}
+
+INSTANTIATE_TEST_SUITE_P(LitTest,
+                         LitTest,
+                         ::testing::Values(std::make_tuple("limited", false),
+                                           std::make_tuple("yes", true),
+                                           std::make_tuple("sunset-sunrise", true),
+                                           std::make_tuple("no", false),
+                                           std::make_tuple("dusk-dawn", true),
+                                           std::make_tuple("automatic", true),
+                                           std::make_tuple("24/7", true),
+                                           std::make_tuple("disused", false),
+                                           std::make_tuple("", false)) // no lit tag
+);

--- a/test/gurka/test_lit.cc
+++ b/test/gurka/test_lit.cc
@@ -34,7 +34,7 @@ TEST_P(LitTest, tagged_lit) {
     ways["AB"]["lit"] = lit_value;
   }
 
-  gurka::map map = gurka::buildtiles(layout, ways, {}, {}, "test/data/tagged_lit");
+  const gurka::map map = gurka::buildtiles(layout, ways, {}, {}, "test/data/tagged_lit");
   std::shared_ptr<baldr::GraphReader> reader =
       test::make_clean_graphreader(map.config.get_child("mjolnir"));
   const auto edge_tuple = gurka::findEdgeByNodes(*reader, layout, "A", "B");

--- a/valhalla/baldr/directededge.h
+++ b/valhalla/baldr/directededge.h
@@ -1126,6 +1126,20 @@ public:
   }
 
   /**
+   * Set the flag indicating whether the edge is lit
+   * @param lit the edge's lit state
+   */
+  void set_lit(const bool lit);
+
+  /**
+   * Is the edge lit?
+   * @return Returns the edge's lit state
+   */
+  bool lit() const {
+    return lit_;
+  }
+
+  /**
    * Create a json object representing this edge
    * @return  Returns the json object
    */
@@ -1192,7 +1206,8 @@ protected:
   uint64_t yield_sign_ : 1;     // Yield/give way sign at end of the directed edge
   uint64_t hov_type_ : 1;       // if (is_hov_only()==true), this means (HOV2=0, HOV3=1)
   uint64_t indoor_ : 1;         // Is this edge indoor
-  uint64_t spare4_ : 5;
+  uint64_t lit_ : 1;            // Is the edge lit?
+  uint64_t spare4_ : 4;
 
   // 5th 8-byte word
   uint64_t turntype_ : 24;      // Turn type (see graphconstants.h)

--- a/valhalla/mjolnir/osmway.h
+++ b/valhalla/mjolnir/osmway.h
@@ -1843,7 +1843,8 @@ struct OSMWay {
   uint16_t use_sidepath_ : 1;
   uint16_t bike_forward_ : 1;
   uint16_t bike_backward_ : 1;
-  uint16_t spare2_ : 4;
+  bool lit_ : 1;
+  uint16_t spare2_ : 3;
 
   uint16_t nodecount_;
 
@@ -1865,9 +1866,6 @@ struct OSMWay {
 
   // layer index(Z-level) of the way relatively to other levels
   int8_t layer_;
-
-  // whether or not the street is lit
-  bool lit_;
 };
 
 } // namespace mjolnir

--- a/valhalla/mjolnir/osmway.h
+++ b/valhalla/mjolnir/osmway.h
@@ -1683,6 +1683,24 @@ struct OSMWay {
   }
 
   /**
+   * Sets the lit state
+   *
+   * @param lit whether the way is lit.
+   */
+  void set_lit(const bool lit) {
+    lit_ = lit;
+  }
+
+  /**
+   * Get the lit state.
+   *
+   * @return bool
+   */
+  bool lit() const {
+    return lit_;
+  }
+
+  /**
    * Get the names for the edge info based on the road class.
    * @param  ref              updated refs from relations.
    * @param  name_offset_map  map of unique names and refs from ways.
@@ -1847,6 +1865,9 @@ struct OSMWay {
 
   // layer index(Z-level) of the way relatively to other levels
   int8_t layer_;
+
+  // whether or not the street is lit
+  bool lit_;
 };
 
 } // namespace mjolnir


### PR DESCRIPTION
fixes #3848 

This PR adds parsing of the `lit` tag:

  - parse the possible values and map them to a boolean value in `graph.lua` 
  - add `lit` as a member variable to `OSMWay`
  - add `lit` as a member variable to the `DirectedEdge` class, thereby allocating one of the remaining bits
  - add the `lit` tag and the values we parse to `taginfo.json`
  
I also added a short parameterized test going through the different possible values of `lit`, including its absence.