### PR TITLE
dont require precommit for proper formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-  # C++
+  # liniting c++ and python
   - repo: local
     hooks:
     - id: format
@@ -7,27 +7,3 @@ repos:
       entry: bash ./scripts/format.sh
       language: system
       pass_filenames: false
-
-  # Python formatter
-  - repo: https://github.com/psf/black
-    rev: 22.10.0
-    hooks:
-      - id: black
-        language_version: python3
-        args: ['--line-length=105', '--skip-string-normalization']
-        files: ^(src/bindings/python/|scripts/)
-
-  # Python linter
-  - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
-    hooks:
-      - id: flake8
-        # E501: ignore line length (black auto-formats)
-        # E731: ignore replace-lambda-with-def warnings
-        # E203: ignore "whitespace before ':'"
-        args: [
-          '--max-line-length=105',
-          '--extend-ignore=E501,E731,E203',
-          '--extend-exclude=src/bindings/python/__init__.py'
-        ]
-        files: ^(src/bindings/python/|scripts/)

--- a/scripts/bash_utils.sh
+++ b/scripts/bash_utils.sh
@@ -27,3 +27,16 @@ function setup_mason {
   fi
 
 }
+
+function setup_python {
+  local python_bin=""
+  if [[ $(command -v python3) != "" ]]; then
+    python_bin="python3"
+  elif [[ $(command -v python) != "" ]]; then
+    python_bin="python"
+  else
+    echo "WARNING: install python3 for linting" 1>&2
+    return
+  fi
+  echo ${python_bin}
+}

--- a/scripts/bash_utils.sh
+++ b/scripts/bash_utils.sh
@@ -27,19 +27,3 @@ function setup_mason {
   fi
 
 }
-
-function setup_pre_commit {
-  local python_bin=""
-  if [[ $(command -v python3) != "" ]]; then
-    python_bin="python3"
-  elif [[ $(command -v python) != "" ]]; then
-    python_bin="python"
-  else
-    echo "WARNING: install python3 to set up pre-commit hooks."
-    return
-  fi
-  echo "INFO: Installing pre-commit"
-  ${python_bin} -m pip install --user --upgrade pre-commit
-  echo "INFO: Setting up pre-commit hooks"
-  ${python_bin} -m pre_commit install
-}

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -25,7 +25,7 @@ find src valhalla test bench -type f -name '*.h' -o -name '*.cc' \
 
 # Python setup
 py=$(setup_python)
-pip install black==22.10.0 flake8==5.0.4
+${py} -m pip install black==22.10.0 flake8==5.0.4
 python_sources=$(LANG=C find scripts src/bindings/python -type f -exec file {} \; | grep -F "Python script" | sed 's/:.*//')
 
 # Python formatter

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -12,7 +12,6 @@ readonly CLANG_FORMAT_VERSION=11.0.0
 
 source scripts/bash_utils.sh
 setup_mason
-setup_pre_commit
 
 ./mason/mason install clang-format $CLANG_FORMAT_VERSION
 ./mason/mason link clang-format $CLANG_FORMAT_VERSION
@@ -22,3 +21,14 @@ echo "Using clang-format $CLANG_FORMAT_VERSION from ${CLANG_FORMAT}"
 
 find src valhalla test bench -type f -name '*.h' -o -name '*.cc' \
   | xargs -I{} -P ${NPROC} ${CLANG_FORMAT} -i -style=file {}
+
+
+# Python setup
+python_sources=$(LANG=C find scripts src/bindings/python -type f -exec file {} \; | grep -F "Python script" | sed 's/:.*//')
+pip install black==22.10.0 flake8==5.0.4
+
+# Python formatter
+python -m black --line-length=105 --skip-string-normalization ${python_sources}
+
+# Python linter
+python -m flake8 --max-line-length=105 --extend-ignore=E501,E731,E203 --extend-exclude=src/bindings/python/__init__.py ${python_sources}

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -24,11 +24,12 @@ find src valhalla test bench -type f -name '*.h' -o -name '*.cc' \
 
 
 # Python setup
-python_sources=$(LANG=C find scripts src/bindings/python -type f -exec file {} \; | grep -F "Python script" | sed 's/:.*//')
+py=$(setup_python)
 pip install black==22.10.0 flake8==5.0.4
+python_sources=$(LANG=C find scripts src/bindings/python -type f -exec file {} \; | grep -F "Python script" | sed 's/:.*//')
 
 # Python formatter
-python -m black --line-length=105 --skip-string-normalization ${python_sources}
+${py} -m black --line-length=105 --skip-string-normalization ${python_sources}
 
 # Python linter
-python -m flake8 --max-line-length=105 --extend-ignore=E501,E731,E203 --extend-exclude=src/bindings/python/__init__.py ${python_sources}
+${py} -m flake8 --max-line-length=105 --extend-ignore=E501,E731,E203 --extend-exclude=src/bindings/python/__init__.py ${python_sources}


### PR DESCRIPTION
i was starting on adding a feature to the extract building python script and i hated that in order to format the code i need to run a precommit hook. i dont like to wait to do the formatting until im ready to commit (yes i know i can force a hook to run without committing but again, its annoying, the format script is for linting). i prefer to format on every save. my ide does this for me and it does it via the format script.

this pr moves the python linting out of pre-commit hooks and puts them into the format script where they belong. the format script is still run by the precommit hook so those who do like this workflow will be unchanged. but those of us that like to format often will now be able to do so in a less kludgy way.