### PR TITLE
fixed time handling for transit service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
    * FIXED: Remove arch specificity from strip command of Python bindings to make it more compatible with other archs [#4040](https://github.com/valhalla/valhalla/pull/4040)
    * FIXED: GraphReader::GetShortcut no longer returns false positives or false negatives [#4019](https://github.com/valhalla/valhalla/pull/4019)
    * FIXED: Tagging with bus=permit or taxi=permit did not override access=no [#4045](https://github.com/valhalla/valhalla/pull/4045)
+   * FIXED: time handling for transit service  [#4052](https://github.com/valhalla/valhalla/pull/4052)
 * **Enhancement**
    * CHANGED: replace boost::optional with C++17's std::optional where possible [#3890](https://github.com/valhalla/valhalla/pull/3890)
    * ADDED: parse `lit` tag on ways and add it to graph [#3893](https://github.com/valhalla/valhalla/pull/3893)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
    * FIXED: Remove arch specificity from strip command of Python bindings to make it more compatible with other archs [#4040](https://github.com/valhalla/valhalla/pull/4040)
    * FIXED: GraphReader::GetShortcut no longer returns false positives or false negatives [#4019](https://github.com/valhalla/valhalla/pull/4019)
    * FIXED: Tagging with bus=permit or taxi=permit did not override access=no [#4045](https://github.com/valhalla/valhalla/pull/4045)
-   * FIXED: time handling for transit service  [#4052](https://github.com/valhalla/valhalla/pull/4052)
+   * FIXED: time handling for transit service [#4052](https://github.com/valhalla/valhalla/pull/4052)
 * **Enhancement**
    * CHANGED: replace boost::optional with C++17's std::optional where possible [#3890](https://github.com/valhalla/valhalla/pull/3890)
    * ADDED: parse `lit` tag on ways and add it to graph [#3893](https://github.com/valhalla/valhalla/pull/3893)

--- a/src/mjolnir/convert_transit.cc
+++ b/src/mjolnir/convert_transit.cc
@@ -218,11 +218,13 @@ ProcessStopPairs(GraphTileBuilder& transit_tilebuilder,
             }
           }
 
+          // service_start_date are relative to our pivot date
           auto d = date::floor<date::days>(DateTime::pivot_date_);
-          date::sys_days start_date =
-              date::sys_days(date::year_month_day(d + date::days(stop_pair.service_start_date())));
-          date::sys_days end_date =
-              date::sys_days(date::year_month_day(d + date::days(stop_pair.service_end_date())));
+          date::sys_days start_date = date::sys_days(date::year_month_day(
+              d +
+              date::floor<date::days>(date::days(stop_pair.service_start_date() / kSecondsPerDay))));
+          date::sys_days end_date = date::sys_days(date::year_month_day(
+              d + date::ceil<date::days>(date::days(stop_pair.service_end_date() / kSecondsPerDay))));
 
           uint64_t days = get_service_days(start_date, end_date, tile_date, dow_mask);
 
@@ -241,13 +243,13 @@ ProcessStopPairs(GraphTileBuilder& transit_tilebuilder,
 
           // if subtractions are between start and end date then turn off bit.
           for (const auto& x : stop_pair.service_except_dates()) {
-            date::sys_days rm_date = date::sys_days(date::year_month_day(d + date::days(x)));
+            date::sys_days rm_date = date::sys_days(date::year_month_day(d + date::days(x / 86400)));
             days = remove_service_day(days, end_date, tile_date, rm_date);
           }
 
           // if additions are between start and end date then turn on bit.
           for (const auto& x : stop_pair.service_added_dates()) {
-            date::sys_days add_date = date::sys_days(date::year_month_day(d + date::days(x)));
+            date::sys_days add_date = date::sys_days(date::year_month_day(d + date::days(x / 86400)));
             days = add_service_day(days, end_date, tile_date, add_date);
           }
 

--- a/src/mjolnir/convert_transit.cc
+++ b/src/mjolnir/convert_transit.cc
@@ -243,13 +243,15 @@ ProcessStopPairs(GraphTileBuilder& transit_tilebuilder,
 
           // if subtractions are between start and end date then turn off bit.
           for (const auto& x : stop_pair.service_except_dates()) {
-            date::sys_days rm_date = date::sys_days(date::year_month_day(d + date::days(x / 86400)));
+            date::sys_days rm_date =
+                date::sys_days(date::year_month_day(d + date::days(x / kSecondsPerDay)));
             days = remove_service_day(days, end_date, tile_date, rm_date);
           }
 
           // if additions are between start and end date then turn on bit.
           for (const auto& x : stop_pair.service_added_dates()) {
-            date::sys_days add_date = date::sys_days(date::year_month_day(d + date::days(x / 86400)));
+            date::sys_days add_date =
+                date::sys_days(date::year_month_day(d + date::days(x / kSecondsPerDay)));
             days = add_service_day(days, end_date, tile_date, add_date);
           }
 

--- a/src/mjolnir/ingest_transit.cc
+++ b/src/mjolnir/ingest_transit.cc
@@ -137,11 +137,11 @@ std::string get_tile_path(const std::string& tile_dir, const GraphId& tile_id) {
 };
 
 // converts service start/end dates of the form (yyyymmdd) into epoch seconds
-uint32_t to_local_epoch_sec(const std::string& dt) {
+uint32_t to_local_pivot_sec(const std::string& dt) {
   date::local_seconds tp;
   std::istringstream in{dt};
   in >> date::parse("%Y%m%d", tp);
-  return static_cast<uint32_t>(tp.time_since_epoch().count());
+  return static_cast<uint32_t>((tp - DateTime::pivot_date_).count());
 };
 
 std::string get_onestop_id_base(const std::string& stop_id, const std::string& feed_name) {
@@ -481,7 +481,7 @@ bool write_stop_pair(
       const gtfs::CalendarDates& trip_calDates = feed.get_calendar_dates(currTrip->service_id);
       bool had_added_date = false;
       for (const auto& cal_date_item : trip_calDates) {
-        auto d = to_local_epoch_sec(cal_date_item.date.get_raw_date());
+        auto d = to_local_pivot_sec(cal_date_item.date.get_raw_date());
         if (cal_date_item.exception_type == gtfs::CalendarDateException::Added) {
           stop_pair->add_service_added_dates(d);
           had_added_date = true;
@@ -505,8 +505,8 @@ bool write_stop_pair(
         stop_pair->set_shape_id(pbf_shape_it->second);
       }
 
-      stop_pair->set_service_start_date(to_local_epoch_sec(trip_calendar->start_date.get_raw_date()));
-      stop_pair->set_service_end_date(to_local_epoch_sec(trip_calendar->end_date.get_raw_date()));
+      stop_pair->set_service_start_date(to_local_pivot_sec(trip_calendar->start_date.get_raw_date()));
+      stop_pair->set_service_end_date(to_local_pivot_sec(trip_calendar->end_date.get_raw_date()));
 
       dangles = dangles || !origin_is_in_tile || !dest_is_in_tile;
       stop_pair->set_bikes_allowed(currTrip->bikes_allowed == gtfs::TripAccess::Yes);

--- a/test/gurka/test_gtfs.cc
+++ b/test/gurka/test_gtfs.cc
@@ -335,10 +335,13 @@ TEST(GtfsExample, MakeProto) {
 
   // constants written in the last function
   auto serviceStartDate =
-      baldr::DateTime::get_formatted_date("2023-01-31").time_since_epoch().count();
-  auto serviceEndDate = baldr::DateTime::get_formatted_date("2024-01-31").time_since_epoch().count();
-  auto addedDate = baldr::DateTime::get_formatted_date("2023-02-02").time_since_epoch().count();
-  auto removedDate = baldr::DateTime::get_formatted_date("2023-02-03").time_since_epoch().count();
+      (baldr::DateTime::get_formatted_date("2023-01-31") - DateTime::pivot_date_).count();
+  auto serviceEndDate =
+      (baldr::DateTime::get_formatted_date("2024-01-31") - DateTime::pivot_date_).count();
+  auto addedDate =
+      (baldr::DateTime::get_formatted_date("2023-02-02") - DateTime::pivot_date_).count();
+  auto removedDate =
+      (baldr::DateTime::get_formatted_date("2023-02-03") - DateTime::pivot_date_).count();
 
   // spawn threads to download all the tiles returning a list of
   // tiles that ended up having dangling stop pairs


### PR DESCRIPTION
Adjusted the transit service time things to always be relative to our own pivot date (01.01.2014), after a quick session with @kevinkreiser (thanks for that!)

The tests did pass before, but that was entirely random. I also tried a few feeds, but again, must've been entirely random successes.