### PR TITLE
log matrix algorithm which was used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
    * CHANGED: replace boost::optional with C++17's std::optional where possible [#3890](https://github.com/valhalla/valhalla/pull/3890)
    * ADDED: parse `lit` tag on ways and add it to graph [#3893](https://github.com/valhalla/valhalla/pull/3893)
    * ADDED: log lat/lon of node where children link edges exceed the configured maximum [#3911](https://github.com/valhalla/valhalla/pull/3911)
+   * ADDED: log matrix algorithm which was used [#3916](https://github.com/valhalla/valhalla/pull/3916)
 
 ## Release Date: 2022-01-03 Valhalla 3.3.0
 * **Removed**

--- a/src/thor/costmatrix.cc
+++ b/src/thor/costmatrix.cc
@@ -114,6 +114,9 @@ std::vector<TimeDistance> CostMatrix::SourceToTarget(
     const sif::mode_costing_t& mode_costing,
     const travel_mode_t mode,
     const float max_matrix_distance) {
+
+  LOG_INFO("matrix::CostMatrix");
+
   // Set the mode and costing
   mode_ = mode;
   costing_ = mode_costing[static_cast<uint32_t>(mode_)];

--- a/valhalla/thor/timedistancematrix.h
+++ b/valhalla/thor/timedistancematrix.h
@@ -55,6 +55,9 @@ public:
                  const float max_matrix_distance,
                  const uint32_t matrix_locations = kAllLocations,
                  const bool invariant = false) {
+
+    LOG_INFO("matrix::TimeDistanceMatrix");
+
     // Set the mode and costing
     mode_ = mode;
     costing_ = mode_costing[static_cast<uint32_t>(mode_)];


### PR DESCRIPTION
Someone reported to find the same performance when using `date_time` as without, which shouldn't happen as it should use TimeDistanceMatrix for the time-aware request and CostMatrix if not, regardless if there's actually any traffic info loaded.

I figured it's good to log the algorithm, similar as we do it for route.