### PR TITLE
replace dockerhub with github docker registry

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -20,7 +20,6 @@ pr:
       - README.md
       - CHANGELOG.md
       - bench/
-      - docker/
       - docs/
       - run_route_scripts/
       - test/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,25 +19,10 @@ commands:
     steps:
       - run: sudo bash ./scripts/install-linux-deps.sh
 
-jobs:    
-  build-docker-images:
-    machine:
-      image: ubuntu-2004:current
-    steps:
-      - checkout
-      - run:
-          name: Build and push Valhalla Docker image
-          command: |
-            if [[ "${CIRCLE_BRANCH}" == "master" ]] || [[ ! -z "${CIRCLE_TAG}" ]]; then
-              BUILD_TAG="${CIRCLE_TAG:-latest}"
-              echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-              docker build --pull --tag valhalla/valhalla:run-${BUILD_TAG} .
-              docker push valhalla/valhalla:run-${BUILD_TAG}
-            fi
-
+jobs:
   lint-build-debug:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2204:current
     resource_class: xlarge
     steps:
       - checkout
@@ -86,7 +71,7 @@ jobs:
 
   build-release:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2204:current
     resource_class: xlarge
     steps:
       - checkout
@@ -159,12 +144,6 @@ workflows:
   version: 2
   build_test_publish:
     jobs:
-      - build-docker-images:
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              only: master
       - lint-build-debug:
           filters:
             tags:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
       - name: Extract branch name
         if: startsWith(github.ref, 'refs/tags/')
         run: echo "##[set-output name=branch;]${GITHUB_REF#refs/heads/}"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install newer git
-      - run: |
+        run: |
           sudo apt-get install -y software-properties-common \
           && sudo apt-get update \
           && sudo add-apt-repository -y ppa:git-core/ppa \

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,7 +22,7 @@ jobs:
           && sudo apt-get update \
           && sudo apt-get install -y git
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         with:
           submodules: 'recursive'
           fetch-depth: 0

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,43 @@
+name: Publish Docker image
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - '*'
+    paths-ignore:
+      - '.gitignore'
+      - '**.md'
+      - 'test/'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      - name: Extract branch name
+        if: startsWith(github.ref, 'refs/tags/')
+        run: echo "##[set-output name=branch;]${GITHUB_REF#refs/heads/}"
+        id: extract_branch
+      - name: Log in to GitHub Docker Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build tagged image
+        uses: docker/build-push-action@v4
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          push: true
+          tags: |
+            ghcr.io/valhalla/valhalla:${{ steps.extract_branch.outputs.branch }}
+      - name: Build latest image
+        uses: docker/build-push-action@v4
+        if: github.ref == 'refs/heads/nn-remove-dockerhub'
+        with:
+          push: false
+          tags: |
+            ghcr.io/valhalla/valhalla:latest
+

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,7 @@ name: Publish Docker image
 on:
   push:
     branches:
-      - '*'
+      - 'master'
     tags:
       - '*'
     paths-ignore:
@@ -11,7 +11,7 @@ on:
       - 'test/'
 
 jobs:
-  publish:
+  build_and_publish:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
@@ -35,7 +35,7 @@ jobs:
           docker build -t ghcr.io/valhalla/valhalla:${{ steps.extract_branch.outputs.branch }} .
           docker push ghcr.io/valhalla/valhalla:${{ steps.extract_branch.outputs.branch }}
       - name: Build latest image
-        if: github.ref == 'refs/heads/nn-remove-dockerhub'
+        if: github.ref == 'refs/heads/master'
         run: |
           docker build -t ghcr.io/valhalla/valhalla:latest .
           docker push ghcr.io/valhalla/valhalla:latest

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: 'recursive'
+          fetch-depth: 0
       - name: Extract branch name
         if: startsWith(github.ref, 'refs/tags/')
         run: echo "##[set-output name=branch;]${GITHUB_REF#refs/heads/}"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -35,7 +35,7 @@ jobs:
           docker build -t ghcr.io/valhalla/valhalla:${{ steps.extract_branch.outputs.tag }} .
           docker push ghcr.io/valhalla/valhalla:${{ steps.extract_branch.outputs.tag }}
       - name: Build latest image
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/nn-remove-dockerhub'
         run: |
           docker build -t ghcr.io/valhalla/valhalla:latest .
           docker push ghcr.io/valhalla/valhalla:latest

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,7 @@ name: Publish Docker image
 on:
   push:
     branches:
-      - '*'
+      - 'master'
     tags:
       - '*'
     paths-ignore:
@@ -35,7 +35,7 @@ jobs:
           docker build -t ghcr.io/valhalla/valhalla:${{ steps.extract_branch.outputs.tag }} .
           docker push ghcr.io/valhalla/valhalla:${{ steps.extract_branch.outputs.tag }}
       - name: Build latest image
-        if: github.ref == 'refs/heads/nn-remove-dockerhub'
+        if: github.ref == 'refs/heads/master'
         run: |
           docker build -t ghcr.io/valhalla/valhalla:latest .
           docker push ghcr.io/valhalla/valhalla:latest

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -44,10 +44,7 @@ jobs:
           tags: |
             ghcr.io/valhalla/valhalla:${{ steps.extract_branch.outputs.branch }}
       - name: Build latest image
-        uses: docker/build-push-action@v4
         if: github.ref == 'refs/heads/nn-remove-dockerhub'
-        with:
-          push: false
-          tags: |
-            ghcr.io/valhalla/valhalla:latest
-
+        run: |
+          docker build -t ghcr.io/valhalla/valhalla:latest .
+          docker push ghcr.io/valhalla/valhalla:latest

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -14,6 +14,13 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      - name: Install newer git
+      - run: |
+          sudo apt-get install -y software-properties-common \
+          && sudo apt-get update \
+          && sudo add-apt-repository -y ppa:git-core/ppa \
+          && sudo apt-get update \
+          && sudo apt-get install -y git
       - name: Check out the repo
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -14,15 +14,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - name: Install newer git
-        run: |
-          sudo apt-get install -y software-properties-common \
-          && sudo apt-get update \
-          && sudo add-apt-repository -y ppa:git-core/ppa \
-          && sudo apt-get update \
-          && sudo apt-get install -y git
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: 'recursive'
           fetch-depth: 0
@@ -37,12 +30,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build tagged image
-        uses: docker/build-push-action@v4
         if: startsWith(github.ref, 'refs/tags/')
-        with:
-          push: true
-          tags: |
-            ghcr.io/valhalla/valhalla:${{ steps.extract_branch.outputs.branch }}
+        run: |
+          docker build -t ghcr.io/valhalla/valhalla:${{ steps.extract_branch.outputs.branch }} .
+          docker push ghcr.io/valhalla/valhalla:${{ steps.extract_branch.outputs.branch }}
       - name: Build latest image
         if: github.ref == 'refs/heads/nn-remove-dockerhub'
         run: |

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,7 @@ name: Publish Docker image
 on:
   push:
     branches:
-      - 'master'
+      - '*'
     tags:
       - '*'
     paths-ignore:
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
       - name: Extract branch name
         if: startsWith(github.ref, 'refs/tags/')
-        run: echo "##[set-output name=branch;]${GITHUB_REF#refs/heads/}"
+        run: echo "##[set-output name=tag;]${GITHUB_REF#refs/tags/}"
         id: extract_branch
       - name: Log in to GitHub Docker Registry
         uses: docker/login-action@v2
@@ -32,8 +32,8 @@ jobs:
       - name: Build tagged image
         if: startsWith(github.ref, 'refs/tags/')
         run: |
-          docker build -t ghcr.io/valhalla/valhalla:${{ steps.extract_branch.outputs.branch }} .
-          docker push ghcr.io/valhalla/valhalla:${{ steps.extract_branch.outputs.branch }}
+          docker build -t ghcr.io/valhalla/valhalla:${{ steps.extract_branch.outputs.tag }} .
+          docker push ghcr.io/valhalla/valhalla:${{ steps.extract_branch.outputs.tag }}
       - name: Build latest image
         if: github.ref == 'refs/heads/master'
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Release Date: 2023-??-?? Valhalla 3.3.1
 * **Removed**
+   * REMOVED: Docker image pushes to Dockerhub [#4033](https://github.com/valhalla/valhalla/pull/4033)
 * **Bug Fix**
    * FIXED: underflow of uint64_t cast for matrix time results [#3906](https://github.com/valhalla/valhalla/pull/3906)
    * FIXED: update vcpkg commit for Azure pipelines to fix libtool mirrors [#3915](https://github.com/valhalla/valhalla/pull/3915)
@@ -33,6 +34,7 @@
    * CHANGED: More conservative estimates for cost of walking slopes [#3982](https://github.com/valhalla/valhalla/pull/3982)
    * ADDED: An option to Slim down Matrix response [#3987](https://github.com/valhalla/valhalla/pull/3987)
    * CHANGED: Updated url for just_gtfs library [#3994](https://github.com/valhalla/valhalla/pull/3995)
+   * ADDED: Docker image pushes to Github's docker registry [#4033](https://github.com/valhalla/valhalla/pull/4033)
 
 ## Release Date: 2023-01-03 Valhalla 3.3.0
 * **Removed**

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN bash /usr/local/src/valhalla/scripts/install-linux-deps.sh
 
 # get the code into the right place and prepare to build it
 COPY . /usr/local/src/valhalla
-RUN ls
+RUN ls -la
 RUN git submodule sync && git submodule update --init --recursive
 RUN rm -rf build && mkdir build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY ./scripts/install-linux-deps.sh /usr/local/src/valhalla/scripts/install-lin
 RUN bash /usr/local/src/valhalla/scripts/install-linux-deps.sh
 
 # get the code into the right place and prepare to build it
-COPY . .
+ADD . .
 RUN ls -la
 RUN git submodule sync && git submodule update --init --recursive
 RUN rm -rf build && mkdir build

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY ./scripts/install-linux-deps.sh /usr/local/src/valhalla/scripts/install-lin
 RUN bash /usr/local/src/valhalla/scripts/install-linux-deps.sh
 
 # get the code into the right place and prepare to build it
-COPY . /usr/local/src/valhalla
+COPY . .
 RUN ls -la
 RUN git submodule sync && git submodule update --init --recursive
 RUN rm -rf build && mkdir build

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY ./scripts/install-linux-deps.sh /usr/local/src/valhalla/scripts/install-lin
 RUN bash /usr/local/src/valhalla/scripts/install-linux-deps.sh
 
 # get the code into the right place and prepare to build it
-ADD . /usr/local/src/valhalla
+COPY . /usr/local/src/valhalla
 RUN ls
 RUN git submodule sync && git submodule update --init --recursive
 RUN rm -rf build && mkdir build

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Documentation is stored in the `docs/` folder in this GitHub repository. It can 
 
 ## Installation
 
-To run Valhalla locally or your own server, we recommend using our Docker image. Checkout the `run-*` docker containers here: https://hub.docker.com/r/valhalla/valhalla/tags. Also, there's a [community Docker image](https://github.com/gis-ops/docker-valhalla) with more "magic" than the native one.
+To run Valhalla locally or your own server, we recommend using our Docker image. Checkout our docker image here: https://github.com/orgs/valhalla/packages. Also, there's a [community Docker image](https://github.com/gis-ops/docker-valhalla) with more "magic" than the native one.
 
 If you want to build Valhalla from source, follow the [documentation](https://valhalla.github.io/valhalla/building/).
 

--- a/scripts/needs_ci_run
+++ b/scripts/needs_ci_run
@@ -40,12 +40,8 @@ def last_build_successful():
         print('CIRCLE_API_TOKEN env not set! Unable to do CI skip check', file=sys.stderr)
         return False, None
 
-    # If master, we run 4 jobs, if PR, we run 3 (no docker workflow)
     # jobs defined in .circleci/config.yml
-    if branch == "master":
-        JOBS = ['build-docker-images', 'lint-build-debug', 'build-release', 'build-osx']
-    else:
-        JOBS = ['lint-build-debug', 'build-release', 'build-osx']
+    JOBS = ['lint-build-debug', 'build-release', 'build-osx']
 
     # Get twice the number of jobs configured. There would be len(JOBS) from this
     # run, while the rest will be from the last run


### PR DESCRIPTION
closes #4029 

Let's try with Github Actions, so much easier. On CircleCI it was running with a default machine as well, not the big ones. So probably similar performance. As temp I enabled to build this branch.

Also removes the `run-` prefix as that's not applicable anymore and since people will have to update the URL they're pulling from anyways, we can break this as well IMO.