### PR TITLE
fix python .so name in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN tar -cvf valhalla.debug.tar valhalla_*.debug && gzip -9 valhalla.debug.tar
 RUN rm -f valhalla_*.debug
 RUN strip --strip-debug --strip-unneeded valhalla_* || true
 RUN strip /usr/local/lib/libvalhalla.a
-RUN strip /usr/lib/python3/dist-packages/valhalla/python_valhalla.cpython-38-x86_64-linux-gnu.so
+RUN strip /usr/lib/python3/dist-packages/valhalla/python_valhalla.cpython-310-x86_64-linux-gnu.so
 
 ####################################################################
 # copy the important stuff from the build stage to the runner image


### PR DESCRIPTION
hot fix: ubuntu 22.04 has python 3.10 installed, not 3.8. _not_ tested locally, got work to do ;) but should work :crossed_fingers: 