### PR TITLE
add source & target index to error/warning 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
    * ADDED: Support for configuring a universal request timeout [#3966](https://github.com/valhalla/valhalla/pull/3966)
    * ADDED: optionally include highway=platform edges for pedestrian access [#3971](https://github.com/valhalla/valhalla/pull/3971)
    * ADDED: `use_lit` costing option for pedestrian costing [#3957](https://github.com/valhalla/valhalla/pull/3957)
+   * ADDED: source & target index when exceeding max distance limit config [#3981](https://github.com/valhalla/valhalla/pull/3981)
 
 ## Release Date: 2023-01-03 Valhalla 3.3.0
 * **Removed**

--- a/src/loki/matrix_action.cc
+++ b/src/loki/matrix_action.cc
@@ -26,6 +26,8 @@ void check_distance(Api& request,
   auto& options = *request.mutable_options();
   bool added_warning = false;
   // see if any locations pairs are unreachable or too far apart
+  uint32_t source_idx = 0;
+  uint32_t target_idx = 0;
   for (auto& source : *options.mutable_sources()) {
     for (auto& target : *options.mutable_targets()) {
       // check if distance between latlngs exceed max distance limit
@@ -38,7 +40,8 @@ void check_distance(Api& request,
 
       if (path_distance > matrix_max_distance) {
         throw valhalla_exception_t{154, std::to_string(static_cast<size_t>(matrix_max_distance)) +
-                                            " meters"};
+                                            " meters, origin " + std::to_string(source_idx) +
+                                            " and target " + std::to_string(target_idx)};
       };
 
       // unset the date_time if beyond the limit
@@ -46,12 +49,16 @@ void check_distance(Api& request,
         source.set_date_time("");
         target.set_date_time("");
         if (max_timedep_distance && !added_warning) {
-          add_warning(request, 200);
+          add_warning(request, 200,
+                      std::to_string(max_timedep_distance) + " meters, origin " +
+                          std::to_string(source_idx) + " and target " + std::to_string(target_idx));
           added_warning = true;
         }
       }
     }
+    target_idx++;
   }
+  source_idx++;
 }
 } // namespace
 

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -1169,11 +1169,12 @@ valhalla_exception_t::valhalla_exception_t(unsigned code, const std::string& ext
 }
 
 // function to add warnings to proto info object
-void add_warning(valhalla::Api& api, unsigned code) {
+void add_warning(valhalla::Api& api, unsigned code, const std::string& extra) {
   auto message = warning_codes.find(code);
   if (message != warning_codes.end()) {
     auto* warning = api.mutable_info()->mutable_warnings()->Add();
-    warning->set_description(message->second);
+    auto msg = extra.empty() ? message->second : message->second + ": " + extra;
+    warning->set_description(msg);
     warning->set_code(message->first);
   }
 }

--- a/valhalla/worker.h
+++ b/valhalla/worker.h
@@ -76,7 +76,7 @@ void ParseApi(const prime_server::http_request_t& http_request, Api& api);
 std::string serialize_error(const valhalla_exception_t& exception, Api& options);
 
 // function to add warnings to proto info object
-void add_warning(valhalla::Api& api, unsigned code);
+void add_warning(valhalla::Api& api, unsigned code, const std::string& extra = "");
 
 #ifdef HAVE_HTTP
 prime_server::worker_t::result_t serialize_error(const valhalla_exception_t& exception,


### PR DESCRIPTION
fixes #3958 

Lets a user know which source/target id is the problem. Though on second thought it's not that super informative; if one pair is off, there's very likely more. Boils down again to people doing the distance checks on their side. Anyways, now that the "work" is done, a merge doesn't hurt either?;) Also adds the ability to pass extra info to warnings.