### PR TITLE
fix "Edit this page" links in documentation

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -50,6 +50,7 @@ markdown_extensions:
 
 site_name: Valhalla Docs
 repo_url: https://github.com/valhalla/valhalla/
+edit_uri: edit/master/docs/docs/
 site_url: https://valhalla.github.io/valhalla
 docs_dir: docs
 nav:


### PR DESCRIPTION
The mkdocs files were moved to the docs/ directory in c0bac7cf7f1c7005194e3cb4e929e00335a74e28,
which broke the "Edit this page" links from the Material theme. This commit fixes these links by configuring edit_uri[1] accordingly.

[1]: https://www.mkdocs.org/user-guide/configuration/#edit_uri
