### PR TITLE
make landmark db operations a pimpl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
    * CHANGED: write traffic tile headers in `valhalla_build_extract` [#4195](https://github.com/valhalla/valhalla/pull/4195)
    * ADDED: `source_percent_along` & `target_percent_along` to /trace_attributes JSON response [#4199](https://github.com/valhalla/valhalla/pull/4199)
    * ADDED: sqlite database to store landmarks along with interfaces of insert and bounding box queries [#4189](https://github.com/valhalla/valhalla/pull/4189)
+   * CHANGED: refactor landmark database interface to use a pimpl [#4202](https://github.com/valhalla/valhalla/pull/4202)
 
 ## Release Date: 2023-05-11 Valhalla 3.4.0
 * **Removed**

--- a/src/mjolnir/landmark_database_builder.cc
+++ b/src/mjolnir/landmark_database_builder.cc
@@ -1,102 +1,106 @@
 #include "mjolnir/landmark_database_builder.h"
 #include "mjolnir/util.h"
+#include "filesystem.h"
 
 
 namespace valhalla {
 namespace mjolnir {
 
+// TODO: this can be a utility and be more generic with a few more options, we could make the prepared
+//  statements on the fly and retrievable by the caller, then anything in the code base that wants to
+//  use sqlite can make use of this utility class. for now its ok to be specific to landmarks though
 struct LandmarkDatabase::db_pimpl {
   sqlite3* db;
   sqlite3_stmt* insert_stmt;
   sqlite3_stmt* bounding_box_stmt;
-  uint32_t ret;
-  char* err_msg = NULL;
-  std::string sql;
-  const std::string database;
-  int open_flags = 0;
-  std::shared_ptr<void> db_conn;
-  bool did_inserts = false;
+  std::shared_ptr<void> spatial_lite;
+  bool vacuum_analyze = false;
+
+  db_pimpl(const std::string& db_name, bool read_only): insert_stmt(nullptr) {
+    // figure out if we need to create it or can just open it up
+    auto flags = read_only ? SQLITE_OPEN_READONLY : SQLITE_OPEN_READWRITE;
+    if (!filesystem::exists(db_name)) {
+      if (read_only)
+        throw std::logic_error("Cannot open sqlite database in read-only mode if it does not exist");
+      flags |= SQLITE_OPEN_CREATE;
+    }
+
+    // get a connection to the database
+    auto ret = sqlite3_open_v2(db_name.c_str(), &db, flags, NULL);
+    if (ret != SQLITE_OK) {
+      throw std::runtime_error("Failed to open sqlite database: " + db_name);
+    }
+
+    // loading spatiaLite as an extension
+    spatial_lite = make_spatialite_cache(db);
+
+    // if the db was empty we need to initialize the schema
+    char* err_msg = nullptr;
+    if (flags & SQLITE_OPEN_CREATE) {
+      // make the table
+      const char* table = "SELECT InitSpatialMetaData(1); CREATE TABLE IF NOT EXISTS landmarks (name TEXT, type TEXT)";
+      ret = sqlite3_exec(db, table, NULL, NULL, &err_msg);
+      if (ret != SQLITE_OK) {
+        sqlite3_free(err_msg);
+        throw std::runtime_error("Sqlite table creation error: " + std::string(err_msg));
+      }
+
+      // add geom column
+      const char* geom = "SELECT AddGeometryColumn('landmarks', 'geom', 4326, 'POINT', 2)";
+      ret = sqlite3_exec(db, geom, NULL, NULL, &err_msg);
+      if (ret != SQLITE_OK) {
+        sqlite3_free(err_msg);
+        throw std::runtime_error("Sqlite geom column creation error: " + std::string(err_msg));
+      }
+
+      // make the index
+      const char* index = "SELECT CreateSpatialIndex('landmarks', 'geom')";
+      ret = sqlite3_exec(db, index, NULL, NULL, &err_msg);
+      if (ret != SQLITE_OK) {
+        sqlite3_free(err_msg);
+        throw std::runtime_error("Sqlite spatial index creation error: " + std::string(err_msg));
+      }
+
+      // prep the insert statement
+      const char* insert = "INSERT INTO landmarks (name, type, geom) VALUES (?, ?, MakePoint(?, ?, 4326))";
+      ret = sqlite3_prepare_v2(db, insert, strlen(insert), &insert_stmt, NULL);
+      if (ret != SQLITE_OK)
+        throw std::runtime_error("Sqlite prepared insert statement error: " + std::string(sqlite3_errmsg(db)));
+    }
+
+    // prep the select statement
+    const char* select = "SELECT name, type, X(geom), Y(geom) FROM landmarks WHERE ST_Covers(BuildMbr(?, ?, ?, ?, 4326), geom)";
+    ret = sqlite3_prepare_v2(db, select, strlen(select), &bounding_box_stmt, NULL);
+    if (ret != SQLITE_OK) {
+      throw std::runtime_error("Sqlite prepared select statement error: " + std::string(sqlite3_errmsg(db)));
+    }
+  }
+  ~db_pimpl(){
+    char* err_msg = nullptr;
+    if (vacuum_analyze && sqlite3_exec(db, "VACUUM", NULL, NULL, &err_msg) != SQLITE_OK) {
+      sqlite3_free(err_msg);
+      LOG_ERROR("Sqlite vacuum error: " + std::string(err_msg));
+    }
+
+    if (vacuum_analyze && sqlite3_exec(db, "ANALYZE", NULL, NULL, &err_msg) != SQLITE_OK) {
+      sqlite3_free(err_msg);
+      LOG_ERROR("Sqlite analyze error: " + std::string(err_msg));
+    }
+
+    sqlite3_finalize(insert_stmt);
+    sqlite3_finalize(bounding_box_stmt);
+    sqlite3_close_v2(db);
+  }
+  std::string last_error() {
+    return std::string(sqlite3_errmsg(db));
+  }
 };
 
-LandmarkDatabase::LandmarkDatabase(const std::string& db_name, bool read_only): insert_stmt(nullptr) {
-  // figure out if we need to create it or can just open it up
-  auto flags = read_only ? SQLITE_OPEN_READONLY : SQLITE_OPEN_READWRITE;
-  if (!filesystem::exists(db_name)) {
-    if (read_only)
-      throw std::logic_error("Cannot open sqlite database in read-only mode if it does not exist");
-    flags |= SQLITE_OPEN_CREATE;
-  }
-
-  // get a connection to the database
-  auto ret = sqlite3_open_v2(db_name.c_str(), &db, flags, NULL);
-  if (ret != SQLITE_OK) {
-    throw std::runtime_error("Failed to open sqlite database: " + db_name);
-  }
-
-  // loading spatiaLite as an extension
-  spatial_lite = make_spatialite_cache(db);
-
-  // if the db was empty we need to initialize the schema
-  char* err_msg = nullptr;
-  if (flags & SQLITE_OPEN_CREATE) {
-    // make the table
-    const char* table = "SELECT InitSpatialMetaData(1); CREATE TABLE IF NOT EXISTS landmarks (name TEXT, type TEXT)";
-    ret = sqlite3_exec(db, table, NULL, NULL, &err_msg);
-    if (ret != SQLITE_OK) {
-      sqlite3_free(err_msg);
-      throw std::runtime_error("Sqlite table creation error: " + std::string(err_msg));
-    }
-
-    // add geom column
-    const char* geom = "SELECT AddGeometryColumn('landmarks', 'geom', 4326, 'POINT', 2)";
-    ret = sqlite3_exec(db, geom, NULL, NULL, &err_msg);
-    if (ret != SQLITE_OK) {
-      sqlite3_free(err_msg);
-      throw std::runtime_error("Sqlite geom column creation error: " + std::string(err_msg));
-    }
-
-    // make the index
-    const char* index = "SELECT CreateSpatialIndex('landmarks', 'geom')";
-    ret = sqlite3_exec(db, index, NULL, NULL, &err_msg);
-    if (ret != SQLITE_OK) {
-      sqlite3_free(err_msg);
-      throw std::runtime_error("Sqlite spatial index creation error: " + std::string(err_msg));
-    }
-
-    // prep the insert statement
-    const char* insert = "INSERT INTO landmarks (name, type, geom) VALUES (?, ?, MakePoint(?, ?, 4326))";
-    ret = sqlite3_prepare_v2(db, insert, strlen(insert), &insert_stmt, NULL);
-    if (ret != SQLITE_OK)
-      throw std::runtime_error("Sqlite prepared insert statement error: " + std::string(sqlite3_errmsg(db)));
-  }
-
-  // prep the select statement
-  const char* select = "SELECT name, type, X(geom), Y(geom) FROM landmarks WHERE ST_Covers(BuildMbr(?, ?, ?, ?, 4326), geom)";
-  ret = sqlite3_prepare_v2(db, select, strlen(select), &bounding_box_stmt, NULL);
-  if (ret != SQLITE_OK) {
-    throw std::runtime_error("Sqlite prepared select statement error: " + std::string(sqlite3_errmsg(db)));
-  }
+LandmarkDatabase::LandmarkDatabase(const std::string& db_name, bool read_only): pimpl(new db_pimpl(db_name, read_only)) {
 }
-
-LandmarkDatabase::~LandmarkDatabase() {
-  char* err_msg = nullptr;
-  if (did_inserts && sqlite3_exec(db, "VACUUM", NULL, NULL, &err_msg) != SQLITE_OK) {
-    sqlite3_free(err_msg);
-    LOG_ERROR("Sqlite vacuum error: " + std::string(err_msg));
-  }
-
-  if (did_inserts && sqlite3_exec(db, "ANALYZE", NULL, NULL, &err_msg) != SQLITE_OK) {
-    sqlite3_free(err_msg);
-    LOG_ERROR("Sqlite analyze error: " + std::string(err_msg));
-  }
-
-  sqlite3_finalize(insert_stmt);
-  sqlite3_finalize(bounding_box_stmt);
-  sqlite3_close_v2(db);
-}
-
 
 void LandmarkDatabase::insert_landmark(const Landmark& landmark) {
+  auto* insert_stmt = pimpl->insert_stmt;
   if (!insert_stmt)
     throw std::logic_error("Sqlite database connection is read-only");
 
@@ -120,8 +124,8 @@ void LandmarkDatabase::insert_landmark(const Landmark& landmark) {
 
   LOG_TRACE(sqlite3_expanded_sql(insert_stmt));
   if (sqlite3_step(insert_stmt) != SQLITE_DONE)
-    throw std::runtime_error("Sqlite could not insert landmark: "+ std::string(sqlite3_errmsg(db)));
-  did_inserts = true;
+    throw std::runtime_error("Sqlite could not insert landmark: " + pimpl->last_error());
+  pimpl->vacuum_analyze = true;
 }
 
 std::vector<Landmark> LandmarkDatabase::get_landmarks_in_bounding_box(const double minLat,
@@ -130,6 +134,7 @@ std::vector<Landmark> LandmarkDatabase::get_landmarks_in_bounding_box(const doub
                                                                       const double maxLong) {
   std::vector<Landmark> landmarks;
 
+  auto* bounding_box_stmt = pimpl->bounding_box_stmt;
   sqlite3_reset(bounding_box_stmt);
   sqlite3_clear_bindings(bounding_box_stmt);
 
@@ -151,12 +156,11 @@ std::vector<Landmark> LandmarkDatabase::get_landmarks_in_bounding_box(const doub
   }
 
   if (ret != SQLITE_DONE && ret != SQLITE_OK) {
-    throw std::runtime_error("Sqlite could not query landmarks in bounding box: " + std::string(sqlite3_errmsg(db)));
+    throw std::runtime_error("Sqlite could not query landmarks in bounding box: " + pimpl->last_error());
   }
 
   return landmarks;
 }
 
 } // end namespace mjolnir
-
 } // end namespace valhalla

--- a/test/gurka/test_landmarks.cc
+++ b/test/gurka/test_landmarks.cc
@@ -18,7 +18,8 @@ protected:
   static void SetUpTestSuite() {
     LandmarkDatabase db(db_name, false);
 
-    ASSERT_NO_THROW(db.insert_landmark(Landmark{"Statue of Liberty", "Monument", -74.044548, 40.689253}));
+    ASSERT_NO_THROW(
+        db.insert_landmark(Landmark{"Statue of Liberty", "Monument", -74.044548, 40.689253}));
     ASSERT_NO_THROW(db.insert_landmark(Landmark{"Eiffel Tower", "Monument", 2.294481, 48.858370}));
     ASSERT_NO_THROW(db.insert_landmark(Landmark{"A", "pseudo", 5., 5.}));
     ASSERT_NO_THROW(db.insert_landmark(Landmark{"B", "pseudo", 10., 10.}));

--- a/test/gurka/test_landmarks.cc
+++ b/test/gurka/test_landmarks.cc
@@ -18,10 +18,10 @@ protected:
   static void SetUpTestSuite() {
     LandmarkDatabase db(db_name, false);
 
-    ASSERT_TRUE(db.insert_landmark(Landmark{"Statue of Liberty", "Monument", -74.044548, 40.689253}));
-    ASSERT_TRUE(db.insert_landmark(Landmark{"Eiffel Tower", "Monument", 2.294481, 48.858370}));
-    ASSERT_TRUE(db.insert_landmark(Landmark{"A", "pseudo", 5., 5.}));
-    ASSERT_TRUE(db.insert_landmark(Landmark{"B", "pseudo", 10., 10.}));
+    ASSERT_NO_THROW(db.insert_landmark(Landmark{"Statue of Liberty", "Monument", -74.044548, 40.689253}));
+    ASSERT_NO_THROW(db.insert_landmark(Landmark{"Eiffel Tower", "Monument", 2.294481, 48.858370}));
+    ASSERT_NO_THROW(db.insert_landmark(Landmark{"A", "pseudo", 5., 5.}));
+    ASSERT_NO_THROW(db.insert_landmark(Landmark{"B", "pseudo", 10., 10.}));
   }
 
   static void TearDownTestSuite() {

--- a/valhalla/mjolnir/landmark_database_builder.h
+++ b/valhalla/mjolnir/landmark_database_builder.h
@@ -15,55 +15,23 @@ struct Landmark {
 
 struct LandmarkDatabase {
 public:
-  LandmarkDatabase(const std::string& db_name, bool read_only) : db(nullptr), database(db_name) {
-    if (!filesystem::exists(database)) {
-      if (read_only) {
-        throw std::runtime_error("invalid option");
-      }
-      open_flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE;
-      connect_database();
-    } else {
-      open_flags = read_only ? SQLITE_OPEN_READONLY : SQLITE_OPEN_READWRITE;
-      connect_database();
-    }
-  }
-
-  ~LandmarkDatabase() {
-    if (did_inserts && !vacuum_analyze()) {
-      LOG_ERROR("cannot do vacuum and analyze");
-    }
-    release_prepared_stmt();
-    close_database();
-  }
-
-  bool insert_landmark(const Landmark& landmark);
-
+  LandmarkDatabase(const std::string& db_name, bool read_only);
+  ~LandmarkDatabase();
+  void insert_landmark(const Landmark& landmark);
   std::vector<Landmark> get_landmarks_in_bounding_box(const double minLat,
                                                       const double minLong,
                                                       const double maxLat,
                                                       const double maxLong);
 
 protected:
+  struct db_pimpl;
+  std::unique_ptr<db_pimpl> pimpl;
+
   sqlite3* db;
   sqlite3_stmt* insert_stmt;
   sqlite3_stmt* bounding_box_stmt;
-  uint32_t ret;
-  char* err_msg = NULL;
-  std::string sql;
-  const std::string database;
-  int open_flags = 0;
-  std::shared_ptr<void> db_conn;
+  std::shared_ptr<void> spatial_lite;
   bool did_inserts = false;
-
-  bool open_database();
-  bool create_landmarks_table();
-  bool create_spatial_index();
-  void close_database();
-  void connect_database();
-  bool prepare_insert_stmt();
-  bool prepare_bounding_box_stmt();
-  bool vacuum_analyze();
-  void release_prepared_stmt();
 };
 
 } // namespace mjolnir

--- a/valhalla/mjolnir/landmark_database_builder.h
+++ b/valhalla/mjolnir/landmark_database_builder.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <string>
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace valhalla {

--- a/valhalla/mjolnir/landmark_database_builder.h
+++ b/valhalla/mjolnir/landmark_database_builder.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "filesystem.h"
-#include "mjolnir/util.h"
+#include <string>
+#include <memory>
+#include <vector>
 
 namespace valhalla {
 namespace mjolnir {
@@ -16,7 +17,6 @@ struct Landmark {
 struct LandmarkDatabase {
 public:
   LandmarkDatabase(const std::string& db_name, bool read_only);
-  ~LandmarkDatabase();
   void insert_landmark(const Landmark& landmark);
   std::vector<Landmark> get_landmarks_in_bounding_box(const double minLat,
                                                       const double minLong,
@@ -25,13 +25,7 @@ public:
 
 protected:
   struct db_pimpl;
-  std::unique_ptr<db_pimpl> pimpl;
-
-  sqlite3* db;
-  sqlite3_stmt* insert_stmt;
-  sqlite3_stmt* bounding_box_stmt;
-  std::shared_ptr<void> spatial_lite;
-  bool did_inserts = false;
+  std::shared_ptr<db_pimpl> pimpl;
 };
 
 } // namespace mjolnir


### PR DESCRIPTION
The pimpl idiom is a powerful one especially for api design. It allows the designer to offer up the api interface without exposing the details of how its implemented, effectively giving the api a PrivateIMPLementation.

I think this best suits pretty much all of our c++ apis but sadly not all of them adhere to this. At any rate this is an attempt to refactor the recent work in #4189 to model this.

In addition to the pimpl I cut down logging as much as possible, I only close the db in the destructor and instead of returning booleans I throw when there is a problem that is unrecoverable

By and large the code is pretty much the same just leaner and meaner