### PR TITLE
only recost matrix pairs which have connections found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
    * FIXED: missing protobuf CMake configuration to link abseil for protobuf >= 3.22.0 [#4207](https://github.com/valhalla/valhalla/pull/4207)
    * FIXED: broken links on the optimized route API page [#4260](https://github.com/valhalla/valhalla/pull/4260)
    * FIXED: remove clearing of headings while calculating a matrix [#4288](https://github.com/valhalla/valhalla/pull/4288)
+   * FIXED: only recost matrix pairs which have connections found [#4344](https://github.com/valhalla/valhalla/pull/4344)
 * **Enhancement**
    * UPDATED: French translations, thanks to @xlqian [#4159](https://github.com/valhalla/valhalla/pull/4159)
    * CHANGED: -j flag for multithreaded executables to override mjolnir.concurrency [#4168](https://github.com/valhalla/valhalla/pull/4168)

--- a/src/thor/costmatrix.cc
+++ b/src/thor/costmatrix.cc
@@ -308,7 +308,7 @@ void CostMatrix::Initialize(
         best_connection_.emplace_back(empty, empty, trivial_cost, 0.0f);
         best_connection_.back().found = true;
       } else {
-        best_connection_.emplace_back(empty, empty, max_cost, kMaxCost);
+        best_connection_.emplace_back(empty, empty, max_cost, static_cast<uint32_t>(kMaxCost));
         source_status_[i].remaining_locations.insert(j);
         target_status_[j].remaining_locations.insert(i);
       }
@@ -977,8 +977,8 @@ void CostMatrix::RecostPaths(GraphReader& graphreader,
   uint32_t idx = 0;
   for (auto best_connection = best_connection_.begin(); best_connection != best_connection_.end();
        ++best_connection, ++idx) {
-    // no need to look at 0 paths, i.e. source == target
-    if (best_connection->cost.secs == 0.f) {
+    // no need to look at source == target or missing connectivity
+    if (best_connection->cost.secs == 0.f || best_connection->distance == kMaxCost) {
       continue;
     }
 


### PR DESCRIPTION
oops.. we tried to recost matrix pairs which had unfound connections, which again led to 400s with `Could not find candidate edge used for label`.