### PR TITLE
fix build with LOGGING_LEVEL=ALL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
    * ADDED: `use_lit` costing option for pedestrian costing [#3957](https://github.com/valhalla/valhalla/pull/3957)
    * CHANGED: Removed stray NULL values in log output[#3974](https://github.com/valhalla/valhalla/pull/3974)
    * CHANGED: More conservative estimates for cost of walking slopes [#3982](https://github.com/valhalla/valhalla/pull/3982)
+   * CHANGED: fix build with LOGGING_LEVEL=ALL [#3992](https://github.com/valhalla/valhalla/pull/3992)
 
 ## Release Date: 2023-01-03 Valhalla 3.3.0
 * **Removed**

--- a/src/baldr/streetnames.cc
+++ b/src/baldr/streetnames.cc
@@ -2,6 +2,8 @@
 #include <optional>
 #include <vector>
 
+#include "midgard/logging.h"
+
 #include "baldr/streetname.h"
 #include "baldr/streetnames.h"
 #include "baldr/verbal_text_formatter.h"

--- a/src/odin/maneuver.cc
+++ b/src/odin/maneuver.cc
@@ -2,14 +2,15 @@
 #include <list>
 #include <utility>
 
-#include "baldr/streetnames.h"
-#include "baldr/streetnames_us.h"
 #include "midgard/constants.h"
 #include "midgard/logging.h"
 #include "midgard/util.h"
 
 #include "odin/maneuver.h"
 #include "odin/transitrouteinfo.h"
+
+#include "baldr/streetnames.h"
+#include "baldr/streetnames_us.h"
 
 #include "proto/common.pb.h"
 #include "proto/directions.pb.h"

--- a/src/odin/sign.cc
+++ b/src/odin/sign.cc
@@ -1,3 +1,5 @@
+#include "midgard/logging.h"
+
 #include "baldr/streetname.h"
 
 #include "odin/sign.h"

--- a/src/odin/signs.cc
+++ b/src/odin/signs.cc
@@ -2,6 +2,8 @@
 #include <cmath>
 #include <utility>
 
+#include "midgard/logging.h"
+
 #include "baldr/verbal_text_formatter.h"
 #include "baldr/verbal_text_formatter_us.h"
 

--- a/src/odin/transitrouteinfo.cc
+++ b/src/odin/transitrouteinfo.cc
@@ -1,3 +1,5 @@
+#include "midgard/logging.h"
+
 #include "odin/transitrouteinfo.h"
 #include "odin/util.h"
 


### PR DESCRIPTION
streetnames.h should be included after mjolnir/logging.h, otherwise:

src/baldr/streetnames.cc:67:13: error: no declaration matches ‘std::string valhalla::baldr::StreetNames::ToParameterString() const’
   67 | std::string StreetNames::ToParameterString() const {
...

Additionally, linking errors are fixed:

/usr/bin/ld: src/libvalhalla.a(maneuver.cc.o): in function `valhalla::odin::Maneuver::ToParameterString[abi:cxx11]() const': maneuver.cc:(.text+0x4e8e): undefined reference to `valhalla::odin::Signs::ToParameterString[abi:cxx11]() const' /usr/bin/ld: src/libvalhalla.a(maneuversbuilder.cc.o): in function `valhalla::odin::ManeuversBuilder::InitializeManeuver(valhalla::odin::Maneuver&, int)': maneuversbuilder.cc:(.text+0xb6ad): undefined reference to `valhalla::odin::TransitRouteInfo::ToParameterString[abi:cxx11]() const' ...

# Issue

https://github.com/valhalla/valhalla/issues/3991

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
