### PR TITLE
specify intel mac build on circle to fix mac builds (but make them super slow..)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
 
   build-osx:
     executor: macos
-    resource_class: large
+    resource_class: macos.x86.medium.gen2
     steps:
       - checkout
       - run: |


### PR DESCRIPTION
circleci changed how they do mac builds to support M1. now they only have one resource class (smaller than what we were using) for intel based builds so for the time being we have to use that: https://circleci.com/docs/using-macos/#available-resource-classes