### PR TITLE
More matrix clearing memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
    * CHANGED: the boost property tree config is now read into a singleton that doesn't need to be passed around anymore [#4220](https://github.com/valhalla/valhalla/pull/4220)
    * ADDED: Update the street name and sign data processing include language and pronunciations [#4268](https://github.com/valhalla/valhalla/pull/4268)
    * CHANGED: more sustainable way to work with protobuf in cmake [#4334](https://github.com/valhalla/valhalla/pull/4334)
+   * ADDED: --optimize & --log-details to valhalla_run_matrix [#4355](https://github.com/valhalla/valhalla/pull/4334)
 
 ## Release Date: 2023-05-11 Valhalla 3.4.0
 * **Removed**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
    * ADDED: Update the street name and sign data processing include language and pronunciations [#4268](https://github.com/valhalla/valhalla/pull/4268)
    * CHANGED: more sustainable way to work with protobuf in cmake [#4334](https://github.com/valhalla/valhalla/pull/4334)
    * ADDED: --optimize & --log-details to valhalla_run_matrix [#4355](https://github.com/valhalla/valhalla/pull/4334)
+   * CHANGED: memory utilization by the matrix endpoint to avoid (de-)allocations [#4362](https://github.com/valhalla/valhalla/pull/4334)
 
 ## Release Date: 2023-05-11 Valhalla 3.4.0
 * **Removed**

--- a/src/thor/astar_bss.cc
+++ b/src/thor/astar_bss.cc
@@ -30,8 +30,7 @@ AStarBSSAlgorithm::AStarBSSAlgorithm(const boost::property_tree::ptree& config)
     : PathAlgorithm(config.get<uint32_t>("max_reserved_labels_count_astar",
                                          kInitialEdgeLabelCountAstar),
                     config.get<bool>("clear_reserved_memory", false)),
-      max_label_count_(std::numeric_limits<uint32_t>::max()), mode_(travel_mode_t::kDrive),
-      travel_type_(0) {
+      mode_(travel_mode_t::kDrive), travel_type_(0) {
 }
 
 // Destructor
@@ -287,11 +286,6 @@ AStarBSSAlgorithm::GetBestPath(valhalla::Location& origin,
       (*interrupt)();
     }
     total_labels = current_labels;
-
-    // Abort if max label count is exceeded
-    if (total_labels > max_label_count_) {
-      return {};
-    }
 
     // Get next element from adjacency list. Check that it is valid. An
     // invalid label indicates there are no edges that can be expanded.

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -107,8 +107,8 @@ void BidirectionalAStar::Init(const PointLL& origll, const PointLL& destll) {
 
   // Reserve size for edge labels - do this here rather than in constructor so
   // to limit how much extra memory is used for persistent objects
-  edgelabels_forward_.reserve(kInitialEdgeLabelCountBidirAstar);
-  edgelabels_reverse_.reserve(kInitialEdgeLabelCountBidirAstar);
+  edgelabels_forward_.reserve(max_reserved_labels_count_);
+  edgelabels_reverse_.reserve(max_reserved_labels_count_);
 
   // Construct adjacency list and initialize edge status lookup.
   // Set bucket size and cost range based on DynamicCost.

--- a/src/thor/costmatrix.cc
+++ b/src/thor/costmatrix.cc
@@ -279,7 +279,7 @@ void CostMatrix::Initialize(
   // Add initial sources status
   source_status_.reserve(source_count_);
   source_hierarchy_limits_.reserve(source_count_);
-  source_adjacency_.resize(source_count_);
+  source_adjacency_.reserve(source_count_);
   source_edgestatus_.resize(source_count_);
   source_edgelabel_.resize(source_count_);
   for (uint32_t i = 0; i < source_count_; i++) {
@@ -295,7 +295,7 @@ void CostMatrix::Initialize(
   // Add initial targets status
   target_status_.reserve(target_count_);
   target_hierarchy_limits_.reserve(target_count_);
-  target_adjacency_.resize(target_count_);
+  target_adjacency_.reserve(target_count_);
   target_edgestatus_.resize(target_count_);
   target_edgelabel_.resize(target_count_);
   for (uint32_t i = 0; i < target_count_; i++) {

--- a/src/thor/costmatrix.cc
+++ b/src/thor/costmatrix.cc
@@ -279,7 +279,7 @@ void CostMatrix::Initialize(
   // Add initial sources status
   source_status_.reserve(source_count_);
   source_hierarchy_limits_.reserve(source_count_);
-  source_adjacency_.reserve(source_count_);
+  source_adjacency_.resize(source_count_);
   source_edgestatus_.resize(source_count_);
   source_edgelabel_.resize(source_count_);
   for (uint32_t i = 0; i < source_count_; i++) {
@@ -295,7 +295,7 @@ void CostMatrix::Initialize(
   // Add initial targets status
   target_status_.reserve(target_count_);
   target_hierarchy_limits_.reserve(target_count_);
-  target_adjacency_.reserve(target_count_);
+  target_adjacency_.resize(target_count_);
   target_edgestatus_.resize(target_count_);
   target_edgelabel_.resize(target_count_);
   for (uint32_t i = 0; i < target_count_; i++) {

--- a/src/thor/dijkstras.cc
+++ b/src/thor/dijkstras.cc
@@ -78,7 +78,7 @@ void Dijkstras::Initialize(label_container_t& labels,
   uint32_t edge_label_reservation;
   uint32_t bucket_count;
   GetExpansionHints(bucket_count, edge_label_reservation);
-  labels.reserve(std::min(max_reserved_labels_count_, edge_label_reservation));
+  labels.reserve(max_reserved_labels_count_);
 
   // Set up lambda to get sort costs
   float range = bucket_count * bucket_size;

--- a/src/thor/multimodal.cc
+++ b/src/thor/multimodal.cc
@@ -43,8 +43,7 @@ MultiModalPathAlgorithm::MultiModalPathAlgorithm(const boost::property_tree::ptr
     : PathAlgorithm(config.get<uint32_t>("max_reserved_labels_count_astar",
                                          kInitialEdgeLabelCountAstar),
                     config.get<bool>("clear_reserved_memory", false)),
-      max_walking_dist_(0), max_label_count_(std::numeric_limits<uint32_t>::max()),
-      mode_(travel_mode_t::kPedestrian), travel_type_(0) {
+      max_walking_dist_(0), mode_(travel_mode_t::kPedestrian), travel_type_(0) {
 }
 
 // Destructor

--- a/src/thor/unidirectional_astar.cc
+++ b/src/thor/unidirectional_astar.cc
@@ -19,8 +19,7 @@ UnidirectionalAStar<expansion_direction, FORWARD>::UnidirectionalAStar(
     : PathAlgorithm(config.get<uint32_t>("max_reserved_labels_count_astar",
                                          kInitialEdgeLabelCountAstar),
                     config.get<bool>("clear_reserved_memory", false)),
-      max_label_count_(std::numeric_limits<uint32_t>::max()), mode_(travel_mode_t::kDrive),
-      travel_type_(0), access_mode_{kAutoAccess} {
+      mode_(travel_mode_t::kDrive), travel_type_(0), access_mode_{kAutoAccess} {
 }
 
 // Default constructor
@@ -492,11 +491,6 @@ std::vector<std::vector<PathInfo>> UnidirectionalAStar<expansion_direction, FORW
       (*interrupt)();
     }
     total_labels = current_labels;
-
-    // Abort if max label count is exceeded
-    if (total_labels > max_label_count_) {
-      return {};
-    }
 
     // Get next element from adjacency list. Check that it is valid. An
     // invalid label indicates there are no edges that can be expanded.

--- a/src/thor/unidirectional_astar.cc
+++ b/src/thor/unidirectional_astar.cc
@@ -584,7 +584,7 @@ void UnidirectionalAStar<expansion_direction, FORWARD>::Init(const midgard::Poin
     astarheuristic_.Init(origll, costing_->AStarCostFactor());
     mincost = astarheuristic_.Get(destll);
   }
-  edgelabels_.reserve(std::min(max_reserved_labels_count_, kInitialEdgeLabelCountAstar));
+  edgelabels_.reserve(max_reserved_labels_count_);
 
   // Construct adjacency list, clear edge status.
   // Set bucket size and cost range based on DynamicCost.

--- a/valhalla/thor/astar_bss.h
+++ b/valhalla/thor/astar_bss.h
@@ -71,19 +71,9 @@ public:
    */
   virtual void Clear() override;
 
-  /**
-   * Set a maximum label count. The path algorithm terminates if this
-   * is exceeded.
-   * @param  max_count  Maximum number of labels to allow.
-   */
-  void set_max_label_count(const uint32_t max_count) {
-    max_label_count_ = max_count;
-  }
-
 protected:
-  uint32_t max_label_count_; // Max label count to allow
-  sif::TravelMode mode_;     // Current travel mode
-  uint8_t travel_type_;      // Current travel type
+  sif::TravelMode mode_; // Current travel mode
+  uint8_t travel_type_;  // Current travel type
 
   // A* heuristic
   AStarHeuristic pedestrian_astarheuristic_;

--- a/valhalla/thor/costmatrix.h
+++ b/valhalla/thor/costmatrix.h
@@ -131,6 +131,7 @@ protected:
   std::shared_ptr<sif::DynamicCost> costing_;
 
   uint32_t max_reserved_labels_count_;
+  bool clear_reserved_memory_;
 
   // Number of source and target locations that can be expanded
   uint32_t source_count_;

--- a/valhalla/thor/multimodal.h
+++ b/valhalla/thor/multimodal.h
@@ -75,9 +75,8 @@ public:
 
 protected:
   uint32_t max_walking_dist_;
-  uint32_t max_label_count_; // Max label count to allow
-  sif::TravelMode mode_;     // Current travel mode
-  uint8_t travel_type_;      // Current travel type
+  sif::TravelMode mode_; // Current travel mode
+  uint8_t travel_type_;  // Current travel type
 
   bool date_set_;
   bool date_before_tile_;

--- a/valhalla/thor/timedistancematrix.h
+++ b/valhalla/thor/timedistancematrix.h
@@ -79,7 +79,7 @@ public:
   inline void clear() {
     auto reservation = clear_reserved_memory_ ? 0 : max_reserved_labels_count_;
     if (edgelabels_.size() > reservation) {
-      edgelabels_.resize(max_reserved_labels_count_);
+      edgelabels_.resize(reservation);
       edgelabels_.shrink_to_fit();
     }
     reset();

--- a/valhalla/thor/unidirectional_astar.h
+++ b/valhalla/thor/unidirectional_astar.h
@@ -73,15 +73,6 @@ public:
     }
   }
 
-  /**
-   * Set a maximum label count. The path algorithm terminates if this
-   * is exceeded.
-   * @param  max_count  Maximum number of labels to allow.
-   */
-  void set_max_label_count(const uint32_t max_count) {
-    max_label_count_ = max_count;
-  }
-
 protected:
   /**
    * Initializes the hierarchy limits, A* heuristic, and adjacency list.
@@ -166,9 +157,8 @@ protected:
    */
   std::vector<PathInfo> FormPath(const uint32_t dest);
 
-  uint32_t max_label_count_; // Max label count to allow
-  sif::TravelMode mode_;     // Current travel mode
-  uint8_t travel_type_;      // Current travel type
+  sif::TravelMode mode_; // Current travel mode
+  uint8_t travel_type_;  // Current travel type
 
   // Hierarchy limits.
   std::vector<sif::HierarchyLimits> hierarchy_limits_;


### PR DESCRIPTION
fixes CostMatrix memory stuff ref https://github.com/valhalla/valhalla/pull/4329#discussion_r1373217995

I ran the same 51 location request as in https://github.com/valhalla/valhalla/pull/4329#issuecomment-1763687934. Those are the times for 10 of those requests on 4 threads (both server & `run_with_server.py`), run each 3 times with very little variance:

|        | run        | time  |
|--------|------------|-------|
| master | 1st        | 45.2s |
| master | subsequent | 40.7s |
| branch | 1st        | 36.7  |
| branch | subsequent | 28.5  |

That's around 20% speedup for the first, uninitialized request and ~30% speedup for subsequent requests. Quite good:) Of course this speedup degrades with more locations and/or more distance in between them. In this example I couldn't make out any noticeable extra memory.