### PR TITLE
added transit level to connectivity map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
    * CHANGED: baldr directory: remove warnings and C++17 adjustments [#4011](https://github.com/valhalla/valhalla/pull/4011)
    * UPDATED: `vcpkg` to latest master, iconv wasn't building anymore [#4066](https://github.com/valhalla/valhalla/pull/4066)
    * CHANGED: pybind11 upgrade for python 3.11 [#4067](https://github.com/valhalla/valhalla/pull/4067)
+   * CHANGED: added transit level to connectivity map [#4082](https://github.com/valhalla/valhalla/pull/4082)
 
 ## Release Date: 2023-01-03 Valhalla 3.3.0
 * **Removed**

--- a/src/baldr/connectivity_map.cc
+++ b/src/baldr/connectivity_map.cc
@@ -137,7 +137,7 @@ connectivity_map_t::connectivity_map_t(const boost::property_tree::ptree& pt,
   }
 
   // All tiles have color 0 (not connected), go through and connect
-  // (build the ColorMap). Transit level uses local hierarchy tiles
+  // (build the ColorMap).
   for (auto& color : colors) {
     if (color.first == transit_level) {
       TileHierarchy::GetTransitLevel().tiles.ColorMap(color.second, not_neighbors);
@@ -196,11 +196,12 @@ std::unordered_set<size_t> connectivity_map_t::get_colors(uint32_t hierarchy_lev
 
 std::string connectivity_map_t::to_geojson(const uint32_t hierarchy_level) const {
   // bail if we dont have the level
-  uint32_t tile_level = (hierarchy_level == transit_level) ? transit_level - 1 : hierarchy_level;
-  if (tile_level >= TileHierarchy::levels().size()) {
+  if (hierarchy_level > TileHierarchy::GetTransitLevel().level) {
     throw std::runtime_error("hierarchy level not found");
   }
-  const auto& tiles = TileHierarchy::levels()[tile_level].tiles;
+  const auto& tiles = hierarchy_level == transit_level
+                          ? TileHierarchy::GetTransitLevel().tiles
+                          : TileHierarchy::levels()[hierarchy_level].tiles;
 
   // make a region map (inverse mapping of color to lists of tiles)
   // could cache this but shouldnt need to call it much
@@ -236,13 +237,14 @@ std::string connectivity_map_t::to_geojson(const uint32_t hierarchy_level) const
 }
 
 std::vector<size_t> connectivity_map_t::to_image(const uint32_t hierarchy_level) const {
-  uint32_t tile_level = (hierarchy_level == transit_level) ? transit_level - 1 : hierarchy_level;
-  if (tile_level >= TileHierarchy::levels().size()) {
+  if (hierarchy_level > TileHierarchy::GetTransitLevel().level) {
     throw std::runtime_error("hierarchy level not found");
   }
-  const auto& level_tiles = TileHierarchy::levels()[tile_level];
+  const auto& level_tiles = hierarchy_level == transit_level
+                                ? TileHierarchy::GetTransitLevel().tiles
+                                : TileHierarchy::levels()[hierarchy_level].tiles;
 
-  std::vector<size_t> tiles(level_tiles.tiles.nrows() * level_tiles.tiles.ncolumns(), 0);
+  std::vector<size_t> tiles(level_tiles.nrows() * level_tiles.ncolumns(), 0);
   auto level = colors.find(hierarchy_level);
   if (level != colors.cend()) {
     for (size_t i = 0; i < tiles.size(); ++i) {

--- a/src/baldr/connectivity_map.cc
+++ b/src/baldr/connectivity_map.cc
@@ -162,16 +162,15 @@ size_t connectivity_map_t::get_color(const GraphId& id) const {
   return color->second;
 }
 
-std::unordered_set<size_t> connectivity_map_t::get_colors(uint32_t hierarchy_level,
+std::unordered_set<size_t> connectivity_map_t::get_colors(const baldr::TileLevel& hierarchy_level,
                                                           const baldr::PathLocation& location,
                                                           float radius) const {
 
   std::unordered_set<size_t> result;
-  auto level = colors.find(hierarchy_level);
+  auto level = colors.find(hierarchy_level.level);
   if (level == colors.cend()) {
     return result;
   }
-  const auto& tiles = TileHierarchy::levels()[hierarchy_level].tiles;
   std::vector<const decltype(location.edges)*> edge_sets{&location.edges, &location.filtered_edges};
   for (const auto* edges : edge_sets) {
     for (const auto& edge : *edges) {
@@ -182,7 +181,7 @@ std::unordered_set<size_t> connectivity_map_t::get_colors(uint32_t hierarchy_lev
       float lngdeg = (radius / DistanceApproximator<PointLL>::MetersPerLngDegree(ll.lat()));
       AABB2<PointLL> bbox(Point2(ll.lng() - lngdeg, ll.lat() - latdeg),
                           Point2(ll.lng() + lngdeg, ll.lat() + latdeg));
-      std::vector<int32_t> tilelist = tiles.TileList(bbox);
+      std::vector<int32_t> tilelist = hierarchy_level.tiles.TileList(bbox);
       for (const auto& id : tilelist) {
         auto color = level->second.find(id);
         if (color != level->second.cend()) {

--- a/src/loki/matrix_action.cc
+++ b/src/loki/matrix_action.cc
@@ -145,7 +145,7 @@ void loki_worker_t::matrix(Api& request) {
       if (!connectivity_map) {
         continue;
       }
-      auto colors = connectivity_map->get_colors(TileHierarchy::levels().back().level, projection, 0);
+      auto colors = connectivity_map->get_colors(TileHierarchy::levels().back(), projection, 0);
       for (auto& color : colors) {
         auto itr = color_counts.find(color);
         if (itr == color_counts.cend()) {

--- a/src/loki/route_action.cc
+++ b/src/loki/route_action.cc
@@ -72,7 +72,7 @@ void loki_worker_t::route(Api& request) {
   check_hierarchy_distance(request);
 
   auto& ped_opts = *options.mutable_costings()->find(Costing::pedestrian)->second.mutable_options();
-  auto connectivity_level = TileHierarchy::levels().back().level;
+  auto connectivity_level = TileHierarchy::levels().back();
   uint32_t connectivity_radius = 0;
   // Validate walking distances (make sure they are in the accepted range)
   if (costing_name == "multimodal" || costing_name == "transit") {
@@ -94,7 +94,7 @@ void loki_worker_t::route(Api& request) {
       throw valhalla_exception_t{156, " Min: " + std::to_string(min_transit_walking_dis) + " Max: " +
                                           std::to_string(max_transit_walking_dis) + " (Meters)"};
     }
-    connectivity_level = TileHierarchy::GetTransitLevel().level;
+    connectivity_level = TileHierarchy::GetTransitLevel();
     connectivity_radius = ped_opts.transit_start_end_max_distance();
   }
 

--- a/src/loki/route_action.cc
+++ b/src/loki/route_action.cc
@@ -71,11 +71,11 @@ void loki_worker_t::route(Api& request) {
   // check distance for hierarchy pruning
   check_hierarchy_distance(request);
 
-  auto& ped_opts = *options.mutable_costings()->find(Costing::pedestrian)->second.mutable_options();
   auto connectivity_level = TileHierarchy::levels().back();
   uint32_t connectivity_radius = 0;
   // Validate walking distances (make sure they are in the accepted range)
   if (costing_name == "multimodal" || costing_name == "transit") {
+    auto& ped_opts = *options.mutable_costings()->find(Costing::pedestrian)->second.mutable_options();
     if (!ped_opts.has_transit_start_end_max_distance_case())
       ped_opts.set_transit_start_end_max_distance(min_transit_walking_dis);
     auto transit_start_end_max_distance = ped_opts.transit_start_end_max_distance();

--- a/src/loki/route_action.cc
+++ b/src/loki/route_action.cc
@@ -71,9 +71,11 @@ void loki_worker_t::route(Api& request) {
   // check distance for hierarchy pruning
   check_hierarchy_distance(request);
 
+  auto& ped_opts = *options.mutable_costings()->find(Costing::pedestrian)->second.mutable_options();
+  auto connectivity_level = TileHierarchy::levels().back().level;
+  uint32_t connectivity_radius = 0;
   // Validate walking distances (make sure they are in the accepted range)
   if (costing_name == "multimodal" || costing_name == "transit") {
-    auto& ped_opts = *options.mutable_costings()->find(Costing::pedestrian)->second.mutable_options();
     if (!ped_opts.has_transit_start_end_max_distance_case())
       ped_opts.set_transit_start_end_max_distance(min_transit_walking_dis);
     auto transit_start_end_max_distance = ped_opts.transit_start_end_max_distance();
@@ -92,6 +94,8 @@ void loki_worker_t::route(Api& request) {
       throw valhalla_exception_t{156, " Min: " + std::to_string(min_transit_walking_dis) + " Max: " +
                                           std::to_string(max_transit_walking_dis) + " (Meters)"};
     }
+    connectivity_level = TileHierarchy::GetTransitLevel().level;
+    connectivity_radius = ped_opts.transit_start_end_max_distance();
   }
 
   // correlate the various locations to the underlying graph
@@ -102,12 +106,10 @@ void loki_worker_t::route(Api& request) {
     for (size_t i = 0; i < locations.size(); ++i) {
       const auto& correlated = projections.at(locations[i]);
       PathLocation::toPBF(correlated, options.mutable_locations(i), *reader);
-      // TODO: get transit level for transit costing
-      // TODO: if transit send a non zero radius
       if (!connectivity_map) {
         continue;
       }
-      auto colors = connectivity_map->get_colors(TileHierarchy::levels().back().level, correlated, 0);
+      auto colors = connectivity_map->get_colors(connectivity_level, correlated, connectivity_radius);
       for (auto color : colors) {
         auto itr = color_counts.find(color);
         if (itr == color_counts.cend()) {

--- a/test/graphreader.cc
+++ b/test/graphreader.cc
@@ -64,8 +64,8 @@ TEST(SimpleCache, CacheLimitsNoOvercommitAfterClear) {
   EXPECT_FALSE(cache.OverCommitted());
 }
 
-void touch_tile(const uint32_t tile_id, const std::string& tile_dir) {
-  auto suffix = GraphTile::FileSuffix({tile_id, 2, 0});
+void touch_tile(const uint32_t tile_id, const std::string& tile_dir, uint8_t level) {
+  auto suffix = GraphTile::FileSuffix({tile_id, level, 0});
   auto fullpath = tile_dir + filesystem::path::preferred_separator + suffix;
   filesystem::create_directories(filesystem::path(fullpath).parent_path());
   int fd = open(fullpath.c_str(), O_CREAT | O_WRONLY, 0644);
@@ -92,25 +92,25 @@ TEST(ConnectivityMap, Basic) {
 
     // create some empty files with tile names
     uint32_t a0 = 0;
-    touch_tile(a0, tile_dir);
+    touch_tile(a0, tile_dir, level.level);
 
     uint32_t a1 = level.tiles.RightNeighbor(a0);
-    touch_tile(a1, tile_dir);
+    touch_tile(a1, tile_dir, level.level);
 
     uint32_t a2 = level.tiles.TopNeighbor(a0);
-    touch_tile(a2, tile_dir);
+    touch_tile(a2, tile_dir, level.level);
 
     uint32_t b0 = level.tiles.RightNeighbor(level.tiles.RightNeighbor(a1));
-    touch_tile(b0, tile_dir);
+    touch_tile(b0, tile_dir, level.level);
 
     uint32_t c0 = level.tiles.TopNeighbor(level.tiles.RightNeighbor(a1));
-    touch_tile(c0, tile_dir);
+    touch_tile(c0, tile_dir, level.level);
 
     uint32_t d0 = level.tiles.TopNeighbor(level.tiles.RightNeighbor(a2));
-    touch_tile(d0, tile_dir);
+    touch_tile(d0, tile_dir, level.level);
 
     uint32_t d1 = level.tiles.TopNeighbor(d0);
-    touch_tile(d1, tile_dir);
+    touch_tile(d1, tile_dir, level.level);
 
     // check that it looks right
     connectivity_map_t conn(pt);

--- a/test/graphreader.cc
+++ b/test/graphreader.cc
@@ -78,52 +78,60 @@ TEST(ConnectivityMap, Basic) {
   boost::property_tree::ptree pt;
   pt.put("tile_dir", "test/gphrdr_test");
   std::string tile_dir = pt.get<std::string>("tile_dir");
-  const auto& level = TileHierarchy::levels()[2];
-  filesystem::remove_all(tile_dir);
+  for (const auto& level : {TileHierarchy::levels()[2], TileHierarchy::GetTransitLevel()}) {
+    filesystem::remove_all(tile_dir);
 
-  // looks like this (XX) means no tile there:
-  /*
-   *     XX d1 XX XX
-   *     XX d0 XX XX
-   *     a2 XX c0 XX
-   *     a0 a1 XX b0
-   *
-   */
+    // looks like this (XX) means no tile there:
+    /*
+     *     XX d1 XX XX
+     *     XX d0 XX XX
+     *     a2 XX c0 XX
+     *     a0 a1 XX b0
+     *
+     */
 
-  // create some empty files with tile names
-  uint32_t a0 = 0;
-  touch_tile(a0, tile_dir);
+    // create some empty files with tile names
+    uint32_t a0 = 0;
+    touch_tile(a0, tile_dir);
 
-  uint32_t a1 = level.tiles.RightNeighbor(a0);
-  touch_tile(a1, tile_dir);
+    uint32_t a1 = level.tiles.RightNeighbor(a0);
+    touch_tile(a1, tile_dir);
 
-  uint32_t a2 = level.tiles.TopNeighbor(a0);
-  touch_tile(a2, tile_dir);
+    uint32_t a2 = level.tiles.TopNeighbor(a0);
+    touch_tile(a2, tile_dir);
 
-  uint32_t b0 = level.tiles.RightNeighbor(level.tiles.RightNeighbor(a1));
-  touch_tile(b0, tile_dir);
+    uint32_t b0 = level.tiles.RightNeighbor(level.tiles.RightNeighbor(a1));
+    touch_tile(b0, tile_dir);
 
-  uint32_t c0 = level.tiles.TopNeighbor(level.tiles.RightNeighbor(a1));
-  touch_tile(c0, tile_dir);
+    uint32_t c0 = level.tiles.TopNeighbor(level.tiles.RightNeighbor(a1));
+    touch_tile(c0, tile_dir);
 
-  uint32_t d0 = level.tiles.TopNeighbor(level.tiles.RightNeighbor(a2));
-  touch_tile(d0, tile_dir);
+    uint32_t d0 = level.tiles.TopNeighbor(level.tiles.RightNeighbor(a2));
+    touch_tile(d0, tile_dir);
 
-  uint32_t d1 = level.tiles.TopNeighbor(d0);
-  touch_tile(d1, tile_dir);
+    uint32_t d1 = level.tiles.TopNeighbor(d0);
+    touch_tile(d1, tile_dir);
 
-  // check that it looks right
-  connectivity_map_t conn(pt);
+    // check that it looks right
+    connectivity_map_t conn(pt);
 
-  EXPECT_EQ(conn.get_color({a0, 2, 0}), conn.get_color({a1, 2, 0})) << "a's should be connected";
-  EXPECT_EQ(conn.get_color({a0, 2, 0}), conn.get_color({a2, 2, 0})) << "a's should be connected";
-  EXPECT_EQ(conn.get_color({a1, 2, 0}), conn.get_color({a2, 2, 0})) << "a's should be connected";
-  EXPECT_EQ(conn.get_color({d0, 2, 0}), conn.get_color({d1, 2, 0})) << "d's should be connected";
-  EXPECT_NE(conn.get_color({c0, 2, 0}), conn.get_color({a1, 2, 0})) << "c is disjoint";
-  EXPECT_NE(conn.get_color({b0, 2, 0}), conn.get_color({a0, 2, 0})) << "b is disjoint";
-  EXPECT_NE(conn.get_color({a2, 2, 0}), conn.get_color({d0, 2, 0})) << "a is disjoint from d";
+    EXPECT_EQ(conn.get_color({a0, level.level, 0}), conn.get_color({a1, level.level, 0}))
+        << "a's should be connected";
+    EXPECT_EQ(conn.get_color({a0, level.level, 0}), conn.get_color({a2, level.level, 0}))
+        << "a's should be connected";
+    EXPECT_EQ(conn.get_color({a1, level.level, 0}), conn.get_color({a2, level.level, 0}))
+        << "a's should be connected";
+    EXPECT_EQ(conn.get_color({d0, level.level, 0}), conn.get_color({d1, level.level, 0}))
+        << "d's should be connected";
+    EXPECT_NE(conn.get_color({c0, level.level, 0}), conn.get_color({a1, level.level, 0}))
+        << "c is disjoint";
+    EXPECT_NE(conn.get_color({b0, level.level, 0}), conn.get_color({a0, level.level, 0}))
+        << "b is disjoint";
+    EXPECT_NE(conn.get_color({a2, level.level, 0}), conn.get_color({d0, level.level, 0}))
+        << "a is disjoint from d";
 
-  filesystem::remove_all(tile_dir);
+    filesystem::remove_all(tile_dir);
+  }
 }
 
 class TestGraphMemory final : public GraphMemory {

--- a/valhalla/baldr/connectivity_map.h
+++ b/valhalla/baldr/connectivity_map.h
@@ -39,8 +39,9 @@ public:
    * @param radius           the radius of the circle
    * @return colors          the colors of the tiles that intersect this circle at this level
    */
-  std::unordered_set<size_t>
-  get_colors(uint32_t hierarchy_level, const baldr::PathLocation& location, float radius) const;
+  std::unordered_set<size_t> get_colors(const baldr::TileLevel& hierarchy_level,
+                                        const baldr::PathLocation& location,
+                                        float radius) const;
 
   /**
    * Returns the geojson representing the connectivity map


### PR DESCRIPTION
To compare colors for transit, we look at level 3 colors but within `transit_start_end_max_distance` meters of correlated edges, which are still missing the transit connection edges. We wanted to eventually add support for  that for multiple reasons anyways: start the journey on such an edge and also to return departure info for `/locate`. For the connectivity map it's not so bad, at least with the default `transit_start_end_max_distance`.

Also lets us determine whether transit tiles are loaded with less resources than currently in #4062.