### PR TITLE
Test directory sign compare

### DIFF
--- a/test/gurka/test_64bit_wayid.cc
+++ b/test/gurka/test_64bit_wayid.cc
@@ -72,7 +72,7 @@ TEST(WayIds, way_ids1) {
   };
   // keep one for each directed edge
   std::multiset<uint64_t> osm_way_ids;
-  for (int i = 0; i < ids.size(); ++i) {
+  for (size_t i = 0; i < ids.size(); ++i) {
     const auto& id = ids[i];
     osm_way_ids.emplace(std::stoull(id));
     osm_way_ids.emplace(std::stoull(id));

--- a/test/gurka/test_match.cc
+++ b/test/gurka/test_match.cc
@@ -118,7 +118,7 @@ D--3--4--C--5--6--E)";
       map.nodes["2"], map.nodes["B"], map.nodes["C"], map.nodes["6"], map.nodes["C"], map.nodes["3"],
   };
   EXPECT_EQ(shape.size(), expected_shape.size());
-  for (int i = 0; i < shape.size(); ++i) {
+  for (size_t i = 0; i < shape.size(); ++i) {
     EXPECT_TRUE(shape[i].ApproximatelyEqual(expected_shape[i]));
   }
 }
@@ -157,7 +157,7 @@ TEST(MapMatch, NodeSnapFix) {
 
   auto expected_shape = decltype(shape){map.nodes["B"], map.nodes["C"], map.nodes["F"]};
   EXPECT_EQ(shape.size(), expected_shape.size());
-  for (int i = 0; i < shape.size(); ++i) {
+  for (size_t i = 0; i < shape.size(); ++i) {
     EXPECT_TRUE(shape[i].ApproximatelyEqual(expected_shape[i]));
   }
 }
@@ -251,7 +251,7 @@ uint32_t TrafficBasedTest::current = 0, TrafficBasedTest::historical = 0,
          TrafficBasedTest::constrained = 0, TrafficBasedTest::freeflow = 0;
 
 uint32_t speed_from_edge(const valhalla::Api& api, bool compare_with_previous_edge = true) {
-  uint32_t kmh = -1;
+  uint32_t kmh = invalid<uint32_t>();
   const auto& nodes = api.trip().routes(0).legs(0).node();
   for (int i = 0; i < nodes.size() - 1; ++i) {
     const auto& node = nodes.Get(i);
@@ -262,7 +262,7 @@ uint32_t speed_from_edge(const valhalla::Api& api, bool compare_with_previous_ed
               node.cost().elapsed_cost().seconds() - node.cost().transition_cost().seconds()) /
              3600.0;
     auto new_kmh = static_cast<uint32_t>(km / h + .5);
-    if (kmh != -1 && compare_with_previous_edge)
+    if (is_valid(kmh) && compare_with_previous_edge)
       EXPECT_EQ(kmh, new_kmh);
     kmh = new_kmh;
   }

--- a/test/gurka/test_osrm_serializer.cc
+++ b/test/gurka/test_osrm_serializer.cc
@@ -54,7 +54,7 @@ TEST(Standalone, HeadingNumberTurnLeft) {
   //
   auto json = gurka::convert_to_json(result, Options::Format::Options_Format_osrm);
   auto heading_number{1};
-  for (int i = 0; i < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++i)
+  for (size_t i = 0; i < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++i)
     ASSERT_EQ(heading_number, json["routes"][0]["legs"][0]["steps"][0]["intersections"][0]["bearings"]
                                   .GetArray()
                                   .Size());
@@ -81,9 +81,9 @@ TEST(Standalone, HeadingNumberTRoute) {
 
   auto json = gurka::convert_to_json(result, Options::Format::Options_Format_osrm);
   std::vector<int> expected_headings{1, 3, 1};
-  for (int i = 0; i < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++i) {
-    for (int j = 0; j < json["routes"][0]["legs"][0]["steps"][i]["intersections"].GetArray().Size();
-         ++j) {
+  for (size_t i = 0; i < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++i) {
+    for (size_t j = 0;
+         j < json["routes"][0]["legs"][0]["steps"][i]["intersections"].GetArray().Size(); ++j) {
       ASSERT_EQ(expected_headings[i],
                 json["routes"][0]["legs"][0]["steps"][i]["intersections"][j]["bearings"]
                     .GetArray()
@@ -111,9 +111,9 @@ TEST(Standalone, HeadingNumberForkRoute) {
 
   auto json = gurka::convert_to_json(result, valhalla::Options_Format_osrm);
   std::vector<int> expected_headings{1, 3, 3, 1};
-  for (int i = 0; i < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++i) {
-    for (int j = 0; j < json["routes"][0]["legs"][0]["steps"][i]["intersections"].GetArray().Size();
-         ++j) {
+  for (size_t i = 0; i < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++i) {
+    for (size_t j = 0;
+         j < json["routes"][0]["legs"][0]["steps"][i]["intersections"].GetArray().Size(); ++j) {
       ASSERT_EQ(expected_headings[i],
                 json["routes"][0]["legs"][0]["steps"][i]["intersections"][j]["bearings"]
                     .GetArray()
@@ -146,9 +146,9 @@ TEST(Standalone, HeadingNumberCrossRoad) {
 
   auto json = gurka::convert_to_json(result, Options::Format::Options_Format_osrm);
   std::vector<int> expected_headings{1, 4, 1};
-  for (int i = 0; i < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++i) {
-    for (int j = 0; j < json["routes"][0]["legs"][0]["steps"][i]["intersections"].GetArray().Size();
-         ++j) {
+  for (size_t i = 0; i < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++i) {
+    for (size_t j = 0;
+         j < json["routes"][0]["legs"][0]["steps"][i]["intersections"].GetArray().Size(); ++j) {
       ASSERT_EQ(expected_headings[i],
                 json["routes"][0]["legs"][0]["steps"][i]["intersections"][j]["bearings"]
                     .GetArray()
@@ -182,9 +182,9 @@ TEST(Standalone, HeadingNumber2CrossRoadPedestrian) {
   auto json = gurka::convert_to_json(result, Options::Format::Options_Format_osrm);
   std::vector<int> expected_headings{1, 4, 4, 1};
   int index{0};
-  for (int i = 0; i < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++i) {
-    for (int j = 0; j < json["routes"][0]["legs"][0]["steps"][i]["intersections"].GetArray().Size();
-         ++j) {
+  for (size_t i = 0; i < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++i) {
+    for (size_t j = 0;
+         j < json["routes"][0]["legs"][0]["steps"][i]["intersections"].GetArray().Size(); ++j) {
       ASSERT_EQ(expected_headings[index++],
                 json["routes"][0]["legs"][0]["steps"][i]["intersections"][j]["bearings"]
                     .GetArray()
@@ -195,9 +195,9 @@ TEST(Standalone, HeadingNumber2CrossRoadPedestrian) {
   result = gurka::do_action(valhalla::Options::route, map, {"A", "G"}, "pedestrian");
   json = gurka::convert_to_json(result, Options::Format::Options_Format_osrm);
   index = 0;
-  for (int i = 0; i < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++i) {
-    for (int j = 0; j < json["routes"][0]["legs"][0]["steps"][i]["intersections"].GetArray().Size();
-         ++j) {
+  for (size_t i = 0; i < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++i) {
+    for (size_t j = 0;
+         j < json["routes"][0]["legs"][0]["steps"][i]["intersections"].GetArray().Size(); ++j) {
       ASSERT_EQ(expected_headings[index++],
                 json["routes"][0]["legs"][0]["steps"][i]["intersections"][j]["bearings"]
                     .GetArray()
@@ -238,7 +238,7 @@ TEST(Standalone, HeadingNumber2CrossRoadAuto) {
     int out_cnt{0};
     std::vector<int> in_indexes{3, 3, 0}; // `in` field expected values
     int in_cnt{0};
-    for (int steps = 0; steps < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++steps) {
+    for (size_t steps = 0; steps < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++steps) {
       int intersection_num =
           json["routes"][0]["legs"][0]["steps"][steps]["intersections"].GetArray().Size();
       for (int intersection = 0; intersection < intersection_num; ++intersection) {
@@ -301,7 +301,7 @@ TEST(Standalone, HeadingNumber2CrossRoadAuto) {
     int in_cnt{0};
 
     // clang-format off
-    for (int step = 0; step < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++step) {
+    for (size_t step = 0; step < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++step) {
 
       int intersection_num = json["routes"][0]["legs"][0]["steps"][step]["intersections"].GetArray().Size();
       for (int intersection = 0; intersection < intersection_num; ++intersection) {
@@ -430,7 +430,7 @@ TEST(Standalone, HeadingNumberAutoRoute) {
   std::vector<int> expected_headings{1, 2, 4, 2, 4, 1};
   int index{0};
   // Validate number of bearings at each intersection of each step.
-  for (int step = 0; step < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++step) {
+  for (size_t step = 0; step < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++step) {
     int intersection_num =
         json["routes"][0]["legs"][0]["steps"][step]["intersections"].GetArray().Size();
     for (int intersection = 0; intersection < intersection_num; ++intersection) {
@@ -457,7 +457,7 @@ TEST(Standalone, HeadingNumberAutoRoute) {
 
   // Validating `in` and `out` edge indexes and bearings at each intersection of each step.
   // clang-format off
-  for (int step = 0; step < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++step) {
+  for (size_t step = 0; step < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++step) {
     int intersection_num = json["routes"][0]["legs"][0]["steps"][step]["intersections"].GetArray().Size();
     for (int intersection = 0; intersection < intersection_num; ++intersection) {
       if (step == 0) {

--- a/test/gurka/test_osrm_serializer.cc
+++ b/test/gurka/test_osrm_serializer.cc
@@ -53,11 +53,12 @@ TEST(Standalone, HeadingNumberTurnLeft) {
                                  {{"/shape_format", "geojson"}});
   //
   auto json = gurka::convert_to_json(result, Options::Format::Options_Format_osrm);
-  auto heading_number{1};
-  for (size_t i = 0; i < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++i)
-    ASSERT_EQ(heading_number, json["routes"][0]["legs"][0]["steps"][0]["intersections"][0]["bearings"]
-                                  .GetArray()
-                                  .Size());
+  std::vector<int> expected_headings{1, 2, 1};
+  for (rapidjson::SizeType i = 0; i < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++i)
+    ASSERT_EQ(expected_headings[i],
+              json["routes"][0]["legs"][0]["steps"][i]["intersections"][0]["bearings"]
+                  .GetArray()
+                  .Size());
 }
 
 TEST(Standalone, HeadingNumberTRoute) {
@@ -81,8 +82,8 @@ TEST(Standalone, HeadingNumberTRoute) {
 
   auto json = gurka::convert_to_json(result, Options::Format::Options_Format_osrm);
   std::vector<int> expected_headings{1, 3, 1};
-  for (size_t i = 0; i < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++i) {
-    for (size_t j = 0;
+  for (rapidjson::SizeType i = 0; i < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++i) {
+    for (rapidjson::SizeType j = 0;
          j < json["routes"][0]["legs"][0]["steps"][i]["intersections"].GetArray().Size(); ++j) {
       ASSERT_EQ(expected_headings[i],
                 json["routes"][0]["legs"][0]["steps"][i]["intersections"][j]["bearings"]
@@ -111,8 +112,8 @@ TEST(Standalone, HeadingNumberForkRoute) {
 
   auto json = gurka::convert_to_json(result, valhalla::Options_Format_osrm);
   std::vector<int> expected_headings{1, 3, 3, 1};
-  for (size_t i = 0; i < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++i) {
-    for (size_t j = 0;
+  for (rapidjson::SizeType i = 0; i < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++i) {
+    for (rapidjson::SizeType j = 0;
          j < json["routes"][0]["legs"][0]["steps"][i]["intersections"].GetArray().Size(); ++j) {
       ASSERT_EQ(expected_headings[i],
                 json["routes"][0]["legs"][0]["steps"][i]["intersections"][j]["bearings"]
@@ -146,8 +147,8 @@ TEST(Standalone, HeadingNumberCrossRoad) {
 
   auto json = gurka::convert_to_json(result, Options::Format::Options_Format_osrm);
   std::vector<int> expected_headings{1, 4, 1};
-  for (size_t i = 0; i < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++i) {
-    for (size_t j = 0;
+  for (rapidjson::SizeType i = 0; i < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++i) {
+    for (rapidjson::SizeType j = 0;
          j < json["routes"][0]["legs"][0]["steps"][i]["intersections"].GetArray().Size(); ++j) {
       ASSERT_EQ(expected_headings[i],
                 json["routes"][0]["legs"][0]["steps"][i]["intersections"][j]["bearings"]
@@ -182,7 +183,7 @@ TEST(Standalone, HeadingNumber2CrossRoadPedestrian) {
   auto json = gurka::convert_to_json(result, Options::Format::Options_Format_osrm);
   std::vector<int> expected_headings{1, 4, 4, 1};
   int index{0};
-  for (size_t i = 0; i < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++i) {
+  for (rapidjson::SizeType i = 0; i < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++i) {
     for (size_t j = 0;
          j < json["routes"][0]["legs"][0]["steps"][i]["intersections"].GetArray().Size(); ++j) {
       ASSERT_EQ(expected_headings[index++],
@@ -195,8 +196,8 @@ TEST(Standalone, HeadingNumber2CrossRoadPedestrian) {
   result = gurka::do_action(valhalla::Options::route, map, {"A", "G"}, "pedestrian");
   json = gurka::convert_to_json(result, Options::Format::Options_Format_osrm);
   index = 0;
-  for (size_t i = 0; i < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++i) {
-    for (size_t j = 0;
+  for (rapidjson::SizeType i = 0; i < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++i) {
+    for (rapidjson::SizeType j = 0;
          j < json["routes"][0]["legs"][0]["steps"][i]["intersections"].GetArray().Size(); ++j) {
       ASSERT_EQ(expected_headings[index++],
                 json["routes"][0]["legs"][0]["steps"][i]["intersections"][j]["bearings"]
@@ -238,7 +239,8 @@ TEST(Standalone, HeadingNumber2CrossRoadAuto) {
     int out_cnt{0};
     std::vector<int> in_indexes{3, 3, 0}; // `in` field expected values
     int in_cnt{0};
-    for (size_t steps = 0; steps < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++steps) {
+    for (rapidjson::SizeType steps = 0;
+         steps < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++steps) {
       int intersection_num =
           json["routes"][0]["legs"][0]["steps"][steps]["intersections"].GetArray().Size();
       for (int intersection = 0; intersection < intersection_num; ++intersection) {
@@ -301,7 +303,7 @@ TEST(Standalone, HeadingNumber2CrossRoadAuto) {
     int in_cnt{0};
 
     // clang-format off
-    for (size_t step = 0; step < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++step) {
+    for (rapidjson::SizeType step = 0; step < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++step) {
 
       int intersection_num = json["routes"][0]["legs"][0]["steps"][step]["intersections"].GetArray().Size();
       for (int intersection = 0; intersection < intersection_num; ++intersection) {
@@ -430,7 +432,8 @@ TEST(Standalone, HeadingNumberAutoRoute) {
   std::vector<int> expected_headings{1, 2, 4, 2, 4, 1};
   int index{0};
   // Validate number of bearings at each intersection of each step.
-  for (size_t step = 0; step < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++step) {
+  for (rapidjson::SizeType step = 0; step < json["routes"][0]["legs"][0]["steps"].GetArray().Size();
+       ++step) {
     int intersection_num =
         json["routes"][0]["legs"][0]["steps"][step]["intersections"].GetArray().Size();
     for (int intersection = 0; intersection < intersection_num; ++intersection) {
@@ -457,7 +460,7 @@ TEST(Standalone, HeadingNumberAutoRoute) {
 
   // Validating `in` and `out` edge indexes and bearings at each intersection of each step.
   // clang-format off
-  for (size_t step = 0; step < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++step) {
+  for (rapidjson::SizeType step = 0; step < json["routes"][0]["legs"][0]["steps"].GetArray().Size(); ++step) {
     int intersection_num = json["routes"][0]["legs"][0]["steps"][step]["intersections"].GetArray().Size();
     for (int intersection = 0; intersection < intersection_num; ++intersection) {
       if (step == 0) {

--- a/test/gurka/test_precision.cc
+++ b/test/gurka/test_precision.cc
@@ -35,7 +35,7 @@ TEST_F(Precision, WaypointsOnNodes) {
                                         map.nodes["D"], map.nodes["E"], map.nodes["F"]};
 
   EXPECT_EQ(shape.size(), expected_shape.size());
-  for (int i = 0; i < shape.size(); ++i) {
+  for (size_t i = 0; i < shape.size(); ++i) {
     EXPECT_NEAR(shape[i].lat(), expected_shape[i].lat(), 0.000001);
     EXPECT_NEAR(shape[i].lng(), expected_shape[i].lng(), 0.000001);
   }
@@ -49,7 +49,7 @@ TEST_F(Precision, PartialOffsetCheckOne) {
                                         map.nodes["D"], map.nodes["E"], map.nodes["2"]};
 
   EXPECT_EQ(shape.size(), expected_shape.size());
-  for (int i = 0; i < shape.size(); ++i) {
+  for (size_t i = 0; i < shape.size(); ++i) {
     EXPECT_NEAR(shape[i].lat(), expected_shape[i].lat(), 0.000001);
     EXPECT_NEAR(shape[i].lng(), expected_shape[i].lng(), 0.000001);
   }
@@ -63,7 +63,7 @@ TEST_F(Precision, PartialOffsetCheckTwo) {
                                         map.nodes["D"], map.nodes["E"], map.nodes["2"]};
 
   EXPECT_EQ(shape.size(), expected_shape.size());
-  for (int i = 0; i < shape.size(); ++i) {
+  for (size_t i = 0; i < shape.size(); ++i) {
     EXPECT_NEAR(shape[i].lat(), expected_shape[i].lat(), 0.000001);
     EXPECT_NEAR(shape[i].lng(), expected_shape[i].lng(), 0.000001);
   }
@@ -77,7 +77,7 @@ TEST_F(Precision, PartialOffsetCheckThree) {
                                         map.nodes["D"], map.nodes["E"], map.nodes["F"]};
 
   EXPECT_EQ(shape.size(), expected_shape.size());
-  for (int i = 0; i < shape.size(); ++i) {
+  for (size_t i = 0; i < shape.size(); ++i) {
     EXPECT_NEAR(shape[i].lat(), expected_shape[i].lat(), 0.000001);
     EXPECT_NEAR(shape[i].lng(), expected_shape[i].lng(), 0.000001);
   }

--- a/test/gurka/test_route.cc
+++ b/test/gurka/test_route.cc
@@ -318,7 +318,7 @@ uint32_t AlgorithmTest::current = 0, AlgorithmTest::historical = 0, AlgorithmTes
          AlgorithmTest::freeflow = 0;
 
 uint32_t speed_from_edge(const valhalla::Api& api, bool compare_with_previous_edge = true) {
-  uint32_t kmh = -1;
+  uint32_t kmh = invalid<uint32_t>();
   const auto& nodes = api.trip().routes(0).legs(0).node();
   for (int i = 0; i < nodes.size() - 1; ++i) {
     const auto& node = nodes.Get(i);
@@ -329,7 +329,7 @@ uint32_t speed_from_edge(const valhalla::Api& api, bool compare_with_previous_ed
               node.cost().elapsed_cost().seconds() - node.cost().transition_cost().seconds()) /
              3600.0;
     auto new_kmh = static_cast<uint32_t>(km / h + .5);
-    if (kmh != -1 && compare_with_previous_edge) {
+    if (is_valid(kmh) && compare_with_previous_edge) {
       EXPECT_EQ(kmh, new_kmh);
     }
     kmh = new_kmh;

--- a/test/gurka/test_time_dependent_tags.cc
+++ b/test/gurka/test_time_dependent_tags.cc
@@ -58,7 +58,7 @@ TEST_F(TimeDependentTags, HourRestrictions) {
                         "test/data/gurka_time_dependent_restrictions_hour",
                         {{"mjolnir.timezone", VALHALLA_BUILD_DIR "test/data/tz.sqlite"}});
 
-  for (int x = 0; x < working_hours.size(); ++x) {
+  for (size_t x = 0; x < working_hours.size(); ++x) {
     auto result =
         gurka::do_action(valhalla::Options::route, map, {"A", "F"}, "auto",
                          {{"/date_time/type", "1"}, {"/date_time/value", working_hours.at(x)}});
@@ -81,7 +81,7 @@ TEST_F(TimeDependentTags, DayRestrictions) {
                         "test/data/gurka_time_dependent_restrictions_day",
                         {{"mjolnir.timezone", VALHALLA_BUILD_DIR "test/data/tz.sqlite"}});
 
-  for (int x = 0; x < working_hours.size(); ++x) {
+  for (size_t x = 0; x < working_hours.size(); ++x) {
     auto result =
         gurka::do_action(valhalla::Options::route, map, {"A", "F"}, "auto",
                          {{"/date_time/type", "1"}, {"/date_time/value", working_hours.at(x)}});
@@ -103,7 +103,7 @@ TEST_F(TimeDependentTags, DayAndHourRestrictions) {
                         "test/data/gurka_time_dependent_restrictions_day_and_hour",
                         {{"mjolnir.timezone", VALHALLA_BUILD_DIR "test/data/tz.sqlite"}});
 
-  for (int x = 0; x < working_hours.size(); ++x) {
+  for (size_t x = 0; x < working_hours.size(); ++x) {
     auto result =
         gurka::do_action(valhalla::Options::route, map, {"A", "F"}, "auto",
                          {{"/date_time/type", "1"}, {"/date_time/value", working_hours.at(x)}});
@@ -125,7 +125,7 @@ TEST_F(TimeDependentTags, ConditionalEdgeRestriction) {
                         "test/data/gurka_time_dependent_restrictions_day_and_hour",
                         {{"mjolnir.timezone", VALHALLA_BUILD_DIR "test/data/tz.sqlite"}});
 
-  for (int x = 0; x < working_hours.size(); ++x) {
+  for (size_t x = 0; x < working_hours.size(); ++x) {
     auto result =
         gurka::do_action(valhalla::Options::route, map, {"A", "F"}, "auto",
                          {{"/date_time/type", "1"}, {"/date_time/value", working_hours.at(x)}});

--- a/test/gurka/test_traffic.cc
+++ b/test/gurka/test_traffic.cc
@@ -48,7 +48,7 @@ TEST(Traffic, BasicUpdates) {
                "Mostly just updates every edge in the file to 24km/h, except for one "
                "specific edge (B->D) where we simulate a closure (speed=0, congestion high)"
             << std::endl;
-  auto cb_setter_24kmh = [&map](baldr::GraphReader& reader, baldr::TrafficTile& tile, int index,
+  auto cb_setter_24kmh = [&map](baldr::GraphReader& reader, baldr::TrafficTile& tile, uint32_t index,
                                 valhalla::baldr::TrafficSpeed* current) -> void {
     baldr::GraphId tile_id(tile.header->tile_id);
     auto BD = gurka::findEdge(reader, map.nodes, "BD", "D", tile_id);
@@ -77,7 +77,7 @@ TEST(Traffic, BasicUpdates) {
 
   std::cout << "[          ] Next, set the speed to the highest possible to ensure nothing breaks"
             << std::endl;
-  auto cb_setter_max = [&map](baldr::GraphReader& reader, baldr::TrafficTile& tile, int index,
+  auto cb_setter_max = [&map](baldr::GraphReader& reader, baldr::TrafficTile& tile, uint32_t index,
                               baldr::TrafficSpeed* current) -> void {
     baldr::GraphId tile_id(tile.header->tile_id);
     auto BD = gurka::findEdge(reader, map.nodes, "BD", "D", tile_id);
@@ -219,7 +219,7 @@ TEST(Traffic, CutGeoms) {
     ts.breakpoint1 = 127;
 
     auto cb_setter_speed = [&map, &ts](baldr::GraphReader& reader, baldr::TrafficTile& tile,
-                                       int index, baldr::TrafficSpeed* current) -> void {
+                                       uint32_t index, baldr::TrafficSpeed* current) -> void {
       baldr::GraphId tile_id(tile.header->tile_id);
       auto BD = gurka::findEdge(reader, map.nodes, "BD", "D", tile_id);
       current->breakpoint1 = 255;
@@ -293,7 +293,7 @@ TEST(Traffic, CutGeoms) {
       ts.breakpoint2 = 200;
 
       auto cb_setter_speed = [&map, &ts](baldr::GraphReader& reader, baldr::TrafficTile& tile,
-                                         int index, baldr::TrafficSpeed* current) -> void {
+                                         uint32_t index, baldr::TrafficSpeed* current) -> void {
         baldr::GraphId tile_id(tile.header->tile_id);
         auto BD = gurka::findEdge(reader, map.nodes, "BD", "D", tile_id);
         baldr::TrafficSpeed* existing =
@@ -377,7 +377,7 @@ TEST(Traffic, CutGeoms) {
       ts.congestion3 = 1;
 
       auto cb_setter_speed = [&map, &ts](baldr::GraphReader& reader, baldr::TrafficTile& tile,
-                                         int index, baldr::TrafficSpeed* current) -> void {
+                                         uint32_t index, baldr::TrafficSpeed* current) -> void {
         baldr::GraphId tile_id(tile.header->tile_id);
         auto BD = gurka::findEdge(reader, map.nodes, "BD", "D", tile_id);
         current->breakpoint1 = 255;
@@ -496,7 +496,7 @@ TEST(Traffic, CutGeoms) {
         ts.congestion3 = 50;
 
         auto cb_setter_speed = [&map, &ts](baldr::GraphReader& reader, baldr::TrafficTile& tile,
-                                           int index, baldr::TrafficSpeed* current) -> void {
+                                           uint32_t index, baldr::TrafficSpeed* current) -> void {
           baldr::GraphId tile_id(tile.header->tile_id);
           auto BD = gurka::findEdge(reader, map.nodes, "BD", "D", tile_id);
           current->breakpoint1 = 255;
@@ -738,7 +738,7 @@ TEST(Traffic, CutGeoms) {
         ts.congestion3 = 50;
 
         auto cb_setter_speed = [&map, &ts](baldr::GraphReader& reader, baldr::TrafficTile& tile,
-                                           int index, baldr::TrafficSpeed* current) -> void {
+                                           uint32_t index, baldr::TrafficSpeed* current) -> void {
           baldr::GraphId tile_id(tile.header->tile_id);
           auto BD = gurka::findEdge(reader, map.nodes, "BD", "D", tile_id);
           current->breakpoint1 = 255;
@@ -849,7 +849,7 @@ TEST_F(WaypointsOnClosuresTest, DepartPointAtClosure) {
   // start from an edge that is closed in a one direction
   {
     LiveTrafficCustomize close_edge = [](baldr::GraphReader& reader, baldr::TrafficTile& tile,
-                                         int index, baldr::TrafficSpeed* current) -> void {
+                                         uint32_t index, baldr::TrafficSpeed* current) -> void {
       baldr::GraphId tile_id(tile.header->tile_id);
       auto BC = gurka::findEdge(reader, closure_map.nodes, "BC", "C", tile_id);
 
@@ -868,7 +868,7 @@ TEST_F(WaypointsOnClosuresTest, DepartPointAtClosure) {
   // start from an edge that is closed in a one direction
   {
     LiveTrafficCustomize close_edge = [](baldr::GraphReader& reader, baldr::TrafficTile& tile,
-                                         int index, baldr::TrafficSpeed* current) -> void {
+                                         uint32_t index, baldr::TrafficSpeed* current) -> void {
       baldr::GraphId tile_id(tile.header->tile_id);
       auto CB = gurka::findEdge(reader, closure_map.nodes, "BC", "B", tile_id);
 
@@ -889,7 +889,7 @@ TEST_F(WaypointsOnClosuresTest, DepartPointAtClosure) {
   // - depart point should be matched to the nearest node;
   {
     LiveTrafficCustomize close_edge = [](baldr::GraphReader& reader, baldr::TrafficTile& tile,
-                                         int index, baldr::TrafficSpeed* current) -> void {
+                                         uint32_t index, baldr::TrafficSpeed* current) -> void {
       baldr::GraphId tile_id(tile.header->tile_id);
 
       auto BC = gurka::findEdge(reader, closure_map.nodes, "BC", "C", tile_id);
@@ -915,7 +915,7 @@ TEST_F(WaypointsOnClosuresTest, ArrivePointAtClosure) {
   // end at edge that is closed in a one direction
   {
     LiveTrafficCustomize close_edge = [](baldr::GraphReader& reader, baldr::TrafficTile& tile,
-                                         int index, baldr::TrafficSpeed* current) -> void {
+                                         uint32_t index, baldr::TrafficSpeed* current) -> void {
       baldr::GraphId tile_id(tile.header->tile_id);
       auto DA = gurka::findEdge(reader, closure_map.nodes, "DA", "A", tile_id);
 
@@ -934,7 +934,7 @@ TEST_F(WaypointsOnClosuresTest, ArrivePointAtClosure) {
   // end at edge that is closed in a one direction
   {
     LiveTrafficCustomize close_edge = [](baldr::GraphReader& reader, baldr::TrafficTile& tile,
-                                         int index, baldr::TrafficSpeed* current) -> void {
+                                         uint32_t index, baldr::TrafficSpeed* current) -> void {
       baldr::GraphId tile_id(tile.header->tile_id);
       auto AD = gurka::findEdge(reader, closure_map.nodes, "DA", "D", tile_id);
 
@@ -955,7 +955,7 @@ TEST_F(WaypointsOnClosuresTest, ArrivePointAtClosure) {
   // - arrive point should be matched to the nearest node;
   {
     LiveTrafficCustomize close_edge = [](baldr::GraphReader& reader, baldr::TrafficTile& tile,
-                                         int index, baldr::TrafficSpeed* current) -> void {
+                                         uint32_t index, baldr::TrafficSpeed* current) -> void {
       baldr::GraphId tile_id(tile.header->tile_id);
 
       auto DA = gurka::findEdge(reader, closure_map.nodes, "DA", "A", tile_id);
@@ -986,7 +986,7 @@ TEST_F(WaypointsOnClosuresTest, IgnoreDepartPointAtClosure) {
   // the edge is closed in both directions
   {
     LiveTrafficCustomize close_edge = [](baldr::GraphReader& reader, baldr::TrafficTile& tile,
-                                         int index, baldr::TrafficSpeed* current) -> void {
+                                         uint32_t index, baldr::TrafficSpeed* current) -> void {
       baldr::GraphId tile_id(tile.header->tile_id);
       auto BC = std::get<0>(gurka::findEdge(reader, closure_map.nodes, "BC", "C"));
       auto CB = std::get<0>(gurka::findEdge(reader, closure_map.nodes, "BC", "B"));
@@ -1004,7 +1004,7 @@ TEST_F(WaypointsOnClosuresTest, IgnoreDepartPointAtClosure) {
   // the edge is closed in both directions but you say you dont care
   {
     LiveTrafficCustomize close_edge = [](baldr::GraphReader& reader, baldr::TrafficTile& tile,
-                                         int index, baldr::TrafficSpeed* current) -> void {
+                                         uint32_t index, baldr::TrafficSpeed* current) -> void {
       baldr::GraphId tile_id(tile.header->tile_id);
       auto BC = std::get<0>(gurka::findEdge(reader, closure_map.nodes, "BC", "C"));
       auto CB = std::get<0>(gurka::findEdge(reader, closure_map.nodes, "BC", "B"));

--- a/test/gurka/test_traffic_smoothing.cc
+++ b/test/gurka/test_traffic_smoothing.cc
@@ -381,7 +381,7 @@ TEST_F(RouteWithTraffic, LiveOnButNotUsed) {
         etas.emplace_back(calculate_eta(result));
       }
     }
-    for (int i = 0; i < etas.size() - 1; ++i) {
+    for (size_t i = 0; i < etas.size() - 1; ++i) {
       // Live traffic is not used, algos should return the same ETA.
       EXPECT_EQ(etas[i], etas[i + 1]);
     }

--- a/test/gurka/test_turn_lanes.cc
+++ b/test/gurka/test_turn_lanes.cc
@@ -11,7 +11,7 @@ void validate_turn_lanes(valhalla::Api& result,
 
   ASSERT_EQ(expected_lanes.size(), etl.node_size() - 1);
 
-  for (size_t i = 1; i < etl.node_size(); ++i) {
+  for (int i = 1; i < etl.node_size(); ++i) {
     auto prev_edge = etl.GetPrevEdge(i);
     ASSERT_TRUE(prev_edge) << "Expected prev_edge on node index " << i;
     ASSERT_EQ(prev_edge->turn_lanes_size(), expected_lanes[i - 1].first)

--- a/test/http_tiles.cc
+++ b/test/http_tiles.cc
@@ -3,11 +3,11 @@
 #include "baldr/curl_tilegetter.h"
 #include "baldr/graphtile.h"
 #include "tyr/actor.h"
-#include "valhalla/filesystem.h"
 #include "valhalla/tile_server.h"
 
 #include <prime_server/prime_server.hpp>
 
+#include <filesystem>
 #include <ostream>
 #include <stdexcept>
 #include <string>
@@ -71,10 +71,10 @@ TEST(HttpTiles, test_no_cache_gz) {
 class HttpTilesWithCache : public ::testing::Test {
 protected:
   void SetUp() override {
-    filesystem::remove_all("url_tile_cache");
+    std::filesystem::remove_all("url_tile_cache");
   }
   void TearDown() override {
-    filesystem::remove_all("url_tile_cache");
+    std::filesystem::remove_all("url_tile_cache");
   }
 };
 

--- a/test/http_tiles.cc
+++ b/test/http_tiles.cc
@@ -126,9 +126,9 @@ void test_tile_download(size_t tile_count, size_t curler_count, size_t thread_co
 
   std::vector<std::thread> threads;
   threads.reserve(thread_count);
-  for (int thread_i = 0; thread_i < thread_count; ++thread_i) {
+  for (size_t thread_i = 0; thread_i < thread_count; ++thread_i) {
     threads.emplace_back([&, thread_i]() {
-      for (int tile_i = 0; tile_i < tile_count; ++tile_i) {
+      for (size_t tile_i = 0; tile_i < tile_count; ++tile_i) {
         bool is_for_this_thread = ((tile_i % thread_count) == thread_i);
         if (!is_for_this_thread) {
           continue;
@@ -173,9 +173,9 @@ void test_graphreader_tile_download(size_t tile_count, size_t curler_count, size
 
   std::vector<std::thread> threads;
   threads.reserve(thread_count);
-  for (int thread_i = 0; thread_i < thread_count; ++thread_i) {
+  for (size_t thread_i = 0; thread_i < thread_count; ++thread_i) {
     threads.emplace_back([&, thread_i]() {
-      for (int tile_i = 0; tile_i < tile_count; ++tile_i) {
+      for (size_t tile_i = 0; tile_i < tile_count; ++tile_i) {
         bool is_for_this_thread = ((tile_i % thread_count) == thread_i);
         if (!is_for_this_thread) {
           continue;

--- a/test/mapmatch.cc
+++ b/test/mapmatch.cc
@@ -1036,12 +1036,12 @@ TEST(Mapmatch, test_leg_duration_trimming) {
     EXPECT_EQ(route_api.trip().routes_size(), match_api.trip().routes_size())
         << "Number of routes differs";
 
-    for (size_t i = 0; i < route_api.trip().routes_size(); ++i) {
+    for (int i = 0; i < route_api.trip().routes_size(); ++i) {
       const auto& rlegs = route_api.trip().routes(i).legs();
       const auto& mlegs = match_api.trip().routes(i).legs();
       EXPECT_EQ(rlegs.size(), mlegs.size()) << "Number of legs differs";
-      printf("Route %zu\n", i);
-      for (size_t j = 0; j < rlegs.size(); ++j) {
+      printf("Route %d\n", i);
+      for (int j = 0; j < rlegs.size(); ++j) {
         auto rtime = rlegs.Get(j).node().rbegin()->cost().elapsed_cost().seconds();
         auto mtime = mlegs.Get(j).node().rbegin()->cost().elapsed_cost().seconds();
         printf("r: %.2f %s\n", rtime, rlegs.Get(j).shape().c_str());

--- a/test/recover_shortcut.cc
+++ b/test/recover_shortcut.cc
@@ -144,7 +144,7 @@ TEST(GetShortcut, check_false_negatives) {
       auto tile = reader.GetGraphTile(tile_id);
 
       valhalla::baldr::GraphId edge_id{tile_id};
-      for (int32_t i = 0; i < tile->header()->directededgecount(); i++, ++edge_id) {
+      for (size_t i = 0; i < tile->header()->directededgecount(); i++, ++edge_id) {
         auto directed_edge = tile->directededge(i);
         if (!directed_edge->is_shortcut()) {
           continue;
@@ -183,7 +183,7 @@ TEST(GetShortcut, check_false_positives) {
       auto tile = reader.GetGraphTile(tile_id);
 
       valhalla::baldr::GraphId edge_id{tile_id};
-      for (int32_t i = 0; i < tile->header()->directededgecount(); i++, ++edge_id) {
+      for (size_t i = 0; i < tile->header()->directededgecount(); i++, ++edge_id) {
         auto shortcut_id = reader.GetShortcut(edge_id);
 
         // Edges that don't belong to any shortcut will lead to invalid shortcut ID and this is fine

--- a/test/shape_attributes.cc
+++ b/test/shape_attributes.cc
@@ -50,7 +50,7 @@ TEST(ShapeAttributes, test_shape_attributes_included) {
   EXPECT_EQ(shape_attributes_speed.Size(), shape.size() - 1);
 
   // Measures the length between point
-  for (int i = 1; i < shape.size(); i++) {
+  for (size_t i = 1; i < shape.size(); i++) {
     auto distance = shape[i].Distance(shape[i - 1]) * .001f;
 
     // Measuring that the length between shape pts is approx. to the shape attributes length
@@ -59,7 +59,7 @@ TEST(ShapeAttributes, test_shape_attributes_included) {
 
   // Assert that the shape attributes (time, length, speed) are equal to their corresponding edge
   // attributes
-  for (int e = 0; e < edges.Size(); e++) {
+  for (rapidjson::SizeType e = 0; e < edges.Size(); e++) {
     auto edge_length = edges[e]["length"].GetDouble();
     auto edge_speed = edges[e]["speed"].GetDouble();
 
@@ -110,7 +110,7 @@ TEST(ShapeAttributes, test_shape_attributes_duplicated_point) {
   EXPECT_EQ(shape_attributes_speed.Size(), shape.size() - 1);
 
   // Measures the length between point
-  for (int i = 1; i < shape.size(); i++) {
+  for (size_t i = 1; i < shape.size(); i++) {
     auto distance = shape[i].Distance(shape[i - 1]) * .001f;
 
     // Measuring that the length between shape pts is approx. to the shape attributes length
@@ -119,7 +119,7 @@ TEST(ShapeAttributes, test_shape_attributes_duplicated_point) {
 
   // Assert that the shape attributes (time, length, speed) are equal to their corresponding edge
   // attributes
-  for (int e = 0; e < edges.Size(); e++) {
+  for (rapidjson::SizeType e = 0; e < edges.Size(); e++) {
     auto edge_length = edges[e]["length"].GetDouble();
     auto edge_speed = edges[e]["speed"].GetDouble();
 
@@ -168,7 +168,7 @@ TEST(ShapeAttributes, test_shape_attributes_no_turncosts) {
   EXPECT_EQ(shape_attributes_speed.Size(), shape.size() - 1);
 
   // Measures the length between point
-  for (int i = 1; i < shape.size(); i++) {
+  for (size_t i = 1; i < shape.size(); i++) {
     auto distance = shape[i].Distance(shape[i - 1]) * .001f;
 
     // Measuring that the length between shape pts is approx. to the shape attributes length

--- a/test/viterbi_search.cc
+++ b/test/viterbi_search.cc
@@ -369,7 +369,7 @@ std::vector<PathWithCost> sort_all_paths(const std::vector<Column>& columns,
 
   const auto& sub_pcs = sort_all_paths(columns, since_time + 1);
   std::vector<PathWithCost> pcs;
-  for (auto id = 0; id < columns[since_time].size(); id++) {
+  for (size_t id = 0; id < columns[since_time].size(); id++) {
     const StateId stateid(since_time, id);
     const auto& state = get_state(columns, stateid);
     for (const auto& sub_pc : sub_pcs) {


### PR DESCRIPTION
#4018 

## Tasklist

- [x] fix -Wsign-compare
- [x] add line on changelog (not needed)

substitutions:
int -> size_t
int -> rapidjson::SizeType

some fixes use the:
```
uint32_t invalid<uint32_t>(); 
....
.. is_valid(kmh) ...
```

On the file with lambdas:
```
LiveTrafficCustomize close_edge = [] .... ( int index -> unit32_t index, ...)
```

**Note:**
 
test/http_tiles.cc contains:
```
#include "valhalla/filesystem.h"  
```
By modifying the file `test/http_tiles.cc` the following warning is expected when running `scripts/clang-tidy-only-diff.sh 4`
```
/home/circleci/project/valhalla/filesystem.h:214:7: warning: Call to function 'strcpy' is insecure as it does not provide bounding of the memory buffer. Replace unbounded copy functions with analogous functions that support length arguments such as 'strlcpy'. CWE-119 [clang-analyzer-security.insecureAPI.strcpy]
      strcpy(entry_->d_name, filename.c_str());
      ^
/home/circleci/project/valhalla/filesystem.h:214:7: note: Call to function 'strcpy' is insecure as it does not provide bounding of the memory buffer. Replace unbounded copy functions with analogous functions that support length arguments such as 'strlcpy'. CWE-119
```