### PR TITLE
Add landmarks to maneuvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
    * ADDED: Support for `bannerInstructions` attribute in OSRM serializer via `banner_instructions` request parameter [#4093](https://github.com/valhalla/valhalla/pull/4093)
    * UPDATED: submodules which had new releases, unless it was a major version change [#4231](https://github.com/valhalla/valhalla/pull/4231)
    * ADDED: the workflow to find landmarks in a graph tile, associate them with nearby edges, and update the graph tile to store the associations [#4278](https://github.com/valhalla/valhalla/pull/4278)
+   * ADDED: update maneuver generation to add nearby landmarks to maneuvers as direction support [#4293](https://github.com/valhalla/valhalla/pull/4293)
 
 ## Release Date: 2023-05-11 Valhalla 3.4.0
 * **Removed**

--- a/docs/docs/api/map-matching/api-reference.md
+++ b/docs/docs/api/map-matching/api-reference.md
@@ -218,6 +218,7 @@ Each `edge` may include:
 | `truck_speed` | Edge truck speed in the units specified. The default is kilometers per hour. |
 | `truck_route` | True if edge is part of a truck network/route. |
 | `end_node` | The node at the end of this edge. See the list of [end node items](#end-node-items) for details. |
+| `landmarks` | List of landmarks along the edge. They are used as direction support in navigation. |
 
 #### Sign items
 

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -11,7 +11,7 @@ message LatLng {
   }
 }
 
-message LandmarkManeuver {
+message RouteLandmark {
   enum Type {
     kUnused = 0;
     kFuel = 1;

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -11,6 +11,35 @@ message LatLng {
   }
 }
 
+message LandmarkManeuver {
+  enum Type {
+    kUnused = 0;
+    kFuel = 1;
+    kPostOffice = 2;
+    kPolice = 3;
+    kFireStation = 4;
+    kCarWash = 5;
+    kRestaurant = 6;
+    kFastFood = 7;
+    kCafe = 8;
+    kBank = 9;
+    kPharmacy = 10;
+    kKindergarten = 11;
+    kBar = 12;
+    kHospital = 13;
+    kPub = 14;
+    kClinic = 15;
+    kTheatre = 16;
+    kCinema = 17;
+    kCasino = 18;
+  }
+  string name = 1;
+  Type type = 2;
+  LatLng lat_lng = 3;
+  double distance = 4;  // landmark's distance along the trip edge. in maneuvers it's landmark's distance to the maneuver
+  bool right = 5;  // landmark is to the right of the route that comes before the maneuver
+}
+
 message BoundingBox {
   LatLng min_ll = 1;
   LatLng max_ll = 2;

--- a/proto/directions.proto
+++ b/proto/directions.proto
@@ -140,7 +140,7 @@ message DirectionsLeg {
     BikeShareStationInfo bss_info = 38;                   // Bike Share Station Info
     bool portions_highway = 39;                           // has portions highway
     bool portions_ferry = 40;                             // has portions ferry
-    repeated LandmarkManeuver landmarks = 41;                     // landmarks correlated with the maneuver
+    repeated RouteLandmark landmarks = 41;                     // landmarks correlated with the maneuver
   }
 
   uint64 trip_id = 1;

--- a/proto/directions.proto
+++ b/proto/directions.proto
@@ -140,6 +140,7 @@ message DirectionsLeg {
     BikeShareStationInfo bss_info = 38;                   // Bike Share Station Info
     bool portions_highway = 39;                           // has portions highway
     bool portions_ferry = 40;                             // has portions ferry
+    repeated LandmarkManeuver landmarks = 41;                     // landmarks correlated with the maneuver
   }
 
   uint64 trip_id = 1;

--- a/proto/directions.proto
+++ b/proto/directions.proto
@@ -140,7 +140,7 @@ message DirectionsLeg {
     BikeShareStationInfo bss_info = 38;                   // Bike Share Station Info
     bool portions_highway = 39;                           // has portions highway
     bool portions_ferry = 40;                             // has portions ferry
-    repeated RouteLandmark landmarks = 41;                     // landmarks correlated with the maneuver
+    repeated RouteLandmark landmarks = 41;                // landmarks correlated with the maneuver
   }
 
   uint64 trip_id = 1;

--- a/proto/trip.proto
+++ b/proto/trip.proto
@@ -173,11 +173,9 @@ message TripLeg {
     // it starts and ends along the length of the edge as a percentage
     float source_along_edge = 49;
     float target_along_edge = 50;
-
     SacScale sac_scale = 51;
     bool shoulder = 52;
     bool indoor = 53;
-
     repeated RouteLandmark landmarks = 54;   // landmarks in the trip leg
   }
 

--- a/proto/trip.proto
+++ b/proto/trip.proto
@@ -178,7 +178,7 @@ message TripLeg {
     bool shoulder = 52;
     bool indoor = 53;
 
-    repeated RouteLandmark landmarks = 54;
+    repeated RouteLandmark landmarks = 54;   // landmarks in the trip leg
   }
 
   message IntersectingEdge {

--- a/proto/trip.proto
+++ b/proto/trip.proto
@@ -178,7 +178,7 @@ message TripLeg {
     bool shoulder = 52;
     bool indoor = 53;
 
-    repeated LandmarkManeuver landmarks = 54;
+    repeated RouteLandmark landmarks = 54;
   }
 
   message IntersectingEdge {

--- a/proto/trip.proto
+++ b/proto/trip.proto
@@ -173,9 +173,12 @@ message TripLeg {
     // it starts and ends along the length of the edge as a percentage
     float source_along_edge = 49;
     float target_along_edge = 50;
+
     SacScale sac_scale = 51;
     bool shoulder = 52;
     bool indoor = 53;
+
+    repeated LandmarkManeuver landmarks = 54;
   }
 
   message IntersectingEdge {

--- a/src/baldr/attributes_controller.cc
+++ b/src/baldr/attributes_controller.cc
@@ -79,6 +79,7 @@ const std::unordered_map<std::string, bool> AttributesController::kDefaultAttrib
     {kEdgeIsUrban, false},
     {kEdgeTaggedValues, true},
     {kEdgeIndoor, true},
+    {kEdgeLandmarks, true},
 
     // Node keys
     {kIncidents, false},

--- a/src/odin/directionsbuilder.cc
+++ b/src/odin/directionsbuilder.cc
@@ -391,6 +391,18 @@ void DirectionsBuilder::PopulateDirectionsLeg(const Options& options,
     auto* trip_bss_info = trip_maneuver->mutable_bss_info();
     trip_bss_info->CopyFrom(maneuver.bss_info());
 
+    // set landmarks
+    // TODO: is there a better way to do this?
+    for (auto& l : maneuver.landmarks()) {
+      auto* landmark = trip_maneuver->mutable_landmarks()->Add();
+      landmark->set_name(l.name());
+      landmark->set_type(l.type());
+      landmark->mutable_lat_lng()->set_lng(l.lat_lng().lng());
+      landmark->mutable_lat_lng()->set_lat(l.lat_lng().lat());
+      landmark->set_distance(l.distance());
+      landmark->set_right(l.right());
+    }
+
     // Travel type
     switch (maneuver.travel_mode()) {
       case TravelMode::kDrive: {

--- a/src/odin/directionsbuilder.cc
+++ b/src/odin/directionsbuilder.cc
@@ -392,15 +392,9 @@ void DirectionsBuilder::PopulateDirectionsLeg(const Options& options,
     trip_bss_info->CopyFrom(maneuver.bss_info());
 
     // set landmarks
-    // TODO: is there a better way to do this?
     for (auto& l : maneuver.landmarks()) {
       auto* landmark = trip_maneuver->mutable_landmarks()->Add();
-      landmark->set_name(l.name());
-      landmark->set_type(l.type());
-      landmark->mutable_lat_lng()->set_lng(l.lat_lng().lng());
-      landmark->mutable_lat_lng()->set_lat(l.lat_lng().lat());
-      landmark->set_distance(l.distance());
-      landmark->set_right(l.right());
+      landmark->CopyFrom(l);
     }
 
     // Travel type

--- a/src/odin/enhancedtrippath.cc
+++ b/src/odin/enhancedtrippath.cc
@@ -548,6 +548,19 @@ float EnhancedTripLeg_Edge::GetLength(const Options::Units& units) {
   return length_km();
 }
 
+std::vector<valhalla::baldr::Landmark> EnhancedTripLeg_Edge::GetLandmarks() const {
+  std::vector<valhalla::baldr::Landmark> landmarks{};
+  if (tagged_value().empty()) {
+    return landmarks;
+  }
+  for (size_t i = 0; i < tagged_value().size(); ++i) {
+    if (tagged_value().Get(i).type() == TaggedValue_Type_kLandmark) {
+      landmarks.emplace_back(tagged_value().Get(i).value());
+    }
+  }
+  return landmarks;
+}
+
 bool EnhancedTripLeg_Edge::HasActiveTurnLane() const {
   for (const auto& turn_lane : turn_lanes()) {
     if (turn_lane.state() == TurnLane::kActive) {

--- a/src/odin/enhancedtrippath.cc
+++ b/src/odin/enhancedtrippath.cc
@@ -553,9 +553,9 @@ std::vector<valhalla::baldr::Landmark> EnhancedTripLeg_Edge::GetLandmarks() cons
   if (tagged_value().empty()) {
     return landmarks;
   }
-  for (size_t i = 0; i < tagged_value().size(); ++i) {
-    if (tagged_value().Get(i).type() == TaggedValue_Type_kLandmark) {
-      landmarks.emplace_back(tagged_value().Get(i).value());
+  for (const auto& tag : tagged_value()) {
+    if (tag.type() == TaggedValue_Type_kLandmark) {
+      landmarks.emplace_back(tag.value());
     }
   }
   return landmarks;

--- a/src/odin/enhancedtrippath.cc
+++ b/src/odin/enhancedtrippath.cc
@@ -548,19 +548,6 @@ float EnhancedTripLeg_Edge::GetLength(const Options::Units& units) {
   return length_km();
 }
 
-std::vector<valhalla::baldr::Landmark> EnhancedTripLeg_Edge::GetLandmarks() const {
-  std::vector<valhalla::baldr::Landmark> landmarks{};
-  if (tagged_value().empty()) {
-    return landmarks;
-  }
-  for (const auto& tag : tagged_value()) {
-    if (tag.type() == TaggedValue_Type_kLandmark) {
-      landmarks.emplace_back(tag.value());
-    }
-  }
-  return landmarks;
-}
-
 bool EnhancedTripLeg_Edge::HasActiveTurnLane() const {
   for (const auto& turn_lane : turn_lanes()) {
     if (turn_lane.state() == TurnLane::kActive) {

--- a/src/odin/maneuver.cc
+++ b/src/odin/maneuver.cc
@@ -1184,11 +1184,11 @@ void Maneuver::set_end_level_ref(const std::string& end_level_ref) {
   end_level_ref_ = end_level_ref;
 }
 
-const std::vector<Landmark>& Maneuver::landmarks() const {
+const std::vector<LandmarkManeuver>& Maneuver::landmarks() const {
   return landmarks_;
 }
 
-void Maneuver::set_landmarks(std::vector<Landmark>& landmarks) {
+void Maneuver::set_landmarks(std::vector<LandmarkManeuver>& landmarks) {
   landmarks_ = std::move(landmarks);
 }
 

--- a/src/odin/maneuver.cc
+++ b/src/odin/maneuver.cc
@@ -1180,15 +1180,15 @@ std::string Maneuver::end_level_ref() const {
   return end_level_ref_;
 }
 
-void Maneuver::set_end_level_ref(std::string end_level_ref) {
-  end_level_ref_ = std::move(end_level_ref);
+void Maneuver::set_end_level_ref(const std::string& end_level_ref) {
+  end_level_ref_ = end_level_ref;
 }
 
-std::vector<Landmark> Maneuver::landmarks() const {
+const std::vector<Landmark>& Maneuver::landmarks() const {
   return landmarks_;
 }
 
-void Maneuver::set_landmarks(const std::vector<Landmark>& landmarks) {
+void Maneuver::set_landmarks(std::vector<Landmark>& landmarks) {
   landmarks_ = std::move(landmarks);
 }
 

--- a/src/odin/maneuver.cc
+++ b/src/odin/maneuver.cc
@@ -1184,12 +1184,12 @@ void Maneuver::set_end_level_ref(const std::string& end_level_ref) {
   end_level_ref_ = end_level_ref;
 }
 
-const std::vector<LandmarkManeuver>& Maneuver::landmarks() const {
+const std::vector<RouteLandmark>& Maneuver::landmarks() const {
   return landmarks_;
 }
 
-void Maneuver::set_landmarks(std::vector<LandmarkManeuver>& landmarks) {
-  landmarks_ = std::move(landmarks);
+void Maneuver::set_landmarks(const std::vector<RouteLandmark>& landmarks) {
+  landmarks_ = landmarks;
 }
 
 #ifdef LOGGING_LEVEL_TRACE

--- a/src/odin/maneuver.cc
+++ b/src/odin/maneuver.cc
@@ -1184,6 +1184,14 @@ void Maneuver::set_end_level_ref(std::string end_level_ref) {
   end_level_ref_ = std::move(end_level_ref);
 }
 
+std::vector<Landmark> Maneuver::landmarks() const {
+  return landmarks_;
+}
+
+void Maneuver::set_landmarks(const std::vector<Landmark>& landmarks) {
+  landmarks_ = std::move(landmarks);
+}
+
 #ifdef LOGGING_LEVEL_TRACE
 std::string Maneuver::ToString() const {
   std::string man_str;

--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -3944,17 +3944,15 @@ void ManeuversBuilder::CollapseMergeManeuvers(std::list<Maneuver>& maneuvers) {
 }
 
 void ManeuversBuilder::AddLandmarksToManeuvers(std::list<Maneuver>& maneuvers) {
-  // the landmarks associated with edges in the previous maneuver. they should be added to the current
-  // maneuver
+  // the landmarks correlated with edges in the previous maneuver
   std::vector<Landmark> landmarks{};
 
   for (auto man = maneuvers.begin(); man != maneuvers.end(); ++man) {
     if (!landmarks.empty()) {
       man->set_landmarks(landmarks);
     }
-    // reset the landmarks to the ones associated with edges in the current maneuver
+    // accumulate landmarks in the current maneuver
     landmarks.clear();
-    // accumulate landmarks from all edges
     for (auto node = man->begin_node_index(); node < man->end_node_index(); ++node) {
       auto curr_edge = trip_path_->GetCurrEdge(node);
       auto curr_landmarks = curr_edge->GetLandmarks();

--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -67,9 +67,6 @@ constexpr float kSmallEndRampForkThreshold = 0.125f;
 constexpr uint32_t kMaxWordCount = 5;
 constexpr uint32_t kMaxStreetNameLength = 25;
 
-// Coefficient to convert kilometers to meters
-constexpr uint32_t kConvertKmtoMeters = 1000;
-
 std::vector<std::string> split(const std::string& source, char delimiter) {
   std::vector<std::string> tokens;
   std::string token;
@@ -3959,7 +3956,7 @@ void ManeuversBuilder::AddLandmarksFromTripLegToManeuvers(std::list<Maneuver>& m
     double distance_from_begin_to_curr_edge = 0; // distance from the begin point of the whole
                                                  // manerver to the begin point of the current edge
     double maneuver_total_distance =
-        man->length() * kConvertKmtoMeters; // total distance of the maneuver in meters
+        man->length() * kMetersPerKm; // total distance of the maneuver in meters
 
     for (auto node = man->begin_node_index(); node < man->end_node_index(); ++node) {
       auto curr_edge = trip_path_->GetCurrEdge(node);
@@ -3975,7 +3972,7 @@ void ManeuversBuilder::AddLandmarksFromTripLegToManeuvers(std::list<Maneuver>& m
         }
         std::move(curr_landmarks.begin(), curr_landmarks.end(), std::back_inserter(landmarks));
         // accumulate the distance from maneuver to the curr edge we are working on
-        distance_from_begin_to_curr_edge += curr_edge->length_km() * kConvertKmtoMeters;
+        distance_from_begin_to_curr_edge += curr_edge->length_km() * kMetersPerKm;
       }
     }
   }

--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -67,6 +67,9 @@ constexpr float kSmallEndRampForkThreshold = 0.125f;
 constexpr uint32_t kMaxWordCount = 5;
 constexpr uint32_t kMaxStreetNameLength = 25;
 
+// Coefficient to convert kilometers to meters
+constexpr uint32_t kConvertKmtoMeters = 1000;
+
 std::vector<std::string> split(const std::string& source, char delimiter) {
   std::vector<std::string> tokens;
   std::string token;
@@ -3956,8 +3959,7 @@ void ManeuversBuilder::AddLandmarksFromTripLegToManeuvers(std::list<Maneuver>& m
     double distance_from_begin_to_curr_edge = 0; // distance from the begin point of the whole
                                                  // manerver to the begin point of the current edge
     double maneuver_total_distance =
-        man->length() * 1000; // total distance of the maneuver in meters
-                              // TODO: use meters for now for the test. change to km later
+        man->length() * kConvertKmtoMeters; // total distance of the maneuver in meters
 
     for (auto node = man->begin_node_index(); node < man->end_node_index(); ++node) {
       auto curr_edge = trip_path_->GetCurrEdge(node);
@@ -3973,7 +3975,7 @@ void ManeuversBuilder::AddLandmarksFromTripLegToManeuvers(std::list<Maneuver>& m
         }
         std::move(curr_landmarks.begin(), curr_landmarks.end(), std::back_inserter(landmarks));
         // accumulate the distance from maneuver to the curr edge we are working on
-        distance_from_begin_to_curr_edge += curr_edge->length_km() * 1000;
+        distance_from_begin_to_curr_edge += curr_edge->length_km() * kConvertKmtoMeters;
       }
     }
   }

--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -3953,9 +3953,11 @@ void ManeuversBuilder::AddLandmarksFromTripLegToManeuvers(std::list<Maneuver>& m
     landmarks.clear();
 
     // accumulate landmarks in the current maneuver
-    double distance_from_begin_to_curr_edge = 0;    // distance from the begin point of the whole
-                                                    // manerver to the begin point of the current edge
-    double maneuver_total_distance = man->length(); // total distance of the maneuver
+    double distance_from_begin_to_curr_edge = 0; // distance from the begin point of the whole
+                                                 // manerver to the begin point of the current edge
+    double maneuver_total_distance =
+        man->length() * 1000; // total distance of the maneuver in meters
+                              // TODO: use meters for now for the test. change to km later
 
     for (auto node = man->begin_node_index(); node < man->end_node_index(); ++node) {
       auto curr_edge = trip_path_->GetCurrEdge(node);
@@ -3971,7 +3973,7 @@ void ManeuversBuilder::AddLandmarksFromTripLegToManeuvers(std::list<Maneuver>& m
         }
         std::move(curr_landmarks.begin(), curr_landmarks.end(), std::back_inserter(landmarks));
         // accumulate the distance from maneuver to the curr edge we are working on
-        distance_from_begin_to_curr_edge += curr_edge->length_km();
+        distance_from_begin_to_curr_edge += curr_edge->length_km() * 1000;
       }
     }
   }

--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -3944,7 +3944,7 @@ void ManeuversBuilder::CollapseMergeManeuvers(std::list<Maneuver>& maneuvers) {
 }
 
 void ManeuversBuilder::AddLandmarksFromTripLegToManeuvers(std::list<Maneuver>& maneuvers) {
-  std::vector<LandmarkManeuver> landmarks{};
+  std::vector<RouteLandmark> landmarks{};
   for (auto man = maneuvers.begin(); man != maneuvers.end(); ++man) {
     // set landmarks correlated with edges in the previous maneuver to the current maneuver
     if (!landmarks.empty()) {
@@ -3959,6 +3959,7 @@ void ManeuversBuilder::AddLandmarksFromTripLegToManeuvers(std::list<Maneuver>& m
 
     for (auto node = man->begin_node_index(); node < man->end_node_index(); ++node) {
       auto curr_edge = trip_path_->GetCurrEdge(node);
+      // multipoint routes with `through` or `via` types can have consecutive copies of the same edge
       if (curr_edge != trip_path_->GetCurrEdge(node + 1)) {
         // every time we are about to leave an edge, collect all landmarks in it
         // and reset distance of each landmark to the distance from the landmark to the maneuver point
@@ -3969,6 +3970,8 @@ void ManeuversBuilder::AddLandmarksFromTripLegToManeuvers(std::list<Maneuver>& m
           l.set_distance(new_distance);
         }
         std::move(curr_landmarks.begin(), curr_landmarks.end(), std::back_inserter(landmarks));
+        // accumulate the distance from maneuver to the curr edge we are working on
+        distance_from_begin_to_curr_edge += curr_edge->length_km();
       }
     }
   }

--- a/src/thor/triplegbuilder.cc
+++ b/src/thor/triplegbuilder.cc
@@ -486,7 +486,8 @@ void SetHeadings(TripLeg_Edge* trip_edge,
  * Add landmarks in the directed edge to trip edge.
  * @param  reader      Graph reader to get access to the graph tile and edge info.
  * @param  trip_edge   Trip path edge to add landmarks.
- * @param  controller  Controller specifying whether we want landmarks in the graph to come out the other side.
+ * @param  controller  Controller specifying whether we want landmarks in the graph to come out the
+ * other side.
  * @param  edge        Directed edge where the landmarks are stored.
  * @param  shape       Trip shape.
  */
@@ -506,7 +507,8 @@ void AddLandmarks(graph_tile_ptr graphtile,
 
         // find the closed point on edge to the landmark
         auto closest = landmark_point.ClosestPoint(shape, begin_index);
-        // TODO: in the future maybe we could allow a request option to have a tighter threshold on how far landmarks should be away from an edge
+        // TODO: in the future maybe we could allow a request option to have a tighter threshold on
+        // how far landmarks should be away from an edge
 
         // add the landmark to trip leg
         auto* landmark = trip_edge->mutable_landmarks()->Add();
@@ -530,7 +532,7 @@ void AddLandmarks(graph_tile_ptr graphtile,
 
         // check which side of the edge the landmark is on
         LineSegment2<PointLL> segment(shape[closest_idx], shape[closest_idx + 1]);
-        bool is_right = segment.IsLeft(landmark_point) <= 0;
+        bool is_right = segment.IsLeft(landmark_point) < 0;
         landmark->set_right(is_right);
       }
     }

--- a/src/thor/triplegbuilder.cc
+++ b/src/thor/triplegbuilder.cc
@@ -491,15 +491,14 @@ void SetHeadings(TripLeg_Edge* trip_edge,
  * @param  edge        Directed edge where the landmarks are stored.
  * @param  shape       Trip shape.
  */
-void AddLandmarks(const graph_tile_ptr& graphtile,
+void AddLandmarks(const EdgeInfo& edgeinfo,
                   TripLeg_Edge* trip_edge,
                   const AttributesController& controller,
                   const DirectedEdge* edge,
                   const std::vector<PointLL>& shape,
                   const uint32_t begin_index) {
   if (controller(kEdgeLandmarks)) {
-    auto ei = graphtile->edgeinfo(edge);
-    for (const auto& tag : ei.GetTags()) {
+    for (const auto& tag : edgeinfo.GetTags()) {
       // get landmarks from tagged values in the edge info
       if (tag.first == baldr::TaggedValue::kLandmark) {
         Landmark lan(tag.second);
@@ -1786,7 +1785,7 @@ void TripLegBuilder::Build(
     SetHeadings(trip_edge, controller, directededge, trip_shape, begin_index);
 
     // Add landmarks in the directededge to the trip leg
-    AddLandmarks(graphtile, trip_edge, controller, directededge, trip_shape, begin_index);
+    AddLandmarks(edgeinfo, trip_edge, controller, directededge, trip_shape, begin_index);
 
     // Add the intersecting edges at the node. Skip it if the node was an inner node (excluding start
     // node and end node) of a shortcut that was recovered.

--- a/src/thor/triplegbuilder.cc
+++ b/src/thor/triplegbuilder.cc
@@ -484,7 +484,7 @@ void SetHeadings(TripLeg_Edge* trip_edge,
 
 /**
  * Add landmarks in the directed edge to trip edge.
- * @param  reader      Graph reader to get access to the graph tile and edge info.
+ * @param  edgeinfo    Edge info of the directed edge.
  * @param  trip_edge   Trip path edge to add landmarks.
  * @param  controller  Controller specifying whether we want landmarks in the graph to come out the
  * other side.

--- a/src/thor/triplegbuilder.cc
+++ b/src/thor/triplegbuilder.cc
@@ -491,7 +491,7 @@ void SetHeadings(TripLeg_Edge* trip_edge,
  * @param  edge        Directed edge where the landmarks are stored.
  * @param  shape       Trip shape.
  */
-void AddLandmarks(graph_tile_ptr graphtile,
+void AddLandmarks(const graph_tile_ptr& graphtile,
                   TripLeg_Edge* trip_edge,
                   const AttributesController& controller,
                   const DirectedEdge* edge,

--- a/src/thor/triplegbuilder.cc
+++ b/src/thor/triplegbuilder.cc
@@ -519,19 +519,19 @@ void AddLandmarks(const EdgeInfo& edgeinfo,
         // calculate the landmark's distance along the edge
         // that is to accumulate distance from the begin point to the closest point to it on the edge
         int closest_idx = std::get<2>(closest);
-
         double distance_along_edge = 0;
-        for (int idx = begin_index; idx < closest_idx; ++idx) {
-          distance_along_edge += shape[idx].Distance(shape[idx + 1]);
+        for (int idx = begin_index + 1; idx <= closest_idx; ++idx) {
+          distance_along_edge += shape[idx].Distance(shape[idx - 1]);
         }
         distance_along_edge += shape[closest_idx].Distance(std::get<0>(closest));
         // the overall distance shouldn't be larger than edge length
         distance_along_edge = std::min(distance_along_edge, static_cast<double>(edge->length()));
         landmark->set_distance(distance_along_edge);
-
         // check which side of the edge the landmark is on
-        LineSegment2<PointLL> segment(shape[closest_idx], shape[closest_idx + 1]);
-        bool is_right = segment.IsLeft(landmark_point) < 0;
+        // quirks of the ClosestPoint function
+        bool is_right = closest_idx == shape.size() - 1
+                            ? landmark_point.IsLeft(shape[closest_idx - 1], shape[closest_idx]) < 0
+                            : landmark_point.IsLeft(shape[closest_idx], shape[closest_idx + 1]) < 0;
         landmark->set_right(is_right);
       }
     }

--- a/src/thor/triplegbuilder.cc
+++ b/src/thor/triplegbuilder.cc
@@ -497,43 +497,45 @@ void AddLandmarks(const EdgeInfo& edgeinfo,
                   const DirectedEdge* edge,
                   const std::vector<PointLL>& shape,
                   const uint32_t begin_index) {
-  if (controller(kEdgeLandmarks)) {
-    for (const auto& tag : edgeinfo.GetTags()) {
-      // get landmarks from tagged values in the edge info
-      if (tag.first == baldr::TaggedValue::kLandmark) {
-        Landmark lan(tag.second);
-        PointLL landmark_point = {lan.lng, lan.lat};
+  if (!controller(kEdgeLandmarks)) {
+    return;
+  }
 
-        // find the closed point on edge to the landmark
-        auto closest = landmark_point.ClosestPoint(shape, begin_index);
-        // TODO: in the future maybe we could allow a request option to have a tighter threshold on
-        // how far landmarks should be away from an edge
+  for (const auto& tag : edgeinfo.GetTags()) {
+    // get landmarks from tagged values in the edge info
+    if (tag.first == baldr::TaggedValue::kLandmark) {
+      Landmark lan(tag.second);
+      PointLL landmark_point = {lan.lng, lan.lat};
 
-        // add the landmark to trip leg
-        auto* landmark = trip_edge->mutable_landmarks()->Add();
-        landmark->set_name(lan.name);
-        landmark->set_type(static_cast<valhalla::RouteLandmark::Type>(lan.type));
-        landmark->mutable_lat_lng()->set_lng(lan.lng);
-        landmark->mutable_lat_lng()->set_lat(lan.lat);
+      // find the closed point on edge to the landmark
+      auto closest = landmark_point.ClosestPoint(shape, begin_index);
+      // TODO: in the future maybe we could allow a request option to have a tighter threshold on
+      // how far landmarks should be away from an edge
 
-        // calculate the landmark's distance along the edge
-        // that is to accumulate distance from the begin point to the closest point to it on the edge
-        int closest_idx = std::get<2>(closest);
-        double distance_along_edge = 0;
-        for (int idx = begin_index + 1; idx <= closest_idx; ++idx) {
-          distance_along_edge += shape[idx].Distance(shape[idx - 1]);
-        }
-        distance_along_edge += shape[closest_idx].Distance(std::get<0>(closest));
-        // the overall distance shouldn't be larger than edge length
-        distance_along_edge = std::min(distance_along_edge, static_cast<double>(edge->length()));
-        landmark->set_distance(distance_along_edge);
-        // check which side of the edge the landmark is on
-        // quirks of the ClosestPoint function
-        bool is_right = closest_idx == shape.size() - 1
-                            ? landmark_point.IsLeft(shape[closest_idx - 1], shape[closest_idx]) < 0
-                            : landmark_point.IsLeft(shape[closest_idx], shape[closest_idx + 1]) < 0;
-        landmark->set_right(is_right);
+      // add the landmark to trip leg
+      auto* landmark = trip_edge->mutable_landmarks()->Add();
+      landmark->set_name(lan.name);
+      landmark->set_type(static_cast<valhalla::RouteLandmark::Type>(lan.type));
+      landmark->mutable_lat_lng()->set_lng(lan.lng);
+      landmark->mutable_lat_lng()->set_lat(lan.lat);
+
+      // calculate the landmark's distance along the edge
+      // that is to accumulate distance from the begin point to the closest point to it on the edge
+      int closest_idx = std::get<2>(closest);
+      double distance_along_edge = 0;
+      for (int idx = begin_index + 1; idx <= closest_idx; ++idx) {
+        distance_along_edge += shape[idx].Distance(shape[idx - 1]);
       }
+      distance_along_edge += shape[closest_idx].Distance(std::get<0>(closest));
+      // the overall distance shouldn't be larger than edge length
+      distance_along_edge = std::min(distance_along_edge, static_cast<double>(edge->length()));
+      landmark->set_distance(distance_along_edge);
+      // check which side of the edge the landmark is on
+      // quirks of the ClosestPoint function
+      bool is_right = closest_idx == (int)shape.size() - 1
+                          ? landmark_point.IsLeft(shape[closest_idx - 1], shape[closest_idx]) < 0
+                          : landmark_point.IsLeft(shape[closest_idx], shape[closest_idx + 1]) < 0;
+      landmark->set_right(is_right);
     }
   }
 }

--- a/test/gurka/test_landmarks.cc
+++ b/test/gurka/test_landmarks.cc
@@ -194,8 +194,8 @@ struct LandmarkInManeuver {
   double _distance;
   bool _right;
 
-  LandmarkInManeuver(std::string name, uint8_t type, double distance, bool right)
-      : _name(std::move(name)), _type(type), _distance(distance), _right(right) {
+  LandmarkInManeuver(const std::string& name, uint8_t type, double distance, bool right)
+      : _name(name), _type(type), _distance(distance), _right(right) {
   }
 
   bool operator<(const LandmarkInManeuver& other) const {
@@ -584,7 +584,7 @@ TEST(LandmarkTest, TestLandmarksInManeuvers) {
   std::sort(end_point_maneuver.begin(), end_point_maneuver.end());
 
   std::map<std::string, std::vector<LandmarkInManeuver>> expected_landmarks_maneuver = {
-      {"S1", {}},
+      {"S1", std::vector<LandmarkInManeuver>{}},
       {"cf", cf_maneuver},
       {"fg", fg_maneuver},
       {"end_point", end_point_maneuver},

--- a/test/gurka/test_landmarks.cc
+++ b/test/gurka/test_landmarks.cc
@@ -194,8 +194,8 @@ struct LandmarkInManeuver {
   double _distance;
   bool _right;
 
-  LandmarkInManeuver(std::string name, uint8_t type, double distance, bool right)
-      : _name(std::move(name)), _type(type), _distance(distance), _right(right) {
+  LandmarkInManeuver(const std::string& name, uint8_t type, double distance, bool right)
+      : _name(name), _type(type), _distance(distance), _right(right) {
   }
 
   bool operator<(const LandmarkInManeuver& other) const {
@@ -584,16 +584,15 @@ TEST(LandmarkTest, TestLandmarksInManeuvers) {
   std::sort(end_point_maneuver.begin(), end_point_maneuver.end());
 
   std::map<std::string, std::vector<LandmarkInManeuver>> expected_landmarks_maneuver = {
-      {"S1", {}},
+      {"S1", std::vector<LandmarkInManeuver>{}},
       {"cf", cf_maneuver},
       {"fg", fg_maneuver},
       {"end_point", end_point_maneuver},
   };
 
-  // check landmarks with expectation one by one
+  // check landmarks with expectations one by one
   for (const auto& man : directions_leg.maneuver()) {
-    std::string street_name =
-        man.street_name_size() == 1 ? street_name = man.street_name(0).value() : "end_point";
+    std::string street_name = man.street_name_size() == 1 ? man.street_name(0).value() : "end_point";
 
     std::vector<LandmarkInManeuver> result_landmarks{};
     for (const auto& l : man.landmarks()) {

--- a/test/gurka/test_landmarks.cc
+++ b/test/gurka/test_landmarks.cc
@@ -194,8 +194,8 @@ struct LandmarkInManeuver {
   double _distance;
   bool _right;
 
-  LandmarkInManeuver(const std::string& name, uint8_t type, double distance, bool right)
-      : _name(name), _type(type), _distance(distance), _right(right) {
+  LandmarkInManeuver(std::string name, uint8_t type, double distance, bool right)
+      : _name(std::move(name)), _type(type), _distance(distance), _right(right) {
   }
 
   bool operator<(const LandmarkInManeuver& other) const {
@@ -584,7 +584,7 @@ TEST(LandmarkTest, TestLandmarksInManeuvers) {
   std::sort(end_point_maneuver.begin(), end_point_maneuver.end());
 
   std::map<std::string, std::vector<LandmarkInManeuver>> expected_landmarks_maneuver = {
-      {"S1", std::vector<LandmarkInManeuver>{}},
+      {"S1", {}},
       {"cf", cf_maneuver},
       {"fg", fg_maneuver},
       {"end_point", end_point_maneuver},

--- a/test/gurka/test_landmarks.cc
+++ b/test/gurka/test_landmarks.cc
@@ -32,6 +32,7 @@ valhalla::gurka::map landmark_map_tile_test;
 
 namespace {
 // this map is correlated with the ascii map in BuildPBFAddLandmarksToTiles
+// put them in the test, dont even have to be const
 const std::map<std::pair<int, int>, std::vector<std::string>> expected_landmarks_tiles = {
     {{0, 55},
      std::vector<std::string>{"gong_shang_yin_hang", "hai_di_lao", "lv_mo_li", "shell"}}, // ae

--- a/test/gurka/test_landmarks.cc
+++ b/test/gurka/test_landmarks.cc
@@ -34,23 +34,23 @@ namespace {
 // this map is correlated with the ascii map in BuildPBFAddLandmarksToTiles
 const std::map<std::pair<int, int>, std::vector<std::string>> expected_landmarks_tiles = {
     {{0, 55},
-     std::vector<std::string>{"lv_mo_li", "gong_shang_yin_hang", "shell", "hai_di_lao"}}, // ae
+     std::vector<std::string>{"gong_shang_yin_hang", "hai_di_lao", "lv_mo_li", "shell"}}, // ae
     {{0, 25},
-     std::vector<std::string>{"sheng_ren_min_yi_yuan", "wan_da", "McDonalds", "you_zheng"}}, // cd
+     std::vector<std::string>{"McDonalds", "sheng_ren_min_yi_yuan", "wan_da", "you_zheng"}}, // cd
     {{1, 35},
-     std::vector<std::string>{"gong_shang_yin_hang", "ju_yuan", "McDonalds", "hai_di_lao",
+     std::vector<std::string>{"McDonalds", "gong_shang_yin_hang", "hai_di_lao", "ju_yuan",
                               "lv_mo_li"}},                                  // ab
-    {{1, 30}, std::vector<std::string>{"wan_da", "ju_yuan", "McDonalds"}},   // bc
-    {{2, 55}, std::vector<std::string>{"wan_da", "McDonalds", "pizza_hut"}}, // cf
+    {{1, 30}, std::vector<std::string>{"McDonalds", "ju_yuan", "wan_da"}},   // bc
+    {{2, 55}, std::vector<std::string>{"McDonalds", "pizza_hut", "wan_da"}}, // cf
     {{2, 65}, std::vector<std::string>{"shell"}},                            // ef
 };
 
 // this map is correlated with the ascii map in LandmarksInManeuvers
 const std::map<std::string, std::vector<std::string>> expected_landmarks_maneuvers = {
     {"S1", std::vector<std::string>{"hai_di_lao", "lv_mo_li", "sheng_ren_min_yi_yuan"}},
-    {"S2", std::vector<std::string>{"gong_shang_yin_hang", "ju_yuan", "sheng_ren_min_yi_yuan",
-                                    "McDonalds"}},
-    {"cf", std::vector<std::string>{"ju_yuan", "you_zheng", "McDonalds"}},
+    {"S2", std::vector<std::string>{"McDonalds", "gong_shang_yin_hang", "ju_yuan",
+                                    "sheng_ren_min_yi_yuan"}},
+    {"cf", std::vector<std::string>{"McDonalds", "ju_yuan", "you_zheng"}},
     {"fg", std::vector<std::string>{"shell", "starbucks", "you_zheng"}},
 };
 
@@ -171,6 +171,7 @@ void CheckLandmarksInTiles(GraphReader& reader, const GraphId& graphid) {
                                ", edge length = " + std::to_string(e.length()));
     }
 
+    std::sort(landmark_names.begin(), landmark_names.end());
     EXPECT_EQ(expected_result->second, landmark_names);
   }
 }
@@ -530,6 +531,7 @@ TEST(LandmarkTest, LandmarksInManeuvers) {
                                edge_name);
     }
 
+    std::sort(landmark_names.begin(), landmark_names.end());
     EXPECT_EQ(expected_result->second, landmark_names);
   }
 }

--- a/test/gurka/test_landmarks.cc
+++ b/test/gurka/test_landmarks.cc
@@ -1,5 +1,6 @@
 #include <filesystem>
 #include <gtest/gtest.h>
+#include <iomanip>
 #include <vector>
 
 #include "baldr/graphreader.h"
@@ -7,10 +8,10 @@
 #include "gurka.h"
 #include "mjolnir/graphtilebuilder.h"
 #include "mjolnir/landmarks.h"
+#include "odin/enhancedtrippath.h"
 #include "test/test.h"
 
 #include <boost/property_tree/ptree.hpp>
-#include <iomanip>
 
 using namespace valhalla;
 using namespace valhalla::baldr;
@@ -30,6 +31,12 @@ const std::string pbf_filename_tile_test = workdir_tiles + "/map.pbf";
 valhalla::gurka::map landmark_map_tile_test;
 
 namespace {
+inline void DisplayLandmark(const Landmark& landmark) {
+  std::cout << "landmark: id = " << landmark.id << ", name = " << landmark.name
+            << ", type = " << static_cast<int>(landmark.type) << ", lng = " << landmark.lng
+            << ", lat = " << landmark.lat << std::endl;
+}
+
 void BuildPBF() {
   const std::string ascii_map = R"(
       a-----b-----c---d
@@ -133,11 +140,8 @@ void CheckLandmarksInTiles(GraphReader& reader, const GraphId& graphid) {
     for (const auto& value : tagged_values) {
       if (value.first != baldr::TaggedValue::kLandmark)
         continue;
-
       count_landmarks++;
-      // Landmark landmark(value.second);
-      // std::cout << landmark.name << " " << static_cast<int>(landmark.type) << " " << landmark.lng
-      //           << " " << landmark.lat << std::endl;
+      // DisplayLandmark(Landmark(value.second));
     }
 
     switch (graphid.level()) {
@@ -177,18 +181,24 @@ void DisplayLandmarksInTiles(GraphReader& reader, const GraphId& graphid) {
     for (const auto& value : tagged_values) {
       if (value.first != baldr::TaggedValue::kLandmark)
         continue;
-
       count_landmarks++;
-      Landmark landmark(value.second);
-      std::cout << landmark.name << " " << static_cast<int>(landmark.type) << " " << landmark.lng
-                << " " << landmark.lat << std::endl;
+      DisplayLandmark(Landmark(value.second));
     }
   }
+}
+
+std::vector<Landmark> ParseLandmarksInTripleg(TripLeg_Edge* tripleg_edge) {
+  odin::EnhancedTripLeg_Edge edge(tripleg_edge);
+  auto landmarks = edge.GetLandmarks();
+
+  for (const auto& l : landmarks) {
+    DisplayLandmark(l);
+  }
+  return landmarks;
 }
 } // namespace
 
 TEST(LandmarkTest, TestBuildDatabase) {
-
   // insert test data
   {
     LandmarkDatabase db_ini(db_path, false);
@@ -209,11 +219,9 @@ TEST(LandmarkTest, TestBuildDatabase) {
   EXPECT_EQ(landmarks.size(), 2); // A and B
 
   LOG_INFO("Get " + std::to_string(landmarks.size()) + " rows");
-  for (const auto& landmark : landmarks) {
-    LOG_INFO("id: " + std::to_string(landmark.id) + ", name: " + landmark.name +
-             ", type: " + std::to_string(static_cast<uint8_t>(landmark.type)) + ", longitude: " +
-             std::to_string(landmark.lng) + ", latitude: " + std::to_string(landmark.lat));
-  }
+  // for (const auto& landmark : landmarks) {
+  //   DisplayLandmark(landmark);
+  // }
 
   landmarks.clear();
   EXPECT_NO_THROW({ landmarks = db.get_landmarks_by_bbox(0, 0, 50, 50); });
@@ -222,7 +230,6 @@ TEST(LandmarkTest, TestBuildDatabase) {
 }
 
 TEST(LandmarkTest, TestParseLandmarks) {
-
   if (!filesystem::exists(workdir)) {
     bool created = filesystem::create_directories(workdir);
     EXPECT_TRUE(created);
@@ -245,11 +252,9 @@ TEST(LandmarkTest, TestParseLandmarks) {
   EXPECT_EQ(landmarks.size(), 3); // A, B, D
 
   LOG_INFO("Get " + std::to_string(landmarks.size()) + " rowsmjolnir");
-  for (const auto& landmark : landmarks) {
-    LOG_INFO("id: " + std::to_string(landmark.id) + ", name: " + landmark.name +
-             ", type: " + std::to_string(static_cast<uint8_t>(landmark.type)) + ", longitude: " +
-             std::to_string(landmark.lng) + ", latitude: " + std::to_string(landmark.lat));
-  }
+  // for (const auto& landmark : landmarks) {
+  //   DisplayLandmark(landmark);
+  // }
 
   EXPECT_TRUE(landmarks[0].type == LandmarkType::bar); // A
   EXPECT_TRUE(landmarks[0].name == "A");
@@ -431,4 +436,105 @@ TEST(LandmarkTest, DISABLED_ErrorTest) {
   DisplayLandmarksInTiles(gr, GraphId("0/002025/0"));
   DisplayLandmarksInTiles(gr, GraphId("1/032220/0"));
   DisplayLandmarksInTiles(gr, GraphId("2/517680/0"));
+}
+
+TEST(LandmarkTest, LandmarksInManeuvers) {
+  const std::string ascii_map = R"(
+    A B           C         D 
+    a-------b-------c------d
+          E |    F  |G
+            |       |
+            e       |    I   J
+              H     f-------g
+                      K
+  )";
+
+  const gurka::nodes nodes = {
+      // landmarks
+      {"A", {{"name", "lv_mo_li"}, {"amenity", "bar"}}},
+      {"B", {{"name", "hai_di_lao"}, {"amenity", "restaurant"}}},
+      {"C", {{"name", "McDonalds"}, {"amenity", "fast_food"}}},
+      {"D", {{"name", "wan_da"}, {"amenity", "cinema"}}},
+      {"E", {{"name", "sheng_ren_min_yi_yuan"}, {"amenity", "hospital"}}},
+      {"F", {{"name", "gong_shang_yin_hang"}, {"amenity", "bank"}}},
+      {"G", {{"name", "ju_yuan"}, {"amenity", "theatre"}}},
+      {"H", {{"name", "pizza_hut"}, {"amenity", "restaurant"}}},
+      {"I", {{"name", "shell"}, {"amenity", "fuel"}}},
+      {"J", {{"name", "starbucks"}, {"amenity", "cafe"}}},
+      {"K", {{"name", "you_zheng"}, {"amenity", "post_office"}}},
+      // non-landmark nodes
+      {"a", {{"junction", "yes"}, {"name", "you_yi_lu_kou"}}},
+      {"b", {{"traffic_signal", "signal"}}},
+      {"c", {{"junction", "yes"}, {"name", "gao_xin_lu_kou"}}},
+      {"d", {{"barrier", "gate"}}},
+      {"e", {{"name", "hua_yuan"}, {"place", "city"}}},
+      {"f", {{"name", "gong_ce"}, {"amenity", "toilets"}}},
+      {"g", {{"barrier", "gate"}, {"access", "yes"}}},
+  };
+
+  const gurka::ways ways = {
+      {"ab", {{"highway", "secondary"}, {"name", "S1"}, {"maxspeed", "80"}}},
+      {"bc", {{"highway", "secondary"}, {"name", "S2"}, {"driving_side", "right"}}},
+      {"cd", {{"highway", "secondary"}, {"lanes", "2"}, {"driving_side", "right"}}},
+      {"be", {{"highway", "secondary"}, {"maxspeed", "60"}}},
+      {"cf", {{"highway", "secondary"}, {"maxspeed", "50"}}},
+      {"fg", {{"highway", "secondary"}, {"maxspeed", "50"}}},
+  };
+
+  const std::string workdir = VALHALLA_BUILD_DIR "test/data/landmarks/maneuvers";
+  const std::string db_path = workdir + "/landmarks.sqlite";
+  const std::string pbf = workdir + "/map.pbf";
+
+  if (!filesystem::exists(workdir)) {
+    bool created = filesystem::create_directories(workdir);
+    EXPECT_TRUE(created);
+  }
+
+  valhalla::gurka::map map{};
+  map.nodes = gurka::detail::map_to_coordinates(ascii_map, 10, {0, 0});
+  detail::build_pbf(map.nodes, ways, nodes, {}, pbf, 0, false);
+
+  map.config =
+      test::make_config(workdir, {{"mjolnir.landmarks_db", db_path}},
+                        {{"additional_data", "mjolnir.traffic_extract", "mjolnir.tile_extract"}});
+
+  // build regular graph tiles from the pbf. there wont be landmarks in them
+  mjolnir::build_tile_set(map.config, {pbf}, mjolnir::BuildStage::kInitialize,
+                          mjolnir::BuildStage::kValidate, false);
+
+  // build landmark database and parse landmarks
+  EXPECT_TRUE(BuildLandmarkFromPBF(map.config.get_child("mjolnir"), {pbf}));
+
+  // add landmarks to the tiles
+  AddLandmarks(map.config);
+
+  // get routing result from point a to g
+  auto result = gurka::do_action(valhalla::Options::route, map, {"a", "g"}, "auto");
+
+  ASSERT_EQ(result.trip().routes_size(), 1);
+  ASSERT_EQ(result.trip().routes(0).legs_size(), 1);
+
+  auto leg = result.trip().routes(0).legs(0);
+  // check each edge in the route
+  for (int i = 0; i < 4; ++i) {
+    // ParseLandmarksInTripleg(&(leg.node(i).edge()));
+
+    // get the landmarks in the leg
+    auto size = leg.node(i).edge().tagged_value_size();
+    size_t count = 0;
+    for (int j = 0; j < size; ++j) {
+      if (leg.node(i).edge().tagged_value().Get(j).type() == TaggedValue_Type_kLandmark) {
+        count++;
+        // Landmark landmark(leg.node(i).edge().tagged_value().Get(j).value());
+        // DisplayLandmark(landmark);
+      }
+    }
+
+    // check number of landmarks
+    if (i == 1) {
+      EXPECT_EQ(count, 4);
+    } else {
+      EXPECT_EQ(count, 3);
+    }
+  }
 }

--- a/valhalla/baldr/attributes_controller.h
+++ b/valhalla/baldr/attributes_controller.h
@@ -75,6 +75,7 @@ const std::string kEdgeDestinationOnly = "edge.destination_only";
 const std::string kEdgeIsUrban = "edge.is_urban";
 const std::string kEdgeTaggedValues = "edge.tagged_values";
 const std::string kEdgeIndoor = "edge.indoor";
+const std::string kEdgeLandmarks = "edge.landmarks";
 
 // Node keys
 const std::string kNodeIntersectingEdgeBeginHeading = "node.intersecting_edge.begin_heading";

--- a/valhalla/baldr/landmark.h
+++ b/valhalla/baldr/landmark.h
@@ -32,25 +32,25 @@ enum class LandmarkType : uint8_t {
   cafe = 8,
   // on the fence about this one, these are often obvious without a name, maybe should go in the upper
   // list?
-  bank = 10,
+  bank = 9,
   // same with this one, in some countries these are obvious and have the little plus sign, in america
   // its not the case and they can be different chains or could be part of a grocery store or
   // anything... speaking of grocery store, why isnt that on the list? also why arent department
   // stores on the list, surely stores would be a good landmark to use (again when they are named)
-  pharmacy = 11,
+  pharmacy = 10,
   // again these could just be a random building with nothing other than a sign like "early years" or
   // something, they better have a name or it will be ambiguous
-  kindergarten = 12,
+  kindergarten = 11,
   // same thing, often just a building
-  bar = 13,
+  bar = 12,
   // this could be very very big like a college campus, i think we should remove this
-  hospital = 14,
+  hospital = 13,
   // same as bar could be just a building need at least a name to have a chance of seeing it
-  pub = 16,
+  pub = 14,
   // generic, could be many many types of clinics also often there are multiple of these located in
   // same "complex", you might have a dentist, orthodontist, ear nose throat and eye specialists all
   // next to each other.
-  clinic = 17,
+  clinic = 15,
   // on the fence about this one, to me this would be in the same category as "museum" or something
   // where its so specialized maybe it doesnt need a name. what keeps me from say ing that is you
   // often cant tell from the outside what function these amenities serve until you read the name

--- a/valhalla/odin/enhancedtrippath.h
+++ b/valhalla/odin/enhancedtrippath.h
@@ -10,7 +10,6 @@
 #include <utility>
 #include <vector>
 
-#include <valhalla/baldr/landmark.h>
 #include <valhalla/baldr/turn.h>
 #include <valhalla/proto/directions.pb.h>
 #include <valhalla/proto/options.pb.h>
@@ -139,6 +138,10 @@ public:
 
   const ::google::protobuf::RepeatedPtrField<::valhalla::TaggedValue>& tagged_value() const {
     return mutable_edge_->tagged_value();
+  }
+
+  const ::google::protobuf::RepeatedPtrField<::valhalla::LandmarkManeuver>& landmarks() const {
+    return mutable_edge_->landmarks();
   }
 
   float length_km() const {
@@ -418,8 +421,6 @@ public:
   std::string GetLevelRef() const;
 
   float GetLength(const Options::Units& units);
-
-  std::vector<valhalla::baldr::Landmark> GetLandmarks() const;
 
   // Turn Lanes
   bool HasActiveTurnLane() const;

--- a/valhalla/odin/enhancedtrippath.h
+++ b/valhalla/odin/enhancedtrippath.h
@@ -140,7 +140,7 @@ public:
     return mutable_edge_->tagged_value();
   }
 
-  const ::google::protobuf::RepeatedPtrField<::valhalla::LandmarkManeuver>& landmarks() const {
+  const ::google::protobuf::RepeatedPtrField<::valhalla::RouteLandmark>& landmarks() const {
     return mutable_edge_->landmarks();
   }
 

--- a/valhalla/odin/enhancedtrippath.h
+++ b/valhalla/odin/enhancedtrippath.h
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include <valhalla/baldr/landmark.h>
 #include <valhalla/baldr/turn.h>
 #include <valhalla/proto/directions.pb.h>
 #include <valhalla/proto/options.pb.h>
@@ -417,6 +418,8 @@ public:
   std::string GetLevelRef() const;
 
   float GetLength(const Options::Units& units);
+
+  std::vector<valhalla::baldr::Landmark> GetLandmarks() const;
 
   // Turn Lanes
   bool HasActiveTurnLane() const;

--- a/valhalla/odin/maneuver.h
+++ b/valhalla/odin/maneuver.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <unordered_map>
 
+#include <valhalla/baldr/landmark.h>
 #include <valhalla/baldr/streetnames.h>
 #include <valhalla/baldr/verbal_text_formatter.h>
 
@@ -396,6 +397,9 @@ public:
   std::string end_level_ref() const;
   void set_end_level_ref(std::string end_level_ref);
 
+  std::vector<Landmark> landmarks() const;
+  void set_landmarks(const std::vector<Landmark>& landmarks);
+
 #ifdef LOGGING_LEVEL_TRACE
   std::string ToString() const;
 
@@ -478,6 +482,9 @@ protected:
   bool building_enter_;
   bool building_exit_;
   std::string end_level_ref_;
+
+  // Landmarks close to the maneuver as direction support
+  std::vector<Landmark> landmarks_;
 
   ////////////////////////////////////////////////////////////////////////////
   // Transit support

--- a/valhalla/odin/maneuver.h
+++ b/valhalla/odin/maneuver.h
@@ -7,7 +7,6 @@
 #include <string>
 #include <unordered_map>
 
-#include <valhalla/baldr/landmark.h>
 #include <valhalla/baldr/streetnames.h>
 #include <valhalla/baldr/verbal_text_formatter.h>
 
@@ -397,8 +396,8 @@ public:
   std::string end_level_ref() const;
   void set_end_level_ref(const std::string& end_level_ref);
 
-  const std::vector<Landmark>& landmarks() const;
-  void set_landmarks(std::vector<Landmark>& landmarks);
+  const std::vector<LandmarkManeuver>& landmarks() const;
+  void set_landmarks(std::vector<LandmarkManeuver>& landmarks);
 
 #ifdef LOGGING_LEVEL_TRACE
   std::string ToString() const;
@@ -483,8 +482,8 @@ protected:
   bool building_exit_;
   std::string end_level_ref_;
 
-  // Landmarks close to the maneuver as direction support
-  std::vector<Landmark> landmarks_;
+  // Landmarks correlated to the maneuver
+  std::vector<LandmarkManeuver> landmarks_;
 
   ////////////////////////////////////////////////////////////////////////////
   // Transit support

--- a/valhalla/odin/maneuver.h
+++ b/valhalla/odin/maneuver.h
@@ -396,8 +396,8 @@ public:
   std::string end_level_ref() const;
   void set_end_level_ref(const std::string& end_level_ref);
 
-  const std::vector<LandmarkManeuver>& landmarks() const;
-  void set_landmarks(std::vector<LandmarkManeuver>& landmarks);
+  const std::vector<RouteLandmark>& landmarks() const;
+  void set_landmarks(const std::vector<RouteLandmark>& landmarks);
 
 #ifdef LOGGING_LEVEL_TRACE
   std::string ToString() const;
@@ -483,7 +483,7 @@ protected:
   std::string end_level_ref_;
 
   // Landmarks correlated to the maneuver
-  std::vector<LandmarkManeuver> landmarks_;
+  std::vector<RouteLandmark> landmarks_;
 
   ////////////////////////////////////////////////////////////////////////////
   // Transit support

--- a/valhalla/odin/maneuver.h
+++ b/valhalla/odin/maneuver.h
@@ -395,10 +395,10 @@ public:
   void set_building_exit(bool building_exit);
 
   std::string end_level_ref() const;
-  void set_end_level_ref(std::string end_level_ref);
+  void set_end_level_ref(const std::string& end_level_ref);
 
-  std::vector<Landmark> landmarks() const;
-  void set_landmarks(const std::vector<Landmark>& landmarks);
+  const std::vector<Landmark>& landmarks() const;
+  void set_landmarks(std::vector<Landmark>& landmarks);
 
 #ifdef LOGGING_LEVEL_TRACE
   std::string ToString() const;

--- a/valhalla/odin/maneuversbuilder.h
+++ b/valhalla/odin/maneuversbuilder.h
@@ -319,6 +319,14 @@ protected:
    */
   void CollapseMergeManeuvers(std::list<Maneuver>& maneuvers);
 
+  /**
+   * Add relevant landmarks to maneuvers as direction support.
+   * Each maneuver should get the landmarks accosiated with edges that make up the previous maneuver.
+   *
+   * @param maneuvers The list of maneuvers to add landmarks.
+   */
+  void AddLandmarksToManeuvers(std::list<Maneuver>& maneuvers);
+
   const Options& options_;
   EnhancedTripLeg* trip_path_;
 };

--- a/valhalla/odin/maneuversbuilder.h
+++ b/valhalla/odin/maneuversbuilder.h
@@ -325,7 +325,7 @@ protected:
    *
    * @param maneuvers The list of maneuvers to add landmarks.
    */
-  void AddLandmarksToManeuvers(std::list<Maneuver>& maneuvers);
+  void AddLandmarksFromTripLegToManeuvers(std::list<Maneuver>& maneuvers);
 
   const Options& options_;
   EnhancedTripLeg* trip_path_;


### PR DESCRIPTION
# Issue

Maneuver generation update: add landmarks as direction support in maneuvers

## Tasklist

 - [x] update triplegbuilder to carry associations into the proto data structure we feed to odin to make his maneuvers
 - [x] in odins maneuver generation loop copy the landmark to the maneuver, update the maneuver definition accordingly (or maybe another definition if appropriate?)

## Relations

[Landmark Routing 5: Maneuver Generation Updates#4137](https://github.com/valhalla/valhalla/issues/4137)
previously closed PR (which is somehow messed up): [Update maneuver generation to add landmarks #4291](https://github.com/valhalla/valhalla/pull/4291)
