### PR TITLE
Change url for just_gtfs submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -45,4 +45,4 @@
 	url = https://github.com/jarro2783/cxxopts.git
 [submodule "third_party/just_gtfs"]
 	path = third_party/just_gtfs
-	url = https://github.com/mapsme/just_gtfs.git
+	url = https://github.com/mesozoic-drones/just_gtfs.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
    * ADDED: `use_lit` costing option for pedestrian costing [#3957](https://github.com/valhalla/valhalla/pull/3957)
    * CHANGED: Removed stray NULL values in log output[#3974](https://github.com/valhalla/valhalla/pull/3974)
    * CHANGED: More conservative estimates for cost of walking slopes [#3982](https://github.com/valhalla/valhalla/pull/3982)
+   * CHANGED: Updated url for just_gtfs library [#3994](https://github.com/valhalla/valhalla/pull/3995)
 
 ## Release Date: 2023-01-03 Valhalla 3.3.0
 * **Removed**


### PR DESCRIPTION
# Issue
https://github.com/valhalla/valhalla/issues/3994

## Description
Update for url to just_gtfs library in .gitmodules and set submodule's commit to Release tag v.1.0.0.

To get this update correctly on your machine:
- Run `git submodule sync --recursive` to reflect that change to project and your working copy.
- Optionally (if you have some errors) you may need to go to the `.git/modules/third_party/just_gtfs `dirercotry and change the `config` file to update git path.


## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

