### PR TITLE
fix the accessibility of transit connect edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
    * FIXED: avoid segfault on invalid exclude_polygons input [#3907](https://github.com/valhalla/valhalla/pull/3907)
    * FIXED: allow \_WIN32_WINNT to be defined by build system [#3933](https://github.com/valhalla/valhalla/issues/3933)
    * FIXED: disconnected stop pairs in gtfs import [#3943](https://github.com/valhalla/valhalla/pull/3943)
+   * FIXED: in/egress traversability in gtfs ingestion is now defaulted to kBoth to enable pedestrian access on transit connect edges and through the in/egress node [#3948](https://github.com/valhalla/valhalla/pull/3948)
 * **Enhancement**
    * CHANGED: replace boost::optional with C++17's std::optional where possible [#3890](https://github.com/valhalla/valhalla/pull/3890)
    * ADDED: parse `lit` tag on ways and add it to graph [#3893](https://github.com/valhalla/valhalla/pull/3893)

--- a/src/mjolnir/ingest_transit.cc
+++ b/src/mjolnir/ingest_transit.cc
@@ -246,8 +246,14 @@ void setup_stops(Transit& tile,
   // change set_type to match the child / parent type.
   node->set_type(static_cast<uint32_t>(node_type));
   node->set_graphid(node_id);
+
   if (node_type != NodeType::kTransitEgress) {
     node->set_prev_type_graphid(prev_id.Is_Valid() ? prev_id : node_id - 1);
+  } // in/egresses need accessibility set so that transit connect edges inherit that access
+  else {
+    // TODO: its unclear how to determine unidirectionality (entrance-only vs exit-only) from the gtfs
+    //  spec, perhaps one should use pathways.txt::is_bidirectional to differentiate?
+    node->set_traversability(static_cast<uint32_t>(Traversability::kBoth));
   }
   node->set_name(tile_stop.stop_name);
   node->set_timezone(tile_stop.stop_timezone);

--- a/test/gurka/test_gtfs.cc
+++ b/test/gurka/test_gtfs.cc
@@ -478,7 +478,7 @@ TEST(GtfsExample, MakeTile) {
 // TODO: TEST THAT TRANSIT ROUTING IS FUNCTIONAL BY MULTIMOTDAL ROUTING THROUGH WAYPOINTS, CHECK THAT
 // THE TRIP TYPE IS A TRANSIT TYPE
 
-TEST(GtfsExample, DISABLED_testRouting) {
+TEST(GtfsExample, testRouting) {
 
   boost::property_tree::ptree pt = get_config();
 


### PR DESCRIPTION
So the transit routing test was failing because the transit connect edges (the ones from the street network to the transit network) are marked with no pedestrian (or any other) access. This was because during the transit gtfs feed ingestion we forgot to set the in/egress node traversability (this can be either none (default), both, entrance or exit). at the moment the ingestion doesnt have the ability to differentiate between entrance and exit so the fix here is to simply set to both (the new default). transitland provided a "directionality" on in/egresses and it is unclear exactly where this comes from.

looking at the spec it might come from `pathways.txt::is_unidirectional` where the spec can tell you between two stops (in this case stop means any of the 4 types: platform, station, in/egress/generic or boarding area) what directions you can walk (the oneway-ness of edges within the station). from that we could determine that if from a an in/egress to a station node  you can only go forward and not reverse then it must be ingress-only and not egress, similar story for from station to in/egress must be egress-only and not ingress. we can and should add a TODO to parse this information in the first phase of ingestion so that in the future we abide by it. for now it is enough to allow access in my opinion.

anyway by allowing access at these nodes, we propogate (in transit builder) that access onto the transit connection edges we create. because these node traversibilities were not set, and their default is `kNone`, when we made the transit connection edges they also got the same access, which is to say no access. costing then couldnt use them to find transit stations in the data and so the first check in the multimodal algorithm failed with: i dont see any freaking transit stations in your data wtf.

with this fixed the algorithm now says it just cant find a path, which is likely to do with schedule information. there are 3 things to check there:

1. either in the feed to tiles conversion is still screwing up the dates (have to check pivot date and numerical conversions as well as schedule validity dates)
2. the test data we put in the test feed is wrong
3. or the test request specifies the date wrong