### PR TITLE
write multiple PBFs if the protobuf object gets too big

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
    * FIXED: disconnected stop pairs in gtfs import [#3943](https://github.com/valhalla/valhalla/pull/3943)
    * FIXED: in/egress traversability in gtfs ingestion is now defaulted to kBoth to enable pedestrian access on transit connect edges and through the in/egress node [#3948](https://github.com/valhalla/valhalla/pull/3948)
    * FIXED: parsing logic needed implicit order of stations/egresses/platforms in the GTFS feeds [#3949](https://github.com/valhalla/valhalla/pull/3949)
+   * FIXED: write multiple PBFs if the protobuf object gets too big [#3954](https://github.com/valhalla/valhalla/pull/3954)
 * **Enhancement**
    * CHANGED: replace boost::optional with C++17's std::optional where possible [#3890](https://github.com/valhalla/valhalla/pull/3890)
    * ADDED: parse `lit` tag on ways and add it to graph [#3893](https://github.com/valhalla/valhalla/pull/3893)

--- a/src/mjolnir/convert_transit.cc
+++ b/src/mjolnir/convert_transit.cc
@@ -1237,6 +1237,7 @@ std::unordered_set<GraphId> convert_transit(const ptree& pt) {
       std::to_string(TileHierarchy::GetTransitLevel().level));
   filesystem::recursive_directory_iterator end_file_itr;
   std::unordered_set<GraphId> all_tiles;
+  // TODO: make this robust to .pbf.x scheme that ingest_traffic generates
   for (; transit_file_itr != end_file_itr; ++transit_file_itr) {
     if (filesystem::is_regular_file(transit_file_itr->path()) &&
         transit_file_itr->path().extension() == ".pbf") {

--- a/valhalla/mjolnir/ingest_transit.h
+++ b/valhalla/mjolnir/ingest_transit.h
@@ -48,16 +48,6 @@ Transit read_pbf(const std::string& file_name, std::mutex& lock);
 Transit read_pbf(const std::string& file_name);
 
 /**
- * @brief Get PBF transit data given a GraphId / tile
- *
- * @param id graphId of the tile
- * @param transit_dir directory where transit data is located
- * @param file_name  name of the file
- * @return transit data of the tile with the given GraphId
- */
-Transit read_pbf(const baldr::GraphId& id, const std::string& transit_dir, std::string& file_name);
-
-/**
  * @brief writes transit information inside the tile to a protobuf
  *
  * @param tile contains transit data


### PR DESCRIPTION
We had a small bug where large PBF objects wouldn't be able to get serialized.

TODO: fix `convert_transit.cc` to handle `.pbf.x` file extensions.