### PR TITLE
ci: add spell-checking with typos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,13 @@ jobs:
           fi
 
           #TODO: validate changelog line format
+
+  spell-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Spell-check
+        uses: crate-ci/typos@master
+        with:
+          config: ./.github/workflows/typos.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,12 @@
-name: Valhalla Changelog Validation
+name: GitHub CI
 on: [pull_request]
 
 jobs:
-  build:
-    name: Changelog Validation
+  changelog:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Validate
+      - name: Validate changelog
         shell: bash
         run: |
           # we dont enforce this on a draft

--- a/.github/workflows/typos.toml
+++ b/.github/workflows/typos.toml
@@ -1,0 +1,60 @@
+# See https://github.com/crate-ci/typos/blob/master/docs/reference.md
+# for an explanation of the available settings.
+
+[default]
+extend-ignore-identifiers-re = [
+   "OTSs", # mentioned in CHANGELOG ... ???
+]
+
+extend-ignore-re = [
+  '"shape": ?"[^"]+"',
+  '"encoded_polyline": ?"[^"]+"',
+  '"id": ?"[^"]+"',
+  'R"\([^)]+\)"',
+]
+
+[default.extend-words]
+segway = "segway"
+subtiles = "subtiles"
+nd = "nd" # node
+Thur = "Thur" # short for Thursday, found in timeparsing.cc
+
+# places
+Pont = "Pont"     # Rue du Pont
+Filles = "Filles" # Rue des Filles
+Unter = "Unter"   # Unter den Linden
+Calle = "Calle"   # street in Spanish
+
+# wrong but fixing it via substitution might make comments more confusing e.g. "index for the informations"
+informations = "informations"
+
+[default.extend-identifiers]
+O_WRONLY = "O_WRONLY"
+countr_zero = "countr_zero"
+skip_opps = "skip_opps"
+
+FO_DELETE = "FO_DELETE"
+FOF_NO_UI = "FOF_NO_UI"
+
+[files]
+extend-exclude = [
+    "*.osm",
+
+    "third_party/",
+    "date_time/",
+    "locales/",
+
+    # test files
+    "test_requests/",
+    "url_de_benchmark_routes.txt",
+
+    "cmake/conan.cmake", # fixing 'setings' for some reason breaks conan
+
+    "test/gurka/", # contains a bunch of two-letter names to refer to edges
+    "src/baldr/admin.cc", # contains a bunch of two-letter country-codes
+
+    # the following files are excluded because they contain some split up
+    # polyline strings that cannot be easily detected with `extend-ignore-re`
+    "test/skadi_service.cc",
+    "test/util_midgard.cc",
+]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
    * FIXED: typo in use value of map matching API (`platform_connection` was misspelled) [#4174](https://github.com/valhalla/valhalla/pull/4174)
 * **Enhancement**
    * UPDATED: French translations, thanks to @xlqian [#4159](https://github.com/valhalla/valhalla/pull/4159)
+   * ADDED: CI runs a spell check on the PR to detect spelling mistakes [#4179](https://github.com/valhalla/valhalla/pull/4179)
 
 ## Release Date: 2023-05-11 Valhalla 3.4.0
 * **Removed**

--- a/docs/docs/api/map-matching/api-reference.md
+++ b/docs/docs/api/map-matching/api-reference.md
@@ -183,7 +183,7 @@ Each `edge` may include:
 | `begin_shape_index` | Index into the list of shape points for the start of the edge. |
 | `end_shape_index` | Index into the list of shape points for the end of the edge. |
 | `traversability` | Traversability values, if available:<ul><li>`forward`</li><li>`backward`</li><li>`both`</li></ul> |
-| `use` | Use values: <ul><li>`tram`</li><li>`road`</li><li>`ramp`</li><li>`turn_channel`</li><li>`track`</li><li>`driveway`</li><li>`alley`</li><li>`parking_aisle`</li><li>`emergency_access`</li><li>`drive_through`</li><li>`culdesac`</li><li>`cycleway`</li><li>`mountain_bike`</li><li>`sidewalk`</li><li>`footway`</li><li>`steps`</li><li>`other`</li><li>`rail-ferry`</li><li>`ferry`</li><li>`rail`</li><li>`bus`</li><li>`egress_connection`</li><li>`platform_connnection`</li><li>`transit_connection`</li></ul> |
+| `use` | Use values: <ul><li>`tram`</li><li>`road`</li><li>`ramp`</li><li>`turn_channel`</li><li>`track`</li><li>`driveway`</li><li>`alley`</li><li>`parking_aisle`</li><li>`emergency_access`</li><li>`drive_through`</li><li>`culdesac`</li><li>`cycleway`</li><li>`mountain_bike`</li><li>`sidewalk`</li><li>`footway`</li><li>`steps`</li><li>`other`</li><li>`rail-ferry`</li><li>`ferry`</li><li>`rail`</li><li>`bus`</li><li>`egress_connection`</li><li>`platform_connection`</li><li>`transit_connection`</li></ul> |
 | `toll` | True if the edge has any toll. |
 | `unpaved` | True if the edge is unpaved or rough pavement. |
 | `tunnel` | True if the edge is a tunnel. |

--- a/src/baldr/tilehierarchy.cc
+++ b/src/baldr/tilehierarchy.cc
@@ -127,10 +127,10 @@ GraphId TileHierarchy::parent(const GraphId& child_tile_id) {
   auto parent_level = child_tile_id.level() - 1;
   const auto& parent_tiling = get_tiling(parent_level);
   const auto& child_tiling = get_tiling(child_tile_id.level());
-  // grab just off of the childs corner to avoid edge cases
+  // grab just off of the child's corner to avoid edge cases
   auto corner = child_tiling.Base(child_tile_id.tileid()) +
                 midgard::VectorXY<double>{parent_tiling.TileSize() / 2, parent_tiling.TileSize() / 2};
-  // pick the parent from the childs coordinate
+  // pick the parent from the child's coordinate
   auto parent_tile_index = parent_tiling.TileId(corner);
   return GraphId(parent_tile_index, parent_level, 0);
 }

--- a/src/baldr/tz_alt.cpp
+++ b/src/baldr/tz_alt.cpp
@@ -2944,12 +2944,12 @@ remove_folder_and_subfolders(const std::string& folder)
     from.assign(folder.begin(), folder.end());
     from.push_back('\0');
     from.push_back('\0');
-    SHFILEOPSTRUCT fo{}; // Zero initialize.
-    fo.wFunc = FO_DELETE;
-    fo.pFrom = from.data();
-    fo.fFlags = FOF_NO_UI;
-    int ret = SHFileOperation(&fo);
-    if (ret == 0 && !fo.fAnyOperationsAborted)
+    SHFILEOPSTRUCT file_op{}; // Zero initialize.
+    file_op.wFunc = FO_DELETE;
+    file_op.pFrom = from.data();
+    file_op.fFlags = FOF_NO_UI;
+    int ret = SHFileOperation(&file_op);
+    if (ret == 0 && !file_op.fAnyOperationsAborted)
         return true;
     return false;
 #    endif  // !USE_SHELL_API

--- a/src/tyr/route_serializer_osrm.cc
+++ b/src/tyr/route_serializer_osrm.cc
@@ -1744,7 +1744,7 @@ using namespace osrm_serializers;
 
 /// Assert equality of two json documents
 //
-// TODO Improve the diffed view of mis-matching documents
+// TODO Improve the diffed view of mismatching documents
 void assert_json_equality(const rapidjson::Document& doc1, const rapidjson::Document& doc2) {
   if (doc1 != doc2) {
     ASSERT_STREQ(rapidjson::serialize(doc1).c_str(), rapidjson::serialize(doc2).c_str());


### PR DESCRIPTION
Now that the typos have been fixed in 9e02e3b24747ed6211f221d429aedac817059b51 this PR adds the [typos spell-checker](https://github.com/crate-ci/typos) to the GitHub CI to prevent the accidental introduction of typos going forward.