### PR TITLE
ignore destonly edges around ferries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
    * FIXED: fix `clear` methods on matrix algorithms and reserve some space for labels with a new config [#4075](https://github.com/valhalla/valhalla/pull/4075)
    * FIXED: fix `valhalla_build_admins` & `valhalla_ways_to_edges` argument parsing [#4097](https://github.com/valhalla/valhalla/pull/4097)
    * FIXED: fail early in `valhalla_build_admins` if parent directory can't be created, also exit with failure [#4099](https://github.com/valhalla/valhalla/pull/4099)
+   * FIXED: when reclassifying ferry edges, remove destonly from ways only if the connecting way was destonly [#4118](https://github.com/valhalla/valhalla/pull/4118)
 * **Enhancement**
    * CHANGED: replace boost::optional with C++17's std::optional where possible [#3890](https://github.com/valhalla/valhalla/pull/3890)
    * ADDED: parse `lit` tag on ways and add it to graph [#3893](https://github.com/valhalla/valhalla/pull/3893)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Release Date: 2022-??-?? Valhalla 3.4.1
 * **Removed**
 * **Bug Fix**
+   * FIXED: when reclassifying ferry edges, remove destonly from ways only if the connecting way was destonly [#4118](https://github.com/valhalla/valhalla/pull/4118)
 * **Enhancement**
 
 ## Release Date: 2023-05-11 Valhalla 3.4.0
@@ -36,7 +37,6 @@
    * FIXED: fix `clear` methods on matrix algorithms and reserve some space for labels with a new config [#4075](https://github.com/valhalla/valhalla/pull/4075)
    * FIXED: fix `valhalla_build_admins` & `valhalla_ways_to_edges` argument parsing [#4097](https://github.com/valhalla/valhalla/pull/4097)
    * FIXED: fail early in `valhalla_build_admins` if parent directory can't be created, also exit with failure [#4099](https://github.com/valhalla/valhalla/pull/4099)
-   * FIXED: when reclassifying ferry edges, remove destonly from ways only if the connecting way was destonly [#4118](https://github.com/valhalla/valhalla/pull/4118)
 * **Enhancement**
    * CHANGED: replace boost::optional with C++17's std::optional where possible [#3890](https://github.com/valhalla/valhalla/pull/3890)
    * ADDED: parse `lit` tag on ways and add it to graph [#3893](https://github.com/valhalla/valhalla/pull/3893)

--- a/src/mjolnir/directededgebuilder.cc
+++ b/src/mjolnir/directededgebuilder.cc
@@ -53,7 +53,7 @@ DirectedEdgeBuilder::DirectedEdgeBuilder(const OSMWay& way,
   set_truck_route(way.truck_route());
 
   // Set destination only to true if the remove_destonly is set to false and either destination only
-  // or no thru traffic is set. remove_destonly can be set to true when reclassifying ferries.
+  // or no thru traffic is set. remove_destonly is set for reclassified paths due to ferries.
   set_dest_only(!remove_destonly && (way.destination_only() || way.no_thru_traffic()));
   if (remove_destonly && (way.destination_only() || way.no_thru_traffic())) {
     LOG_DEBUG("Overriding dest_only attribution to false for ferry.");

--- a/src/mjolnir/directededgebuilder.cc
+++ b/src/mjolnir/directededgebuilder.cc
@@ -26,7 +26,7 @@ DirectedEdgeBuilder::DirectedEdgeBuilder(const OSMWay& way,
                                          const bool minor,
                                          const uint32_t restrictions,
                                          const uint32_t bike_network,
-                                         const bool reclass_ferry)
+                                         const bool remove_destonly)
     : DirectedEdge() {
   set_endnode(endnode);
   set_use(use);
@@ -52,11 +52,10 @@ DirectedEdgeBuilder::DirectedEdgeBuilder(const OSMWay& way,
 
   set_truck_route(way.truck_route());
 
-  // Set destination only to true if the reclass_ferry is set to false and either destination only or
-  // no thru traffic is set. Adding the reclass_ferry check allows us to know if we should override
-  // the destination only attribution
-  set_dest_only(!reclass_ferry && (way.destination_only() || way.no_thru_traffic()));
-  if (reclass_ferry && (way.destination_only() || way.no_thru_traffic())) {
+  // Set destination only to true if the remove_destonly is set to false and either destination only
+  // or no thru traffic is set. remove_destonly can be set to true when reclassifying ferries.
+  set_dest_only(!remove_destonly && (way.destination_only() || way.no_thru_traffic()));
+  if (remove_destonly && (way.destination_only() || way.no_thru_traffic())) {
     LOG_DEBUG("Overriding dest_only attribution to false for ferry.");
   }
   set_dismount(way.dismount());

--- a/src/mjolnir/ferry_connections.cc
+++ b/src/mjolnir/ferry_connections.cc
@@ -42,7 +42,7 @@ uint32_t ShortestPath(const uint32_t start_node_idx,
                       sequence<Edge>& edges,
                       sequence<Node>& nodes,
                       const bool inbound,
-                      const uint32_t rc) {
+                      const bool first_edge_destonly) {
   // Method to get the shape for an edge - since LL is stored as a pair of
   // floats we need to change into PointLL to get length of an edge
   const auto EdgeShape = [&way_nodes](size_t idx, const size_t count) {
@@ -80,7 +80,7 @@ uint32_t ShortestPath(const uint32_t start_node_idx,
     // Add node to list of node labels, set the node status and add
     // to the adjacency set
     uint32_t nodelabel_index = 0;
-    node_labels.emplace_back(0.0f, node_idx, node_idx);
+    node_labels.emplace_back(0.0f, node_idx, node_idx, first_edge_destonly, first_edge_destonly);
     node_status[node_idx] = {kTemporary, nodelabel_index};
     adjset.push({0.0f, nodelabel_index});
     nodelabel_index++;
@@ -96,6 +96,7 @@ uint32_t ShortestPath(const uint32_t start_node_idx,
       float current_cost = expand_node.first;
       label_idx = expand_node.second;
       uint32_t expand_node_idx = node_labels[label_idx].node_index;
+      const bool pred_destonly = node_labels[label_idx].dest_only;
       adjset.pop();
 
       // Skip if already labeled - this can happen if an edge is already in
@@ -112,7 +113,7 @@ uint32_t ShortestPath(const uint32_t start_node_idx,
       // Have seen cases where the immediate connections are high class roads
       // but then there are service roads (lanes) immediately after (like
       // Twawwassen Terminal near Vancouver,BC)
-      if (n > 400 && GetBestNonFerryClass(expanded_bundle.node_edges) <= rc) {
+      if (n > 400 && GetBestNonFerryClass(expanded_bundle.node_edges) <= kFerryUpClass) {
         break;
       }
       n++;
@@ -162,9 +163,12 @@ uint32_t ShortestPath(const uint32_t start_node_idx,
           continue;
         }
 
-        // Get cost - need the length and speed of the edge; Use a penalty if an edge is
-        // destination_only and calculate it in the cost
-        float penalty = w.destination_only() ? 300 : 0;
+        // if the first edge was destonly and the previous edge was as well, add no penalty
+        float penalty =
+            (first_edge_destonly ? (!pred_destonly && w.destination_only()) : w.destination_only())
+                ? 300
+                : 0;
+        // Get cost - need the length and speed of the edge;
         auto shape = EdgeShape(edge.llindex_, edge.attributes.llcount);
         float cost = current_cost + ((valhalla::midgard::length(shape) * 3.6f) / w.speed()) + penalty;
 
@@ -177,7 +181,10 @@ uint32_t ShortestPath(const uint32_t start_node_idx,
         }
 
         // Add to the node labels and adjacency set. Skip if this is a loop.
-        node_labels.emplace_back(cost, endnode, expand_node_idx);
+        const bool remove_destonly =
+            first_edge_destonly ? (pred_destonly && w.destination_only()) : false;
+        node_labels.emplace_back(cost, endnode, expand_node_idx, w.destination_only(),
+                                 remove_destonly);
         node_status[endnode] = {kTemporary, nodelabel_index};
         adjset.push({cost, nodelabel_index});
         nodelabel_index++;
@@ -196,8 +203,9 @@ uint32_t ShortestPath(const uint32_t start_node_idx,
     uint16_t path_access = baldr::kVehicularAccess;
     while (true) {
       // Get the edge between this node and the predecessor
-      uint32_t idx = node_labels[label_idx].node_index;
-      uint32_t pred_node = node_labels[label_idx].pred_node_index;
+      const NodeLabel& node_lab = node_labels[label_idx];
+      uint32_t idx = node_lab.node_index;
+      uint32_t pred_node = node_lab.pred_node_index;
       auto expand_node_itr = nodes[idx];
       auto bundle2 = collect_node_edges(expand_node_itr, nodes, edges);
       for (auto& edge : bundle2.node_edges) {
@@ -210,9 +218,10 @@ uint32_t ShortestPath(const uint32_t start_node_idx,
           } else if ((forward && !inbound) || (!forward && inbound)) {
             path_access &= update_edge.fwd_access;
           }
-          if (update_edge.attributes.importance > rc) {
-            update_edge.attributes.importance = rc;
+          if (update_edge.attributes.importance > kFerryUpClass) {
+            update_edge.attributes.importance = kFerryUpClass;
             update_edge.attributes.reclass_ferry = true;
+            update_edge.attributes.remove_destonly = node_lab.remove_dest_only;
             element = update_edge;
             edge_count++;
           }
@@ -290,8 +299,7 @@ bool ShortFerry(const uint32_t node_index,
 void ReclassifyFerryConnections(const std::string& ways_file,
                                 const std::string& way_nodes_file,
                                 const std::string& nodes_file,
-                                const std::string& edges_file,
-                                const uint32_t rc) {
+                                const std::string& edges_file) {
   LOG_INFO("Reclassifying ferry connection graph edges...");
 
   sequence<OSMWay> ways(ways_file, false);
@@ -311,7 +319,7 @@ void ReclassifyFerryConnections(const std::string& ways_file,
   while (node_itr != nodes.end()) {
     auto bundle = collect_node_edges(node_itr, nodes, edges);
     if (bundle.node.ferry_edge_ && bundle.node.non_ferry_edge_ &&
-        GetBestNonFerryClass(bundle.node_edges) > rc &&
+        GetBestNonFerryClass(bundle.node_edges) > kFerryUpClass &&
         !ShortFerry(node_itr.position(), bundle, edges, nodes, way_nodes)) {
       // Form shortest path from node along each edge connected to the ferry,
       // track until the specified RC is reached
@@ -329,6 +337,11 @@ void ReclassifyFerryConnections(const std::string& ways_file,
                                     ? edge.first.targetnode_
                                     : edge.first.sourcenode_;
 
+        // if the non-ferry edge connecting on land is dest_only, we will unset dest_only
+        // for all ways encountered during the expansion, to counteract a popular mapping
+        // error, see https://github.com/valhalla/valhalla/issues/3942
+        const bool remove_destonly = (*ways[edge.first.wayindex_]).destination_only();
+
         // Check if edge is oneway towards the ferry or outbound from the
         // ferry. If edge is drivable both ways we need to expand it twice-
         // once with a driveable path towards the ferry and once with a
@@ -337,15 +350,15 @@ void ReclassifyFerryConnections(const std::string& ways_file,
           // Driveable in both directions - get an inbound path and an
           // outbound path.
           total_count += ShortestPath(node_itr.position(), end_node_idx, ways, way_nodes, edges,
-                                      nodes, true, rc);
+                                      nodes, true, remove_destonly);
           total_count += ShortestPath(node_itr.position(), end_node_idx, ways, way_nodes, edges,
-                                      nodes, false, rc);
+                                      nodes, false, remove_destonly);
         } else {
           // Check if oneway inbound to the ferry
           bool inbound =
               (edge.first.sourcenode_ == node_itr.position()) ? edge_rev_access : edge_fwd_access;
           total_count += ShortestPath(node_itr.position(), end_node_idx, ways, way_nodes, edges,
-                                      nodes, inbound, rc);
+                                      nodes, inbound, remove_destonly);
         }
         ferry_endpoint_count++;
 
@@ -353,7 +366,8 @@ void ReclassifyFerryConnections(const std::string& ways_file,
         // we do not immediately determine we hit the specified classification
         sequence<Edge>::iterator element = edges[edge.second];
         auto update_edge = *element;
-        update_edge.attributes.importance = rc;
+        update_edge.attributes.importance = kFerryUpClass;
+        update_edge.attributes.remove_destonly = remove_destonly;
         element = update_edge;
         total_count++;
       }

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -778,7 +778,7 @@ void BuildTileSet(const std::string& ways_file,
                                  truck_speed, use, static_cast<RoadClass>(edge.attributes.importance),
                                  n, has_signal, has_stop, has_yield,
                                  ((has_stop || has_yield) ? node.minor() : false), restrictions,
-                                 bike_network, edge.attributes.reclass_ferry);
+                                 bike_network, edge.attributes.remove_destonly);
           graphtile.directededges().emplace_back(de);
           DirectedEdge& directededge = graphtile.directededges().back();
           // temporarily set the leaves tile flag to indicate when we need to search the access.bin
@@ -1238,15 +1238,8 @@ void GraphBuilder::Build(const boost::property_tree::ptree& pt,
     LOG_WARN("Not reclassifying link graph edges");
   }
 
-  // Reclassify ferry connection edges - use the highway classification cutoff
-  baldr::RoadClass rc = baldr::RoadClass::kPrimary;
-  for (auto& level : TileHierarchy::levels()) {
-    if (level.name == "highway") {
-      rc = level.importance;
-    }
-  }
-  ReclassifyFerryConnections(ways_file, way_nodes_file, nodes_file, edges_file,
-                             static_cast<uint32_t>(rc));
+  // Reclassify ferry connection edges - uses RoadClass::kPrimary (highway classification) as cutoff
+  ReclassifyFerryConnections(ways_file, way_nodes_file, nodes_file, edges_file);
   unsigned int threads =
       std::max(static_cast<unsigned int>(1),
                pt.get<unsigned int>("mjolnir.concurrency", std::thread::hardware_concurrency()));

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -778,7 +778,7 @@ void BuildTileSet(const std::string& ways_file,
                                  truck_speed, use, static_cast<RoadClass>(edge.attributes.importance),
                                  n, has_signal, has_stop, has_yield,
                                  ((has_stop || has_yield) ? node.minor() : false), restrictions,
-                                 bike_network, edge.attributes.remove_destonly);
+                                 bike_network, edge.attributes.reclass_ferry);
           graphtile.directededges().emplace_back(de);
           DirectedEdge& directededge = graphtile.directededges().back();
           // temporarily set the leaves tile flag to indicate when we need to search the access.bin

--- a/valhalla/mjolnir/directededgebuilder.h
+++ b/valhalla/mjolnir/directededgebuilder.h
@@ -19,23 +19,22 @@ class DirectedEdgeBuilder : public baldr::DirectedEdge {
 public:
   /**
    * Constructor with arguments.
-   * @param  way            OSM way info generated from parsing OSM tags with Lua.
-   * @param  endnode        GraphId of the end node of this directed edge.
-   * @param  length         Length in meters.
-   * @param  speed          Average speed in kph.
-   * @param  truck_speed    Truck speed limit in kph.
-   * @param  use            Use of the edge.
-   * @param  rc             Road class / importance
-   * @param  localidx       Index of the edge (from the node) on the local level
-   * @param  signal         Traffic signal
-   * @param  stop_sign      Stop sign
-   * @param  yield_sign     Yield sign
-   * @param  minor          Does the stop or yield only apply to minor roads?
-   * @param  restrictions   Mask of simple turn restrictions at the end node
-   *                        of this directed edge.
-   * @param  bike_network   Mask of bike_networks from relations.
-   * @param  reclass_ferry  Reclassify ferry boolean; Allows us to drop destination only attribution
-   * or anything that would prevent seeing a ferry connection
+   * @param  way             OSM way info generated from parsing OSM tags with Lua.
+   * @param  endnode         GraphId of the end node of this directed edge.
+   * @param  length          Length in meters.
+   * @param  speed           Average speed in kph.
+   * @param  truck_speed     Truck speed limit in kph.
+   * @param  use             Use of the edge.
+   * @param  rc              Road class / importance
+   * @param  localidx        Index of the edge (from the node) on the local level
+   * @param  signal          Traffic signal
+   * @param  stop_sign       Stop sign
+   * @param  yield_sign      Yield sign
+   * @param  minor           Does the stop or yield only apply to minor roads?
+   * @param  restrictions    Mask of simple turn restrictions at the end node
+   *                         of this directed edge.
+   * @param  bike_network    Mask of bike_networks from relations.
+   * @param  remove_destonly Drop dest_only attribution if necessary for ferry connections
    */
   DirectedEdgeBuilder(const OSMWay& way,
                       const baldr::GraphId& endnode,
@@ -52,7 +51,7 @@ public:
                       const bool minor,
                       const uint32_t restrictions,
                       const uint32_t bike_network,
-                      const bool reclass_ferry);
+                      const bool remove_destonly);
 };
 
 } // namespace mjolnir

--- a/valhalla/mjolnir/directededgebuilder.h
+++ b/valhalla/mjolnir/directededgebuilder.h
@@ -34,7 +34,7 @@ public:
    * @param  restrictions    Mask of simple turn restrictions at the end node
    *                         of this directed edge.
    * @param  bike_network    Mask of bike_networks from relations.
-   * @param  remove_destonly Drop dest_only attribution if necessary for ferry connections
+   * @param  remove_destonly Drop dest_only attribution for reclassified ferry paths
    */
   DirectedEdgeBuilder(const OSMWay& way,
                       const baldr::GraphId& endnode,

--- a/valhalla/mjolnir/ferry_connections.h
+++ b/valhalla/mjolnir/ferry_connections.h
@@ -32,14 +32,18 @@ constexpr uint32_t kPermanent = 1;
 // be "adjacent" to an node that is permanently labeled.
 constexpr uint32_t kTemporary = 2;
 
+constexpr uint32_t kFerryUpClass = static_cast<uint32_t>(baldr::RoadClass::kPrimary);
+
 // NodeLabel - for simple shortest path
 struct NodeLabel {
   float cost;
   uint32_t node_index;
   uint32_t pred_node_index;
+  bool dest_only;
+  bool remove_dest_only;
 
-  NodeLabel(const float c, const uint32_t n, const uint32_t p)
-      : cost(c), node_index(n), pred_node_index(p) {
+  NodeLabel(const float c, const uint32_t n, const uint32_t p, const bool d, const bool r)
+      : cost(c), node_index(n), pred_node_index(p), dest_only(d), remove_dest_only(r) {
   }
 };
 
@@ -72,7 +76,7 @@ uint32_t ShortestPath(const uint32_t start_node_idx,
                       sequence<Edge>& edges,
                       sequence<Node>& nodes,
                       const bool inbound,
-                      const uint32_t rc);
+                      const bool remove_dest_only);
 
 /**
  * Check if the ferry included in this node bundle is short. Must be
@@ -93,8 +97,7 @@ bool ShortFerry(const uint32_t node_index,
 void ReclassifyFerryConnections(const std::string& ways_file,
                                 const std::string& way_nodes_file,
                                 const std::string& nodes_file,
-                                const std::string& edges_file,
-                                const uint32_t rc);
+                                const std::string& edges_file);
 
 } // namespace mjolnir
 } // namespace valhalla

--- a/valhalla/mjolnir/ferry_connections.h
+++ b/valhalla/mjolnir/ferry_connections.h
@@ -40,10 +40,9 @@ struct NodeLabel {
   uint32_t node_index;
   uint32_t pred_node_index;
   bool dest_only;
-  bool remove_dest_only;
 
-  NodeLabel(const float c, const uint32_t n, const uint32_t p, const bool d, const bool r)
-      : cost(c), node_index(n), pred_node_index(p), dest_only(d), remove_dest_only(r) {
+  NodeLabel(const float c, const uint32_t n, const uint32_t p, const bool d)
+      : cost(c), node_index(n), pred_node_index(p), dest_only(d) {
   }
 };
 

--- a/valhalla/mjolnir/node_expander.h
+++ b/valhalla/mjolnir/node_expander.h
@@ -54,12 +54,14 @@ struct Edge {
                                //   short enough it may be internal to
                                //   an intersection
     uint64_t driveable_ferry : 1;
-    uint64_t reclass_ferry : 1; // Has edge been reclassified due to
-                                // ferry connection
-    uint64_t turn_channel : 1;  // Link edge should be a turn channel
-    uint64_t way_begin : 1;     // True if first edge of way
-    uint64_t way_end : 1;       // True if last edge of way
-    uint64_t spare : 25;
+    uint64_t reclass_ferry : 1;   // Has edge been reclassified due to
+                                  // ferry connection
+    uint64_t turn_channel : 1;    // Link edge should be a turn channel
+    uint64_t way_begin : 1;       // True if first edge of way
+    uint64_t way_end : 1;         // True if last edge of way
+    uint64_t remove_destonly : 1; // During ferry reclassification we decide to remove dest_only
+                                  // if the reclassified path starts with a dest_only at the ferry
+    uint64_t spare : 24;
   };
   EdgeAttributes attributes;
 
@@ -106,6 +108,7 @@ struct Edge {
     e.attributes.driveable_ferry = (way.ferry() || way.rail()) && (drive_fwd || drive_rev);
     e.attributes.reclass_link = false;
     e.attributes.reclass_ferry = false;
+    e.attributes.remove_destonly = false;
     e.attributes.has_names =
         (way.name_index_ != 0 || way.name_en_index_ != 0 || way.alt_name_index_ != 0 ||
          way.official_name_index_ != 0 || way.ref_index_ != 0 || way.int_ref_index_ != 0);

--- a/valhalla/mjolnir/node_expander.h
+++ b/valhalla/mjolnir/node_expander.h
@@ -54,14 +54,12 @@ struct Edge {
                                //   short enough it may be internal to
                                //   an intersection
     uint64_t driveable_ferry : 1;
-    uint64_t reclass_ferry : 1;   // Has edge been reclassified due to
-                                  // ferry connection
-    uint64_t turn_channel : 1;    // Link edge should be a turn channel
-    uint64_t way_begin : 1;       // True if first edge of way
-    uint64_t way_end : 1;         // True if last edge of way
-    uint64_t remove_destonly : 1; // During ferry reclassification we decide to remove dest_only
-                                  // if the reclassified path starts with a dest_only at the ferry
-    uint64_t spare : 24;
+    uint64_t reclass_ferry : 1; // Has edge been reclassified due to
+                                // ferry connection, will remove dest_only tag from DE
+    uint64_t turn_channel : 1;  // Link edge should be a turn channel
+    uint64_t way_begin : 1;     // True if first edge of way
+    uint64_t way_end : 1;       // True if last edge of way
+    uint64_t spare : 25;
   };
   EdgeAttributes attributes;
 
@@ -108,7 +106,6 @@ struct Edge {
     e.attributes.driveable_ferry = (way.ferry() || way.rail()) && (drive_fwd || drive_rev);
     e.attributes.reclass_link = false;
     e.attributes.reclass_ferry = false;
-    e.attributes.remove_destonly = false;
     e.attributes.has_names =
         (way.name_index_ != 0 || way.name_en_index_ != 0 || way.alt_name_index_ != 0 ||
          way.official_name_index_ != 0 || way.ref_index_ != 0 || way.int_ref_index_ != 0);


### PR DESCRIPTION
fixes https://github.com/valhalla/valhalla/issues/3942

In the end #1905 was mostly missing to unset `destonly` on a ferry-connecting edge. I threw in some more bug fixes around the reclassification and a bit more logic to not penalize destonly edges if the ferry-connecting edge was destonly. If the ferry-connecting edge wasn't destonly, we will always penalize any destonly edges while expanding for reclassification.