### PR TITLE
Fix matrix_locations when used in pbf request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
    * ADDED: `use_lit` costing option for pedestrian costing [#3957](https://github.com/valhalla/valhalla/pull/3957)
    * CHANGED: Removed stray NULL values in log output[#3974](https://github.com/valhalla/valhalla/pull/3974)
    * CHANGED: More conservative estimates for cost of walking slopes [#3982](https://github.com/valhalla/valhalla/pull/3982)
+   * FIXED: Fix matrix_locations when used in pbf request [#3997](https://github.com/valhalla/valhalla/pull/3997)
 
 ## Release Date: 2023-01-03 Valhalla 3.3.0
 * **Removed**

--- a/proto/options.proto
+++ b/proto/options.proto
@@ -476,8 +476,8 @@ message Options {
   repeated ExpansionProperties expansion_properties = 51;          // The array keys (ExpansionTypes enum) to return in the /expansions's GeoJSON "properties"
   PbfFieldSelector pbf_field_selector = 52;                        // Which pbf fields to include in the pbf format response
   bool reverse = 53;                                               // should the isochrone expansion be done in the reverse direction, ignored for multimodal isochrones
-  uint32 matrix_locations = 54;                                    // Number of matrix locations found that will trigger an early exit from
-                                                                   // a one to many or many to one time distance matrix. Does not affect
-                                                                   // sources_to_targets when either sources or targets has more than 1 location
+  oneof has_matrix_locations {                                     // Number of matrix locations found that will trigger an early exit from
+    uint32 matrix_locations = 54;                                  // a one to many or many to one time distance matrix. Does not affect
+  }                                                                // sources_to_targets when either sources or targets has more than 1 location
                                                                    // or when CostMatrix is the selected matrix mode.
 }

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -975,7 +975,7 @@ void from_json(rapidjson::Document& doc, Options::Action action, Api& api) {
   auto matrix_locations = rapidjson::get_optional<int>(doc, "/matrix_locations");
   if (matrix_locations && (options.sources_size() == 1 || options.targets_size() == 1)) {
     options.set_matrix_locations(*matrix_locations);
-  } else {
+  } else if (!options.has_matrix_locations_case()) {
     options.set_matrix_locations(std::numeric_limits<uint32_t>::max());
   }
 


### PR DESCRIPTION
# Issue

fixes #3996

Needed to use one_of in options.proto and check has_matrix_locations_case() in the else case so we do not overwrite a properly set matrix_locations value in the incoming pbf request.

## Tasklist

 - [ ] Add tests
 - [x] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
