### PR TITLE
Move complex turn restriction check out of can_form_shortcut()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
    * FIXED: time handling for transit service [#4052](https://github.com/valhalla/valhalla/pull/4052)
    * FIXED: multiple smaller bugs while testing more multimodal /route & /isochrones [#4055](https://github.com/valhalla/valhalla/pull/4055)
    * FIXED: `FindLuaJit.cmake` to include Windows paths/library names [#4067](https://github.com/valhalla/valhalla/pull/4067)
+   * FIXED: Move complex turn restriction check out of can_form_shortcut() [#4047](https://github.com/valhalla/valhalla/pull/4047)
 * **Enhancement**
    * CHANGED: replace boost::optional with C++17's std::optional where possible [#3890](https://github.com/valhalla/valhalla/pull/3890)
    * ADDED: parse `lit` tag on ways and add it to graph [#3893](https://github.com/valhalla/valhalla/pull/3893)

--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -758,7 +758,6 @@ GraphId GraphReader::GetShortcut(const GraphId& id) {
         continue;
       }
       if (continuing_edge != nullptr) {
-        LOG_WARN("GraphReader::GetShortcut found multiple potential continuing edges, aborting");
         continuing_edge = directededge + (nodeinfo->edge_count() - i);
         continue;
       }
@@ -769,7 +768,7 @@ GraphId GraphReader::GetShortcut(const GraphId& id) {
 
   // No shortcuts on the local level or transit level.
   if (id.level() >= TileHierarchy::levels().back().level) {
-    LOG_WARN("GraphReader::GetShortcut was called with a lever that doesn't contain shortcuts");
+    LOG_WARN("GraphReader::GetShortcut was called with a level that doesn't contain shortcuts");
     return {};
   }
 
@@ -812,7 +811,7 @@ GraphId GraphReader::GetShortcut(const GraphId& id) {
     // it means we must have started the traversal outside a shortcuts internal edges
     if (!directededge->superseded() && shortcut_at_node) {
       LOG_WARN(
-          "GraphReader::GetShortcut found a shortcut but it's not superseding the edge we arrived on");
+          "GraphReader::GetShortcut found a shortcut but it's not superseding the edge it arrived on");
       break;
     }
 

--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -768,7 +768,7 @@ GraphId GraphReader::GetShortcut(const GraphId& id) {
 
   // No shortcuts on the local level or transit level.
   if (id.level() >= TileHierarchy::levels().back().level) {
-    LOG_WARN("GraphReader::GetShortcut was called with a level that doesn't contain shortcuts");
+    LOG_DEBUG("GraphReader::GetShortcut was called with a level that doesn't contain shortcuts");
     return {};
   }
 
@@ -791,7 +791,7 @@ GraphId GraphReader::GetShortcut(const GraphId& id) {
     // directed edge.
     cont_de = (node == nullptr) ? GetOpposingEdge(id) : continuing_edge(tile, edgeid, node);
     if (cont_de == nullptr) {
-      LOG_WARN("GraphReader::GetShortcut found no clear continuing edge");
+      LOG_DEBUG("GraphReader::GetShortcut found no clear continuing edge");
       break;
     }
 
@@ -810,7 +810,7 @@ GraphId GraphReader::GetShortcut(const GraphId& id) {
     // If this edge is itself not the beginning of a shortcut, but we encountered another shortcut
     // it means we must have started the traversal outside a shortcuts internal edges
     if (!directededge->superseded() && shortcut_at_node) {
-      LOG_WARN(
+      LOG_DEBUG(
           "GraphReader::GetShortcut found a shortcut but it's not superseding the edge it arrived on");
       break;
     }

--- a/src/mjolnir/shortcutbuilder.cc
+++ b/src/mjolnir/shortcutbuilder.cc
@@ -59,6 +59,12 @@ bool EdgesMatch(const graph_tile_ptr& tile, const DirectedEdge* edge1, const Dir
     return false;
   }
 
+  // Neither edge can be part of a complex turn restriction
+  if (edge1->start_restriction() || edge1->end_restriction() || edge2->start_restriction() ||
+      edge2->end_restriction()) {
+    return false;
+  }
+
   // classification, link, use, and attributes must also match.
   // NOTE: might want "better" bridge attribution. Seems most overpasses
   // get marked as a bridge and lead to less shortcuts - so we don't consider

--- a/test/recover_shortcut.cc
+++ b/test/recover_shortcut.cc
@@ -134,30 +134,36 @@ TEST(RecoverShortcut, test_recover_shortcut_edges_cache) {
 TEST(GetShortcut, check_false_negatives) {
   GraphReader reader(conf.get_child("mjolnir"));
 
-  auto tile_set = reader.GetTileSet();
-  for (const valhalla::baldr::GraphId& tile_id : tile_set) {
-    auto tile = reader.GetGraphTile(tile_id);
+  for (const auto& level : TileHierarchy::levels()) {
+    // we don't get shortcuts on level 2 and up
+    if (level.level > 1)
+      continue;
 
-    valhalla::baldr::GraphId edge_id{tile_id};
-    for (int32_t i = 0; i < tile->header()->directededgecount(); i++, ++edge_id) {
-      auto directed_edge = tile->directededge(i);
-      if (!directed_edge->is_shortcut()) {
-        continue;
-      }
+    auto tile_set = reader.GetTileSet(level.level);
+    for (const valhalla::baldr::GraphId& tile_id : tile_set) {
+      auto tile = reader.GetGraphTile(tile_id);
 
-      // If the edge is a shortcut, let's recover its edges
-      auto edges_of_shortcut = reader.RecoverShortcut(edge_id);
+      valhalla::baldr::GraphId edge_id{tile_id};
+      for (int32_t i = 0; i < tile->header()->directededgecount(); i++, ++edge_id) {
+        auto directed_edge = tile->directededge(i);
+        if (!directed_edge->is_shortcut()) {
+          continue;
+        }
 
-      for (const auto& edge_of_shortcut : edges_of_shortcut) {
-        // Resolve the shortcut that the edge belongs to, this must always be valid
-        auto shortcut_id = reader.GetShortcut(edge_of_shortcut);
-        EXPECT_TRUE(shortcut_id.Is_Valid());
+        // If the edge is a shortcut, let's recover its edges
+        auto edges_of_shortcut = reader.RecoverShortcut(edge_id);
 
-        if (shortcut_id.Is_Valid()) {
-          // The resolved shortcut must always the same as the one we recovered in the first place
-          auto directed_shortcut = reader.directededge(shortcut_id);
-          EXPECT_TRUE(directed_shortcut->is_shortcut());
-          EXPECT_EQ(shortcut_id, edge_id);
+        for (const auto& edge_of_shortcut : edges_of_shortcut) {
+          // Resolve the shortcut that the edge belongs to, this must always be valid
+          auto shortcut_id = reader.GetShortcut(edge_of_shortcut);
+          EXPECT_TRUE(shortcut_id.Is_Valid());
+
+          if (shortcut_id.Is_Valid()) {
+            // The resolved shortcut must always the same as the one we recovered in the first place
+            auto directed_shortcut = reader.directededge(shortcut_id);
+            EXPECT_TRUE(directed_shortcut->is_shortcut());
+            EXPECT_EQ(shortcut_id, edge_id);
+          }
         }
       }
     }
@@ -167,41 +173,47 @@ TEST(GetShortcut, check_false_negatives) {
 TEST(GetShortcut, check_false_positives) {
   GraphReader reader(conf.get_child("mjolnir"));
 
-  auto tile_set = reader.GetTileSet();
-  for (const valhalla::baldr::GraphId& tile_id : tile_set) {
-    auto tile = reader.GetGraphTile(tile_id);
+  for (const auto& level : TileHierarchy::levels()) {
+    // we don't get shortcuts on level 2 and up
+    if (level.level > 1)
+      continue;
 
-    valhalla::baldr::GraphId edge_id{tile_id};
-    for (int32_t i = 0; i < tile->header()->directededgecount(); i++, ++edge_id) {
-      auto shortcut_id = reader.GetShortcut(edge_id);
+    auto tile_set = reader.GetTileSet(level.level);
+    for (const valhalla::baldr::GraphId& tile_id : tile_set) {
+      auto tile = reader.GetGraphTile(tile_id);
 
-      // Edges that don't belong to any shortcut will lead to invalid shortcut ID and this is fine
-      if (!shortcut_id.Is_Valid()) {
-        continue;
-      }
+      valhalla::baldr::GraphId edge_id{tile_id};
+      for (int32_t i = 0; i < tile->header()->directededgecount(); i++, ++edge_id) {
+        auto shortcut_id = reader.GetShortcut(edge_id);
 
-      // If edge_id was already referencing a shortcut we must get the same ID back
-      auto directed_edge = reader.directededge(edge_id);
-      if (directed_edge->is_shortcut()) {
-        EXPECT_TRUE(shortcut_id == edge_id);
-        continue;
-      }
-
-      // If the returned shortcut ID is valid it must reference an actual shortcut
-      auto directed_shortcut = reader.directededge(shortcut_id);
-      EXPECT_TRUE(directed_shortcut->is_shortcut());
-
-      if (directed_shortcut->is_shortcut()) {
-        auto edges_of_shortcut = reader.RecoverShortcut(shortcut_id);
-        auto found_edge = false;
-
-        for (const auto& edge_of_shortcut : edges_of_shortcut) {
-          if (edge_of_shortcut == edge_id) {
-            found_edge = true;
-            break;
-          }
+        // Edges that don't belong to any shortcut will lead to invalid shortcut ID and this is fine
+        if (!shortcut_id.Is_Valid()) {
+          continue;
         }
-        EXPECT_TRUE(found_edge);
+
+        // If edge_id was already referencing a shortcut we must get the same ID back
+        auto directed_edge = reader.directededge(edge_id);
+        if (directed_edge->is_shortcut()) {
+          EXPECT_TRUE(shortcut_id == edge_id);
+          continue;
+        }
+
+        // If the returned shortcut ID is valid it must reference an actual shortcut
+        auto directed_shortcut = reader.directededge(shortcut_id);
+        EXPECT_TRUE(directed_shortcut->is_shortcut());
+
+        if (directed_shortcut->is_shortcut()) {
+          auto edges_of_shortcut = reader.RecoverShortcut(shortcut_id);
+          auto found_edge = false;
+
+          for (const auto& edge_of_shortcut : edges_of_shortcut) {
+            if (edge_of_shortcut == edge_id) {
+              found_edge = true;
+              break;
+            }
+          }
+          EXPECT_TRUE(found_edge);
+        }
       }
     }
   }

--- a/valhalla/baldr/directededge.h
+++ b/valhalla/baldr/directededge.h
@@ -570,9 +570,9 @@ public:
    * @return true if the edge is not a shortcut, not related to transit and not under construction
    */
   bool can_form_shortcut() const {
-    return !is_shortcut() && !bss_connection() && !start_restriction() && !end_restriction() &&
-           use() != Use::kTransitConnection && use() != Use::kEgressConnection &&
-           use() != Use::kPlatformConnection && use() != Use::kConstruction;
+    return !is_shortcut() && !bss_connection() && use() != Use::kTransitConnection &&
+           use() != Use::kEgressConnection && use() != Use::kPlatformConnection &&
+           use() != Use::kConstruction;
   }
 
   /**


### PR DESCRIPTION
This is a workaround to make shortcut recovery reliable. Currently it fails in certain cases where complex turn restrictions flags are changed (especially removed) during graph validation. This makes shortcuts that were generated correctly and deterministically by shortcut builder, suddenly ambiguous to the shortcut recovery.

Like before, shortcuts are never built across restrictions, but with this change the shortcut builder and shortcut recovery are equally aware of the restricted edges.