### PR TITLE
Update narrative generation with landmarks

### DIFF
--- a/locales/bg-BG.json
+++ b/locales/bg-BG.json
@@ -39,8 +39,33 @@
         "2": "Дръжте <RELATIVE_DIRECTION> по <BEGIN_STREET_NAMES>. Продължете по <STREET_NAMES>.",
         "3": "Дръжте <RELATIVE_DIRECTION> за да останете на <STREET_NAMES>.",
         "4": "Дръжте <RELATIVE_DIRECTION> на <JUNCTION_NAME>.",
-        "5": "Дръжте <RELATIVE_DIRECTION> към <TOWARD_SIGN>."
+        "5": "Дръжте <RELATIVE_DIRECTION> към <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "пешеходата пътека",
         "вело алеята",
@@ -79,8 +104,33 @@
         "2": "Дръжте <RELATIVE_DIRECTION> към <BEGIN_STREET_NAMES>.",
         "3": "Дръжте <RELATIVE_DIRECTION> за да останете на <STREET_NAMES>.",
         "4": "Дръжте <RELATIVE_DIRECTION> на <JUNCTION_NAME>.",
-        "5": "Дръжте <RELATIVE_DIRECTION> към <TOWARD_SIGN>."
+        "5": "Дръжте <RELATIVE_DIRECTION> към <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "пешеходата пътека",
         "вело алеята",
@@ -1068,6 +1118,7 @@
         "4": "Присъединете се към <TOWARD_SIGN>.",
         "5": "Присъединете се от <RELATIVE_DIRECTION> към <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "ляво",
         "дясно"
@@ -1108,6 +1159,7 @@
         "4": "Присъединете се към <TOWARD_SIGN>.",
         "5": "Присъединете се от <RELATIVE_DIRECTION> към <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "ляво",
         "дясно"
@@ -1393,8 +1445,33 @@
         "2": "Направете остър завой на <RELATIVE_DIRECTION> по <BEGIN_STREET_NAMES>. Продължете по <STREET_NAMES>.",
         "3": "Направете остър завой на <RELATIVE_DIRECTION> за да останете на <STREET_NAMES>.",
         "4": "Направете остър завой на <RELATIVE_DIRECTION> на <JUNCTION_NAME>.",
-        "5": "Направете остър завой на <RELATIVE_DIRECTION> към <TOWARD_SIGN>."
+        "5": "Направете остър завой на <RELATIVE_DIRECTION> към <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "пешеходата пътека",
         "вело алеята",
@@ -1433,8 +1510,33 @@
         "2": "Направете остър завой на <RELATIVE_DIRECTION> по <BEGIN_STREET_NAMES>.",
         "3": "Направете остър завой на <RELATIVE_DIRECTION> за да останете на <STREET_NAMES>",
         "4": "Направете остър завой на <RELATIVE_DIRECTION> на <JUNCTION_NAME>.",
-        "5": "Направете остър завой на <RELATIVE_DIRECTION> към <TOWARD_SIGN>."
+        "5": "Направете остър завой на <RELATIVE_DIRECTION> към <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "пешеходата пътека",
         "вело алеята",
@@ -1952,8 +2054,33 @@
         "2": "Завийте на <RELATIVE_DIRECTION> по <BEGIN_STREET_NAMES>. Продължете по <STREET_NAMES>.",
         "3": "Завийте на <RELATIVE_DIRECTION> за да останете на <STREET_NAMES>.",
         "4": "Завийте на <RELATIVE_DIRECTION> на <JUNCTION_NAME>.",
-        "5": "Завийте на <RELATIVE_DIRECTION> към <TOWARD_SIGN>."
+        "5": "Завийте на <RELATIVE_DIRECTION> към <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "пешеходата пътека",
         "вело алеята",
@@ -1992,8 +2119,33 @@
         "2": "Завийте на <RELATIVE_DIRECTION> по <BEGIN_STREET_NAMES>.",
         "3": "Завийте на <RELATIVE_DIRECTION> за да останете на <STREET_NAMES>.",
         "4": "Завийте на <RELATIVE_DIRECTION> на <JUNCTION_NAME>.",
-        "5": "Завийте на <RELATIVE_DIRECTION> към <TOWARD_SIGN>."
+        "5": "Завийте на <RELATIVE_DIRECTION> към <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "пешеходата пътека",
         "вело алеята",
@@ -2036,6 +2188,7 @@
         "6": "Направете обратен завой на<RELATIVE_DIRECTION> на <JUNCTION_NAME>.",
         "7": "Направете <RELATIVE_DIRECTION> обратен завой към <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "пешеходата пътека",
         "вело алеята",
@@ -2084,6 +2237,7 @@
         "6": "Направете обратен завой на<RELATIVE_DIRECTION> на <JUNCTION_NAME>.",
         "7": "Направете <RELATIVE_DIRECTION> обратен завой към <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "пешеходата пътека",
         "вело алеята",

--- a/locales/ca-ES.json
+++ b/locales/ca-ES.json
@@ -39,8 +39,33 @@
         "2": "Queda't a <RELATIVE_DIRECTION> cap a <BEGIN_STREET_NAMES>. Continua per <STREET_NAMES>.",
         "3": "Queda't a <RELATIVE_DIRECTION> per continuar per <STREET_NAMES>.",
         "4": "Bear <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Bear <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Bear <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "la vorera",
         "el carril bici",
@@ -79,8 +104,33 @@
         "2": "Queda't a <RELATIVE_DIRECTION> cap a <BEGIN_STREET_NAMES>.",
         "3": "Queda't a <RELATIVE_DIRECTION> per continuar per <STREET_NAMES>.",
         "4": "Bear <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Bear <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Bear <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "la vorera",
         "el carril bici",
@@ -1068,6 +1118,7 @@
         "4": "Merge toward <TOWARD_SIGN>.",
         "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "l'esquerra",
         "la dreta"
@@ -1108,6 +1159,7 @@
         "4": "Merge toward <TOWARD_SIGN>.",
         "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "l'esquerra",
         "la dreta"
@@ -1393,8 +1445,33 @@
         "2": "Gir tancat a <RELATIVE_DIRECTION> cap a <BEGIN_STREET_NAMES>. Continua per <STREET_NAMES>.",
         "3": "Gir tancat a <RELATIVE_DIRECTION> per continuar per <STREET_NAMES>.",
         "4": "Make a sharp <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Make a sharp <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Make a sharp <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "la vorera",
         "el carril bici",
@@ -1433,8 +1510,33 @@
         "2": "Gir tancat a <RELATIVE_DIRECTION> cap a <BEGIN_STREET_NAMES>.",
         "3": "Gir tancat a <RELATIVE_DIRECTION> per continuar per <STREET_NAMES>.",
         "4": "Make a sharp <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Make a sharp <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Make a sharp <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "la vorera",
         "el carril bici",
@@ -1952,8 +2054,33 @@
         "2": "Gira a <RELATIVE_DIRECTION> cap a <BEGIN_STREET_NAMES>. Continua per <STREET_NAMES>.",
         "3": "Gira a <RELATIVE_DIRECTION> per continuar per <STREET_NAMES>.",
         "4": "Turn <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Turn <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Turn <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "la vorera",
         "el carril bici",
@@ -1992,8 +2119,33 @@
         "2": "Gira a <RELATIVE_DIRECTION> cap a <BEGIN_STREET_NAMES>.",
         "3": "Gira a <RELATIVE_DIRECTION> per continuar per <STREET_NAMES>.",
         "4": "Turn <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Turn <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Turn <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "la vorera",
         "el carril bici",
@@ -2036,6 +2188,7 @@
         "6": "Make a <RELATIVE_DIRECTION> U-turn at <JUNCTION_NAME>.",
         "7": "Make a <RELATIVE_DIRECTION> U-turn toward <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "la vorera",
         "el carril bici",
@@ -2084,6 +2237,7 @@
         "6": "Make a <RELATIVE_DIRECTION> U-turn at <JUNCTION_NAME>.",
         "7": "Make a <RELATIVE_DIRECTION> U-turn toward <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "la vorera",
         "el carril bici",

--- a/locales/cs-CZ.json
+++ b/locales/cs-CZ.json
@@ -39,8 +39,33 @@
         "2": "Držte se <RELATIVE_DIRECTION> na <BEGIN_STREET_NAMES>. Pokračujte na <STREET_NAMES>.",
         "3": "Držte se <RELATIVE_DIRECTION>, abyste zůstali na <STREET_NAMES>.",
         "4": "Držte se <RELATIVE_DIRECTION> na <JUNCTION_NAME>.",
-        "5": "Držte se <RELATIVE_DIRECTION> směrem na <TOWARD_SIGN>."
+        "5": "Držte se <RELATIVE_DIRECTION> směrem na <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "chodník",
         "cyklostezka",
@@ -79,8 +104,33 @@
         "2": "Držte se <RELATIVE_DIRECTION> na <BEGIN_STREET_NAMES>.",
         "3": "Držte se <RELATIVE_DIRECTION>, abyste zůstali na <STREET_NAMES>.",
         "4": "Držte se <RELATIVE_DIRECTION> na <JUNCTION_NAME>.",
-        "5": "Držte se <RELATIVE_DIRECTION> směrem na <TOWARD_SIGN>."
+        "5": "Držte se <RELATIVE_DIRECTION> směrem na <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "chodník",
         "cyklostezka",
@@ -1068,6 +1118,7 @@
         "4": "Zařaďte se směrem na <TOWARD_SIGN>.",
         "5": "Zařaďte se <RELATIVE_DIRECTION> směrem na <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "vlevo",
         "vpravo"
@@ -1108,6 +1159,7 @@
         "4": "Zařaďte se směrem na <TOWARD_SIGN>.",
         "5": "Zařaďte se <RELATIVE_DIRECTION> směrem na <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "vlevo",
         "vpravo"
@@ -1393,8 +1445,33 @@
         "2": "Odbočte ostře <RELATIVE_DIRECTION> na <BEGIN_STREET_NAMES>. Pokračujte na <STREET_NAMES>.",
         "3": "Odbočte ostře <RELATIVE_DIRECTION>, abyste zůstali na <STREET_NAMES>.",
         "4": "Na <JUNCTION_NAME> odbočte ostře <RELATIVE_DIRECTION>.",
-        "5": "Odbočte ostře <RELATIVE_DIRECTION> směrem na <TOWARD_SIGN>."
+        "5": "Odbočte ostře <RELATIVE_DIRECTION> směrem na <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "chodník",
         "cyklostezka",
@@ -1433,8 +1510,33 @@
         "2": "Odbočte ostře <RELATIVE_DIRECTION> na <BEGIN_STREET_NAMES>.",
         "3": "Odbočte ostře <RELATIVE_DIRECTION>, abyste zůstali na <STREET_NAMES>.",
         "4": "Na <JUNCTION_NAME> odbočte ostře <RELATIVE_DIRECTION>.",
-        "5": "Odbočte ostře <RELATIVE_DIRECTION> směrem na <TOWARD_SIGN>."
+        "5": "Odbočte ostře <RELATIVE_DIRECTION> směrem na <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "chodník",
         "cyklostezka",
@@ -1952,8 +2054,33 @@
         "2": "Odbočte <RELATIVE_DIRECTION> na <BEGIN_STREET_NAMES>. Pokračujte na <STREET_NAMES>.",
         "3": "Odbočte <RELATIVE_DIRECTION>, abyste zůstali na <STREET_NAMES>.",
         "4": "Odbočte <RELATIVE_DIRECTION> na <JUNCTION_NAME>.",
-        "5": "Odbočte <RELATIVE_DIRECTION> směrem na <TOWARD_SIGN>."
+        "5": "Odbočte <RELATIVE_DIRECTION> směrem na <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "chodník",
         "cyklostezka",
@@ -1992,8 +2119,33 @@
         "2": "Odbočte <RELATIVE_DIRECTION> na <BEGIN_STREET_NAMES>.",
         "3": "Odbočte <RELATIVE_DIRECTION>, abyste zůstali na <STREET_NAMES>.",
         "4": "Odbočte <RELATIVE_DIRECTION> na <JUNCTION_NAME>.",
-        "5": "Odbočte <RELATIVE_DIRECTION> směrem na <TOWARD_SIGN>."
+        "5": "Odbočte <RELATIVE_DIRECTION> směrem na <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "chodník",
         "cyklostezka",
@@ -2036,6 +2188,7 @@
         "6": "Na <JUNCTION_NAME> se otočte o 180° <RELATIVE_DIRECTION> .",
         "7": "Otočte se o 180° <RELATIVE_DIRECTION> směrem na <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "chodník",
         "cyklostezka",
@@ -2084,6 +2237,7 @@
         "6": "Na <JUNCTION_NAME> se otočte o 180 °<RELATIVE_DIRECTION>.",
         "7": "Otočte se o 180° <RELATIVE_DIRECTION> směrem na <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "chodník",
         "cyklostezka",

--- a/locales/da-DK.json
+++ b/locales/da-DK.json
@@ -39,8 +39,33 @@
         "2": "Styr mod <RELATIVE_DIRECTION> på <BEGIN_STREET_NAMES>. Fortsæt ind på <STREET_NAMES>.",
         "3": "Styr mod <RELATIVE_DIRECTION> for at blive på <STREET_NAMES>.",
         "4": "Styr mod <RELATIVE_DIRECTION> ved <JUNCTION_NAME>.",
-        "5": "Styr mod <RELATIVE_DIRECTION> mod <TOWARD_SIGN>."
+        "5": "Styr mod <RELATIVE_DIRECTION> mod <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "fortovet",
         "cykelstien",
@@ -79,8 +104,33 @@
         "2": "Styr mod <RELATIVE_DIRECTION> ind på <BEGIN_STREET_NAMES>.",
         "3": "Styr mod <RELATIVE_DIRECTION> for at blive på <STREET_NAMES>.",
         "4": "Styr mod <RELATIVE_DIRECTION> ved <JUNCTION_NAME>.",
-        "5": "Styr mod <RELATIVE_DIRECTION> mod <TOWARD_SIGN>."
+        "5": "Styr mod <RELATIVE_DIRECTION> mod <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "fortovet",
         "cykelstien",
@@ -1068,6 +1118,7 @@
         "4": "Flet mod <TOWARD_SIGN>.",
         "5": "Flet <RELATIVE_DIRECTION> mod <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "venstre",
         "højre"
@@ -1108,6 +1159,7 @@
         "4": "Flet mod <TOWARD_SIGN>.",
         "5": "Flet <RELATIVE_DIRECTION> mod <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "venstre",
         "højre"
@@ -1393,8 +1445,33 @@
         "2": "Drej skarpt til <RELATIVE_DIRECTION> ind på <BEGIN_STREET_NAMES>. Fortsæt på <STREET_NAMES>.",
         "3": "Drej skarpt til <RELATIVE_DIRECTION> for at blive på <STREET_NAMES>.",
         "4": "Drej skarpt til <RELATIVE_DIRECTION> ved <JUNCTION_NAME>.",
-        "5": "Drej skarpt til <RELATIVE_DIRECTION> mod <TOWARD_SIGN>."
+        "5": "Drej skarpt til <RELATIVE_DIRECTION> mod <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "fortovet",
         "cykelstien",
@@ -1433,8 +1510,33 @@
         "2": "Drej skarpt til <RELATIVE_DIRECTION> ind på <BEGIN_STREET_NAMES>.",
         "3": "Drej skarpt til <RELATIVE_DIRECTION> for at blive på <STREET_NAMES>.",
         "4": "Drej skarpt til <RELATIVE_DIRECTION> ved <JUNCTION_NAME>.",
-        "5": "Drej skarpt til <RELATIVE_DIRECTION> mod <TOWARD_SIGN>."
+        "5": "Drej skarpt til <RELATIVE_DIRECTION> mod <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "fortovet",
         "cykelstien",
@@ -1952,8 +2054,33 @@
         "2": "Drej til <RELATIVE_DIRECTION> ind på <BEGIN_STREET_NAMES>. Fortsæt på <STREET_NAMES>.",
         "3": "Drej til <RELATIVE_DIRECTION> for at blive på <STREET_NAMES>.",
         "4": "Drej til <RELATIVE_DIRECTION> ved <JUNCTION_NAME>.",
-        "5": "Drej til <RELATIVE_DIRECTION> mod <TOWARD_SIGN>."
+        "5": "Drej til <RELATIVE_DIRECTION> mod <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "fortovet",
         "cykelstien",
@@ -1992,8 +2119,33 @@
         "2": "Drej til <RELATIVE_DIRECTION> ind på <BEGIN_STREET_NAMES>.",
         "3": "Drej til <RELATIVE_DIRECTION> for at blive på <STREET_NAMES>.",
         "4": "Drej til <RELATIVE_DIRECTION> ved <JUNCTION_NAME>.",
-        "5": "Drej til <RELATIVE_DIRECTION> mod <TOWARD_SIGN>."
+        "5": "Drej til <RELATIVE_DIRECTION> mod <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "fortovet",
         "cykelstien",
@@ -2036,6 +2188,7 @@
         "6": "Foretag en <RELATIVE_DIRECTION> u-vending ved <JUNCTION_NAME>.",
         "7": "Foretag en <RELATIVE_DIRECTION> u-vending mod <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "fortovet",
         "cykelstien",
@@ -2084,6 +2237,7 @@
         "6": "Foretag en <RELATIVE_DIRECTION> u-vending ved <JUNCTION_NAME>.",
         "7": "Foretag en <RELATIVE_DIRECTION> u-vending mod <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "fortovet",
         "cykelstien",

--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -39,8 +39,33 @@
         "2": "Leicht nach <RELATIVE_DIRECTION> auf <BEGIN_STREET_NAMES> abbiegen. Dann weiter auf <STREET_NAMES>.",
         "3": "Leicht nach <RELATIVE_DIRECTION> abbiegen um auf <STREET_NAMES> zu bleiben.",
         "4": "An <JUNCTION_NAME> leicht nach <RELATIVE_DIRECTION> abbiegen.",
-        "5": "Leicht nach <RELATIVE_DIRECTION> in Richtung <TOWARD_SIGN> abbiegen."
+        "5": "Leicht nach <RELATIVE_DIRECTION> in Richtung <TOWARD_SIGN> abbiegen.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "Fußweg",
         "Radweg",
@@ -79,8 +104,33 @@
         "2": "Leicht nach <RELATIVE_DIRECTION> auf <BEGIN_STREET_NAMES> abbiegen. Dann weiter auf <STREET_NAMES>.",
         "3": "Leicht nach <RELATIVE_DIRECTION> abbiegen um auf <STREET_NAMES> zu bleiben.",
         "4": "An <JUNCTION_NAME> leicht nach <RELATIVE_DIRECTION> abbiegen.",
-        "5": "Leicht nach <RELATIVE_DIRECTION> in Richtung <TOWARD_SIGN> abbiegen."
+        "5": "Leicht nach <RELATIVE_DIRECTION> in Richtung <TOWARD_SIGN> abbiegen.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "Fußweg",
         "Radweg",
@@ -1068,6 +1118,7 @@
         "4": "In Richtung <TOWARD_SIGN> einfädeln.",
         "5": "In Richtung <TOWARD_SIGN> nach <RELATIVE_DIRECTION> einfädeln."
       },
+      "landmark_types": [],
       "relative_directions": [
         "Links",
         "Rechts"
@@ -1108,6 +1159,7 @@
         "4": "In Richtung <TOWARD_SIGN> einfädeln.",
         "5": "In Richtung <TOWARD_SIGN> nach <RELATIVE_DIRECTION> einfädeln."
       },
+      "landmark_types": [],
       "relative_directions": [
         "Links",
         "Rechts"
@@ -1393,8 +1445,33 @@
         "2": "Scharf nach <RELATIVE_DIRECTION> auf <BEGIN_STREET_NAMES> abbiegen. Dann weiter auf <STREET_NAMES>.",
         "3": "Scharf nach <RELATIVE_DIRECTION> abbiegen um auf <STREET_NAMES> zu bleiben.",
         "4": "An <JUNCTION_NAME> scharf nach <RELATIVE_DIRECTION> abbiegen.",
-        "5": "Scharf nach <RELATIVE_DIRECTION> in Richtung <TOWARD_SIGN> abbiegen."
+        "5": "Scharf nach <RELATIVE_DIRECTION> in Richtung <TOWARD_SIGN> abbiegen.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "Fußweg",
         "Radweg",
@@ -1433,8 +1510,33 @@
         "2": "Scharf nach <RELATIVE_DIRECTION> auf <BEGIN_STREET_NAMES> abbiegen.",
         "3": "Scharf nach <RELATIVE_DIRECTION> abbiegen um auf <STREET_NAMES> zu bleiben.",
         "4": "An <JUNCTION_NAME> scharf nach <RELATIVE_DIRECTION> abbiegen.",
-        "5": "Scharf nach <RELATIVE_DIRECTION> in Richtung <TOWARD_SIGN> abbiegen."
+        "5": "Scharf nach <RELATIVE_DIRECTION> in Richtung <TOWARD_SIGN> abbiegen.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "Fußweg",
         "Radweg",
@@ -1952,8 +2054,33 @@
         "2": "<RELATIVE_DIRECTION> auf <BEGIN_STREET_NAMES> abbiegen. Dann weiter auf <STREET_NAMES>.",
         "3": "<RELATIVE_DIRECTION> abbiegen um auf <STREET_NAMES> zu bleiben.",
         "4": "An <JUNCTION_NAME> nach <RELATIVE_DIRECTION> abbiegen.",
-        "5": "In Richtung <TOWARD_SIGN> nach <RELATIVE_DIRECTION> abbiegen."
+        "5": "In Richtung <TOWARD_SIGN> nach <RELATIVE_DIRECTION> abbiegen.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "Fußweg",
         "Radweg",
@@ -1992,8 +2119,33 @@
         "2": "<RELATIVE_DIRECTION> auf <BEGIN_STREET_NAMES> abbiegen. Dann weiter auf <STREET_NAMES>.",
         "3": "<RELATIVE_DIRECTION> abbiegen um auf <STREET_NAMES> zu bleiben.",
         "4": "An <JUNCTION_NAME> nach <RELATIVE_DIRECTION> abbiegen.",
-        "5": "In Richtung <TOWARD_SIGN> nach <RELATIVE_DIRECTION> abbiegen."
+        "5": "In Richtung <TOWARD_SIGN> nach <RELATIVE_DIRECTION> abbiegen.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "Fußweg",
         "Radweg",
@@ -2036,6 +2188,7 @@
         "6": "An <JUNCTION_NAME> eine Kehrtwende nach <RELATIVE_DIRECTION> machen.",
         "7": "In Richtung <TOWARD_SIGN> eine Kehrtwende nach <RELATIVE_DIRECTION> machen."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "Fußweg",
         "Radweg",
@@ -2084,6 +2237,7 @@
         "6": "An <JUNCTION_NAME> eine Kehrtwende nach <RELATIVE_DIRECTION> machen.",
         "7": "In Richtung <TOWARD_SIGN> eine Kehrtwende nach <RELATIVE_DIRECTION> machen."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "Fußweg",
         "Radweg",

--- a/locales/el-GR.json
+++ b/locales/el-GR.json
@@ -39,8 +39,33 @@
         "2": "Στρίψτε ελαφρώς <RELATIVE_DIRECTION> στη <BEGIN_STREET_NAMES>. Συνεχίστε στη <STREET_NAMES>.",
         "3": "Στρίψτε ελαφρώς <RELATIVE_DIRECTION> για να παραμείνετε στη <STREET_NAMES>.",
         "4": "Στρίψτε ελαφρώς <RELATIVE_DIRECTION> στη <JUNCTION_NAME>.",
-        "5": "Στρίψτε <RELATIVE_DIRECTION> προς <TOWARD_SIGN>."
+        "5": "Στρίψτε <RELATIVE_DIRECTION> προς <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "διάβαση πεζών",
         "ποδηλατοδρόμος",
@@ -79,8 +104,33 @@
         "2": "Στρίψτε ελαφρώς <RELATIVE_DIRECTION> στη <BEGIN_STREET_NAMES>.",
         "3": "Στρίψτε ελαφρώς <RELATIVE_DIRECTION> για να παραμείνετε στη <STREET_NAMES>.",
         "4": "Στρίψτε ελαφρώς <RELATIVE_DIRECTION> στη <JUNCTION_NAME>.",
-        "5": "Στρίψτε <RELATIVE_DIRECTION> προς <TOWARD_SIGN>."
+        "5": "Στρίψτε <RELATIVE_DIRECTION> προς <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "διάβαση πεζών",
         "ποδηλατοδρόμος ",
@@ -1068,6 +1118,7 @@
         "4": "Μπείτε στη <TOWARD_SIGN>.",
         "5": "Μπείτε <RELATIVE_DIRECTION> προς <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "αριστερά",
         "δεξιά"
@@ -1108,6 +1159,7 @@
         "4": "Μπείτε στη <TOWARD_SIGN>.",
         "5": "Μπείτε <RELATIVE_DIRECTION> προς <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "αριστερά",
         "δεξιά"
@@ -1393,8 +1445,33 @@
         "2": "Πάρτε κλειστή στροφή <RELATIVE_DIRECTION> στη <BEGIN_STREET_NAMES>. Συνεχίστε στη <STREET_NAMES>.",
         "3": "Πάρτε κλειστή στροφή <RELATIVE_DIRECTION> για να παραμείνετε στη <STREET_NAMES>.",
         "4": "Πάρτε κλειστή στροφή <RELATIVE_DIRECTION> για να παραμείνετε στη <JUNCTION_NAME>.",
-        "5": "Πάρτε κλειστή στροφή <RELATIVE_DIRECTION> προς <STREET_NAMES>."
+        "5": "Πάρτε κλειστή στροφή <RELATIVE_DIRECTION> προς <STREET_NAMES>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "διάβαση πεζών",
         "ποδηλατοδρόμος ",
@@ -1433,8 +1510,33 @@
         "2": "Πάρτε κλειστή στροφή <RELATIVE_DIRECTION> προς <BEGIN_STREET_NAMES>.",
         "3": "Πάρτε κλειστή στροφή <RELATIVE_DIRECTION> για να παραμείνετε στη <STREET_NAMES>.",
         "4": "Πάρτε κλειστή στροφή <RELATIVE_DIRECTION> για να παραμείνετε στη <JUNCTION_NAME>.",
-        "5": "Πάρτε κλειστή στροφή <RELATIVE_DIRECTION> προς <STREET_NAMES>."
+        "5": "Πάρτε κλειστή στροφή <RELATIVE_DIRECTION> προς <STREET_NAMES>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "διάβαση πεζών",
         "ποδηλατοδρόμος ",
@@ -1952,8 +2054,33 @@
         "2": "Στρίψτε <RELATIVE_DIRECTION> στη <BEGIN_STREET_NAMES>. Συνεχίστε στη <STREET_NAMES>.",
         "3": "Στρίψτε <RELATIVE_DIRECTION> για να παραμείνετε στη <STREET_NAMES>.",
         "4": "Στρίψτε <RELATIVE_DIRECTION> στη <JUNCTION_NAME>.",
-        "5": "Στρίψτε <RELATIVE_DIRECTION> προς <TOWARD_SIGN>."
+        "5": "Στρίψτε <RELATIVE_DIRECTION> προς <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "διάβαση πεζών",
         "ποδηλατοδρόμος ",
@@ -1992,8 +2119,33 @@
         "2": "Στρίψτε <RELATIVE_DIRECTION> στη <BEGIN_STREET_NAMES>.",
         "3": "Στρίψτε <RELATIVE_DIRECTION> για να παραμείνετε στη <STREET_NAMES>.",
         "4": "Στρίψτε <RELATIVE_DIRECTION> στη <JUNCTION_NAME>.",
-        "5": "Στρίψτε <RELATIVE_DIRECTION> προς <TOWARD_SIGN>."
+        "5": "Στρίψτε <RELATIVE_DIRECTION> προς <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "διάβαση πεζών",
         "ποδηλατοδρόμος ",
@@ -2036,6 +2188,7 @@
         "6": "Στρίψτε ελαφρώς <RELATIVE_DIRECTION> στη <JUNCTION_NAME>.",
         "7": "Κάντε αναστροφή <RELATIVE_DIRECTION> προς <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "διάβαση πεζών",
         "ποδηλατοδρόμος ",
@@ -2084,6 +2237,7 @@
         "6": "Κάντε αναστροφή <RELATIVE_DIRECTION> στη <JUNCTION_NAME>.",
         "7": "Κάντε αναστροφή <RELATIVE_DIRECTION> προς <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "διάβαση πεζών",
         "ποδηλατοδρόμος ",

--- a/locales/en-GB.json
+++ b/locales/en-GB.json
@@ -37,8 +37,33 @@
         "2": "Move <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>.",
         "3": "Move <RELATIVE_DIRECTION> to stay on <STREET_NAMES>.",
         "4": "Move <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Move <RELATIVE_DIRECTION> towards <TOWARD_SIGN>."
+        "5": "Move <RELATIVE_DIRECTION> towards <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "the walkway",
         "the cycleway",
@@ -77,8 +102,33 @@
         "2": "Move <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>.",
         "3": "Move <RELATIVE_DIRECTION> to stay on <STREET_NAMES>.",
         "4": "Move <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Move <RELATIVE_DIRECTION> towards <TOWARD_SIGN>."
+        "5": "Move <RELATIVE_DIRECTION> towards <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "the walkway",
         "the cycleway",
@@ -1066,6 +1116,7 @@
         "4": "Merge towards <TOWARD_SIGN>.",
         "5": "Merge <RELATIVE_DIRECTION> towards <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "left",
         "right"
@@ -1106,6 +1157,7 @@
         "4": "Merge towards <TOWARD_SIGN>.",
         "5": "Merge <RELATIVE_DIRECTION> towards <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "left",
         "right"
@@ -1391,8 +1443,33 @@
         "2": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>.",
         "3": "Make a sharp <RELATIVE_DIRECTION> to stay on <STREET_NAMES>.",
         "4": "Make a sharp <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Make a sharp <RELATIVE_DIRECTION> towards <TOWARD_SIGN>."
+        "5": "Make a sharp <RELATIVE_DIRECTION> towards <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "the walkway",
         "the cycleway",
@@ -1431,8 +1508,33 @@
         "2": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>.",
         "3": "Make a sharp <RELATIVE_DIRECTION> to stay on <STREET_NAMES>.",
         "4": "Make a sharp <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Make a sharp <RELATIVE_DIRECTION> towards <TOWARD_SIGN>."
+        "5": "Make a sharp <RELATIVE_DIRECTION> towards <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "the walkway",
         "the cycleway",
@@ -1950,8 +2052,33 @@
         "2": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>.",
         "3": "Turn <RELATIVE_DIRECTION> to stay on <STREET_NAMES>.",
         "4": "Turn <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Turn <RELATIVE_DIRECTION> towards <TOWARD_SIGN>."
+        "5": "Turn <RELATIVE_DIRECTION> towards <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "the walkway",
         "the cycleway",
@@ -1990,8 +2117,33 @@
         "2": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>.",
         "3": "Turn <RELATIVE_DIRECTION> to stay on <STREET_NAMES>.",
         "4": "Turn <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Turn <RELATIVE_DIRECTION> towards <TOWARD_SIGN>."
+        "5": "Turn <RELATIVE_DIRECTION> towards <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "the walkway",
         "the cycleway",
@@ -2034,6 +2186,7 @@
         "6": "Make a <RELATIVE_DIRECTION> U-turn at <JUNCTION_NAME>.",
         "7": "Make a <RELATIVE_DIRECTION> U-turn towards <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "the walkway",
         "the cycleway",
@@ -2082,6 +2235,7 @@
         "6": "Make a <RELATIVE_DIRECTION> U-turn at <JUNCTION_NAME>.",
         "7": "Make a <RELATIVE_DIRECTION> U-turn towards <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "the walkway",
         "the cycleway",

--- a/locales/en-US-x-pirate.json
+++ b/locales/en-US-x-pirate.json
@@ -39,8 +39,33 @@
         "2": "Bear <RELATIVE_DIRECTION> me matey onto <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>.",
         "3": "Bear <RELATIVE_DIRECTION> me matey to stay on <STREET_NAMES>.",
         "4": "Bear <RELATIVE_DIRECTION> me matey at <JUNCTION_NAME>.",
-        "5": "Bear <RELATIVE_DIRECTION> me matey toward <TOWARD_SIGN>."
+        "5": "Bear <RELATIVE_DIRECTION> me matey toward <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "solid ground",
         "th' bike pirate way",
@@ -79,8 +104,33 @@
         "2": "Bear <RELATIVE_DIRECTION> me matey onto <BEGIN_STREET_NAMES>.",
         "3": "Bear <RELATIVE_DIRECTION> me matey to stay on <STREET_NAMES>.",
         "4": "Bear <RELATIVE_DIRECTION> me matey at <JUNCTION_NAME>.",
-        "5": "Bear <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Bear <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "solid ground",
         "th' bike pirate way",
@@ -1068,6 +1118,7 @@
         "4": "Merge toward <TOWARD_SIGN>.",
         "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "port",
         "starboard"
@@ -1108,6 +1159,7 @@
         "4": "Merge toward <TOWARD_SIGN>.",
         "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "port",
         "starboard"
@@ -1393,8 +1445,33 @@
         "2": "Arrr, make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>.",
         "3": "Make a sharp <RELATIVE_DIRECTION> matey to stay on <STREET_NAMES>.",
         "4": "Make a sharp <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Make a sharp <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Make a sharp <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "solid ground",
         "th' bike pirate way",
@@ -1433,8 +1510,33 @@
         "2": "Arrr, make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>.",
         "3": "Make a sharp <RELATIVE_DIRECTION> matey to stay on <STREET_NAMES>.",
         "4": "Make a sharp <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Make a sharp <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Make a sharp <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "solid ground",
         "th' bike pirate way",
@@ -1952,8 +2054,33 @@
         "2": "Arrr, turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>. Aye, continue on <STREET_NAMES>.",
         "3": "Turn <RELATIVE_DIRECTION> matey to stay on <STREET_NAMES>.",
         "4": "Turn <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Turn <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Turn <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "solid ground",
         "th' bike pirate way",
@@ -1992,8 +2119,33 @@
         "2": "Arrr, turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>.",
         "3": "Turn <RELATIVE_DIRECTION> matey to stay on <STREET_NAMES>.",
         "4": "Turn <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Turn <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Turn <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "solid ground",
         "th' bike pirate way",
@@ -2036,6 +2188,7 @@
         "6": "Make a <RELATIVE_DIRECTION> U-turn at <JUNCTION_NAME>.",
         "7": "Make a <RELATIVE_DIRECTION> U-turn toward <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "solid ground",
         "th' bike pirate way",
@@ -2084,6 +2237,7 @@
         "6": "Make a <RELATIVE_DIRECTION> U-turn at <JUNCTION_NAME>.",
         "7": "Make a <RELATIVE_DIRECTION> U-turn toward <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "solid ground",
         "th' bike pirate way",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -39,8 +39,33 @@
         "2": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>.",
         "3": "Bear <RELATIVE_DIRECTION> to stay on <STREET_NAMES>.",
         "4": "Bear <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Bear <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Bear <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "the walkway",
         "the cycleway",
@@ -79,8 +104,33 @@
         "2": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>.",
         "3": "Bear <RELATIVE_DIRECTION> to stay on <STREET_NAMES>.",
         "4": "Bear <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Bear <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Bear <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "the walkway",
         "the cycleway",
@@ -1068,6 +1118,7 @@
         "4": "Merge toward <TOWARD_SIGN>.",
         "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "left",
         "right"
@@ -1108,6 +1159,7 @@
         "4": "Merge toward <TOWARD_SIGN>.",
         "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "left",
         "right"
@@ -1393,8 +1445,33 @@
         "2": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>.",
         "3": "Make a sharp <RELATIVE_DIRECTION> to stay on <STREET_NAMES>.",
         "4": "Make a sharp <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Make a sharp <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Make a sharp <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "the walkway",
         "the cycleway",
@@ -1433,8 +1510,33 @@
         "2": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>.",
         "3": "Make a sharp <RELATIVE_DIRECTION> to stay on <STREET_NAMES>.",
         "4": "Make a sharp <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Make a sharp <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Make a sharp <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "the walkway",
         "the cycleway",
@@ -1952,8 +2054,33 @@
         "2": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>. Continue on <STREET_NAMES>.",
         "3": "Turn <RELATIVE_DIRECTION> to stay on <STREET_NAMES>.",
         "4": "Turn <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Turn <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Turn <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "the walkway",
         "the cycleway",
@@ -1992,8 +2119,33 @@
         "2": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES>.",
         "3": "Turn <RELATIVE_DIRECTION> to stay on <STREET_NAMES>.",
         "4": "Turn <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Turn <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Turn <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "the walkway",
         "the cycleway",
@@ -2036,6 +2188,7 @@
         "6": "Make a <RELATIVE_DIRECTION> U-turn at <JUNCTION_NAME>.",
         "7": "Make a <RELATIVE_DIRECTION> U-turn toward <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "the walkway",
         "the cycleway",
@@ -2084,6 +2237,7 @@
         "6": "Make a <RELATIVE_DIRECTION> U-turn at <JUNCTION_NAME>.",
         "7": "Make a <RELATIVE_DIRECTION> U-turn toward <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "the walkway",
         "the cycleway",

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -39,8 +39,33 @@
         "2": "Siga por la <RELATIVE_DIRECTION> hacia <BEGIN_STREET_NAMES>. Continúe en <STREET_NAMES>.",
         "3": "Manténgase a la <RELATIVE_DIRECTION> para permanecer en <STREET_NAMES>.",
         "4": "Siga por la <RELATIVE_DIRECTION> en <JUNCTION_NAME>.",
-        "5": "Siga por la <RELATIVE_DIRECTION> en dirección a <TOWARD_SIGN>."
+        "5": "Siga por la <RELATIVE_DIRECTION> en dirección a <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "la calzada",
         "el carril bici",
@@ -79,8 +104,33 @@
         "2": "Siga por la <RELATIVE_DIRECTION> hacia <BEGIN_STREET_NAMES>.",
         "3": "Manténgase a la <RELATIVE_DIRECTION> para permanecer en <STREET_NAMES>.",
         "4": "Siga por la <RELATIVE_DIRECTION> en <JUNCTION_NAME>.",
-        "5": "Siga por la <RELATIVE_DIRECTION> en dirección a <TOWARD_SIGN>."
+        "5": "Siga por la <RELATIVE_DIRECTION> en dirección a <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "la calzada",
         "el carril bici",
@@ -1068,6 +1118,7 @@
         "4": "Incorpórese en dirección a <TOWARD_SIGN>.",
         "5": "Incorpórese a la <RELATIVE_DIRECTION> en dirección a <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "izquierda",
         "derecha"
@@ -1108,6 +1159,7 @@
         "4": "Incorpórese en dirección a <TOWARD_SIGN>.",
         "5": "Incorpórese a la <RELATIVE_DIRECTION> en dirección a <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "izquierda",
         "derecha"
@@ -1393,8 +1445,33 @@
         "2": "Gire completamente a la <RELATIVE_DIRECTION> hacia <BEGIN_STREET_NAMES>. Continúe en <STREET_NAMES>.",
         "3": "Gire completamente a la <RELATIVE_DIRECTION> para permanecer en <STREET_NAMES>.",
         "4": "Gire completamente a la <RELATIVE_DIRECTION> en <JUNCTION_NAME>.",
-        "5": "Gire completamente a la <RELATIVE_DIRECTION> en dirección a <TOWARD_SIGN>."
+        "5": "Gire completamente a la <RELATIVE_DIRECTION> en dirección a <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "la calzada",
         "el carril bici",
@@ -1433,8 +1510,33 @@
         "2": "Gire completamente a la <RELATIVE_DIRECTION> hacia <BEGIN_STREET_NAMES>.",
         "3": "Gire completamente a la <RELATIVE_DIRECTION> para permanecer en <STREET_NAMES>.",
         "4": "Gire completamente a la <RELATIVE_DIRECTION> en <JUNCTION_NAME>.",
-        "5": "Gire completamente a la <RELATIVE_DIRECTION> en dirección a <TOWARD_SIGN>."
+        "5": "Gire completamente a la <RELATIVE_DIRECTION> en dirección a <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "la calzada",
         "el carril bici",
@@ -1952,8 +2054,33 @@
         "2": "Gire a la <RELATIVE_DIRECTION> hacia <BEGIN_STREET_NAMES>. Continúe en <STREET_NAMES>.",
         "3": "Gire a la <RELATIVE_DIRECTION> para permanecer en <STREET_NAMES>.",
         "4": "Gire a la <RELATIVE_DIRECTION> en <JUNCTION_NAME>.",
-        "5": "Gire a la <RELATIVE_DIRECTION> en dirección a <TOWARD_SIGN>."
+        "5": "Gire a la <RELATIVE_DIRECTION> en dirección a <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "la calzada",
         "el carril bici",
@@ -1992,8 +2119,33 @@
         "2": "Gire a la <RELATIVE_DIRECTION> hacia <BEGIN_STREET_NAMES>.",
         "3": "Gire a la <RELATIVE_DIRECTION> para permanecer en <STREET_NAMES>.",
         "4": "Gire a la <RELATIVE_DIRECTION> en <JUNCTION_NAME>.",
-        "5": "Gire a la <RELATIVE_DIRECTION> en dirección a <TOWARD_SIGN>."
+        "5": "Gire a la <RELATIVE_DIRECTION> en dirección a <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "la calzada",
         "el carril bici",
@@ -2036,6 +2188,7 @@
         "6": "Haga un cambio de sentido a la <RELATIVE_DIRECTION> en <JUNCTION_NAME>.",
         "7": "Haga un cambio de sentido a la <RELATIVE_DIRECTION> en dirección a <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "la calzada",
         "el carril bici",
@@ -2084,6 +2237,7 @@
         "6": "Haga un cambio de sentido a la <RELATIVE_DIRECTION> en <JUNCTION_NAME>.",
         "7": "Haga un cambio de sentido a la <RELATIVE_DIRECTION> en dirección a <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "la calzada",
         "el carril bici",

--- a/locales/et-EE.json
+++ b/locales/et-EE.json
@@ -39,8 +39,33 @@
         "2": "Võta suunaks <RELATIVE_DIRECTION> <BEGIN_STREET_NAMES> teed mööda. Jätka piki <STREET_NAMES>.",
         "3": "Võta suunaks <RELATIVE_DIRECTION> ja jää <STREET_NAMES> teele.",
         "4": "<JUNCTION_NAME> teeristis võta suunaks <RELATIVE_DIRECTION>.",
-        "5": "Võta suunaks <RELATIVE_DIRECTION> <TOWARD_SIGN> poole."
+        "5": "Võta suunaks <RELATIVE_DIRECTION> <TOWARD_SIGN> poole.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "läbipääs",
         "rattatee",
@@ -79,8 +104,33 @@
         "2": "Võta suunaks <RELATIVE_DIRECTION> <BEGIN_STREET_NAMES> teele.",
         "3": "Võta suunaks <RELATIVE_DIRECTION> ja jää <STREET_NAMES> teele.",
         "4": "<JUNCTION_NAME> teeristis võta suunaks <RELATIVE_DIRECTION>.",
-        "5": "Võta suunaks <RELATIVE_DIRECTION> <TOWARD_SIGN> poole."
+        "5": "Võta suunaks <RELATIVE_DIRECTION> <TOWARD_SIGN> poole.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "läbipääs",
         "rattatee",
@@ -1068,6 +1118,7 @@
         "4": "Liitu sõidurajaga <TOWARD_SIGN> suunas.",
         "5": "Liitu sõidurajaga <RELATIVE_DIRECTION> <TOWARD_SIGN> suunas."
       },
+      "landmark_types": [],
       "relative_directions": [
         "vasakul",
         "paremal"
@@ -1108,6 +1159,7 @@
         "4": "Liitu sõidurajaga <TOWARD_SIGN> suunas.",
         "5": "Liitu sõidurajaga <RELATIVE_DIRECTION> <TOWARD_SIGN> suunas."
       },
+      "landmark_types": [],
       "relative_directions": [
         "vasakul",
         "paremal"
@@ -1393,8 +1445,33 @@
         "2": "Pööra järsult <RELATIVE_DIRECTION> <BEGIN_STREET_NAMES> tänavale. Jätka mööda <STREET_NAMES> teed.",
         "3": "Pööra järsult <RELATIVE_DIRECTION> ja jätka <STREET_NAMES> teel.",
         "4": "<JUNCTION_NAME> teeristis pööra järsult <RELATIVE_DIRECTION>.",
-        "5": "Pööra järsult <RELATIVE_DIRECTION> <TOWARD_SIGN> suunas."
+        "5": "Pööra järsult <RELATIVE_DIRECTION> <TOWARD_SIGN> suunas.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "läbipääs",
         "rattatee",
@@ -1433,8 +1510,33 @@
         "2": "Pööra järsult <RELATIVE_DIRECTION> <BEGIN_STREET_NAMES> teele.",
         "3": "Pööra järsult <RELATIVE_DIRECTION> ja jätka <STREET_NAMES> teel.",
         "4": "<JUNCTION_NAME> teeristis pööra järsult <RELATIVE_DIRECTION>.",
-        "5": "Pööra järsult <RELATIVE_DIRECTION> <TOWARD_SIGN> suunas."
+        "5": "Pööra järsult <RELATIVE_DIRECTION> <TOWARD_SIGN> suunas.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "läbipääs",
         "rattatee",
@@ -1952,8 +2054,33 @@
         "2": "Pööra <RELATIVE_DIRECTION> <BEGIN_STREET_NAMES> teele. Liigu edasi mööda <STREET_NAMES> teed.",
         "3": "Pööra <RELATIVE_DIRECTION> ja jätka mööda <STREET_NAMES> teed.",
         "4": "<JUNCTION_NAME> teeristis pööra <RELATIVE_DIRECTION>.",
-        "5": "Pööra <RELATIVE_DIRECTION> <TOWARD_SIGN> suunas."
+        "5": "Pööra <RELATIVE_DIRECTION> <TOWARD_SIGN> suunas.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "läbipääs",
         "rattatee",
@@ -1992,8 +2119,33 @@
         "2": "Pööra <RELATIVE_DIRECTION> <BEGIN_STREET_NAMES> teele.",
         "3": "Pööra <RELATIVE_DIRECTION> ja jätka mööda <STREET_NAMES> teed.",
         "4": "<JUNCTION_NAME> teeristis pööra <RELATIVE_DIRECTION>.",
-        "5": "Pööra <RELATIVE_DIRECTION> <TOWARD_SIGN> suunas."
+        "5": "Pööra <RELATIVE_DIRECTION> <TOWARD_SIGN> suunas.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "läbipääs",
         "rattatee",
@@ -2036,6 +2188,7 @@
         "6": "<JUNCTION_NAME> teeristist pööra <RELATIVE_DIRECTION> tagasi.",
         "7": "<RELATIVE_DIRECTION> pööra tagasi <TOWARD_SIGN> suunas."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "läbipääs",
         "rattatee",
@@ -2084,6 +2237,7 @@
         "6": "<JUNCTION_NAME> teeristis pööra <RELATIVE_DIRECTION> tagasi.",
         "7": "<RELATIVE_DIRECTION> pööra tagasi <TOWARD_SIGN> suunas."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "läbipääs",
         "rattatee",

--- a/locales/fi-FI.json
+++ b/locales/fi-FI.json
@@ -39,8 +39,33 @@
         "2": "Jatka <RELATIVE_DIRECTION> kadulle <BEGIN_STREET_NAMES>. ‎Jatka eteenpäin kadulla <STREET_NAMES>.",
         "3": "Jatka <RELATIVE_DIRECTION> Jatkaaksesi kadulla ‎‎<STREET_NAMES>.",
         "4": "Jatka <RELATIVE_DIRECTION> liittymässä <JUNCTION_NAME>.",
-        "5": "Jatka <RELATIVE_DIRECTION> suuntana <TOWARD_SIGN>."
+        "5": "Jatka <RELATIVE_DIRECTION> suuntana <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "kävelyreitti",
         "pyöräilyreitti",
@@ -79,8 +104,33 @@
         "2": "Jatka <RELATIVE_DIRECTION> kadulle ‎‎<BEGIN_STREET_NAMES>.",
         "3": "Jatka<RELATIVE_DIRECTION> Jatkaaksesi kadulla ‎‎<STREET_NAMES>.",
         "4": "Jatka <RELATIVE_DIRECTION> liittymässä ‎‎<JUNCTION_NAME>.",
-        "5": "Jatka <RELATIVE_DIRECTION> suuntana <TOWARD_SIGN>."
+        "5": "Jatka <RELATIVE_DIRECTION> suuntana <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "kävelyreitti",
         "pyöräilyreitti",
@@ -1068,6 +1118,7 @@
         "4": "Liity suuntana <TOWARD_SIGN>.",
         "5": "Liity <RELATIVE_DIRECTION> suuntana <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "vasemmalle",
         "oikealle"
@@ -1108,6 +1159,7 @@
         "4": "Liity suuntana <TOWARD_SIGN>.",
         "5": "Liity <RELATIVE_DIRECTION> suuntana <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "vasemmalle",
         "oikealle"
@@ -1393,8 +1445,33 @@
         "2": "Käänny tiukasti <RELATIVE_DIRECTION> kadulle ‎‎<BEGIN_STREET_NAMES>. Jatka kadulla <STREET_NAMES>.",
         "3": "Käänny tiukasti <RELATIVE_DIRECTION> pysyäksesi kadulla ‎‎<STREET_NAMES>.",
         "4": "Käänny tiukasti <RELATIVE_DIRECTION> liittymässä ‎‎<JUNCTION_NAME>.",
-        "5": "Käänny tiukasti <RELATIVE_DIRECTION> suuntana ‎‎<TOWARD_SIGN>."
+        "5": "Käänny tiukasti <RELATIVE_DIRECTION> suuntana ‎‎<TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "kävelyreitti",
         "pyöräilyreitti",
@@ -1433,8 +1510,33 @@
         "2": "Käänny tiukasti <RELATIVE_DIRECTION> kadulle ‎‎<BEGIN_STREET_NAMES>.",
         "3": "Käänny tiukasti <RELATIVE_DIRECTION> pysyäksesi kadulla ‎‎<STREET_NAMES>.",
         "4": "Käänny tiukasti <RELATIVE_DIRECTION> liittymässä ‎‎<JUNCTION_NAME>.",
-        "5": "Käänny tiukasti <RELATIVE_DIRECTION> suuntana ‎‎<TOWARD_SIGN>."
+        "5": "Käänny tiukasti <RELATIVE_DIRECTION> suuntana ‎‎<TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "kävelyreitti",
         "pyöräilyreitti",
@@ -1952,8 +2054,33 @@
         "2": "Käänny <RELATIVE_DIRECTION> kadulle <BEGIN_STREET_NAMES>. ‎Jatka kadulla <STREET_NAMES>.",
         "3": "Käänny <RELATIVE_DIRECTION> pysyäksesi kadulla ‎‎<STREET_NAMES>.",
         "4": "Käänny <RELATIVE_DIRECTION> liittymässä <JUNCTION_NAME>.",
-        "5": "Käänny <RELATIVE_DIRECTION> suuntana <TOWARD_SIGN>."
+        "5": "Käänny <RELATIVE_DIRECTION> suuntana <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "kävelyreitti",
         "pyöräilyreitti",
@@ -1992,8 +2119,33 @@
         "2": "Käänny <RELATIVE_DIRECTION> kadulle ‎‎<BEGIN_STREET_NAMES>.",
         "3": "Käänny <RELATIVE_DIRECTION> pysyäksesi kadulla ‎‎<STREET_NAMES>.",
         "4": "Käänny <RELATIVE_DIRECTION> liittymässä ‎‎<JUNCTION_NAME>.",
-        "5": "Käänny <RELATIVE_DIRECTION> suuntana <TOWARD_SIGN>."
+        "5": "Käänny <RELATIVE_DIRECTION> suuntana <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "kävelyreitti",
         "pyöräilyreitti",
@@ -2036,6 +2188,7 @@
         "6": "Tee U-käännös <RELATIVE_DIRECTION> liittymässä ‎‎<JUNCTION_NAME>.",
         "7": "Tee U-käännös <RELATIVE_DIRECTION> suuntana ‎‎<TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "kävelyreitti",
         "pyöräilyreitti",
@@ -2084,6 +2237,7 @@
         "6": "Tee U-käännös <RELATIVE_DIRECTION> liittymässä ‎‎<JUNCTION_NAME>.",
         "7": "Tee U-käännös <RELATIVE_DIRECTION> suuntana ‎‎<TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "kävelyreitti",
         "pyöräilyreitti",

--- a/locales/fr-FR.json
+++ b/locales/fr-FR.json
@@ -39,8 +39,33 @@
         "2": "Serrez à <RELATIVE_DIRECTION> dans <BEGIN_STREET_NAMES>. Continuez sur <STREET_NAMES>.",
         "3": "Serrez à <RELATIVE_DIRECTION> pour rester sur <STREET_NAMES>.",
         "4": "Serrez à <RELATIVE_DIRECTION> à <JUNCTION_NAME>.",
-        "5": "Serrez à <RELATIVE_DIRECTION> vers <TOWARD_SIGN>."
+        "5": "Serrez à <RELATIVE_DIRECTION> vers <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "l'allée",
         "la piste cyclable",
@@ -79,8 +104,33 @@
         "2": "Serrez à <RELATIVE_DIRECTION> dans <BEGIN_STREET_NAMES>.",
         "3": "Serrez à <RELATIVE_DIRECTION> pour rester sur <STREET_NAMES>.",
         "4": "Serrez à <RELATIVE_DIRECTION> à <JUNCTION_NAME>.",
-        "5": "Serrez à <RELATIVE_DIRECTION> vers <TOWARD_SIGN>."
+        "5": "Serrez à <RELATIVE_DIRECTION> vers <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "l'allée",
         "la piste cyclable",
@@ -1068,6 +1118,7 @@
         "4": "Insérez-vous vers <TOWARD_SIGN>.",
         "5": "Insérez-vous à <RELATIVE_DIRECTION> vers <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "gauche",
         "droite"
@@ -1108,6 +1159,7 @@
         "4": "Insérez-vous vers <TOWARD_SIGN>.",
         "5": "Insérez-vous à <RELATIVE_DIRECTION> vers <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "gauche",
         "droite"
@@ -1393,8 +1445,33 @@
         "2": "Tournez tout de suite à <RELATIVE_DIRECTION> dans <BEGIN_STREET_NAMES>. Continuez sur <STREET_NAMES>.",
         "3": "Tournez tout de suite à <RELATIVE_DIRECTION> pour rester sur <STREET_NAMES>.",
         "4": "Tournez tout de suite à <RELATIVE_DIRECTION> à <JUNCTION_NAME>.",
-        "5": "Tournez tout de suite à <RELATIVE_DIRECTION> vers <TOWARD_SIGN>."
+        "5": "Tournez tout de suite à <RELATIVE_DIRECTION> vers <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "l'allée",
         "la piste cyclable",
@@ -1433,8 +1510,33 @@
         "2": "Tournez tout de suite à <RELATIVE_DIRECTION> dans <BEGIN_STREET_NAMES>.",
         "3": "Tournez tout de suite à <RELATIVE_DIRECTION> pour rester sur <STREET_NAMES>.",
         "4": "Tournez tout de suite à <RELATIVE_DIRECTION> à <JUNCTION_NAME>.",
-        "5": "Tournez tout de suite à <RELATIVE_DIRECTION> vers <TOWARD_SIGN>."
+        "5": "Tournez tout de suite à <RELATIVE_DIRECTION> vers <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "l'allée",
         "la piste cyclable",
@@ -1952,8 +2054,33 @@
         "2": "Tournez à <RELATIVE_DIRECTION> dans <BEGIN_STREET_NAMES>. Continuez sur <STREET_NAMES>.",
         "3": "Tournez à <RELATIVE_DIRECTION> pour rester sur <STREET_NAMES>.",
         "4": "Tournez à <RELATIVE_DIRECTION> à <JUNCTION_NAME>.",
-        "5": "Tournez à <RELATIVE_DIRECTION> vers <TOWARD_SIGN>."
+        "5": "Tournez à <RELATIVE_DIRECTION> vers <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "l'allée",
         "la piste cyclable",
@@ -1992,8 +2119,33 @@
         "2": "Tournez à <RELATIVE_DIRECTION> dans <BEGIN_STREET_NAMES>.",
         "3": "Tournez à <RELATIVE_DIRECTION> pour rester sur <STREET_NAMES>.",
         "4": "Tournez à <RELATIVE_DIRECTION> à <JUNCTION_NAME>.",
-        "5": "Tournez à <RELATIVE_DIRECTION> vers <TOWARD_SIGN>."
+        "5": "Tournez à <RELATIVE_DIRECTION> vers <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "l'allée",
         "la piste cyclable",
@@ -2036,6 +2188,7 @@
         "6": "Faites demi-tour à <RELATIVE_DIRECTION> à <JUNCTION_NAME>.",
         "7": "Faites demi-tour à <RELATIVE_DIRECTION> vers <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "l'allée",
         "la piste cyclable",
@@ -2084,6 +2237,7 @@
         "6": "Faites demi-tour à <RELATIVE_DIRECTION> à <JUNCTION_NAME>.",
         "7": "Faites demi-tour à <RELATIVE_DIRECTION> vers <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "l'allée",
         "la piste cyclable",

--- a/locales/hi-IN.json
+++ b/locales/hi-IN.json
@@ -39,8 +39,33 @@
         "2": "<RELATIVE_DIRECTION> ओर <STREET_NAMES> पर बढ़े. <STREET_NAMES> पर बने रहें.",
         "3": "<RELATIVE_DIRECTION> ओर <STREET_NAMES> पर बने रहें.",
         "4": "Bear <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Bear <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Bear <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "रास्ते",
         "साइकिल रास्ते",
@@ -79,8 +104,33 @@
         "2": "<RELATIVE_DIRECTION> ओर <BEGIN_STREET_NAMES> पर बढ़े.",
         "3": "<RELATIVE_DIRECTION> ओर <STREET_NAMES> पर बने रहें.",
         "4": "Bear <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Bear <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Bear <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "रास्ते",
         "साइकिल रास्ते",
@@ -1068,6 +1118,7 @@
         "4": "Merge toward <TOWARD_SIGN>.",
         "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "बाएं",
         "दाएँ"
@@ -1108,6 +1159,7 @@
         "4": "Merge toward <TOWARD_SIGN>.",
         "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "बाएं",
         "दाएँ"
@@ -1393,8 +1445,33 @@
         "2": "<BEGIN_STREET_NAMES> पर तेज <RELATIVE_DIRECTION> मुड़ें. <STREET_NAMES> पर बने रहें.",
         "3": "<STREET_NAMES> पर बने रहने के लिए तेज <RELATIVE_DIRECTION> मुड़ें.",
         "4": "Make a sharp <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Make a sharp <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Make a sharp <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "रास्ते",
         "साइकिल रास्ते",
@@ -1433,8 +1510,33 @@
         "2": "<BEGIN_STREET_NAMES> पर तेज <RELATIVE_DIRECTION> मुड़ें.",
         "3": "<STREET_NAMES> पर बने रहने के लिए <RELATIVE_DIRECTION> मुड़ें.",
         "4": "Make a sharp <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Make a sharp <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Make a sharp <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "रास्ते",
         "साइकिल रास्ते",
@@ -1952,8 +2054,33 @@
         "2": "<BEGIN_STREET_NAMES> पर <RELATIVE_DIRECTION> मुड़ें. <STREET_NAMES> पर बने रहें.",
         "3": "<STREET_NAMES> पर बने रहने के लिए <RELATIVE_DIRECTION> मुड़ें.",
         "4": "Turn <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Turn <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Turn <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "रास्ते",
         "साइकिल रास्ते",
@@ -1992,8 +2119,33 @@
         "2": "<BEGIN_STREET_NAMES> पर <RELATIVE_DIRECTION> मुड़ें.",
         "3": "<STREET_NAMES> पर बने रहने के लिए <RELATIVE_DIRECTION> मुड़ें.",
         "4": "Turn <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Turn <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Turn <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "रास्ते",
         "साइकिल रास्ते",
@@ -2036,6 +2188,7 @@
         "6": "Make a <RELATIVE_DIRECTION> U-turn at <JUNCTION_NAME>.",
         "7": "Make a <RELATIVE_DIRECTION> U-turn toward <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "रास्ते",
         "साइकिल रास्ते",
@@ -2084,6 +2237,7 @@
         "6": "Make a <RELATIVE_DIRECTION> U-turn at <JUNCTION_NAME>.",
         "7": "Make a <RELATIVE_DIRECTION> U-turn toward <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "रास्ते",
         "साइकिल रास्ते",

--- a/locales/hu-HU.json
+++ b/locales/hu-HU.json
@@ -39,8 +39,33 @@
         "2": "Forduljon <RELATIVE_DIRECTION> a(z) <BEGIN_STREET_NAMES> utcára. Haladjon tovább a(z) <STREET_NAMES> utcán.",
         "3": "Forduljon <RELATIVE_DIRECTION>, hogy a(z) <STREET_NAMES> utcán maradjon.",
         "4": "Forduljon <RELATIVE_DIRECTION> a(z) <JUNCTION_NAME> útkereszteződésnél.",
-        "5": "Forduljon balra <RELATIVE_DIRECTION> a(z) <TOWARD_SIGN> jelzés felé."
+        "5": "Forduljon balra <RELATIVE_DIRECTION> a(z) <TOWARD_SIGN> jelzés felé.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "a sétány",
         "a kerékpárút",
@@ -79,8 +104,33 @@
         "2": "Forduljon <RELATIVE_DIRECTION> a(z) <BEGIN_STREET_NAMES>.",
         "3": "Forduljon <RELATIVE_DIRECTION> hogy a(z) <STREET_NAMES> utcán maradjon.",
         "4": "Forduljon <RELATIVE_DIRECTION> a(z) <JUNCTION_NAME> útkereszteződésnél.",
-        "5": "Forduljon <RELATIVE_DIRECTION> a(z) <TOWARD_SIGN> jel felé."
+        "5": "Forduljon <RELATIVE_DIRECTION> a(z) <TOWARD_SIGN> jel felé.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "a sétány",
         "a kerékpárút",
@@ -1068,6 +1118,7 @@
         "4": "Úttorkolat <TOWARD_SIGN> felé.",
         "5": "Úttorkolat <RELATIVE_DIRECTION> felé <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "balra",
         "jobbra"
@@ -1108,6 +1159,7 @@
         "4": "Úttorkolat a(z) <TOWARD_SIGN> felé.",
         "5": "Úttorkolat <RELATIVE_DIRECTION> a(z) <TOWARD_SIGN> felé."
       },
+      "landmark_types": [],
       "relative_directions": [
         "balra",
         "jobbra"
@@ -1393,8 +1445,33 @@
         "2": "Forduljon élesen <RELATIVE_DIRECTION> a(z) <BEGIN_STREET_NAMES> utcára. Haladjon tovább a(z) <STREET_NAMES> utcán.",
         "3": "Forduljon élesen <RELATIVE_DIRECTION>, hogy a(z) <STREET_NAMES> utcán maradjon.",
         "4": "Forduljon élesen <RELATIVE_DIRECTION> a(z) <JUNCTION_NAME> útkereszteződésnél.",
-        "5": "Forduljon élesen <RELATIVE_DIRECTION> a(z) <TOWARD_SIGN> felé."
+        "5": "Forduljon élesen <RELATIVE_DIRECTION> a(z) <TOWARD_SIGN> felé.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "a sétány",
         "a kerékpárút",
@@ -1433,8 +1510,33 @@
         "2": "Forduljon élesen <RELATIVE_DIRECTION> a(z) <BEGIN_STREET_NAMES> utcára.",
         "3": "Forduljon élesen <RELATIVE_DIRECTION>, hogy a(z) <STREET_NAMES> utcán maradjon.",
         "4": "Forduljon élesen <RELATIVE_DIRECTION> a(z) <JUNCTION_NAME> útkereszteződésnél.",
-        "5": "Forduljon élesen <RELATIVE_DIRECTION> a(z) <TOWARD_SIGN> felé."
+        "5": "Forduljon élesen <RELATIVE_DIRECTION> a(z) <TOWARD_SIGN> felé.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "a sétány",
         "a kerékpárút",
@@ -1952,8 +2054,33 @@
         "2": "Forduljon <RELATIVE_DIRECTION> a(z) <BEGIN_STREET_NAMES> utcára. Haladjon tovább a(z) <STREET_NAMES> utcán.",
         "3": "Forduljon <RELATIVE_DIRECTION>, hogy a(z) <STREET_NAMES> utcán maradjon.",
         "4": "Forduljon <RELATIVE_DIRECTION> a(z) <JUNCTION_NAME> útkeresztaződésnél.",
-        "5": "Forduljon <RELATIVE_DIRECTION> a(z) <TOWARD_SIGN> felé."
+        "5": "Forduljon <RELATIVE_DIRECTION> a(z) <TOWARD_SIGN> felé.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "a sétány",
         "a kerékpárút",
@@ -1992,8 +2119,33 @@
         "2": "Forduljon <RELATIVE_DIRECTION> a(z) <BEGIN_STREET_NAMES> utcára.",
         "3": "Forduljon <RELATIVE_DIRECTION>, hogy a(z) <STREET_NAMES> utcán maradjon.",
         "4": "Forduljon <RELATIVE_DIRECTION> a(z) <JUNCTION_NAME> útkereszteződésnél.",
-        "5": "Forduljon <RELATIVE_DIRECTION> a(z) <TOWARD_SIGN> felé."
+        "5": "Forduljon <RELATIVE_DIRECTION> a(z) <TOWARD_SIGN> felé.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "a sétány",
         "a kerékpárút",
@@ -2036,6 +2188,7 @@
         "6": "Végezzen egy <RELATIVE_DIRECTION> megfordulást a(z) <JUNCTION_NAME> útkereszteződésnél.",
         "7": "Végezzen egy <RELATIVE_DIRECTION> Umegfordulást a(z) <TOWARD_SIGN> felé."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "a sétány",
         "a kerékpárút",
@@ -2084,6 +2237,7 @@
         "6": "Végezzen egy <RELATIVE_DIRECTION> megfordulást a(z) <JUNCTION_NAME> útkereszteződésnél.",
         "7": "VÉgezzen egy <RELATIVE_DIRECTION> megfordulást a(z) <TOWARD_SIGN> felé."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "a sétány",
         "a kerékpárút",

--- a/locales/it-IT.json
+++ b/locales/it-IT.json
@@ -39,8 +39,33 @@
         "2": "Mantieni la <RELATIVE_DIRECTION> su <BEGIN_STREET_NAMES>. Continua su <STREET_NAMES>.",
         "3": "Svolta a <RELATIVE_DIRECTION> per rimanere su <STREET_NAMES>.",
         "4": "Arrivato a <JUNCTION_NAME>, svolta a <RELATIVE_DIRECTION>.",
-        "5": "Svolta a <RELATIVE_DIRECTION> verso <TOWARD_SIGN>."
+        "5": "Svolta a <RELATIVE_DIRECTION> verso <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "la passerella",
         "la pista ciclabile",
@@ -79,8 +104,33 @@
         "2": "Mantieni la <RELATIVE_DIRECTION> su <BEGIN_STREET_NAMES>.",
         "3": "Svolta a <RELATIVE_DIRECTION> per rimanere su <STREET_NAMES>.",
         "4": "Arrivato a <JUNCTION_NAME>, svolta a <RELATIVE_DIRECTION>.",
-        "5": "Svolta a <RELATIVE_DIRECTION> verso <TOWARD_SIGN>."
+        "5": "Svolta a <RELATIVE_DIRECTION> verso <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "la passerella",
         "la pista ciclabile",
@@ -1068,6 +1118,7 @@
         "4": "Immettiti verso <TOWARD_SIGN>.",
         "5": "Immettiti a <RELATIVE_DIRECTION> verso <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "sinistra",
         "destra"
@@ -1108,6 +1159,7 @@
         "4": "Immettiti verso <TOWARD_SIGN>.",
         "5": "Immettiti a <RELATIVE_DIRECTION> verso <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "sinistra",
         "destra"
@@ -1393,8 +1445,33 @@
         "2": "Fai un curva a gomito a <RELATIVE_DIRECTION> verso <BEGIN_STREET_NAMES>. Continua su <STREET_NAMES>.",
         "3": "Fai un curva a gomito a <RELATIVE_DIRECTION> per rimanere su <STREET_NAMES>.",
         "4": "Arrivato a <JUNCTION_NAME>, fai un curva a gomito a <RELATIVE_DIRECTION>.",
-        "5": "Fai un curva a gomito a <RELATIVE_DIRECTION> verso <TOWARD_SIGN>."
+        "5": "Fai un curva a gomito a <RELATIVE_DIRECTION> verso <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "la passerella",
         "la pista ciclabile",
@@ -1433,8 +1510,33 @@
         "2": "Fai un curva a gomito a <RELATIVE_DIRECTION> su <BEGIN_STREET_NAMES>.",
         "3": "Fai un curva a gomito a <RELATIVE_DIRECTION> per rimanere su <STREET_NAMES>.",
         "4": "Arrivato a <JUNCTION_NAME>. fai un curva a gomito a <RELATIVE_DIRECTION>.",
-        "5": "Fai un curva a gomito a <RELATIVE_DIRECTION> verso <TOWARD_SIGN>."
+        "5": "Fai un curva a gomito a <RELATIVE_DIRECTION> verso <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "la passerella",
         "la pista ciclabile",
@@ -1952,8 +2054,33 @@
         "2": "Svolta a <RELATIVE_DIRECTION> su <BEGIN_STREET_NAMES>. Continua su <STREET_NAMES>.",
         "3": "Svolta a <RELATIVE_DIRECTION> per rimanere su <STREET_NAMES>.",
         "4": "Arrivato a <JUNCTION_NAME>, svolta a <RELATIVE_DIRECTION>.",
-        "5": "Svolta a <RELATIVE_DIRECTION> verso <TOWARD_SIGN>."
+        "5": "Svolta a <RELATIVE_DIRECTION> verso <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "la passerella",
         "la pista ciclabile",
@@ -1992,8 +2119,33 @@
         "2": "Svolta a <RELATIVE_DIRECTION> su <BEGIN_STREET_NAMES>.",
         "3": "Svolta a <RELATIVE_DIRECTION> per rimanere su <STREET_NAMES>.",
         "4": "Arrivato a <JUNCTION_NAME>, svolta a <RELATIVE_DIRECTION>.",
-        "5": "Svolta a <RELATIVE_DIRECTION> verso <TOWARD_SIGN>."
+        "5": "Svolta a <RELATIVE_DIRECTION> verso <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "la passerella",
         "la pista ciclabile",
@@ -2036,6 +2188,7 @@
         "6": "Arrivato a <JUNCTION_NAME>, fai un'inversione di marcia a <RELATIVE_DIRECTION>.",
         "7": "Fai un'inversione di marcia a <RELATIVE_DIRECTION> verso <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "la passerella",
         "la pista ciclabile",
@@ -2084,6 +2237,7 @@
         "6": "Arrivato a <JUNCTION_NAME>, fai un'inversione di marcia a <RELATIVE_DIRECTION>.",
         "7": "Fai un'inversione di marcia a <RELATIVE_DIRECTION> verso <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "la passerella",
         "la pista ciclabile",

--- a/locales/ja-JP.json
+++ b/locales/ja-JP.json
@@ -39,8 +39,33 @@
         "2": "<RELATIVE_DIRECTION>方向、<BEGIN_STREET_NAMES>です。その先<STREET_NAMES>です。",
         "3": "<RELATIVE_DIRECTION>方向です。その先<STREET_NAMES>です。",
         "4": "<JUNCTION_NAME>を<RELATIVE_DIRECTION>方向です。",
-        "5": "<RELATIVE_DIRECTION>方向、<TOWARD_SIGN>方面です。"
+        "5": "<RELATIVE_DIRECTION>方向、<TOWARD_SIGN>方面です。",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "歩道",
         "自転車道",
@@ -79,8 +104,33 @@
         "2": "<RELATIVE_DIRECTION>方向です。その先<BEGIN_STREET_NAMES>です。",
         "3": "<RELATIVE_DIRECTION>方向です。その先<STREET_NAMES>です。",
         "4": "<JUNCTION_NAME>を<RELATIVE_DIRECTION>方向です。",
-        "5": "<RELATIVE_DIRECTION>方向、<TOWARD_SIGN>方面です。"
+        "5": "<RELATIVE_DIRECTION>方向、<TOWARD_SIGN>方面です。",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "歩道",
         "自転車道",
@@ -1068,6 +1118,7 @@
         "4": "<TOWARD_SIGN>方面に合流です。",
         "5": "<RELATIVE_DIRECTION>方向に合流です。<TOWARD_SIGN>方面に進みます。"
       },
+      "landmark_types": [],
       "relative_directions": [
         "左",
         "右"
@@ -1108,6 +1159,7 @@
         "4": "<TOWARD_SIGN>方面に合流です。",
         "5": "<RELATIVE_DIRECTION>方向に合流です。<TOWARD_SIGN>方面に進みます。"
       },
+      "landmark_types": [],
       "relative_directions": [
         "左",
         "右"
@@ -1393,8 +1445,33 @@
         "2": "斜め<RELATIVE_DIRECTION>手前方向、<BEGIN_STREET_NAMES>です。その先、<STREET_NAMES>です。",
         "3": "斜め<RELATIVE_DIRECTION>手前方向です。その先<STREET_NAMES>です。",
         "4": "<JUNCTION_NAME>を斜め<RELATIVE_DIRECTION>手前方向です。",
-        "5": "斜め<RELATIVE_DIRECTION>手前方向、<TOWARD_SIGN>方面です。"
+        "5": "斜め<RELATIVE_DIRECTION>手前方向、<TOWARD_SIGN>方面です。",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "歩道",
         "自転車道",
@@ -1433,8 +1510,33 @@
         "2": "斜め<RELATIVE_DIRECTION>手前方向です。その先<BEGIN_STREET_NAMES>です。",
         "3": "斜め<RELATIVE_DIRECTION>手前方向です。その先<STREET_NAMES>です。",
         "4": "<JUNCTION_NAME>を斜め<RELATIVE_DIRECTION>手前方向です。",
-        "5": "斜め<RELATIVE_DIRECTION>手前方向、<TOWARD_SIGN>方面です。"
+        "5": "斜め<RELATIVE_DIRECTION>手前方向、<TOWARD_SIGN>方面です。",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "歩道",
         "自転車道",
@@ -1952,8 +2054,33 @@
         "2": "<RELATIVE_DIRECTION>方向、<BEGIN_STREET_NAMES>です。その先、<STREET_NAMES>です。",
         "3": "<RELATIVE_DIRECTION>方向です。その先<STREET_NAMES>です。",
         "4": "<JUNCTION_NAME>を<RELATIVE_DIRECTION>方向です。",
-        "5": "<RELATIVE_DIRECTION>方向、<TOWARD_SIGN>方面です。"
+        "5": "<RELATIVE_DIRECTION>方向、<TOWARD_SIGN>方面です。",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "歩道",
         "自転車道",
@@ -1992,8 +2119,33 @@
         "2": "<RELATIVE_DIRECTION>方向です。その先<BEGIN_STREET_NAMES>です。",
         "3": "<RELATIVE_DIRECTION>方向です。その先<STREET_NAMES>です。",
         "4": "<JUNCTION_NAME>を<RELATIVE_DIRECTION>方向です。",
-        "5": "<RELATIVE_DIRECTION>方向、<TOWARD_SIGN>方面です。"
+        "5": "<RELATIVE_DIRECTION>方向、<TOWARD_SIGN>方面です。",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "歩道",
         "自転車道",
@@ -2036,6 +2188,7 @@
         "6": "<JUNCTION_NAME>を<RELATIVE_DIRECTION>方向、Uターンです。",
         "7": "<RELATIVE_DIRECTION>方向、<TOWARD_SIGN>方面にUターンです。"
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "歩道",
         "自転車道",
@@ -2084,6 +2237,7 @@
         "6": "<JUNCTION_NAME>を<RELATIVE_DIRECTION>方向、Uターンです。",
         "7": "<RELATIVE_DIRECTION>方向、<TOWARD_SIGN>方面にUターンです。"
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "歩道",
         "自転車道",

--- a/locales/nb-NO.json
+++ b/locales/nb-NO.json
@@ -39,8 +39,33 @@
         "2": "Hold til <RELATIVE_DIRECTION> inn på <BEGIN_STREET_NAMES>. Fortsett på <STREET_NAMES>.",
         "3": "Hold til <RELATIVE_DIRECTION> for å holde deg på <STREET_NAMES>.",
         "4": "Hold til <RELATIVE_DIRECTION> ved <JUNCTION_NAME>.",
-        "5": "Hold til <RELATIVE_DIRECTION> mot <TOWARD_SIGN>."
+        "5": "Hold til <RELATIVE_DIRECTION> mot <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "gangveien",
         "sykkelveien",
@@ -79,8 +104,33 @@
         "2": "Hold til <RELATIVE_DIRECTION> inn på <BEGIN_STREET_NAMES>.",
         "3": "Hold til <RELATIVE_DIRECTION> for å holde deg på <STREET_NAMES>.",
         "4": "Hold til <RELATIVE_DIRECTION> ved <JUNCTION_NAME>.",
-        "5": "Hold til <RELATIVE_DIRECTION> mot <TOWARD_SIGN>."
+        "5": "Hold til <RELATIVE_DIRECTION> mot <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "gangveien",
         "sykkelveien",
@@ -1068,6 +1118,7 @@
         "4": "Flett mot <TOWARD_SIGN>.",
         "5": "Flett til <RELATIVE_DIRECTION> mot <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "venstre",
         "høyre"
@@ -1108,6 +1159,7 @@
         "4": "Flett mot <TOWARD_SIGN>.",
         "5": "Flett til <RELATIVE_DIRECTION> mot <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "venstre",
         "høyre"
@@ -1393,8 +1445,33 @@
         "2": "Ta en skarp sving mot <RELATIVE_DIRECTION> inn på <BEGIN_STREET_NAMES>. Fortsett på <STREET_NAMES>.",
         "3": "Ta en skarp sving mot <RELATIVE_DIRECTION> for å holde deg på <STREET_NAMES>.",
         "4": "Ta en skarp sving mot <RELATIVE_DIRECTION> ved <JUNCTION_NAME>.",
-        "5": "Ta en skarp sving mot <RELATIVE_DIRECTION> mot <TOWARD_SIGN>."
+        "5": "Ta en skarp sving mot <RELATIVE_DIRECTION> mot <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "gangveien",
         "sykkelveien",
@@ -1433,8 +1510,33 @@
         "2": "Ta en skarp sving mot <RELATIVE_DIRECTION> inn på <BEGIN_STREET_NAMES>.",
         "3": "Ta en skarp sving mot <RELATIVE_DIRECTION> for å holde deg på <STREET_NAMES>.",
         "4": "Ta en skarp sving mot <RELATIVE_DIRECTION> ved <JUNCTION_NAME>.",
-        "5": "Ta en skarp sving mot <RELATIVE_DIRECTION> mot <TOWARD_SIGN>."
+        "5": "Ta en skarp sving mot <RELATIVE_DIRECTION> mot <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "gangveien",
         "sykkelveien",
@@ -1952,8 +2054,33 @@
         "2": "Ta til <RELATIVE_DIRECTION> inn på <BEGIN_STREET_NAMES>. Fortsett på <STREET_NAMES>.",
         "3": "Ta til <RELATIVE_DIRECTION> for å holde deg på <STREET_NAMES>.",
         "4": "Ta til <RELATIVE_DIRECTION> ved <JUNCTION_NAME>.",
-        "5": "Ta til <RELATIVE_DIRECTION> mot <TOWARD_SIGN>."
+        "5": "Ta til <RELATIVE_DIRECTION> mot <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "gangveien",
         "sykkelveien",
@@ -1992,8 +2119,33 @@
         "2": "Ta til <RELATIVE_DIRECTION> inn på <BEGIN_STREET_NAMES>.",
         "3": "Ta til <RELATIVE_DIRECTION> for å holde deg på <STREET_NAMES>.",
         "4": "Ta til <RELATIVE_DIRECTION> ved <JUNCTION_NAME>.",
-        "5": "Ta til <RELATIVE_DIRECTION> mot <TOWARD_SIGN>."
+        "5": "Ta til <RELATIVE_DIRECTION> mot <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "gangveien",
         "sykkelveien",
@@ -2036,6 +2188,7 @@
         "6": "Ta en U-sving mot <RELATIVE_DIRECTION> ved <JUNCTION_NAME>.",
         "7": "Ta en U-sving mot <RELATIVE_DIRECTION> mot <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "gangveien",
         "sykkelveien",
@@ -2084,6 +2237,7 @@
         "6": "Ta en U-sving mot <RELATIVE_DIRECTION> ved <JUNCTION_NAME>.",
         "7": "Ta en U-sving mot <RELATIVE_DIRECTION> mot <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "gangveien",
         "sykkelveien",

--- a/locales/nl-NL.json
+++ b/locales/nl-NL.json
@@ -39,8 +39,33 @@
         "2": "Sla <RELATIVE_DIRECTION>af en ga <BEGIN_STREET_NAMES> op. Ga verder op <STREET_NAMES>.",
         "3": "Sla <RELATIVE_DIRECTION>af om op <STREET_NAMES> te blijven.",
         "4": "Sla <RELATIVE_DIRECTION>af bij <JUNCTION_NAME>.",
-        "5": "Sla <RELATIVE_DIRECTION>af naar <TOWARD_SIGN>."
+        "5": "Sla <RELATIVE_DIRECTION>af naar <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "het voetpad",
         "het fietspad",
@@ -79,8 +104,33 @@
         "2": "<RELATIVE_DIRECTION> afslaan en <BEGIN_STREET_NAMES> ingaan.",
         "3": "<RELATIVE_DIRECTION> afslaan om op <STREET_NAMES> te blijven.",
         "4": "<RELATIVE_DIRECTION> afslaan bij <JUNCTION_NAME>.",
-        "5": "<RELATIVE_DIRECTION> afslaan richting <TOWARD_SIGN>."
+        "5": "<RELATIVE_DIRECTION> afslaan richting <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "het voetpad",
         "het fietspad",
@@ -1068,6 +1118,7 @@
         "4": "Voeg in richting <TOWARD_SIGN>.",
         "5": "Voeg <RELATIVE_DIRECTION> in richting <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "links",
         "rechts"
@@ -1108,6 +1159,7 @@
         "4": "Invoegen richting <TOWARD_SIGN>.",
         "5": "<RELATIVE_DIRECTION> invoegen richting <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "Links",
         "Rechts"
@@ -1393,8 +1445,33 @@
         "2": "Neem een scherpe bocht <RELATIVE_DIRECTION> naar <BEGIN_STREET_NAMES>. Ga verder op <STREET_NAMES>.",
         "3": "Neem een scherpe bocht <RELATIVE_DIRECTION> om op <STREET_NAMES> te blijven.",
         "4": "Neem een scherpe bocht <RELATIVE_DIRECTION> bij <JUNCTION_NAME>.",
-        "5": "Neem een scherpe bocht <RELATIVE_DIRECTION> richting <TOWARD_SIGN>."
+        "5": "Neem een scherpe bocht <RELATIVE_DIRECTION> richting <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "het voetpad",
         "het fietspad",
@@ -1433,8 +1510,33 @@
         "2": "Scherpe bocht naar <RELATIVE_DIRECTION> nemen naar <BEGIN_STREET_NAMES>.",
         "3": "Scherpe bocht naar <RELATIVE_DIRECTION> nemen om op <STREET_NAMES> te blijven.",
         "4": "Scherpe bocht naar <RELATIVE_DIRECTION> nemen bij <JUNCTION_NAME>.",
-        "5": "Scherpe bocht naar <RELATIVE_DIRECTION> nemen richting <TOWARD_SIGN>."
+        "5": "Scherpe bocht naar <RELATIVE_DIRECTION> nemen richting <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "het voetpad",
         "het fietspad",
@@ -1952,8 +2054,33 @@
         "2": "Sla <RELATIVE_DIRECTION>af naar <BEGIN_STREET_NAMES>. Ga verder op <STREET_NAMES>.",
         "3": "Sla <RELATIVE_DIRECTION>af om op <STREET_NAMES> te blijven.",
         "4": "Sla <RELATIVE_DIRECTION>af bij <JUNCTION_NAME>.",
-        "5": "Sla <RELATIVE_DIRECTION>af richting <TOWARD_SIGN>."
+        "5": "Sla <RELATIVE_DIRECTION>af richting <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "het voetpad",
         "het fietspad",
@@ -1992,8 +2119,33 @@
         "2": "<RELATIVE_DIRECTION> afslaan naar <BEGIN_STREET_NAMES>.",
         "3": "<RELATIVE_DIRECTION> afslaan om op <STREET_NAMES> te blijven.",
         "4": "<RELATIVE_DIRECTION> afslaan bij <JUNCTION_NAME>.",
-        "5": "<RELATIVE_DIRECTION> afslaan richting <TOWARD_SIGN>."
+        "5": "<RELATIVE_DIRECTION> afslaan richting <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "het voetpad",
         "het fietspad",
@@ -2036,6 +2188,7 @@
         "6": "Keer <RELATIVE_DIRECTION>om bij <JUNCTION_NAME>.",
         "7": "Keer <RELATIVE_DIRECTION>om richting <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "het voetpad",
         "het fietspad",
@@ -2084,6 +2237,7 @@
         "6": "<RELATIVE_DIRECTION> omkeren bij <JUNCTION_NAME>.",
         "7": "<RELATIVE_DIRECTION> omkeren richting <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "het voetpad",
         "het fietspad",

--- a/locales/pl-PL.json
+++ b/locales/pl-PL.json
@@ -39,8 +39,33 @@
         "2": "Skręć <RELATIVE_DIRECTION> w: <BEGIN_STREET_NAMES>. Kontynuuj wzdłuż: <STREET_NAMES>.",
         "3": "Skręć <RELATIVE_DIRECTION>, pozostając na: <STREET_NAMES>.",
         "4": "Skręć <RELATIVE_DIRECTION> na <JUNCTION_NAME>.",
-        "5": "Skręć <RELATIVE_DIRECTION>, kierunek: <TOWARD_SIGN>."
+        "5": "Skręć <RELATIVE_DIRECTION>, kierunek: <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "chodnik",
         "ścieżka rowerowa",
@@ -79,8 +104,33 @@
         "2": "Skręć <RELATIVE_DIRECTION> w: <BEGIN_STREET_NAMES>.",
         "3": "Skręć <RELATIVE_DIRECTION>, pozostając na: <STREET_NAMES>.",
         "4": "Skręć <RELATIVE_DIRECTION> na <JUNCTION_NAME>.",
-        "5": "Skręć <RELATIVE_DIRECTION>, kierunek: <TOWARD_SIGN>."
+        "5": "Skręć <RELATIVE_DIRECTION>, kierunek: <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "chodnik",
         "ścieżka rowerowa",
@@ -1068,6 +1118,7 @@
         "4": "Wjedź, kierunek: <TOWARD_SIGN>.",
         "5": "Wjedź <RELATIVE_DIRECTION>, kierunek: <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "w lewo",
         "w prawo"
@@ -1108,6 +1159,7 @@
         "4": "Wjedź, kierunek: <TOWARD_SIGN>.",
         "5": "Wjedź <RELATIVE_DIRECTION>, kierunek: <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "w lewo",
         "w prawo"
@@ -1393,8 +1445,33 @@
         "2": "Skręć ostro <RELATIVE_DIRECTION> w stronę: <BEGIN_STREET_NAMES>. Kontynuuj wzdłuż: <STREET_NAMES>.",
         "3": "Skręć ostro <RELATIVE_DIRECTION>, pozostając na: <STREET_NAMES>.",
         "4": "Skręć ostro <RELATIVE_DIRECTION> na <JUNCTION_NAME>.",
-        "5": "Skręć ostro <RELATIVE_DIRECTION>, kierunek: <TOWARD_SIGN>."
+        "5": "Skręć ostro <RELATIVE_DIRECTION>, kierunek: <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "chodnik",
         "ścieżka rowerowa",
@@ -1433,8 +1510,33 @@
         "2": "Skręć ostro <RELATIVE_DIRECTION> w stronę: <BEGIN_STREET_NAMES>.",
         "3": "Skręć ostro <RELATIVE_DIRECTION>, pozostając na: <STREET_NAMES>.",
         "4": "Skręć ostro <RELATIVE_DIRECTION> na <JUNCTION_NAME>.",
-        "5": "Skręć ostro <RELATIVE_DIRECTION>, kierunek: <TOWARD_SIGN>."
+        "5": "Skręć ostro <RELATIVE_DIRECTION>, kierunek: <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "chodnik",
         "ścieżka rowerowa",
@@ -1952,8 +2054,33 @@
         "2": "Skręć <RELATIVE_DIRECTION> w stronę: <BEGIN_STREET_NAMES>. Kontynuuj wzdłuż: <STREET_NAMES>.",
         "3": "Skręć <RELATIVE_DIRECTION>, pozostając na: <STREET_NAMES>.",
         "4": "Skręć <RELATIVE_DIRECTION> na <JUNCTION_NAME>.",
-        "5": "Skręć <RELATIVE_DIRECTION>, kierunek: <TOWARD_SIGN>."
+        "5": "Skręć <RELATIVE_DIRECTION>, kierunek: <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "chodnik",
         "ścieżka rowerowa",
@@ -1992,8 +2119,33 @@
         "2": "Skręć <RELATIVE_DIRECTION> w stronę: <BEGIN_STREET_NAMES>.",
         "3": "Skręć <RELATIVE_DIRECTION>, pozostając na: <STREET_NAMES>.",
         "4": "Skręć <RELATIVE_DIRECTION> na <JUNCTION_NAME>.",
-        "5": "Skręć <RELATIVE_DIRECTION>, kierunek: <TOWARD_SIGN>."
+        "5": "Skręć <RELATIVE_DIRECTION>, kierunek: <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "chodnik",
         "ścieżka rowerowa",
@@ -2036,6 +2188,7 @@
         "6": "Zawróć <RELATIVE_DIRECTION> na <JUNCTION_NAME>.",
         "7": "Zawróć <RELATIVE_DIRECTION>, kierunek: <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "chodnik",
         "ścieżka rowerowa",
@@ -2084,6 +2237,7 @@
         "6": "Zawróć <RELATIVE_DIRECTION> na <JUNCTION_NAME>.",
         "7": "Zawróć <RELATIVE_DIRECTION>, kierunek: <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "chodnik",
         "ścieżka rowerowa",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -37,8 +37,33 @@
         "2": "Mantenha-se <RELATIVE_DIRECTION> na <BEGIN_STREET_NAMES>, então continue em <STREET_NAMES>.",
         "3": "Mantenha-se <RELATIVE_DIRECTION> e continue em <STREET_NAMES>.",
         "4": "Bear <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Bear <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Bear <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "a calçada",
         "a ciclovia",
@@ -77,8 +102,33 @@
         "2": "Mantenha-se <RELATIVE_DIRECTION> para <BEGIN_STREET_NAMES>.",
         "3": "Mantenha-se <RELATIVE_DIRECTION> e continue em <STREET_NAMES>.",
         "4": "Bear <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Bear <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Bear <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "a calçada",
         "a ciclovia",
@@ -1066,6 +1116,7 @@
         "4": "Merge toward <TOWARD_SIGN>.",
         "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "à esquerda",
         "à direita"
@@ -1106,6 +1157,7 @@
         "4": "Merge toward <TOWARD_SIGN>.",
         "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "à esquerda",
         "à direita"
@@ -1391,8 +1443,33 @@
         "2": "Faça uma curva fechada <RELATIVE_DIRECTION> para <BEGIN_STREET_NAMES>, então continue em <STREET_NAMES>.",
         "3": "Faça uma curva fechada <RELATIVE_DIRECTION> e continue em <STREET_NAMES>.",
         "4": "Make a sharp <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Make a sharp <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Make a sharp <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "a calçada",
         "a ciclovia",
@@ -1431,8 +1508,33 @@
         "2": "Faça uma curva fechada <RELATIVE_DIRECTION> para <BEGIN_STREET_NAMES>.",
         "3": "Faça uma curva fechada <RELATIVE_DIRECTION> e continue em <STREET_NAMES>.",
         "4": "Make a sharp <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Make a sharp <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Make a sharp <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "a calçada",
         "a ciclovia",
@@ -1950,8 +2052,33 @@
         "2": "Vire <RELATIVE_DIRECTION> para <BEGIN_STREET_NAMES>, então continue em <STREET_NAMES>.",
         "3": "Vire <RELATIVE_DIRECTION> para continuar em <STREET_NAMES>.",
         "4": "Turn <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Turn <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Turn <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "a calçada",
         "a ciclovia",
@@ -1990,8 +2117,33 @@
         "2": "Vire <RELATIVE_DIRECTION> para <BEGIN_STREET_NAMES>.",
         "3": "Vire <RELATIVE_DIRECTION> para continuar em <STREET_NAMES>.",
         "4": "Turn <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Turn <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Turn <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "a calçada",
         "a ciclovia",
@@ -2034,6 +2186,7 @@
         "6": "Make a <RELATIVE_DIRECTION> U-turn at <JUNCTION_NAME>.",
         "7": "Make a <RELATIVE_DIRECTION> U-turn toward <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "a calçada",
         "a ciclovia",
@@ -2082,6 +2235,7 @@
         "6": "Make a <RELATIVE_DIRECTION> U-turn at <JUNCTION_NAME>.",
         "7": "Make a <RELATIVE_DIRECTION> U-turn toward <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "a calçada",
         "a ciclovia",

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -39,8 +39,33 @@
         "2": "Vire à <RELATIVE_DIRECTION> em direção à <BEGIN_STREET_NAMES>. Continue na <STREET_NAMES>.",
         "3": "Vire à <RELATIVE_DIRECTION> para se manter na <STREET_NAMES>.",
         "4": "Vire à <RELATIVE_DIRECTION> na <JUNCTION_NAME>.",
-        "5": "Vire à <RELATIVE_DIRECTION> em direção à <TOWARD_SIGN>."
+        "5": "Vire à <RELATIVE_DIRECTION> em direção à <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "o passeio",
         "a ciclovia",
@@ -79,8 +104,33 @@
         "2": "Vire à <RELATIVE_DIRECTION> em direção à <BEGIN_STREET_NAMES>.",
         "3": "Vire à <RELATIVE_DIRECTION> para se manter na <STREET_NAMES>.",
         "4": "Vire à <RELATIVE_DIRECTION> na <JUNCTION_NAME>.",
-        "5": "Vire à <RELATIVE_DIRECTION> em direção à<TOWARD_SIGN>."
+        "5": "Vire à <RELATIVE_DIRECTION> em direção à<TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "o passeio",
         "a ciclovia",
@@ -1068,6 +1118,7 @@
         "4": "Vire em direção a <TOWARD_SIGN>.",
         "5": "Vire à <RELATIVE_DIRECTION> em direção a <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "esquerda",
         "direita"
@@ -1108,6 +1159,7 @@
         "4": "Vire em direção a <TOWARD_SIGN>.",
         "5": "Vire à <RELATIVE_DIRECTION> em direção a <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "esquerda",
         "direita"
@@ -1393,8 +1445,33 @@
         "2": "Faça uma curva apertada à <RELATIVE_DIRECTION> em direção à <BEGIN_STREET_NAMES>. Continue na <STREET_NAMES>.",
         "3": "Faça uma curva apertada à <RELATIVE_DIRECTION> para se manter na <STREET_NAMES>.",
         "4": "Faça uma curva apertada à <RELATIVE_DIRECTION> na <JUNCTION_NAME>.",
-        "5": "Faça uma curva apertada à <RELATIVE_DIRECTION> em direção a <TOWARD_SIGN>."
+        "5": "Faça uma curva apertada à <RELATIVE_DIRECTION> em direção a <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "o passeio",
         "a ciclovia",
@@ -1433,8 +1510,33 @@
         "2": "Faça uma curva apertada à <RELATIVE_DIRECTION> em direção à <BEGIN_STREET_NAMES>.",
         "3": "Faça uma curva apertada à <RELATIVE_DIRECTION> para se manter na <STREET_NAMES>.",
         "4": "Faça uma curva apertada à <RELATIVE_DIRECTION> na <JUNCTION_NAME>.",
-        "5": "Faça uma curva apertada à <RELATIVE_DIRECTION> em direção a <TOWARD_SIGN>."
+        "5": "Faça uma curva apertada à <RELATIVE_DIRECTION> em direção a <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "o passeio",
         "a ciclovia",
@@ -1952,8 +2054,33 @@
         "2": "Vire à <RELATIVE_DIRECTION> em direção à <BEGIN_STREET_NAMES>. Continue na <STREET_NAMES>.",
         "3": "Vire à <RELATIVE_DIRECTION> para se manter na <STREET_NAMES>.",
         "4": "Vire à <RELATIVE_DIRECTION> na <JUNCTION_NAME>.",
-        "5": "Vire à <RELATIVE_DIRECTION> em direção a <TOWARD_SIGN>."
+        "5": "Vire à <RELATIVE_DIRECTION> em direção a <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "o passeio",
         "a ciclovia",
@@ -1992,8 +2119,33 @@
         "2": "Vire à <RELATIVE_DIRECTION> em direção à <BEGIN_STREET_NAMES>.",
         "3": "Vire à <RELATIVE_DIRECTION> para se manter na <STREET_NAMES>.",
         "4": "Vire à <RELATIVE_DIRECTION> na <JUNCTION_NAME>.",
-        "5": "Vire à <RELATIVE_DIRECTION> em direção a <TOWARD_SIGN>."
+        "5": "Vire à <RELATIVE_DIRECTION> em direção a <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "o passeio",
         "a ciclovia",
@@ -2036,6 +2188,7 @@
         "6": "Faça uma inversão de marcha à <RELATIVE_DIRECTION> na <JUNCTION_NAME>.",
         "7": "Faça uma inversão de marcha à <RELATIVE_DIRECTION> em direção a <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "o passeio",
         "a ciclovia",
@@ -2084,6 +2237,7 @@
         "6": "Faça uma inversão de marcha à <RELATIVE_DIRECTION> na <JUNCTION_NAME>.",
         "7": "Faça uma inversão de marcha à <RELATIVE_DIRECTION> em direção a <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "o passeio",
         "a ciclovia",

--- a/locales/ro-RO.json
+++ b/locales/ro-RO.json
@@ -39,8 +39,33 @@
         "2": "Îndreaptă-te <RELATIVE_DIRECTION> spre <BEGIN_STREET_NAMES>. Continuă pe <STREET_NAMES>.",
         "3": "Îndreaptă-te spre <RELATIVE_DIRECTION> pentru a rămâne pe <STREET_NAMES>.",
         "4": "Îndreaptă-te spre<RELATIVE_DIRECTION> la <JUNCTION_NAME>.",
-        "5": "Îndreaptă-te <RELATIVE_DIRECTION> spre <TOWARD_SIGN>."
+        "5": "Îndreaptă-te <RELATIVE_DIRECTION> spre <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "alee",
         "pistă pentru biciclete",
@@ -79,8 +104,33 @@
         "2": "Îndreaptă-te spre <RELATIVE_DIRECTION> pe <BEGIN_STREET_NAMES>.",
         "3": "Îndreaptă-te spre <RELATIVE_DIRECTION> pentru a rămâne pe <STREET_NAMES>.",
         "4": "Îndreaptă-te spre <RELATIVE_DIRECTION> la <JUNCTION_NAME>.",
-        "5": "Îndreaptă-te <RELATIVE_DIRECTION> spre <TOWARD_SIGN>."
+        "5": "Îndreaptă-te <RELATIVE_DIRECTION> spre <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "alee",
         "pistă pentru biciclete",
@@ -1068,6 +1118,7 @@
         "4": "Intră pe banda spre <TOWARD_SIGN>.",
         "5": "Intră pe banda <RELATIVE_DIRECTION> spre <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "stânga",
         "dreapta"
@@ -1108,6 +1159,7 @@
         "4": "Intră pe banda spre <TOWARD_SIGN>.",
         "5": "Intră pe banda <RELATIVE_DIRECTION> spre <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "stânga",
         "dreapta"
@@ -1393,8 +1445,33 @@
         "2": "Virează strâns la <RELATIVE_DIRECTION> pe <BEGIN_STREET_NAMES>. Continuă pe <STREET_NAMES>.",
         "3": "Virează strâns la <RELATIVE_DIRECTION> pentru a rămâne pe <STREET_NAMES>.",
         "4": "Virează strâns la <RELATIVE_DIRECTION> la <JUNCTION_NAME>.",
-        "5": "Virează strâns la <RELATIVE_DIRECTION> spre <TOWARD_SIGN>."
+        "5": "Virează strâns la <RELATIVE_DIRECTION> spre <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "alee",
         "pistă pentru biciclete",
@@ -1433,8 +1510,33 @@
         "2": "Virează strâns la <RELATIVE_DIRECTION> pe <BEGIN_STREET_NAMES>.",
         "3": "Virează strâns la <RELATIVE_DIRECTION> pentru a rămâne pe <STREET_NAMES>.",
         "4": "Virează strâns la <RELATIVE_DIRECTION> la <JUNCTION_NAME>.",
-        "5": "Virează strâns la <RELATIVE_DIRECTION> spre <TOWARD_SIGN>."
+        "5": "Virează strâns la <RELATIVE_DIRECTION> spre <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "alee",
         "pistă pentru biciclete",
@@ -1952,8 +2054,33 @@
         "2": "Virează la <RELATIVE_DIRECTION> pe <BEGIN_STREET_NAMES>. Continuă pe <STREET_NAMES>.",
         "3": "Virează la <RELATIVE_DIRECTION> pentru a rămâne pe <STREET_NAMES>.",
         "4": "Virează la <RELATIVE_DIRECTION> la <JUNCTION_NAME>.",
-        "5": "Virează la <RELATIVE_DIRECTION> spre <TOWARD_SIGN>."
+        "5": "Virează la <RELATIVE_DIRECTION> spre <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "alee",
         "pistă pentru biciclete",
@@ -1992,8 +2119,33 @@
         "2": "Virează la <RELATIVE_DIRECTION> pe <BEGIN_STREET_NAMES>.",
         "3": "Virează la <RELATIVE_DIRECTION> pentru a rămâne pe <STREET_NAMES>.",
         "4": "Virează la <RELATIVE_DIRECTION> la <JUNCTION_NAME>.",
-        "5": "Virează la <RELATIVE_DIRECTION> spre <TOWARD_SIGN>."
+        "5": "Virează la <RELATIVE_DIRECTION> spre <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "alee",
         "pistă pentru biciclete",
@@ -2036,6 +2188,7 @@
         "6": "Întoarce la <RELATIVE_DIRECTION> la <JUNCTION_NAME>.",
         "7": "Întoarce la <RELATIVE_DIRECTION> spre <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "alee",
         "pistă pentru biciclete",
@@ -2084,6 +2237,7 @@
         "6": "Întoarce la <RELATIVE_DIRECTION> la <JUNCTION_NAME>.",
         "7": "Întoarce la <RELATIVE_DIRECTION> spre <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "alee",
         "pistă pentru biciclete",

--- a/locales/ru-RU.json
+++ b/locales/ru-RU.json
@@ -39,8 +39,33 @@
         "2": "Поверните <RELATIVE_DIRECTION> на <BEGIN_STREET_NAMES>. Затем двигайтесь по <STREET_NAMES>.",
         "3": "Поверните <RELATIVE_DIRECTION>, оставаясь на <STREET_NAMES>.",
         "4": "Поверните <RELATIVE_DIRECTION> на <JUNCTION_NAME>.",
-        "5": "Поверните <RELATIVE_DIRECTION> к <TOWARD_SIGN>."
+        "5": "Поверните <RELATIVE_DIRECTION> к <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "пешеходную дорожку",
         "велосипедную дорожку",
@@ -79,8 +104,33 @@
         "2": "Поверните <RELATIVE_DIRECTION> на <BEGIN_STREET_NAMES>.",
         "3": "Поверните <RELATIVE_DIRECTION>, оставаясь на <STREET_NAMES>.",
         "4": "Поверните <RELATIVE_DIRECTION> на <JUNCTION_NAME>.",
-        "5": "Поверните <RELATIVE_DIRECTION> к <TOWARD_SIGN>."
+        "5": "Поверните <RELATIVE_DIRECTION> к <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "пешеходную дорожку",
         "велосипедную дорожку",
@@ -1068,6 +1118,7 @@
         "4": "Выезжайте к <TOWARD_SIGN>.",
         "5": "Выезжайте <RELATIVE_DIRECTION> к <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "налево",
         "направо"
@@ -1108,6 +1159,7 @@
         "4": "Выезжайте к <TOWARD_SIGN>.",
         "5": "Выезжайте <RELATIVE_DIRECTION> к <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "налево",
         "направо"
@@ -1393,8 +1445,33 @@
         "2": "Круто поверните <RELATIVE_DIRECTION> на <BEGIN_STREET_NAMES>. Следуйте далее по <STREET_NAMES>.",
         "3": "Круто поверните <RELATIVE_DIRECTION>, оставаясь на <STREET_NAMES>.",
         "4": "Круто поверните <RELATIVE_DIRECTION> через <JUNCTION_NAME>.",
-        "5": "Круто поверните <RELATIVE_DIRECTION> к <TOWARD_SIGN>."
+        "5": "Круто поверните <RELATIVE_DIRECTION> к <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "пешеходной дорожке",
         "велосипедной дорожке",
@@ -1433,8 +1510,33 @@
         "2": "Круто поверните <RELATIVE_DIRECTION> на <BEGIN_STREET_NAMES>.",
         "3": "Круто поверните <RELATIVE_DIRECTION>, оставаясь на <STREET_NAMES>.",
         "4": "Круто поверните <RELATIVE_DIRECTION> через <JUNCTION_NAME>.",
-        "5": "Круто поверните <RELATIVE_DIRECTION> к <TOWARD_SIGN>."
+        "5": "Круто поверните <RELATIVE_DIRECTION> к <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "пешеходной дорожке",
         "велосипедной дорожке",
@@ -1952,8 +2054,33 @@
         "2": "Поверните <RELATIVE_DIRECTION> на <BEGIN_STREET_NAMES>. Продолжайте движение по <STREET_NAMES>.",
         "3": "Поверните <RELATIVE_DIRECTION>, чтобы остаться на <STREET_NAMES>.",
         "4": "Поверните <RELATIVE_DIRECTION> на <JUNCTION_NAME>.",
-        "5": "Поверните <RELATIVE_DIRECTION> к <TOWARD_SIGN>."
+        "5": "Поверните <RELATIVE_DIRECTION> к <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "пешеходную дорожку",
         "велосипедную дорожку",
@@ -1992,8 +2119,33 @@
         "2": "Поверните <RELATIVE_DIRECTION> на <BEGIN_STREET_NAMES>.",
         "3": "Поверните <RELATIVE_DIRECTION>, чтобы остаться на <STREET_NAMES>.",
         "4": "Поверните <RELATIVE_DIRECTION> на <JUNCTION_NAME>.",
-        "5": "Поверните <RELATIVE_DIRECTION> к <TOWARD_SIGN>."
+        "5": "Поверните <RELATIVE_DIRECTION> к <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "пешеходную дорожку",
         "велосипедную дорожку",
@@ -2036,6 +2188,7 @@
         "6": "Развернитесь <RELATIVE_DIRECTION> на <JUNCTION_NAME>.",
         "7": "Развернитесь <RELATIVE_DIRECTION> в сторону <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "пешеходной дорожке",
         "велосипедной дорожке",
@@ -2084,6 +2237,7 @@
         "6": "Развернитесь <RELATIVE_DIRECTION> на <JUNCTION_NAME>.",
         "7": "Развернитесь <RELATIVE_DIRECTION> в сторону <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "пешеходной дорожке",
         "велосипедной дорожке",

--- a/locales/sk-SK.json
+++ b/locales/sk-SK.json
@@ -39,8 +39,33 @@
         "2": "Odbočte mierne <RELATIVE_DIRECTION> na <BEGIN_STREET_NAMES>. Pokračujte na <STREET_NAMES>.",
         "3": "Odbočte mierne <RELATIVE_DIRECTION>, aby ste zostali na <STREET_NAMES>.",
         "4": "Bear <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Bear <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Bear <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "chodník",
         "cyklocesta",
@@ -79,8 +104,33 @@
         "2": "Mierne <RELATIVE_DIRECTION> na <BEGIN_STREET_NAMES>. Pokračujte na <STREET_NAMES>.",
         "3": "Mierne <RELATIVE_DIRECTION> a zostaňte na <STREET_NAMES>.",
         "4": "Bear <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Bear <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Bear <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "chodník",
         "cyklocestu",
@@ -1068,6 +1118,7 @@
         "4": "Merge toward <TOWARD_SIGN>.",
         "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "vľavo",
         "vpravo"
@@ -1108,6 +1159,7 @@
         "4": "Merge toward <TOWARD_SIGN>.",
         "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "vľavo",
         "vpravo"
@@ -1393,8 +1445,33 @@
         "2": "Odbočte ostro <RELATIVE_DIRECTION> na <BEGIN_STREET_NAMES>. Pokračujte na <STREET_NAMES>.",
         "3": "Odbočte ostro <RELATIVE_DIRECTION>, aby ste zostali na <STREET_NAMES>.",
         "4": "Make a sharp <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Make a sharp <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Make a sharp <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "chodník",
         "cyklocestu",
@@ -1433,8 +1510,33 @@
         "2": "Odbočte ostro <RELATIVE_DIRECTION> na <BEGIN_STREET_NAMES>. Pokračujte na <STREET_NAMES>.",
         "3": "Odbočte ostro <RELATIVE_DIRECTION> a zostaňte na <STREET_NAMES>.",
         "4": "Make a sharp <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Make a sharp <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Make a sharp <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "chodník",
         "cyklocestu",
@@ -1952,8 +2054,33 @@
         "2": "Odbočte <RELATIVE_DIRECTION> na <BEGIN_STREET_NAMES>. Pokračujte na <STREET_NAMES>.",
         "3": "Odbočte <RELATIVE_DIRECTION>, aby ste zostali na <STREET_NAMES>.",
         "4": "Turn <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Turn <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Turn <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "chodník",
         "cyklocestu",
@@ -1992,8 +2119,33 @@
         "2": "Odbočte <RELATIVE_DIRECTION> na <BEGIN_STREET_NAMES>. Pokračujte na <STREET_NAMES>.",
         "3": "Odbočte <RELATIVE_DIRECTION> a zostaňte na <STREET_NAMES>.",
         "4": "Turn <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Turn <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Turn <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "chodník",
         "cyklocestu",
@@ -2036,6 +2188,7 @@
         "6": "Make a <RELATIVE_DIRECTION> U-turn at <JUNCTION_NAME>.",
         "7": "Make a <RELATIVE_DIRECTION> U-turn toward <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "chodník",
         "cyklocestu",
@@ -2084,6 +2237,7 @@
         "6": "Make a <RELATIVE_DIRECTION> U-turn at <JUNCTION_NAME>.",
         "7": "Make a <RELATIVE_DIRECTION> U-turn toward <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "chodník",
         "cyklocestu",

--- a/locales/sl-SI.json
+++ b/locales/sl-SI.json
@@ -39,8 +39,33 @@
         "2": "Držite se <RELATIVE_DIRECTION>, da pridete na <BEGIN_STREET_NAMES>. Nadaljujte po <STREET_NAMES>.",
         "3": "Držite se <RELATIVE_DIRECTION>, da ostanete na <STREET_NAMES>.",
         "4": "Bear <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Bear <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Bear <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "pešpot",
         "kolesarsko stezo",
@@ -79,8 +104,33 @@
         "2": "Držite se <RELATIVE_DIRECTION>, da pridete na <BEGIN_STREET_NAMES>.",
         "3": "Držite se <RELATIVE_DIRECTION>, da ostanete na <STREET_NAMES>.",
         "4": "Bear <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Bear <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Bear <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "pešpot",
         "kolesarsko stezo",
@@ -1068,6 +1118,7 @@
         "4": "Merge toward <TOWARD_SIGN>.",
         "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "levo",
         "desno"
@@ -1108,6 +1159,7 @@
         "4": "Merge toward <TOWARD_SIGN>.",
         "5": "Merge <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "levo",
         "desno"
@@ -1393,8 +1445,33 @@
         "2": "Zavijte ostro <RELATIVE_DIRECTION> na <BEGIN_STREET_NAMES>. Nadaljujte po <STREET_NAMES>.",
         "3": "Zavijte ostro <RELATIVE_DIRECTION>, da ostanete na <STREET_NAMES>.",
         "4": "Make a sharp <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Make a sharp <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Make a sharp <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "pešpot",
         "kolesarsko stezo",
@@ -1433,8 +1510,33 @@
         "2": "Zavijte ostro <RELATIVE_DIRECTION> na <BEGIN_STREET_NAMES>.",
         "3": "Zavijte ostro <RELATIVE_DIRECTION>, da ostanete na <STREET_NAMES>.",
         "4": "Make a sharp <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Make a sharp <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Make a sharp <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "pešpot",
         "kolesarsko stezo",
@@ -1952,8 +2054,33 @@
         "2": "Zavijte <RELATIVE_DIRECTION> na <BEGIN_STREET_NAMES>. Nadaljujte po <STREET_NAMES>.",
         "3": "Zavijte <RELATIVE_DIRECTION>, da ostanete na <STREET_NAMES>.",
         "4": "Turn <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Turn <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Turn <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "pešpot",
         "kolesarsko stezo",
@@ -1992,8 +2119,33 @@
         "2": "Zavijte <RELATIVE_DIRECTION> na <BEGIN_STREET_NAMES>.",
         "3": "Zavijte <RELATIVE_DIRECTION>, da ostanete na <STREET_NAMES>.",
         "4": "Turn <RELATIVE_DIRECTION> at <JUNCTION_NAME>.",
-        "5": "Turn <RELATIVE_DIRECTION> toward <TOWARD_SIGN>."
+        "5": "Turn <RELATIVE_DIRECTION> toward <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "pešpot",
         "kolesarsko stezo",
@@ -2036,6 +2188,7 @@
         "6": "Make a <RELATIVE_DIRECTION> U-turn at <JUNCTION_NAME>.",
         "7": "Make a <RELATIVE_DIRECTION> U-turn toward <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "pešpot",
         "kolesarsko stezo",
@@ -2084,6 +2237,7 @@
         "6": "Make a <RELATIVE_DIRECTION> U-turn at <JUNCTION_NAME>.",
         "7": "Make a <RELATIVE_DIRECTION> U-turn toward <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "pešpot",
         "kolesarsko stezo",

--- a/locales/sv-SE.json
+++ b/locales/sv-SE.json
@@ -39,8 +39,33 @@
         "2": "Sväng <RELATIVE_DIRECTION> in på <BEGIN_STREET_NAMES>. Fortsätt på <STREET_NAMES>.",
         "3": "Sväng <RELATIVE_DIRECTION> för att stanna kvar på <STREET_NAMES>.",
         "4": "Sväng <RELATIVE_DIRECTION> i <JUNCTION_NAME>.",
-        "5": "Sväng <RELATIVE_DIRECTION> mot <TOWARD_SIGN>."
+        "5": "Sväng <RELATIVE_DIRECTION> mot <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "gångvägen",
         "cykelbanan",
@@ -79,8 +104,33 @@
         "2": "Sväng <RELATIVE_DIRECTION> in på <BEGIN_STREET_NAMES>.",
         "3": "Sväng <RELATIVE_DIRECTION> för att stanna kvar på <STREET_NAMES>.",
         "4": "Sväng <RELATIVE_DIRECTION> i <JUNCTION_NAME>.",
-        "5": "Sväng <RELATIVE_DIRECTION> mot <TOWARD_SIGN>."
+        "5": "Sväng <RELATIVE_DIRECTION> mot <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "gångvägen",
         "cykelbanan",
@@ -1068,6 +1118,7 @@
         "4": "Kör in mot <TOWARD_SIGN>.",
         "5": "Kör till <RELATIVE_DIRECTION> mot <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "vänster",
         "höger"
@@ -1108,6 +1159,7 @@
         "4": "Kör in mot <TOWARD_SIGN>.",
         "5": "Kör in till <RELATIVE_DIRECTION> mot <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "vänster",
         "höger"
@@ -1393,8 +1445,33 @@
         "2": "Gör en skarp sväng till <RELATIVE_DIRECTION> in på <BEGIN_STREET_NAMES>. Fortsätt på <STREET_NAMES>.",
         "3": "Gör en skarp sväng till <RELATIVE_DIRECTION> för att stanna kvar på  <STREET_NAMES>.",
         "4": "Gör en skarp sväng till <RELATIVE_DIRECTION> i <JUNCTION_NAME>.",
-        "5": "Gör en skarp sväng till <RELATIVE_DIRECTION> mot <TOWARD_SIGN>."
+        "5": "Gör en skarp sväng till <RELATIVE_DIRECTION> mot <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "gångvägen",
         "cykelbanan",
@@ -1433,8 +1510,33 @@
         "2": "Gör en skarp sväng till <RELATIVE_DIRECTION> in på <BEGIN_STREET_NAMES>.",
         "3": "Gör en skarp sväng till <RELATIVE_DIRECTION> för att stanna kvar på  <STREET_NAMES>.",
         "4": "Gör en skarp sväng till <RELATIVE_DIRECTION> i <JUNCTION_NAME>.",
-        "5": "Gör en skarp sväng till <RELATIVE_DIRECTION> mot <TOWARD_SIGN>."
+        "5": "Gör en skarp sväng till <RELATIVE_DIRECTION> mot <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "gångvägen",
         "cykelbanan",
@@ -1952,8 +2054,33 @@
         "2": "Sväng <RELATIVE_DIRECTION> in på <BEGIN_STREET_NAMES>. Fortsätt på <STREET_NAMES>.",
         "3": "Sväng <RELATIVE_DIRECTION> för att stanna kvar på <STREET_NAMES>.",
         "4": "Sväng <RELATIVE_DIRECTION> vid <JUNCTION_NAME>.",
-        "5": "Sväng <RELATIVE_DIRECTION> mot <TOWARD_SIGN>."
+        "5": "Sväng <RELATIVE_DIRECTION> mot <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "gångvägen",
         "cykelbanan",
@@ -1992,8 +2119,33 @@
         "2": "Sväng <RELATIVE_DIRECTION> in på <BEGIN_STREET_NAMES>.",
         "3": "Sväng <RELATIVE_DIRECTION> för att stanna kvar på <STREET_NAMES>.",
         "4": "Sväng <RELATIVE_DIRECTION> i <JUNCTION_NAME>.",
-        "5": "Sväng <RELATIVE_DIRECTION> mot <TOWARD_SIGN>."
+        "5": "Sväng <RELATIVE_DIRECTION> mot <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "gångvägen",
         "cykelbanan",
@@ -2036,6 +2188,7 @@
         "6": "Gör en <RELATIVE_DIRECTION> U-sväng vid <JUNCTION_NAME>.",
         "7": "Gör en <RELATIVE_DIRECTION> U-sväng mot <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "gångvägen",
         "cykelbanan",
@@ -2084,6 +2237,7 @@
         "6": "Gör en <RELATIVE_DIRECTION> U-sväng vid <JUNCTION_NAME>.",
         "7": "Gör en <RELATIVE_DIRECTION> U-sväng mot <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "gångvägen",
         "cykelbanan",

--- a/locales/tr-TR.json
+++ b/locales/tr-TR.json
@@ -39,8 +39,33 @@
         "2": "<BEGIN_STREET_NAMES> caddesine doğru <RELATIVE_DIRECTION> yönelin. <STREET_NAMES> caddesine devam edin.",
         "3": "<STREET_NAMES> caddesinde kalmak için <RELATIVE_DIRECTION> yönelin.",
         "4": "<JUNCTION_NAME> kavşağında <RELATIVE_DIRECTION> yönelin.",
-        "5": "<TOWARD_SIGN> işaretine doğru <RELATIVE_DIRECTION> yönelin."
+        "5": "<TOWARD_SIGN> işaretine doğru <RELATIVE_DIRECTION> yönelin.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "yaya geçidi",
         "bisiklet yolu",
@@ -79,8 +104,33 @@
         "2": "<BEGIN_STREET_NAMES> caddesine doğru <RELATIVE_DIRECTION> yönelin.",
         "3": "<STREET_NAMES> caddesinde kalmak için <RELATIVE_DIRECTION> yönelin.",
         "4": "<JUNCTION_NAME> kavşağında <RELATIVE_DIRECTION> yönelin.",
-        "5": "<TOWARD_SIGN> işaretine doğru <RELATIVE_DIRECTION> yönelin."
+        "5": "<TOWARD_SIGN> işaretine doğru <RELATIVE_DIRECTION> yönelin.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "yaya geçidi",
         "bisiklet yolu",
@@ -1068,6 +1118,7 @@
         "4": "<TOWARD_SIGN> işaretine doğru yola katılın.",
         "5": "<RELATIVE_DIRECTION>dan yola katılın toward <TOWARD_SIGN> işaretine doğru."
       },
+      "landmark_types": [],
       "relative_directions": [
         "sol",
         "sağ"
@@ -1108,6 +1159,7 @@
         "4": "<TOWARD_SIGN> işaretine doğru yola katılın.",
         "5": "<RELATIVE_DIRECTION> doğru <TOWARD_SIGN> işaretine katılın."
       },
+      "landmark_types": [],
       "relative_directions": [
         "sol",
         "sağ"
@@ -1393,8 +1445,33 @@
         "2": "<BEGIN_STREET_NAMES> caddesine doğru <RELATIVE_DIRECTION>a keskin bir dönüş yapın. <STREET_NAMES> caddesine devam edin.",
         "3": "<STREET_NAMES> caddesinde kalmak için <RELATIVE_DIRECTION>a doğru keskin bir dönüş yapın.",
         "4": "<JUNCTION_NAME> kavşağında <RELATIVE_DIRECTION>a doğru keskin bir dönüş yapın.",
-        "5": "<TOWARD_SIGN> işaretine doğru <RELATIVE_DIRECTION>a keskin bir dönüş yapın."
+        "5": "<TOWARD_SIGN> işaretine doğru <RELATIVE_DIRECTION>a keskin bir dönüş yapın.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "yaya geçidi",
         "bisiklet yolu",
@@ -1433,8 +1510,33 @@
         "2": "<BEGIN_STREET_NAMES> caddesine doğru <RELATIVE_DIRECTION>a keskin bir dönüş yapın.",
         "3": "<STREET_NAMES> caddesinde kalmak için <RELATIVE_DIRECTION>a doğru keskin bir dönüş yapın.",
         "4": "<JUNCTION_NAME> kavşağında <RELATIVE_DIRECTION>a doğru keskin bir dönüş yapın.",
-        "5": "<TOWARD_SIGN> işaretine doğru <RELATIVE_DIRECTION>a keskin bir dönüş yapın."
+        "5": "<TOWARD_SIGN> işaretine doğru <RELATIVE_DIRECTION>a keskin bir dönüş yapın.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "yaya geçidi",
         "bisiklet yolu",
@@ -1952,8 +2054,33 @@
         "2": "<BEGIN_STREET_NAMES> caddesine doğru <RELATIVE_DIRECTION>a dönün.<STREET_NAMES> caddesine devam edin.",
         "3": "<STREET_NAMES> caddesinde kalmak için <RELATIVE_DIRECTION>a dönün.",
         "4": "<JUNCTION_NAME> kavşağında <RELATIVE_DIRECTION>a dönün.",
-        "5": "<TOWARD_SIGN> işaretine doğru <RELATIVE_DIRECTION>a dönün."
+        "5": "<TOWARD_SIGN> işaretine doğru <RELATIVE_DIRECTION>a dönün.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "yaya geçidi",
         "bisiklet yolu",
@@ -1992,8 +2119,33 @@
         "2": "<BEGIN_STREET_NAMES> caddesine doğru <RELATIVE_DIRECTION>a dönün.",
         "3": "<STREET_NAMES> caddesinde kalmak için <RELATIVE_DIRECTION>a dönün.",
         "4": "<JUNCTION_NAME> kavşağında <RELATIVE_DIRECTION>a dönün.",
-        "5": "<TOWARD_SIGN> işaretine doğru <RELATIVE_DIRECTION>a dönün."
+        "5": "<TOWARD_SIGN> işaretine doğru <RELATIVE_DIRECTION>a dönün.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "yaya geçidi",
         "bisiklet yolu",
@@ -2036,6 +2188,7 @@
         "6": "<JUNCTION_NAME> kavşağında <RELATIVE_DIRECTION>a doğru U dönüşü yapın.",
         "7": "<TOWARD_SIGN> işaretine doğru <RELATIVE_DIRECTION>a doğru U dönüşü yapın."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "yaya geçidi",
         "bisiklet yolu",
@@ -2084,6 +2237,7 @@
         "6": "<JUNCTION_NAME> kavşağında <RELATIVE_DIRECTION>a doğru U dönüşü yapın.",
         "7": "<TOWARD_SIGN> işaretine doğru <RELATIVE_DIRECTION>a doğru U dönüşü yapın."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "yaya geçidi",
         "bisiklet yolu",

--- a/locales/uk-UA.json
+++ b/locales/uk-UA.json
@@ -39,8 +39,33 @@
         "2": "Рухайтесь <RELATIVE_DIRECTION> на <BEGIN_STREET_NAMES>. Далі по <STREET_NAMES>.",
         "3": "Рухайтесь <RELATIVE_DIRECTION> щоб залишатись на <STREET_NAMES>.",
         "4": "Рухайтесь <RELATIVE_DIRECTION> через <JUNCTION_NAME>.",
-        "5": "Рухайтесь <RELATIVE_DIRECTION> в напрямку <TOWARD_SIGN>."
+        "5": "Рухайтесь <RELATIVE_DIRECTION> в напрямку <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "пішохідній доріжці",
         "велодоріжці",
@@ -79,8 +104,33 @@
         "2": "Рухайтесь <RELATIVE_DIRECTION> на <BEGIN_STREET_NAMES>.",
         "3": "Рухайтесь <RELATIVE_DIRECTION> щоб залишатись на <STREET_NAMES>.",
         "4": "Рухайтесь <RELATIVE_DIRECTION> на <JUNCTION_NAME>.",
-        "5": "Рухайтесь <RELATIVE_DIRECTION> в напрямку <TOWARD_SIGN>."
+        "5": "Рухайтесь <RELATIVE_DIRECTION> в напрямку <TOWARD_SIGN>.",
+        "6": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Bear <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Bear <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Bear <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "пішохідній доріжці",
         "велодоріжці",
@@ -1068,6 +1118,7 @@
         "4": "Приєднайтеся до потоку в напрямку <TOWARD_SIGN>.",
         "5": "Приєднайтеся до потоку <RELATIVE_DIRECTION> в напрямку <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "ліворуч",
         "праворуч"
@@ -1108,6 +1159,7 @@
         "4": "Приєднайтеся до потоку в напрямку <TOWARD_SIGN>.",
         "5": "Приєднайтеся до потоку <RELATIVE_DIRECTION> в напрямку <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "relative_directions": [
         "ліворуч",
         "праворуч"
@@ -1393,8 +1445,33 @@
         "2": "Різко поверніть <RELATIVE_DIRECTION> на <BEGIN_STREET_NAMES>. Продовжуйте рух по <STREET_NAMES>.",
         "3": "Різко поверніть <RELATIVE_DIRECTION> щоб залишатись на <STREET_NAMES>.",
         "4": "Різко поверніть <RELATIVE_DIRECTION> через <JUNCTION_NAME>.",
-        "5": "Різко поверніть <RELATIVE_DIRECTION> в напрямку <TOWARD_SIGN>."
+        "5": "Різко поверніть <RELATIVE_DIRECTION> в напрямку <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "пішохідній доріжці",
         "велодоріжці",
@@ -1433,8 +1510,33 @@
         "2": "Різко поверніть <RELATIVE_DIRECTION> на <BEGIN_STREET_NAMES>.",
         "3": "Різко поверніть <RELATIVE_DIRECTION> щоб залишатись на <STREET_NAMES>.",
         "4": "Різко поверніть <RELATIVE_DIRECTION> через <JUNCTION_NAME>.",
-        "5": "Різко поверніть <RELATIVE_DIRECTION> в напрямку <TOWARD_SIGN>."
+        "5": "Різко поверніть <RELATIVE_DIRECTION> в напрямку <TOWARD_SIGN>.",
+        "6": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Make a sharp <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Make a sharp <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Make a sharp <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "пішохідній доріжці",
         "велодоріжці",
@@ -1952,8 +2054,33 @@
         "2": "Поверніть <RELATIVE_DIRECTION> на <BEGIN_STREET_NAMES>. Продовжуйте рух по <STREET_NAMES>.",
         "3": "Поверніть <RELATIVE_DIRECTION> щоб залишатись на <STREET_NAMES>.",
         "4": "Поверніть <RELATIVE_DIRECTION> на <JUNCTION_NAME>.",
-        "5": "Поверніть <RELATIVE_DIRECTION> в напрямку <TOWARD_SIGN>."
+        "5": "Поверніть <RELATIVE_DIRECTION> в напрямку <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>. Continue on <STREET_NAMES>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "пішохідній доріжці",
         "велодоріжці",
@@ -1992,8 +2119,33 @@
         "2": "Поверніть <RELATIVE_DIRECTION> на <BEGIN_STREET_NAMES>.",
         "3": "Поверніть <RELATIVE_DIRECTION> щоб залишатись на <STREET_NAMES>.",
         "4": "Поверніть <RELATIVE_DIRECTION> на <JUNCTION_NAME>.",
-        "5": "Поверніть <RELATIVE_DIRECTION> в напрямку <TOWARD_SIGN>."
+        "5": "Поверніть <RELATIVE_DIRECTION> в напрямку <TOWARD_SIGN>.",
+        "6": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "7": "Turn <RELATIVE_DIRECTION> onto <STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "8": "Turn <RELATIVE_DIRECTION> onto <BEGIN_STREET_NAMES> at the <LANDMARK_TYPE> <LANDMARK_NAME>.",
+        "9": "Turn <RELATIVE_DIRECTION> at the <LANDMARK_TYPE> <LANDMARK_NAME> to stay on <STREET_NAMES>."
       },
+      "landmark_types": [
+        "unused",
+        "gas station",
+        "post office",
+        "police station",
+        "fire station",
+        "car wash",
+        "restaurant",
+        "fast food",
+        "cafe",
+        "bank",
+        "pharmacy",
+        "kindergarden",
+        "bar",
+        "hospital",
+        "pub",
+        "clinic",
+        "theatre",
+        "cinema",
+        "casino"
+      ],
       "empty_street_name_labels": [
         "пішохідній доріжці",
         "велодоріжці",
@@ -2036,6 +2188,7 @@
         "6": "Розверніться <RELATIVE_DIRECTION> на <JUNCTION_NAME>.",
         "7": "Розверніться <RELATIVE_DIRECTION> в напрямку <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "пішохідній доріжці",
         "велодоріжці",
@@ -2084,6 +2237,7 @@
         "6": "Розверніться <RELATIVE_DIRECTION> на <JUNCTION_NAME>.",
         "7": "Розверніться <RELATIVE_DIRECTION> в напрямку <TOWARD_SIGN>."
       },
+      "landmark_types": [],
       "empty_street_name_labels": [
         "пішохідній доріжці",
         "велодоріжці",

--- a/src/odin/narrative_dictionary.cc
+++ b/src/odin/narrative_dictionary.cc
@@ -421,6 +421,9 @@ void NarrativeDictionary::Load(TurnSubset& turn_handle,
   // Populate empty_street_name_labels
   turn_handle.empty_street_name_labels =
       as_vector<std::string>(turn_subset_pt, kEmptyStreetNameLabelsKey);
+
+  // Populate landmark types
+  turn_handle.landmark_types = as_vector<std::string>(turn_subset_pt, kLandmarkTypesKey);
 }
 
 void NarrativeDictionary::Load(RampSubset& ramp_handle,

--- a/test/gurka/test_landmarks.cc
+++ b/test/gurka/test_landmarks.cc
@@ -611,4 +611,14 @@ TEST(LandmarkTest, TestLandmarksInManeuvers) {
       EXPECT_EQ(result_landmarks[i], expected->second[i]);
     }
   }
+
+  // check narrative generation
+  const std::vector<std::string> expected_narrative =
+      {"Drive east on S1.", "Turn right onto cf at the theatre ju_yuan.",
+       "Turn left onto fg at the post office you_zheng.", "You have arrived at your destination."};
+  std::vector<std::string> narrative{};
+  for (const auto& man : directions_leg.maneuver()) {
+    narrative.push_back(man.text_instruction());
+  }
+  EXPECT_EQ(narrative, expected_narrative);
 }

--- a/valhalla/odin/narrative_dictionary.h
+++ b/valhalla/odin/narrative_dictionary.h
@@ -95,6 +95,7 @@ constexpr auto kFerryLabelKey = "ferry_label";
 constexpr auto kStationLabelKey = "station_label";
 constexpr auto kEmptyTransitNameLabelsKey = "empty_transit_name_labels";
 constexpr auto kTransitStopCountLabelsKey = "transit_stop_count_labels";
+constexpr auto kLandmarkTypesKey = "landmark_types";
 
 constexpr auto kPluralCategoryZeroKey = "zero";
 constexpr auto kPluralCategoryOneKey = "one";
@@ -157,7 +158,8 @@ constexpr auto kTransitHeadSignTag = "<TRANSIT_HEADSIGN>";
 constexpr auto kTransitPlatformCountTag = "<TRANSIT_STOP_COUNT>";
 constexpr auto kTransitPlatformCountLabelTag = "<TRANSIT_STOP_COUNT_LABEL>";
 constexpr auto kLevelTag = "<LEVEL>";
-
+constexpr auto kLandmarkNameTag = "<LANDMARK_NAME>";
+constexpr auto kLandmarkTypeTag = "<LANDMARK_TYPE>";
 } // namespace
 
 namespace valhalla {
@@ -193,6 +195,7 @@ struct ContinueVerbalSubset : ContinueSubset {
 struct TurnSubset : PhraseSet {
   std::vector<std::string> relative_directions;
   std::vector<std::string> empty_street_name_labels;
+  std::vector<std::string> landmark_types;
 };
 
 struct RampSubset : PhraseSet {

--- a/valhalla/odin/narrativebuilder.h
+++ b/valhalla/odin/narrativebuilder.h
@@ -501,6 +501,17 @@ protected:
 
   /////////////////////////////////////////////////////////////////////////////
   /**
+   * Returns the landmark type string of the specified RouteLandmark Type value.
+   *
+   * @param type The RouteLandmark Type to process.
+   *
+   * @return the landmark type string.
+   */
+  std::string FormLandmarkType(RouteLandmark_Type type,
+                               const std::vector<std::string>& landmark_types);
+
+  /////////////////////////////////////////////////////////////////////////////
+  /**
    * Returns the transit name in this precedence - depending on which one exists:
    *    1) Short name
    * or 2) Long name


### PR DESCRIPTION
# Issue

Update narrative generation process to support the use of landmarks in text guidance.

## Tasklist

 - [ ] Update the maneuver types in locales to support landmark replacements. (update the en-us one, and wait for translations)
 - [ ] Update the narrative generation to pick phrases that support the use of landmarks.
 - [ ] Update tests and the changelog accordingly.

## Requirements / Relations
[Landmark Routing 6: Narrative Generation Updates #4138](https://github.com/valhalla/valhalla/issues/4138)
