### PR TITLE
fix stitching errors in gtfs ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
    * FIXED: fix CHANGELOG release year (2022->2023) [#3927](https://github.com/valhalla/valhalla/pull/3927)
    * FIXED: avoid segfault on invalid exclude_polygons input [#3907](https://github.com/valhalla/valhalla/pull/3907)
    * FIXED: allow \_WIN32_WINNT to be defined by build system [#3933](https://github.com/valhalla/valhalla/issues/3933)
+   * FIXED: disconnected stop pairs in gtfs import [#3943](https://github.com/valhalla/valhalla/pull/3943)
 * **Enhancement**
    * CHANGED: replace boost::optional with C++17's std::optional where possible [#3890](https://github.com/valhalla/valhalla/pull/3890)
    * ADDED: parse `lit` tag on ways and add it to graph [#3893](https://github.com/valhalla/valhalla/pull/3893)

--- a/test/gurka/test_gtfs.cc
+++ b/test/gurka/test_gtfs.cc
@@ -328,11 +328,10 @@ TEST(GtfsExample, MakeProto) {
 
       // stop_pair info
       for (int i = 0; i < transit.stop_pairs_size(); i++) {
+        EXPECT_TRUE(transit.stop_pairs(i).has_origin_graphid());
+        EXPECT_TRUE(transit.stop_pairs(i).has_destination_graphid());
         stop_pairs.insert(transit.stop_pairs(i).origin_onestop_id());
         stop_pairs.insert(transit.stop_pairs(i).destination_onestop_id());
-        // TODO: we have to have properly stitched together all the pairs
-        // EXPECT_FALSE(transit.stop_pairs(i).origin_graphid() != kInvalidGraphId);
-        // EXPECT_FALSE(transit.stop_pairs(i).destination_graphid() != kInvalidGraphId);
       }
 
       // calendar information

--- a/test/gurka/test_gtfs.cc
+++ b/test/gurka/test_gtfs.cc
@@ -121,19 +121,19 @@ TEST(GtfsExample, WriteGtfs) {
   };
   feed.add_stop(nemo);
   struct gtfs::Stop nemo_egress {
-    .stop_id = stopOneID + "_" + to_string(NodeType::kTransitEgress),
-    .stop_name = gtfs::Text("POINT NEMO"), .coordinates_present = true,
-    .stop_lat = station_one_ll->second.second, .stop_lon = station_one_ll->second.first,
-    .parent_station = stopOneID, .location_type = gtfs::StopLocationType::EntranceExit,
-    .stop_timezone = "America/Toronto", .wheelchair_boarding = "1",
+    .stop_id = stopOneID + "_rotating_door_eh", .stop_name = gtfs::Text("POINT NEMO"),
+    .coordinates_present = true, .stop_lat = station_one_ll->second.second,
+    .stop_lon = station_one_ll->second.first, .parent_station = stopOneID,
+    .location_type = gtfs::StopLocationType::EntranceExit, .stop_timezone = "America/Toronto",
+    .wheelchair_boarding = "1",
   };
   feed.add_stop(nemo_egress);
   struct gtfs::Stop nemo_platform {
-    .stop_id = stopOneID + "_" + to_string(NodeType::kMultiUseTransitPlatform),
-    .stop_name = gtfs::Text("POINT NEMO"), .coordinates_present = true,
-    .stop_lat = station_one_ll->second.second, .stop_lon = station_one_ll->second.first,
-    .parent_station = stopOneID, .location_type = gtfs::StopLocationType::StopOrPlatform,
-    .stop_timezone = "America/Toronto", .wheelchair_boarding = "1",
+    .stop_id = stopOneID + "_ledge_to_the_train_bucko", .stop_name = gtfs::Text("POINT NEMO"),
+    .coordinates_present = true, .stop_lat = station_one_ll->second.second,
+    .stop_lon = station_one_ll->second.first, .parent_station = stopOneID,
+    .location_type = gtfs::StopLocationType::StopOrPlatform, .stop_timezone = "America/Toronto",
+    .wheelchair_boarding = "1",
   };
   feed.add_stop(nemo_platform);
 
@@ -152,6 +152,15 @@ TEST(GtfsExample, WriteGtfs) {
     .stop_timezone = "America/Toronto", .wheelchair_boarding = "1",
   };
   feed.add_stop(thirdStop);
+  struct gtfs::Stop thirdStopPlatform {
+    .stop_id = stopThreeID + "_walk_the_plank_pal", .stop_name = gtfs::Text("THIRD STOP"),
+    .coordinates_present = true, .stop_lat = station_three_ll->second.second,
+    .stop_lon = station_three_ll->second.first, .parent_station = stopThreeID,
+    .location_type = gtfs::StopLocationType::StopOrPlatform, .stop_timezone = "America/Toronto",
+    .wheelchair_boarding = "1",
+  };
+  feed.add_stop(thirdStopPlatform);
+
   feed.write_stops(path_directory);
 
   // write routes.txt
@@ -181,8 +190,11 @@ TEST(GtfsExample, WriteGtfs) {
   feed.write_trips(path_directory);
 
   // write stop_times.txt
-  std::string stopIds[3] = {stopOneID + "_" + to_string(NodeType::kMultiUseTransitPlatform),
-                            stopTwoID, stopThreeID};
+  std::string stopIds[3] = {
+      stopOneID + "_ledge_to_the_train_bucko",
+      stopTwoID,
+      stopThreeID + "_walk_the_plank_pal",
+  };
   for (int i = 0; i < 6; i++) {
     struct StopTime stopTime {
       .trip_id = "", .stop_id = "", .stop_sequence = 0, .arrival_time = Time("6:00:00"),
@@ -257,7 +269,7 @@ TEST(GtfsExample, WriteGtfs) {
   EXPECT_EQ(trips[0].trip_id, tripOneID);
 
   const auto& stops = feed_reader.get_stops();
-  EXPECT_EQ(stops.size(), 5);
+  EXPECT_EQ(stops.size(), 6);
   EXPECT_EQ(stops[0].stop_id, stopOneID);
 
   const auto& shapes = feed_reader.get_shapes();
@@ -351,15 +363,17 @@ TEST(GtfsExample, MakeProto) {
   }
   EXPECT_EQ(stops.size(), 9);
   std::string stopIds[3] = {stopOneID, stopTwoID, stopThreeID};
-  std::string stop_pair_ids[3] = {stopOneID + "_" + to_string(NodeType::kMultiUseTransitPlatform),
-                                  stopTwoID + "_" + to_string(NodeType::kMultiUseTransitPlatform),
-                                  stopThreeID + "_" + to_string(NodeType::kMultiUseTransitPlatform)};
+  std::string stop_pair_ids[3] = {
+      stopOneID + "_ledge_to_the_train_bucko",
+      stopTwoID + "_" + to_string(NodeType::kMultiUseTransitPlatform),
+      stopThreeID + "_walk_the_plank_pal",
+  };
 
   for (const auto& stopID : stopIds) {
-    EXPECT_EQ(*stops.find(stopID), stopID);
+    EXPECT_TRUE(stops.find(stopID) != stops.end());
   }
   for (const auto& stop_pair_id : stop_pair_ids) {
-    EXPECT_EQ(*stops.find(stop_pair_id), stop_pair_id);
+    EXPECT_TRUE(stops.find(stop_pair_id) != stops.end());
   }
   // TODO: MAKE SURE ALL THE GENEREATED STOPS ARE ALSO TESTED FOR
 }
@@ -384,7 +398,7 @@ TEST(GtfsExample, MakeTile) {
 
   GraphReader reader(pt.get_child("mjolnir"));
   auto graphids = reader.GetTileSet();
-  int totalNodes = 0;
+  size_t transit_nodes = 0;
   std::unordered_map<baldr::Use, size_t> uses;
   for (auto graphid : graphids) {
     LOG_INFO("Working on : " + std::to_string(graphid));
@@ -407,7 +421,7 @@ TEST(GtfsExample, MakeTile) {
       LOG_INFO("There are " + std::to_string(tile->GetNodes().size()) + " nodes inside tile " +
                std::to_string(graphid));
     }
-    totalNodes += tile->header()->nodecount();
+    transit_nodes += tile->header()->nodecount();
     std::unordered_set<NodeType> node_types = {NodeType::kMultiUseTransitPlatform,
                                                NodeType::kTransitStation, NodeType::kTransitEgress};
     std::vector<PointLL> station_coords = {station_one_ll->second, station_two_ll->second,
@@ -450,14 +464,15 @@ TEST(GtfsExample, MakeTile) {
     }
   }
 
-  EXPECT_EQ(totalNodes, 9);
+  EXPECT_EQ(transit_nodes, 9);
   EXPECT_EQ(uses[Use::kRoad], 6);
-  // TODO: transit connect edges should only exist between egress and street nodes
-  // EXPECT_EQ(uses[Use::kTransitConnection], 6);
+  // NOTE: there are 4 for every station (3 of those) because we connect to both ends of the closest
+  // edge to the station and the connections are bidirectional (as per usual)
+  EXPECT_EQ(uses[Use::kTransitConnection], 12);
   EXPECT_EQ(uses[Use::kPlatformConnection], 6);
   EXPECT_EQ(uses[Use::kEgressConnection], 6);
-  // TODO: it looks like convert transit skips putting any actual rail edges into level 3
-  // EXPECT_EQ(uses[Use::kRail], 4);
+  // TODO: this is the only time in the graph that we dont have opposing directed edges (should fix)
+  EXPECT_EQ(uses[Use::kRail], 2);
 }
 
 // TODO: TEST THAT TRANSIT ROUTING IS FUNCTIONAL BY MULTIMOTDAL ROUTING THROUGH WAYPOINTS, CHECK THAT


### PR DESCRIPTION
After merging #3700 i wrote a huge pr description with the work left to do. i will convert that into an issue and we can burn down the tasks but today i bring  you the first task already burned down. There were errors about not being able to find the origin/destination stops of some of the stop pairs (the connections between stations where you actually ride on public transit). this makes other things fail. thankfully the problem wasnt all that complex. i'll describe the fix in the diff, comments should as well

ok so the only sad thing about fixing the stitching error was that the error wasnt stitching at all. this means that in a separate pr we need to offset the graph a bit more so that a trip crosses tiles (forcing stitchign to have to happen). i can add this to the list of things we need to do