### PR TITLE
Add primary key for landmark database and landmark getter via primary key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
    * CHANGED: refactor landmark database interface to use a pimpl [#4202](https://github.com/valhalla/valhalla/pull/4202)
    * ADDED: support for `:forward` and `:backward` for `motor_vehicle`, `vehicle`, `foot` and `bicycle` tag prefixes [#4204](https://github.com/valhalla/valhalla/pull/4204)
    * ADDED: add `valhalla_build_landmarks` to parse POIs from osm pbfs and store them as landmarks in the landmark sqlite database [#4201](https://github.com/valhalla/valhalla/pull/4201)
+   * ADDED: add primary key in the landmark sqlite database and a method to retrieve a landmark via its primary key [#4224](https://github.com/valhalla/valhalla/pull/4224)
 
 ## Release Date: 2023-05-11 Valhalla 3.4.0
 * **Removed**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
    * CHANGED: refactor landmark database interface to use a pimpl [#4202](https://github.com/valhalla/valhalla/pull/4202)
    * ADDED: support for `:forward` and `:backward` for `motor_vehicle`, `vehicle`, `foot` and `bicycle` tag prefixes [#4204](https://github.com/valhalla/valhalla/pull/4204)
    * ADDED: add `valhalla_build_landmarks` to parse POIs from osm pbfs and store them as landmarks in the landmark sqlite database [#4201](https://github.com/valhalla/valhalla/pull/4201)
-   * ADDED: add primary key in the landmark sqlite database and a method to retrieve a landmark via its primary key [#4224](https://github.com/valhalla/valhalla/pull/4224)
+   * ADDED: add primary key in the landmark sqlite database and a method to retrieve landmarks via their primary keys [#4224](https://github.com/valhalla/valhalla/pull/4224)
 
 ## Release Date: 2023-05-11 Valhalla 3.4.0
 * **Removed**

--- a/src/mjolnir/landmark_builder.cc
+++ b/src/mjolnir/landmark_builder.cc
@@ -211,7 +211,7 @@ std::vector<Landmark> LandmarkDatabase::get_landmarks_by_ids(const std::vector<i
   }
 
   // execute the statement and fetch the results
-  std::vector<Landmark> landmarks;
+  std::vector<Landmark> landmarks{};
   while ((ret = sqlite3_step(get_landmarks_by_ids_stmt)) == SQLITE_ROW) {
     int64_t landmark_id = static_cast<int64_t>(sqlite3_column_int64(get_landmarks_by_ids_stmt, 0));
     const char* name =

--- a/src/mjolnir/landmark_builder.cc
+++ b/src/mjolnir/landmark_builder.cc
@@ -194,7 +194,7 @@ void LandmarkDatabase::insert_landmark(const std::string& name,
   pimpl->vacuum_analyze = true;
 }
 
-Landmark LandmarkDatabase::get_landmark(const uint32_t pkey) {
+Landmark LandmarkDatabase::get_landmark(const int64_t pkey) {
   auto* get_landmark_stmt = pimpl->get_landmark_stmt;
 
   sqlite3_reset(get_landmark_stmt);
@@ -207,12 +207,7 @@ Landmark LandmarkDatabase::get_landmark(const uint32_t pkey) {
   if (ret == SQLITE_ROW) {
     uint32_t landmark_id = static_cast<uint32_t>(sqlite3_column_int(get_landmark_stmt, 0));
     const char* name = reinterpret_cast<const char*>(sqlite3_column_text(get_landmark_stmt, 1));
-
-    int landmark_type = -1;
-    if (sqlite3_column_type(get_landmark_stmt, 2) != SQLITE_NULL) {
-      landmark_type = sqlite3_column_int(get_landmark_stmt, 2);
-    }
-
+    int landmark_type = sqlite3_column_int(get_landmark_stmt, 2);
     double lng = sqlite3_column_double(get_landmark_stmt, 3);
     double lat = sqlite3_column_double(get_landmark_stmt, 4);
 
@@ -245,14 +240,9 @@ std::vector<Landmark> LandmarkDatabase::get_landmarks_in_bounding_box(const doub
 
   int ret = sqlite3_step(bounding_box_stmt);
   while (ret == SQLITE_ROW) {
-    uint32_t landmark_id = static_cast<uint32_t>(sqlite3_column_int(bounding_box_stmt, 0));
+    auto landmark_id = static_cast<int64_t>(sqlite3_column_int64(bounding_box_stmt, 0));
     const char* name = reinterpret_cast<const char*>(sqlite3_column_text(bounding_box_stmt, 1));
-
-    int landmark_type = -1;
-    if (sqlite3_column_type(bounding_box_stmt, 2) != SQLITE_NULL) {
-      landmark_type = sqlite3_column_int(bounding_box_stmt, 2);
-    }
-
+    int landmark_type = sqlite3_column_int(bounding_box_stmt, 2);
     double lng = sqlite3_column_double(bounding_box_stmt, 3);
     double lat = sqlite3_column_double(bounding_box_stmt, 4);
 

--- a/test/gurka/test_landmarks.cc
+++ b/test/gurka/test_landmarks.cc
@@ -126,11 +126,8 @@ TEST(LandmarkTest, TestParseLandmarks) {
   EXPECT_TRUE(std::get<2>(landmarks[2]) == LandmarkType::cinema); // D
   EXPECT_TRUE(std::get<1>(landmarks[2]) == "wan da");
 
-  // check landmark getter
-  Landmark result{};
-  for (uint32_t pkey = 1; pkey < 4; pkey++) {
-    EXPECT_NO_THROW({ result = db.get_landmark_by_id(pkey); });
-    EXPECT_TRUE(std::get<0>(result) == pkey);
-  }
-  EXPECT_THROW({ result = db.get_landmark_by_id(4); }, std::runtime_error); // only three landmarks exist
+  // check getting multiple landmarks by ids
+  landmarks.clear();
+  EXPECT_NO_THROW({ landmarks = db.get_landmarks_by_ids({1, 2, 3, 4}); });
+  EXPECT_EQ(landmarks.size(), 3);
 }

--- a/test/gurka/test_landmarks.cc
+++ b/test/gurka/test_landmarks.cc
@@ -74,10 +74,10 @@ TEST(LandmarkTest, TestBuildDatabase) {
 
   LOG_INFO("Get " + std::to_string(landmarks.size()) + " rows");
   for (const auto& landmark : landmarks) {
-    LOG_INFO("name: " + std::get<0>(landmark) +
-             ", type: " + std::to_string(static_cast<uint8_t>(std::get<1>(landmark))) +
-             ", longitude: " + std::to_string(std::get<2>(landmark)) +
-             ", latitude: " + std::to_string(std::get<3>(landmark)));
+    LOG_INFO("id: " + std::to_string(std::get<0>(landmark)) + ", name: " + std::get<1>(landmark) +
+             ", type: " + std::to_string(static_cast<uint8_t>(std::get<2>(landmark))) +
+             ", longitude: " + std::to_string(std::get<3>(landmark)) +
+             ", latitude: " + std::to_string(std::get<4>(landmark)));
   }
 
   landmarks.clear();
@@ -113,16 +113,24 @@ TEST(LandmarkTest, TestParseLandmarks) {
 
   LOG_INFO("Get " + std::to_string(landmarks.size()) + " rows");
   for (const auto& landmark : landmarks) {
-    LOG_INFO("name: " + std::get<0>(landmark) +
-             ", type: " + std::to_string(static_cast<uint8_t>(std::get<1>(landmark))) +
-             ", longitude: " + std::to_string(std::get<2>(landmark)) +
-             ", latitude: " + std::to_string(std::get<3>(landmark)));
+    LOG_INFO("id: " + std::to_string(std::get<0>(landmark)) + ", name: " + std::get<1>(landmark) +
+             ", type: " + std::to_string(static_cast<uint8_t>(std::get<2>(landmark))) +
+             ", longitude: " + std::to_string(std::get<3>(landmark)) +
+             ", latitude: " + std::to_string(std::get<4>(landmark)));
   }
 
-  EXPECT_TRUE(std::get<1>(landmarks[0]) == LandmarkType::bar); // A
-  EXPECT_TRUE(std::get<0>(landmarks[0]) == "A");
-  EXPECT_TRUE(std::get<1>(landmarks[1]) == LandmarkType::restaurant); // B
-  EXPECT_TRUE(std::get<0>(landmarks[1]) == "hai di lao");
-  EXPECT_TRUE(std::get<1>(landmarks[2]) == LandmarkType::cinema); // D
-  EXPECT_TRUE(std::get<0>(landmarks[2]) == "wan da");
+  EXPECT_TRUE(std::get<2>(landmarks[0]) == LandmarkType::bar); // A
+  EXPECT_TRUE(std::get<1>(landmarks[0]) == "A");
+  EXPECT_TRUE(std::get<2>(landmarks[1]) == LandmarkType::restaurant); // B
+  EXPECT_TRUE(std::get<1>(landmarks[1]) == "hai di lao");
+  EXPECT_TRUE(std::get<2>(landmarks[2]) == LandmarkType::cinema); // D
+  EXPECT_TRUE(std::get<1>(landmarks[2]) == "wan da");
+
+  // check landmark getter
+  Landmark result{};
+  for (uint32_t pkey = 1; pkey < 4; pkey++) {
+    EXPECT_NO_THROW({ result = db.get_landmark(pkey); });
+    EXPECT_TRUE(std::get<0>(result) == pkey);
+  }
+  EXPECT_THROW({ result = db.get_landmark(4); }, std::runtime_error); // only three landmarks exist
 }

--- a/test/gurka/test_landmarks.cc
+++ b/test/gurka/test_landmarks.cc
@@ -127,7 +127,18 @@ TEST(LandmarkTest, TestParseLandmarks) {
   EXPECT_TRUE(std::get<1>(landmarks[2]) == "wan da");
 
   // check getting multiple landmarks by ids
-  landmarks.clear();
   EXPECT_NO_THROW({ landmarks = db.get_landmarks_by_ids({1, 2, 3, 4}); });
+  EXPECT_EQ(landmarks.size(), 3);
+
+  EXPECT_NO_THROW({ landmarks = db.get_landmarks_by_ids({0, 937, 45, 15, 200, 353, 2386}); });
+  EXPECT_EQ(landmarks.size(), 0);
+
+  EXPECT_NO_THROW({ landmarks = db.get_landmarks_by_ids({2, 3, 5, 7, 11, 13, 17, 19, 23, 29}); });
+  EXPECT_EQ(landmarks.size(), 2);
+
+  EXPECT_NO_THROW({ landmarks = db.get_landmarks_by_ids({4}); });
+  EXPECT_EQ(landmarks.size(), 0);
+
+  EXPECT_NO_THROW({ landmarks = db.get_landmarks_by_ids({3, 2, 1}); });
   EXPECT_EQ(landmarks.size(), 3);
 }

--- a/test/gurka/test_landmarks.cc
+++ b/test/gurka/test_landmarks.cc
@@ -68,7 +68,7 @@ TEST(LandmarkTest, TestBuildDatabase) {
   LandmarkDatabase db(db_path, true);
 
   std::vector<Landmark> landmarks{};
-  EXPECT_NO_THROW({ landmarks = db.get_landmarks_in_bounding_box(30, 30, 40, 40); });
+  EXPECT_NO_THROW({ landmarks = db.get_landmarks_by_bbox(30, 30, 40, 40); });
 
   EXPECT_EQ(landmarks.size(), 2); // A and B
 
@@ -81,7 +81,7 @@ TEST(LandmarkTest, TestBuildDatabase) {
   }
 
   landmarks.clear();
-  EXPECT_NO_THROW({ landmarks = db.get_landmarks_in_bounding_box(0, 0, 50, 50); });
+  EXPECT_NO_THROW({ landmarks = db.get_landmarks_by_bbox(0, 0, 50, 50); });
 
   EXPECT_EQ(landmarks.size(), 3); // A, B, Eiffel Tower
 }
@@ -108,7 +108,7 @@ TEST(LandmarkTest, TestParseLandmarks) {
   std::vector<Landmark> landmarks{};
   LandmarkDatabase db(db_path, true);
 
-  EXPECT_NO_THROW({ landmarks = db.get_landmarks_in_bounding_box(-5, 0, 0, 10); });
+  EXPECT_NO_THROW({ landmarks = db.get_landmarks_by_bbox(-5, 0, 0, 10); });
   EXPECT_EQ(landmarks.size(), 3); // A, B, D
 
   LOG_INFO("Get " + std::to_string(landmarks.size()) + " rows");
@@ -129,8 +129,8 @@ TEST(LandmarkTest, TestParseLandmarks) {
   // check landmark getter
   Landmark result{};
   for (uint32_t pkey = 1; pkey < 4; pkey++) {
-    EXPECT_NO_THROW({ result = db.get_landmark(pkey); });
+    EXPECT_NO_THROW({ result = db.get_landmark_by_id(pkey); });
     EXPECT_TRUE(std::get<0>(result) == pkey);
   }
-  EXPECT_THROW({ result = db.get_landmark(4); }, std::runtime_error); // only three landmarks exist
+  EXPECT_THROW({ result = db.get_landmark_by_id(4); }, std::runtime_error); // only three landmarks exist
 }

--- a/valhalla/mjolnir/landmark_builder.h
+++ b/valhalla/mjolnir/landmark_builder.h
@@ -118,7 +118,8 @@ public:
 
   /**
    * Retrieve a vector of landmarks from the database within the specified bounding box.
-   * Bounding box is a rectangle area defined by min latitude, max latitude, min longitude, and max longitude.s
+   * Bounding box is a rectangle area defined by min latitude, max latitude, min longitude, and max
+   * longitude.s
    * @param minLat The minimum latitude of the bounding box.
    * @param minLong The minimum longitude of the bounding box.
    * @param maxLat The maximum latitude of the bounding box.
@@ -147,8 +148,8 @@ protected:
 
 /**
  * Build landmark database and insert landmarks data from the PBF files to the database.
- * This function reads landmark data from PBF files specified in the `input_files` vector. 
- * It then parses the data to extract landmark nodes and stores the landmarks in the database. 
+ * This function reads landmark data from PBF files specified in the `input_files` vector.
+ * It then parses the data to extract landmark nodes and stores the landmarks in the database.
  * The database is automatically built based on the configuration settings provided in `pt`.
  * @param pt The configuration settings for the landmark building process.
  * @param input_files A vector of file paths to the PBF input files.

--- a/valhalla/mjolnir/landmark_builder.h
+++ b/valhalla/mjolnir/landmark_builder.h
@@ -60,7 +60,7 @@ enum class LandmarkType : uint8_t {
   casino = 18,
 };
 
-using Landmark = std::tuple<std::string, LandmarkType, double, double>;
+using Landmark = std::tuple<uint32_t, std::string, LandmarkType, double, double>;
 
 inline LandmarkType string_to_landmark_type(const std::string& s) {
   static const std::unordered_map<std::string, LandmarkType> string_to_landmark_type =
@@ -98,10 +98,13 @@ public:
                        const LandmarkType& type,
                        const double lng,
                        const double lat);
+
   std::vector<Landmark> get_landmarks_in_bounding_box(const double minLat,
                                                       const double minLong,
                                                       const double maxLat,
                                                       const double maxLong);
+
+  Landmark get_landmark(const uint32_t pkey);
 
 protected:
   struct db_pimpl;

--- a/valhalla/mjolnir/landmark_builder.h
+++ b/valhalla/mjolnir/landmark_builder.h
@@ -147,7 +147,7 @@ protected:
 };
 
 /**
- * Build landmark database and insert landmarks data from the PBF files to the database.
+ * Build a SQLite landmark database and insert landmarks data from the PBF files to the database.
  * This function reads landmark data from PBF files specified in the `input_files` vector.
  * It then parses the data to extract landmark nodes and stores the landmarks in the database.
  * The database is automatically built based on the configuration settings provided in `pt`.

--- a/valhalla/mjolnir/landmark_builder.h
+++ b/valhalla/mjolnir/landmark_builder.h
@@ -92,18 +92,52 @@ inline LandmarkType string_to_landmark_type(const std::string& s) {
 
 struct LandmarkDatabase {
 public:
+  /**
+   * LandmarkDatabase constructor.
+   * Create a new LandmarkDatabase object that connects to the SQLite landmark database
+   * with the given `db_name`. The `read_only` parameter determines whether the
+   * database connection is read-only or read-write.
+   * @param db_name The file path of the SQLite database to connect to.
+   * @param read_only Set to true to open the database in read-only mode, false for read-write.
+   */
   LandmarkDatabase(const std::string& db_name, bool read_only);
 
+  /**
+   * Insert a new landmark into the database.
+   * This function inserts a new landmark into the database with the given `name`, `type`,
+   * `lng`, and `lat`. The landmark's primary key will be automatically assigned by the database.
+   * @param name The name of the landmark.
+   * @param type The type of the landmark (LandmarkType enum).
+   * @param lng The longitude of the landmark.
+   * @param lat The latitude of the landmark.
+   */
   void insert_landmark(const std::string& name,
                        const LandmarkType& type,
                        const double lng,
                        const double lat);
 
+  /**
+   * Retrieve a vector of landmarks from the database within the specified bounding box.
+   * Bounding box is a rectangle area defined by min latitude, max latitude, min longitude, and max longitude.s
+   * @param minLat The minimum latitude of the bounding box.
+   * @param minLong The minimum longitude of the bounding box.
+   * @param maxLat The maximum latitude of the bounding box.
+   * @param maxLong The maximum longitude of the bounding box.
+   * @return A vector of Landmark objects within the specified bounding box.
+   */
   std::vector<Landmark> get_landmarks_by_bbox(const double minLat,
                                               const double minLong,
                                               const double maxLat,
                                               const double maxLong);
 
+  /**
+   * Retrieve a vector of landmarks that match the provided primary keys.
+   * NOTE: The return size may be less than the size of the input if some of the provided
+   * primary keys do not exist in the database. In such cases, the function will skip the missing IDs
+   * without throwing an exception.
+   * @param pkeys A vector of int64_t representing the primary keys of the landmarks to retrieve.
+   * @return A vector of Landmark objects matching the given primary keys.
+   */
   std::vector<Landmark> get_landmarks_by_ids(const std::vector<int64_t>& pkeys);
 
 protected:
@@ -111,6 +145,15 @@ protected:
   std::shared_ptr<db_pimpl> pimpl;
 };
 
+/**
+ * Build landmark database and insert landmarks data from the PBF files to the database.
+ * This function reads landmark data from PBF files specified in the `input_files` vector. 
+ * It then parses the data to extract landmark nodes and stores the landmarks in the database. 
+ * The database is automatically built based on the configuration settings provided in `pt`.
+ * @param pt The configuration settings for the landmark building process.
+ * @param input_files A vector of file paths to the PBF input files.
+ * @return True if landmarks were successfully built and inserted into the database, false otherwise.
+ */
 bool BuildLandmarkFromPBF(const boost::property_tree::ptree& pt,
                           const std::vector<std::string>& input_files);
 

--- a/valhalla/mjolnir/landmark_builder.h
+++ b/valhalla/mjolnir/landmark_builder.h
@@ -60,7 +60,7 @@ enum class LandmarkType : uint8_t {
   casino = 18,
 };
 
-using Landmark = std::tuple<uint32_t, std::string, LandmarkType, double, double>;
+using Landmark = std::tuple<int64_t, std::string, LandmarkType, double, double>;
 
 inline LandmarkType string_to_landmark_type(const std::string& s) {
   static const std::unordered_map<std::string, LandmarkType> string_to_landmark_type =
@@ -104,7 +104,7 @@ public:
                                                       const double maxLat,
                                                       const double maxLong);
 
-  Landmark get_landmark(const uint32_t pkey);
+  Landmark get_landmark(const int64_t pkey);
 
 protected:
   struct db_pimpl;

--- a/valhalla/mjolnir/landmark_builder.h
+++ b/valhalla/mjolnir/landmark_builder.h
@@ -99,12 +99,12 @@ public:
                        const double lng,
                        const double lat);
 
-  std::vector<Landmark> get_landmarks_in_bounding_box(const double minLat,
-                                                      const double minLong,
-                                                      const double maxLat,
-                                                      const double maxLong);
+  std::vector<Landmark> get_landmarks_by_bbox(const double minLat,
+                                              const double minLong,
+                                              const double maxLat,
+                                              const double maxLong);
 
-  Landmark get_landmark(const int64_t pkey);
+  Landmark get_landmark_by_id(const int64_t pkey);
 
 protected:
   struct db_pimpl;

--- a/valhalla/mjolnir/landmark_builder.h
+++ b/valhalla/mjolnir/landmark_builder.h
@@ -104,7 +104,7 @@ public:
                                               const double maxLat,
                                               const double maxLong);
 
-  Landmark get_landmark_by_id(const int64_t pkey);
+  std::vector<Landmark> get_landmarks_by_ids(const std::vector<int64_t>& pkeys);
 
 protected:
   struct db_pimpl;

--- a/valhalla/mjolnir/landmark_builder.h
+++ b/valhalla/mjolnir/landmark_builder.h
@@ -97,6 +97,7 @@ public:
    * Create a new LandmarkDatabase object that connects to the SQLite landmark database
    * with the given `db_name`. The `read_only` parameter determines whether the
    * database connection is read-only or read-write.
+   *
    * @param db_name The file path of the SQLite database to connect to.
    * @param read_only Set to true to open the database in read-only mode, false for read-write.
    */
@@ -106,6 +107,7 @@ public:
    * Insert a new landmark into the database.
    * This function inserts a new landmark into the database with the given `name`, `type`,
    * `lng`, and `lat`. The landmark's primary key will be automatically assigned by the database.
+   *
    * @param name The name of the landmark.
    * @param type The type of the landmark (LandmarkType enum).
    * @param lng The longitude of the landmark.
@@ -119,7 +121,8 @@ public:
   /**
    * Retrieve a vector of landmarks from the database within the specified bounding box.
    * Bounding box is a rectangle area defined by min latitude, max latitude, min longitude, and max
-   * longitude.s
+   * longitude.
+   *
    * @param minLat The minimum latitude of the bounding box.
    * @param minLong The minimum longitude of the bounding box.
    * @param maxLat The maximum latitude of the bounding box.
@@ -136,6 +139,7 @@ public:
    * NOTE: The return size may be less than the size of the input if some of the provided
    * primary keys do not exist in the database. In such cases, the function will skip the missing IDs
    * without throwing an exception.
+   *
    * @param pkeys A vector of int64_t representing the primary keys of the landmarks to retrieve.
    * @return A vector of Landmark objects matching the given primary keys.
    */
@@ -151,6 +155,7 @@ protected:
  * This function reads landmark data from PBF files specified in the `input_files` vector.
  * It then parses the data to extract landmark nodes and stores the landmarks in the database.
  * The database is automatically built based on the configuration settings provided in `pt`.
+ *
  * @param pt The configuration settings for the landmark building process.
  * @param input_files A vector of file paths to the PBF input files.
  * @return True if landmarks were successfully built and inserted into the database, false otherwise.


### PR DESCRIPTION
# Issue
To faciliate landmark storage in tiles, primary key is added in landmark databse to enable getting a landmark via its primary key.
 
## Tasklist

 - [x] add primary key to the landmarks database 
 - [x] add a method to be able to retreive a landmark from the db via its primary key

## Requirements / Relations

[Landmark Routing 3: Tile Storage of Associated Landmarks](https://github.com/valhalla/valhalla/issues/4135)
