### PR TITLE
fix test when day is past 27

### DIFF
--- a/test/gurka/test_gtfs.cc
+++ b/test/gurka/test_gtfs.cc
@@ -862,6 +862,7 @@ TEST(GtfsExample, route_trip1) {
   // wrap around the next month if it's getting critical
   if (tmrw_int > 27) {
     auto new_month = std::to_string(std::stoul(std::string(&req_time[5], &req_time[7])) + 1);
+    new_month = std::string(2 - std::min(2UL, new_month.length()), '0') + new_month;
     req_time.replace(req_time.find('T') - 5, 2, new_month);
     tmrw_int -= 20;
   }


### PR DESCRIPTION
when the day is past 27 (could be 28 really), it would create a month string of e.g. `5` instead of `05`, so the test would fail.