### PR TITLE
bus=permit doesnt not override access=no

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
    * FIXED: duplicated recosting names should throw [#4042](https://github.com/valhalla/valhalla/pull/4042)
    * FIXED: Remove arch specificity from strip command of Python bindings to make it more compatible with other archs [#4040](https://github.com/valhalla/valhalla/pull/4040)
    * FIXED: GraphReader::GetShortcut no longer returns false positives or false negatives [#4019](https://github.com/valhalla/valhalla/pull/4019)
+   * FIXED: Tagging with bus=permit or taxi=permit did not override access=no [#4045](https://github.com/valhalla/valhalla/pull/4045)
 * **Enhancement**
    * CHANGED: replace boost::optional with C++17's std::optional where possible [#3890](https://github.com/valhalla/valhalla/pull/3890)
    * ADDED: parse `lit` tag on ways and add it to graph [#3893](https://github.com/valhalla/valhalla/pull/3893)

--- a/lua/graph.lua
+++ b/lua/graph.lua
@@ -232,7 +232,8 @@ bus = {
 ["restricted"] = "true",
 ["destination"] = "true",
 ["delivery"] = "false",
-["official"] = "false"
+["official"] = "false",
+["permit"] = "true"
 }
 
 taxi = {
@@ -244,7 +245,8 @@ taxi = {
 ["restricted"] = "true",
 ["destination"] = "true",
 ["delivery"] = "false",
-["official"] = "false"
+["official"] = "false",
+["permit"] = "true"
 }
 
 psv = {
@@ -538,7 +540,8 @@ motor_cycle_node = {
 ["official"] = 0,
 ["public"] = 1024,
 ["restricted"] = 1024,
-["allowed"] = 1024
+["allowed"] = 1024,
+["permit"] = 1024
 }
 
 bus_node = {
@@ -551,6 +554,7 @@ bus_node = {
 ["destination"] = 64,
 ["delivery"] = 0,
 ["official"] = 0,
+["permit"] = 64
 }
 
 taxi_node = {
@@ -562,7 +566,8 @@ taxi_node = {
 ["restricted"] = 32,
 ["destination"] = 32,
 ["delivery"] = 0,
-["official"] = 0
+["official"] = 0,
+["permit"] = 32
 }
 
 truck_node = {

--- a/test/gurka/test_access_psv.cc
+++ b/test/gurka/test_access_psv.cc
@@ -49,8 +49,8 @@ TEST(Standalone, AccessPsvWay) {
       {"GK", {{"highway", "primary"}}},
       {"KJ", {{"highway", "primary"}}},
       {"LI", {{"highway", "primary"}}},
-      {"MN", {{"highway", "busway"}, {"access", "no"}, {"bus", "yes"}}},
-      {"NO", {{"highway", "busway"}, {"access", "no"}, {"bus", "yes"}}},
+      {"MN", {{"highway", "residential"}, {"access", "no"}, {"bus", "permit"}, {"taxi", "permit"}}},
+      {"NO", {{"highway", "residential"}, {"access", "no"}, {"bus", "permit"}, {"taxi", "permit"}}},
   };
 
   const auto layout =
@@ -82,8 +82,12 @@ TEST(Standalone, AccessPsvWay) {
                    std::runtime_error);
   }
 
-  // Test highway=busway overriding access=no
+  // Test bus=permit overriding access=no
   auto result = gurka::do_action(valhalla::Options::route, map, {"M", "O"}, "bus");
+  gurka::assert::raw::expect_path(result, {"MN", "NO"});
+
+  // Test taxi=permit overriding access=no
+  result = gurka::do_action(valhalla::Options::route, map, {"M", "O"}, "taxi");
   gurka::assert::raw::expect_path(result, {"MN", "NO"});
 }
 

--- a/test/gurka/test_access_psv.cc
+++ b/test/gurka/test_access_psv.cc
@@ -25,6 +25,8 @@ TEST(Standalone, AccessPsvWay) {
                 F-------G-------K
                 |
                 H
+
+        M------N------O
     )";
 
   const gurka::ways ways = {
@@ -47,6 +49,8 @@ TEST(Standalone, AccessPsvWay) {
       {"GK", {{"highway", "primary"}}},
       {"KJ", {{"highway", "primary"}}},
       {"LI", {{"highway", "primary"}}},
+      {"MN", {{"highway", "busway"}, {"access", "no"}}},
+      {"NO", {{"highway", "busway"}, {"access", "no"}}},
   };
 
   const auto layout =
@@ -77,6 +81,10 @@ TEST(Standalone, AccessPsvWay) {
       EXPECT_THROW(gurka::do_action(valhalla::Options::route, map, {"D", "L"}, c),
                    std::runtime_error);
   }
+
+  // Test highway=busway overriding access=no
+  auto result = gurka::do_action(valhalla::Options::route, map, {"M", "O"}, "bus");
+  gurka::assert::raw::expect_path(result, {"MN", "NO"});
 }
 
 TEST(Standalone, AccessPsvNode) {

--- a/test/gurka/test_access_psv.cc
+++ b/test/gurka/test_access_psv.cc
@@ -49,8 +49,8 @@ TEST(Standalone, AccessPsvWay) {
       {"GK", {{"highway", "primary"}}},
       {"KJ", {{"highway", "primary"}}},
       {"LI", {{"highway", "primary"}}},
-      {"MN", {{"highway", "busway"}, {"access", "no"}}},
-      {"NO", {{"highway", "busway"}, {"access", "no"}}},
+      {"MN", {{"highway", "busway"}, {"access", "no"}, {"bus", "yes"}}},
+      {"NO", {{"highway", "busway"}, {"access", "no"}, {"bus", "yes"}}},
   };
 
   const auto layout =


### PR DESCRIPTION
fixes #4044

it was noticed that `access=no` wins over `highway=busway`. that does not seem to make sense so we probably have to fix up the lua. it is likely this tagging is meant to tell us no one is allow on it... except buses.

EDIT:

as per usual i am thorougly confused after reading the osm wiki. it is clear that overriding access with `bus=yes` is what is normally used, but its not clear that `highway=busway` should function the same. the way our interpretation seems to work is we get default access from the `highway` tag then we turn it off or let it on depending on what the `access` tag says, then finally we let that access for various modes get overriden by things like `bus=yes` or `bicycle=yes` etc.

so im thinking perhaps this particular bridge is a tagging issue. adding `bus=yes` to it allows the test pass.

EDIT:

lua was missing overrides for `bus=permit` and `taxi=permit` on ways. node access was also missing and for motorcycle as well