### PR TITLE
make PointXY and GeoPoint non-virtual

### DIFF
--- a/valhalla/midgard/point2.h
+++ b/valhalla/midgard/point2.h
@@ -39,8 +39,6 @@ public:
   using typename std::pair<PrecisionT, PrecisionT>::second_type;
   using value_type = typename std::pair<PrecisionT, PrecisionT>::first_type;
 
-  virtual ~PointXY() = default;
-
   /**
    * Get the x component.
    * @return  Returns the x component of the point.
@@ -78,7 +76,7 @@ public:
    * @param   x   x coordinate position.
    * @param   y   y coordinate position.
    */
-  virtual void Set(const PrecisionT x, const PrecisionT y) {
+  void Set(const PrecisionT x, const PrecisionT y) {
     first = x;
     second = y;
   }
@@ -174,7 +172,7 @@ public:
    * @param  p2  End point of the segment.
    * @return  Returns true if this point is left of the segment.
    */
-  virtual PrecisionT IsLeft(const PointXY<PrecisionT>& p1, const PointXY<PrecisionT>& p2) const {
+  PrecisionT IsLeft(const PointXY<PrecisionT>& p1, const PointXY<PrecisionT>& p2) const {
     return (p2.x() - p1.x()) * (y() - p1.y()) - (x() - p1.x()) * (p2.y() - p1.y());
   }
 

--- a/valhalla/midgard/pointll.h
+++ b/valhalla/midgard/pointll.h
@@ -55,9 +55,6 @@ public:
   GeoPoint(const PointXY<PrecisionT>& p) : PointXY<PrecisionT>(p) {
   }
 
-  virtual ~GeoPoint() {
-  }
-
   /**
    * cast the lon lat to a 64bit value with 7 decimals places of precision the layout is:
    * bitfield {
@@ -242,10 +239,9 @@ public:
    * @param  p2  End point of the segment.
    * @return  Returns a positive value if this point is left of the segment.
    */
-  virtual value_type IsLeft(const GeoPoint& p1, const GeoPoint& p2) const {
+  value_type IsLeft(const GeoPoint& p1, const GeoPoint& p2) const {
     return (p2.lng() - p1.lng()) * (lat() - p1.lat()) - (lng() - p1.lng()) * (p2.lat() - p1.lat());
   }
-  using PointXY<PrecisionT>::IsLeft;
 
   /**
    * Tests whether this point is within a polygon.


### PR DESCRIPTION
Non-virtual classes smaller, non-virtual methods faster. There no dynamic casts and calls of virtual methods.