### PR TITLE
Remove trailing comma making JSON invalid

### DIFF
--- a/taginfo.json
+++ b/taginfo.json
@@ -7352,6 +7352,6 @@
         "way"
       ],
       "description": "Considers the way lit"
-    },
+    }
   ]
 }


### PR DESCRIPTION
Tiny fix to make taginfo.json JSON valid again.