### PR TITLE
Update vcpkg & FindLuaJIT.cmake to find Windows artifacts

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -137,7 +137,7 @@ jobs:
           for /f "delims=" %%x in ('.\vswhere.exe -latest -property InstallationPath') do set VSPATH=%%x
           popd
           call "%VSPATH%\VC\Auxiliary\Build\vcvars64.bat"
-          cmake --build %BUILD_DIR% --config %BUILD_CFG% -- /clp:ErrorsOnly /p:BuildInParallel=true /m:2
+          cmake --build %BUILD_DIR% --config %BUILD_CFG% . -- /clp:ErrorsOnly /p:BuildInParallel=true /m:2
         displayName: 'Run CMake to build'
 
       - script: |

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -137,7 +137,7 @@ jobs:
           for /f "delims=" %%x in ('.\vswhere.exe -latest -property InstallationPath') do set VSPATH=%%x
           popd
           call "%VSPATH%\VC\Auxiliary\Build\vcvars64.bat"
-          cmake --build %BUILD_DIR% --config %BUILD_CFG% --target ALL_BUILD -- /clp:ErrorsOnly /p:BuildInParallel=true /m:2
+          cmake --build %BUILD_DIR% --config %BUILD_CFG%
         displayName: 'Run CMake to build'
 
       - script: |

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -137,7 +137,7 @@ jobs:
           for /f "delims=" %%x in ('.\vswhere.exe -latest -property InstallationPath') do set VSPATH=%%x
           popd
           call "%VSPATH%\VC\Auxiliary\Build\vcvars64.bat"
-          cmake --build %BUILD_DIR% --config %BUILD_CFG%
+          cmake --build %BUILD_DIR% --config %BUILD_CFG% -- /clp:ErrorsOnly /p:BuildInParallel=true /m:2
         displayName: 'Run CMake to build'
 
       - script: |

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -126,7 +126,7 @@ jobs:
           popd
           call "%VSPATH%\VC\Auxiliary\Build\vcvars64.bat"
           cmake --version
-          cmake -G "Ninja" -H$(Build.SourcesDirectory) -B%BUILD_DIR% -DCMAKE_BUILD_TYPE=%BUILD_CFG% -DCMAKE_TOOLCHAIN_FILE=%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake -DVCPKG_APPLOCAL_DEPS=ON -DENABLE_DATA_TOOLS=ON -DENABLE_TOOLS=ON -DENABLE_PYTHON_BINDINGS=ON -DENABLE_TESTS=OFF -DENABLE_CCACHE=OFF -DENABLE_HTTP=OFF -DENABLE_SERVICES=OFF -DENABLE_BENCHMARKS=OFF -DLUA_INCLUDE_DIR=%VCPKG_DIR%\installed\%TRIPLET%-windows\include\luajit -DLUA_LIBRARIES=%VCPKG_DIR%\installed\%TRIPLET%-windows\lib\lua51.lib"
+          cmake -G "Ninja" -H$(Build.SourcesDirectory) -B%BUILD_DIR% -DCMAKE_BUILD_TYPE=%BUILD_CFG% -DCMAKE_TOOLCHAIN_FILE=%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake -DVCPKG_APPLOCAL_DEPS=ON -DENABLE_DATA_TOOLS=ON -DENABLE_TOOLS=ON -DENABLE_PYTHON_BINDINGS=ON -DENABLE_TESTS=OFF -DENABLE_CCACHE=OFF -DENABLE_HTTP=OFF -DENABLE_SERVICES=OFF -DENABLE_BENCHMARKS=OFF
         env:
           CONAN_USER_HOME: $(CONAN_HOME)
         displayName: 'Run CMake to configure build'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -41,8 +41,7 @@ jobs:
       VCPKG_DIR: '$(Build.SourcesDirectory)\vcpkg'
       VCPKG_ROOT: '$(Build.SourcesDirectory)\vcpkg'
       VCPKG_INSTALLATION_ROOT: '$(Build.SourcesDirectory)\vcpkg'
-      # points to recent commit in master after a bug fix in vcpkg
-      VCPKG_REF: '51e10eb'
+      VCPKG_REF: '45b0e4b'
       TRIPLET: 'x64'
       CONAN_HOME: '$(Build.SourcesDirectory)/conan'
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -137,7 +137,7 @@ jobs:
           for /f "delims=" %%x in ('.\vswhere.exe -latest -property InstallationPath') do set VSPATH=%%x
           popd
           call "%VSPATH%\VC\Auxiliary\Build\vcvars64.bat"
-          cmake --build %BUILD_DIR% --config %BUILD_CFG% . -- /clp:ErrorsOnly /p:BuildInParallel=true /m:2
+          cmake --build %BUILD_DIR% --config %BUILD_CFG% --target ALL_BUILD -- /clp:ErrorsOnly /p:BuildInParallel=true /m:2
         displayName: 'Run CMake to build'
 
       - script: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
    * FIXED: Tagging with bus=permit or taxi=permit did not override access=no [#4045](https://github.com/valhalla/valhalla/pull/4045)
    * FIXED: Upgrade RapidJSON to address undefined behavior [#4051](https://github.com/valhalla/valhalla/pull/4051)
    * FIXED: time handling for transit service [#4052](https://github.com/valhalla/valhalla/pull/4052)
+   * FIXED: `FindLuaJit.cmake` to include Windows paths/library names [#4067](https://github.com/valhalla/valhalla/pull/4067)
 * **Enhancement**
    * CHANGED: replace boost::optional with C++17's std::optional where possible [#3890](https://github.com/valhalla/valhalla/pull/3890)
    * ADDED: parse `lit` tag on ways and add it to graph [#3893](https://github.com/valhalla/valhalla/pull/3893)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
    * CHANGED: Updated url for just_gtfs library [#3994](https://github.com/valhalla/valhalla/pull/3995)
    * ADDED: Docker image pushes to Github's docker registry [#4033](https://github.com/valhalla/valhalla/pull/4033)
    * ADDED: `disable_hierarchy_pruning` costing option to find the actual optimal route for motorized costing modes, i.e `auto`, `motorcycle`, `motor_scooter`, `bus`, `truck` & `taxi`. [#4000](https://github.com/valhalla/valhalla/pull/4000)
+   * UPDATED: `vcpkg` to latest master, iconv wasn't building anymore [#4066](https://github.com/valhalla/valhalla/pull/4066)
 
 ## Release Date: 2023-01-03 Valhalla 3.3.0
 * **Removed**

--- a/cmake/FindLuaJIT.cmake
+++ b/cmake/FindLuaJIT.cmake
@@ -10,7 +10,7 @@
 find_path(LUA_INCLUDE_DIR luajit.h
   HINTS
     ENV LUA_DIR
-  PATH_SUFFIXES include/luajit-2.0 include/luajit-2.1 include
+  PATH_SUFFIXES include/luajit-2.0 include/luajit-2.1 include/luajit include
   PATHS
   ~/Library/Frameworks
   /Library/Frameworks
@@ -21,7 +21,7 @@ find_path(LUA_INCLUDE_DIR luajit.h
 )
 
 find_library(LUA_LIBRARY
-  NAMES luajit-5.1
+  NAMES luajit-5.1 lua51
   HINTS
     ENV LUA_DIR
   PATH_SUFFIXES lib

--- a/docs/docs/building.md
+++ b/docs/docs/building.md
@@ -121,9 +121,9 @@ git -C C:\path\to\vcpkg checkout f4bd6423
 cd C:\path\to\project
 C:\path\to\vcpkg.exe --triplet x64-windows install "@.vcpkg_deps.txt"
 ```
-2. Let CMake configure the build with the required modules enabled. **Note**, you have to manually link LuaJIT for some reason, e.g. the final command for `x64` could look like
+2. Let CMake configure the build with the required modules enabled. The final command for `x64` could look like
 ```
-"C:\Program Files\CMake\bin\cmake.EXE" --no-warn-unused-cli -DENABLE_TOOLS=ON -DENABLE_DATA_TOOLS=ON -DENABLE_PYTHON_BINDINGS=ON -DENABLE_HTTP=ON -DENABLE_CCACHE=OFF -DENABLE_SERVICES=OFF -DENABLE_BENCHMARKS=OFF -DENABLE_TESTS=OFF -DLUA_LIBRARIES=path\to\vcpkg\installed\x64-windows\lib\lua51.lib -DLUA_INCLUDE_DIR=path\to\vcpkg\installed\x64-windows\include\luajit -DVCPKG_TARGET_TRIPLET=x64-windows -DCMAKE_TOOLCHAIN_FILE=path\to\vcpkg\scripts\buildsystems\vcpkg.cmake -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE -Hpath/to/project -Bpath/to/project/build -G "Visual Studio 16 2019" -T host=x64 -A x64
+"C:\Program Files\CMake\bin\cmake.EXE" --no-warn-unused-cli -DENABLE_TOOLS=ON -DENABLE_DATA_TOOLS=ON -DENABLE_PYTHON_BINDINGS=ON -DENABLE_HTTP=ON -DENABLE_CCACHE=OFF -DENABLE_SERVICES=OFF -DENABLE_BENCHMARKS=OFF -DENABLE_TESTS=OFF -DVCPKG_TARGET_TRIPLET=x64-windows -DCMAKE_TOOLCHAIN_FILE=path\to\vcpkg\scripts\buildsystems\vcpkg.cmake -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE -Hpath/to/project -Bpath/to/project/build -G "Visual Studio 16 2019" -T host=x64 -A x64
 ```
 3. Run the build for all targets.
 ```

--- a/docs/docs/building.md
+++ b/docs/docs/building.md
@@ -128,7 +128,7 @@ C:\path\to\vcpkg.exe --triplet x64-windows install "@.vcpkg_deps.txt"
 3. Run the build for all targets.
 ```
 cd C:\path\to\project
-cmake -B build .
+cmake -B build --config Release -- /clp:ErrorsOnly /p:BuildInParallel=true /m:8
 ```
 
 The artifacts will be built to `./build/Release`.


### PR DESCRIPTION
`libiconv` wasn't building with the old commit on a new Windows system. It does build when pointing to the most recent commit. Couple of related questions:

- should we just point at master instead? This is happening regularly, likely Windows/MSVC updates causing that and we don't catch in CI because it's caching dependencies
- ~~the build finished fine, both Debug & Release, but I can't execute anything.. I get `The program '[12004] valhalla_build_tiles.exe' has exited with code -1073741515 (0xc0000135)` right.. Apparently missing _some_ `.dll`, but which?! CI executes graph builds fine for a Release build. Since the build finishes properly I guess I'm missing some Windows runtime `.dll`. I installed VS build tools on top of VS Code (+ the relevant extensions), which should include the relevant C++ runtime environment, right? Do you have maybe any idea where to start debugging @mloskot ? (I know it's hard to suggest anything, but is there any way that it tells which DLL I'm missing?)~~