### PR TITLE
fix error message on shapefile download failure

### DIFF
--- a/scripts/valhalla_build_timezones
+++ b/scripts/valhalla_build_timezones
@@ -231,7 +231,7 @@ Atlantic/St_Helena,Africa/Abidjan
 EOF
 
 echo "downloading timezone polygon file." 1>&2
-curl -L -s -o ./timezones-with-oceans.shapefile.zip ${url} || error_exit "wget failed for " ${url}
+curl -L -s -o ./timezones-with-oceans.shapefile.zip ${url} || error_exit "curl failed for ${url}"
 unzip ./timezones-with-oceans.shapefile.zip 1>&2 || error_exit "unzip failed"
 
 tz_file=$(mktemp)


### PR DESCRIPTION
minor - the URL wasn't interpolated correctly, also updated it to reflect that it uses curl instead of wget