### PR TITLE
update vcpkg commit for Azure pipelines to fix libtool mirrors 

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -29,12 +29,12 @@ pr:
   drafts: false
 
 jobs:
-  - job: VS2019
-    displayName: 'Windows 2019 | VS2019'
+  - job: VS2022
+    displayName: 'Windows 2022 | VS2022'
     timeoutInMinutes: 120
 
     pool:
-      vmImage: 'windows-2019'
+      vmImage: 'windows-2022'
 
     variables:
       BUILD_CFG: 'Release'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -7,7 +7,10 @@
 
 # No wildcards allowed for file patterns...
 # skip draft PR's, skip all commits except for PRs to master
-trigger: none
+trigger:
+  branches:
+    include:
+      - master
 pr:
   branches:
     include:
@@ -39,7 +42,8 @@ jobs:
       VCPKG_DIR: '$(Build.SourcesDirectory)\vcpkg'
       VCPKG_ROOT: '$(Build.SourcesDirectory)\vcpkg'
       VCPKG_INSTALLATION_ROOT: '$(Build.SourcesDirectory)\vcpkg'
-      VCPKG_REF: '2023.01.09'
+      # points to recent commit in master after a bug fix in vcpkg
+      VCPKG_REF: '51e10eb'
       TRIPLET: 'x64'
       CONAN_HOME: '$(Build.SourcesDirectory)/conan'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * **Removed**
 * **Bug Fix**
    * FIXED: underflow of uint64_t cast for matrix time results [#3906](https://github.com/valhalla/valhalla/pull/3906)
+   * FIXED: update vcpkg commit for Azure pipelines to fix libtool mirrors [#3915](https://github.com/valhalla/valhalla/pull/3915)
 * **Enhancement**
    * CHANGED: replace boost::optional with C++17's std::optional where possible [#3890](https://github.com/valhalla/valhalla/pull/3890)
    * ADDED: parse `lit` tag on ways and add it to graph [#3893](https://github.com/valhalla/valhalla/pull/3893)


### PR DESCRIPTION
and build azure on master pushes

fixes #3914 
