### PR TITLE
parsing logic needed implicit order of stations/egresses/platforms the GTFS feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
    * FIXED: avoid segfault on invalid exclude_polygons input [#3907](https://github.com/valhalla/valhalla/pull/3907)
    * FIXED: allow \_WIN32_WINNT to be defined by build system [#3933](https://github.com/valhalla/valhalla/issues/3933)
    * FIXED: disconnected stop pairs in gtfs import [#3943](https://github.com/valhalla/valhalla/pull/3943)
+   * FIXED: 
 * **Enhancement**
    * CHANGED: replace boost::optional with C++17's std::optional where possible [#3890](https://github.com/valhalla/valhalla/pull/3890)
    * ADDED: parse `lit` tag on ways and add it to graph [#3893](https://github.com/valhalla/valhalla/pull/3893)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
    * FIXED: avoid segfault on invalid exclude_polygons input [#3907](https://github.com/valhalla/valhalla/pull/3907)
    * FIXED: allow \_WIN32_WINNT to be defined by build system [#3933](https://github.com/valhalla/valhalla/issues/3933)
    * FIXED: disconnected stop pairs in gtfs import [#3943](https://github.com/valhalla/valhalla/pull/3943)
-   * FIXED: 
    * FIXED: in/egress traversability in gtfs ingestion is now defaulted to kBoth to enable pedestrian access on transit connect edges and through the in/egress node [#3948](https://github.com/valhalla/valhalla/pull/3948)
+   * FIXED: parsing logic needed implicit order of stations/egresses/platforms in the GTFS feeds [#3949](https://github.com/valhalla/valhalla/pull/3949)
 * **Enhancement**
    * CHANGED: replace boost::optional with C++17's std::optional where possible [#3890](https://github.com/valhalla/valhalla/pull/3890)
    * ADDED: parse `lit` tag on ways and add it to graph [#3893](https://github.com/valhalla/valhalla/pull/3893)

--- a/src/mjolnir/ingest_transit.cc
+++ b/src/mjolnir/ingest_transit.cc
@@ -184,9 +184,10 @@ std::priority_queue<tile_transit_info_t> select_transit_tiles(const boost::prope
           // 1) this stop has none or 2) its parent station is in another tile
           // TODO: need to handle the 2nd case somehow!
           auto parent_station = feed.get_stop(stop.parent_station);
-          if (tile_info.graphid !=
-              GraphId(local_tiles.TileId(parent_station->stop_lat, parent_station->stop_lon),
-                      TileHierarchy::GetTransitLevel().level, 0)) {
+          if (parent_station &&
+              tile_info.graphid !=
+                  GraphId(local_tiles.TileId(parent_station->stop_lat, parent_station->stop_lon),
+                          TileHierarchy::GetTransitLevel().level, 0)) {
             LOG_WARN("Station ID " + stop.parent_station + " is not in stop's " + stop.stop_id +
                      " tile: " + std::to_string(tile_info.graphid));
           }

--- a/src/mjolnir/ingest_transit.cc
+++ b/src/mjolnir/ingest_transit.cc
@@ -326,6 +326,7 @@ std::unordered_map<feed_object_t, GraphId> write_stops(Transit& tile,
     }
     // We require platforms as well so if we didnt add at least 1 we need to fake one now
     if (tile.nodes_size() == node_count) {
+      LOG_WARN("Generated platform for station " + station_as_stop->stop_id);
       setup_stops(tile, *station_as_stop, node_id, platform_node_ids, station.feed,
                   NodeType::kMultiUseTransitPlatform, true, prev_id);
     }

--- a/test/gurka/test_gtfs.cc
+++ b/test/gurka/test_gtfs.cc
@@ -113,13 +113,6 @@ TEST(GtfsExample, WriteGtfs) {
   feed.write_agencies(path_directory);
 
   // write stops.txt
-  struct gtfs::Stop nemo {
-    .stop_id = stopOneID, .stop_name = gtfs::Text("POINT NEMO"), .coordinates_present = true,
-    .stop_lat = station_one_ll->second.second, .stop_lon = station_one_ll->second.first,
-    .parent_station = "", .location_type = gtfs::StopLocationType::Station,
-    .stop_timezone = "America/Toronto", .wheelchair_boarding = "1",
-  };
-  feed.add_stop(nemo);
   struct gtfs::Stop nemo_egress {
     .stop_id = stopOneID + "_rotating_door_eh", .stop_name = gtfs::Text("POINT NEMO"),
     .coordinates_present = true, .stop_lat = station_one_ll->second.second,
@@ -136,6 +129,13 @@ TEST(GtfsExample, WriteGtfs) {
     .wheelchair_boarding = "1",
   };
   feed.add_stop(nemo_platform);
+  struct gtfs::Stop nemo {
+    .stop_id = stopOneID, .stop_name = gtfs::Text("POINT NEMO"), .coordinates_present = true,
+    .stop_lat = station_one_ll->second.second, .stop_lon = station_one_ll->second.first,
+    .parent_station = "", .location_type = gtfs::StopLocationType::Station,
+    .stop_timezone = "America/Toronto", .wheelchair_boarding = "1",
+  };
+  feed.add_stop(nemo);
 
   struct gtfs::Stop secondStop {
     .stop_id = stopTwoID, .stop_name = gtfs::Text("SECOND STOP"), .coordinates_present = true,
@@ -270,7 +270,7 @@ TEST(GtfsExample, WriteGtfs) {
 
   const auto& stops = feed_reader.get_stops();
   EXPECT_EQ(stops.size(), 6);
-  EXPECT_EQ(stops[0].stop_id, stopOneID);
+  EXPECT_EQ(stops[2].stop_id, stopOneID);
 
   const auto& shapes = feed_reader.get_shapes();
   EXPECT_EQ(shapes.size(), 6);


### PR DESCRIPTION
Fixed a bug in `ingest_transit` which assumed that stations are always the first entities in a GTFS feed's `stops.txt`, which the spec doesn't mention and very sure isn't the case for real GTFS feeds.

Also refactored a lot to make the logic (and variable names) a bit saner;)