### PR TITLE
sudo install python dependencies on OSX

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,7 @@ commands:
   install_macos_dependencies:
     steps:
       - run: brew install protobuf cmake ccache libtool libspatialite pkg-config luajit curl wget czmq lz4 spatialite-tools unzip
-      # NOTE, cython only for pyyaml local build on the runner because of conan pinning
-      - run: sudo python3 -m pip install shapely "conan<2.0.0" requests cython
+      - run: sudo python3 -m pip install shapely "conan<2.0.0"
       - run: git clone https://github.com/kevinkreiser/prime_server --recurse-submodules && cd prime_server && ./autogen.sh && ./configure && make -j8 && make install
   install_linux_dependencies:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,8 @@ commands:
   install_macos_dependencies:
     steps:
       - run: brew install protobuf cmake ccache libtool libspatialite pkg-config luajit curl wget czmq lz4 spatialite-tools unzip
-      - run: sudo /usr/bin/python3 -m pip install shapely "conan<2.0.0" requests
+      # NOTE, cython only for pyyaml local build on the runner because of conan pinning
+      - run: sudo /usr/bin/python3 -m pip install shapely "conan<2.0.0" requests cython
       - run: git clone https://github.com/kevinkreiser/prime_server --recurse-submodules && cd prime_server && ./autogen.sh && ./configure && make -j8 && make install
   install_linux_dependencies:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,7 @@ commands:
   install_macos_dependencies:
     steps:
       - run: brew install protobuf cmake ccache libtool libspatialite pkg-config luajit curl wget czmq lz4 spatialite-tools unzip
-      - run: /usr/bin/python3 -m pip install --user requests
-      - run: pip3 install shapely "conan<2.0.0"
+      - run: sudo /usr/bin/python3 -m pip install shapely "conan<2.0.0" requests
       - run: git clone https://github.com/kevinkreiser/prime_server --recurse-submodules && cd prime_server && ./autogen.sh && ./configure && make -j8 && make install
   install_linux_dependencies:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ commands:
     steps:
       - run: brew install protobuf cmake ccache libtool libspatialite pkg-config luajit curl wget czmq lz4 spatialite-tools unzip
       # NOTE, cython only for pyyaml local build on the runner because of conan pinning
-      - run: sudo /usr/bin/python3 -m pip install shapely "conan<2.0.0" requests cython
+      - run: sudo python3 -m pip install shapely "conan<2.0.0" requests cython
       - run: git clone https://github.com/kevinkreiser/prime_server --recurse-submodules && cd prime_server && ./autogen.sh && ./configure && make -j8 && make install
   install_linux_dependencies:
     steps:


### PR DESCRIPTION
OSX fails because conan 1.x depends on `pyyaml<6.0` and apparently there's already pyyaml 6.x installed, which it can't uninstall bcs of lacking permissions, so use `sudo` to install python packages.