### PR TITLE
split arm and amd workflows

### DIFF
--- a/.github/workflows/docker-build-arm.yml
+++ b/.github/workflows/docker-build-arm.yml
@@ -1,0 +1,51 @@
+name: Publish Arm64 Docker Image
+on:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - '*'
+    paths-ignore:
+      - '.gitignore'
+      - '**.md'
+      - 'test/'
+
+jobs:
+  build_and_publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+          fetch-depth: 0
+      - name: Extract tag name
+        if: startsWith(github.ref, 'refs/tags/')
+        run: echo "##[set-output name=tag;]${GITHUB_REF#refs/tags/}"
+        id: extract_tag
+      - name: Log in to GitHub Docker Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build tag image
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          sudo apt update --yes
+          sudo apt install --yes --quiet binfmt-support qemu-user-static qemu-system
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          docker buildx create --name mybuilder
+          docker buildx use mybuilder
+          docker buildx inspect --bootstrap
+          docker buildx build --push --platform linux/arm64 --tag ghcr.io/valhalla/valhalla:${{ steps.extract_tag.outputs.tag }} .
+      - name: Build latest image
+        if: github.ref == 'refs/heads/master'
+        run: |
+          sudo apt update --yes
+          sudo apt install --yes --quiet binfmt-support qemu-user-static qemu-system
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          docker buildx create --name mybuilder
+          docker buildx use mybuilder
+          docker buildx inspect --bootstrap
+          docker buildx build --push --platform linux/arm64 --tag ghcr.io/valhalla/valhalla:latest .

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,4 +1,4 @@
-name: Publish Docker image
+name: Publish Amd64 Docker Image
 on:
   push:
     branches:
@@ -32,20 +32,8 @@ jobs:
       - name: Build tag image
         if: startsWith(github.ref, 'refs/tags/')
         run: |
-          sudo apt update --yes
-          sudo apt install --yes --quiet binfmt-support qemu-user-static qemu-system
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-          docker buildx create --name mybuilder
-          docker buildx use mybuilder
-          docker buildx inspect --bootstrap
-          docker buildx build --push --platform linux/amd64,linux/arm64 --tag ghcr.io/valhalla/valhalla:${{ steps.extract_tag.outputs.tag }} .
+          docker buildx build --push --platform linux/amd64 --tag ghcr.io/valhalla/valhalla:${{ steps.extract_tag.outputs.tag }} .
       - name: Build latest image
         if: github.ref == 'refs/heads/master'
         run: |
-          sudo apt update --yes
-          sudo apt install --yes --quiet binfmt-support qemu-user-static qemu-system
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-          docker buildx create --name mybuilder
-          docker buildx use mybuilder
-          docker buildx inspect --bootstrap
-          docker buildx build --push --platform linux/amd64,linux/arm64 --tag ghcr.io/valhalla/valhalla:latest .
+          docker buildx build --push --platform linux/amd64 --tag ghcr.io/valhalla/valhalla:latest .

--- a/.github/workflows/docker_build_arm_manual.yml
+++ b/.github/workflows/docker_build_arm_manual.yml
@@ -1,0 +1,31 @@
+name: Build Manual Arm64 Docker Image
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build_image:
+    name: Manual docker image build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
+        fetch-depth: 0
+
+    - name: Log in to GitHub Docker Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build latest image
+      run: |
+        sudo apt update --yes
+        sudo apt install --yes --quiet binfmt-support qemu-user-static qemu-system
+        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        docker buildx create --name mybuilder
+        docker buildx use mybuilder
+        docker buildx inspect --bootstrap
+        docker buildx build --push --platform linux/arm64 --tag ghcr.io/valhalla/valhalla:manually_triggered_build .

--- a/.github/workflows/docker_build_manual.yml
+++ b/.github/workflows/docker_build_manual.yml
@@ -1,4 +1,4 @@
-name: Build manual Docker image
+name: Build Manual Amd64 Docker Image
 
 on:
   workflow_dispatch:
@@ -22,10 +22,4 @@ jobs:
 
     - name: Build latest image
       run: |
-        sudo apt update --yes
-        sudo apt install --yes --quiet binfmt-support qemu-user-static qemu-system
-        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-        docker buildx create --name mybuilder
-        docker buildx use mybuilder
-        docker buildx inspect --bootstrap
-        docker buildx build --push --platform linux/amd64,linux/arm64 --tag ghcr.io/valhalla/valhalla:manually_triggered_build .
+        docker buildx build --push --platform linux/amd64 --tag ghcr.io/valhalla/valhalla:manually_triggered_build .


### PR DESCRIPTION
in #4213 we got support for linux arm builds. in that pr i also added to our docker publishing the ability to publish arm docker containers. i put both amd and arm builds in the same invocation of `docker buildx build`. this of course works but apparently we run the github runner out of space.  the builds with symbols (which is what we do) do take up a crap ton of space. by decoupling these workflows we can try to avoid running out of space. also it will make it super easy to run the arm one on arm hardware when thet becomes available (which should speed up the build a lot since it wont be doing the build via emulation)