### PR TITLE
Add use_tunnels option

### DIFF
--- a/proto/options.proto
+++ b/proto/options.proto
@@ -311,6 +311,9 @@ message Costing {
     uint32 axle_count = 81;
     float use_lit = 82;
     bool disable_hierarchy_pruning = 83;
+    oneof has_use_tunnels {
+      float use_tunnels = 84;
+    }
   }
 
   oneof has_options {


### PR DESCRIPTION
# Add Tunnel  factor to Autocost

Presently valhalla cannot avoid roads if tunnel is present. These changes will add tunnel factor in Edge Cost Calculations. 

The program was tested solely for our own use cases, which might differ otherwise. I acknowledge that these changes have the potential to impact other use cases, and it is essential to exercise caution and thorough testing when merging them to the master. Your expert opinion is requested to help us review, test, and adapt these modifications as needed. I am also looking forward to other implementation ideas and discussions about how we can tackle this issue. 

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [x] If you made changes to the lua files, update the [taginfo](taginfo.json) too.



Adrika Mukherjee adrika.mukherjee@mercedes-benz.com, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
