### PR TITLE
Ignore warnings from other sources

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,6 +10,7 @@ jobs:
     name: Build and deploy docs
 
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'valhalla' }}
 
     steps:
       - name: Checkout

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,8 @@ if (NOT Boost_FOUND)
 endif()
 find_package(Boost ${boost_VERSION} REQUIRED)
 add_definitions(-DBOOST_NO_CXX11_SCOPED_ENUMS)
+add_definitions(-DBOOST_ALLOW_DEPRECATED_HEADERS)
+add_definitions(-DBOOST_BIND_GLOBAL_PLACEHOLDERS)
 
 if(NOT TARGET CURL::CURL)
   add_library(CURL::CURL INTERFACE IMPORTED)

--- a/src/baldr/tz_alt.cpp
+++ b/src/baldr/tz_alt.cpp
@@ -96,7 +96,17 @@
 #  include <windows.h>
 #endif  // _WIN32
 
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 #include "date/tz_private.h"
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
+#endif
 
 #include "date_time_africa.h"
 #include "date_time_antarctica.h"

--- a/src/odin/util.cc
+++ b/src/odin/util.cc
@@ -9,8 +9,18 @@
 #include <regex>
 #include <sstream>
 
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 #include <date/date.h>
 #include <date/tz.h>
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
+#endif
 
 #include "baldr/turnlanes.h"
 #include "locales.h"

--- a/valhalla/baldr/datetime.h
+++ b/valhalla/baldr/datetime.h
@@ -16,8 +16,18 @@
 // https://github.com/valhalla/valhalla/pull/3878#issuecomment-1365487437
 #define HAS_UNCAUGHT_EXCEPTIONS 1
 
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 #include <date/date.h>
 #include <date/tz.h>
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
+#endif
 
 #include <valhalla/baldr/graphconstants.h>
 #include <valhalla/baldr/nodeinfo.h>


### PR DESCRIPTION
Related to #4006  Issue

- [x] Add tests
   - This [gh-pages action](https://github.com/cvvergara/valhalla/actions/runs/4326343992) shows that docs are not been deployed on a branch
   - This [other one](https://github.com/cvvergara/valhalla/actions/runs/4326326310/jobs/7553605261) attempts to deploy docs
- [x] (Add fixes) Visually ignoring warnings not from Valhala (when using GCC)
   - Boost warnings are ignored
   - Warnings from `third_party/date` are ignored
   - Some warning remain, like for libprotobuf.
