### PR TITLE
fixed underflow of uint64_t cast for matrix time results

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -39,7 +39,7 @@ jobs:
       VCPKG_DIR: '$(Build.SourcesDirectory)\vcpkg'
       VCPKG_ROOT: '$(Build.SourcesDirectory)\vcpkg'
       VCPKG_INSTALLATION_ROOT: '$(Build.SourcesDirectory)\vcpkg'
-      VCPKG_REF: '2022.08.15'
+      VCPKG_REF: '2023.01.09'
       TRIPLET: 'x64'
       CONAN_HOME: '$(Build.SourcesDirectory)/conan'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Release Date: 2022-??-?? Valhalla 3.3.1
 * **Removed**
 * **Bug Fix**
+   * FIXED: underflow of uint64_t cast for matrix time results [#3906](https://github.com/valhalla/valhalla/pull/3890)
 * **Enhancement**
    * CHANGED: replace boost::optional with C++17's std::optional where possible [#3890](https://github.com/valhalla/valhalla/pull/3890)
    * ADDED: parse `lit` tag on ways and add it to graph [#3893](https://github.com/valhalla/valhalla/pull/3893)

--- a/test/gurka/test_matrix_time_dependent.cc
+++ b/test/gurka/test_matrix_time_dependent.cc
@@ -36,7 +36,7 @@ void check_dist(const rapidjson::Document& result,
                         std::to_string(i % origin_td.Size());
       EXPECT_NEAR(v.GetObject()["distance"].GetFloat(), exp_dists[i], 0.01) << msg;
       if (valid_traffic) {
-        EXPECT_TRUE(v.GetObject().HasMember("date_time"));
+        EXPECT_TRUE(v.GetObject().HasMember("date_time")) << msg;
       }
       i++;
     }

--- a/valhalla/thor/timedistancematrix.h
+++ b/valhalla/thor/timedistancematrix.h
@@ -229,6 +229,7 @@ protected:
                           const baldr::DirectedEdge* edge,
                           const graph_tile_ptr& tile,
                           const sif::EdgeLabel& pred,
+                          const baldr::TimeInfo& time_info,
                           const uint32_t matrix_locations);
 
   /**


### PR DESCRIPTION
We had bug report per email from a client that sometimes the matrix (with traffic enabled) gives a unreasonable high `time` result of 4294967295. I looked and it's possible we're casting negative floats to uint64_t.