### PR TITLE
Avoid Issues with GraphReader::GetBeginNodeId

### DIFF
--- a/test/gurka/gurka.cc
+++ b/test/gurka/gurka.cc
@@ -567,7 +567,7 @@ findEdge(valhalla::baldr::GraphReader& reader,
  * @param end_node_name    name of the end node
  * @return the edge_id and its edge
  */
-std::tuple<const baldr::GraphId, const baldr::DirectedEdge*>
+std::tuple<baldr::GraphId, const baldr::DirectedEdge*>
 findEdgeByNodes(valhalla::baldr::GraphReader& reader,
                 const nodelayout& nodes,
                 const std::string& begin_node_name,

--- a/test/gurka/gurka.h
+++ b/test/gurka/gurka.h
@@ -172,7 +172,7 @@ findEdge(valhalla::baldr::GraphReader& reader,
  * @param end_node_name    name of the end node
  * @return the edge_id and its edge
  */
-std::tuple<const baldr::GraphId, const baldr::DirectedEdge*>
+std::tuple<baldr::GraphId, const baldr::DirectedEdge*>
 findEdgeByNodes(valhalla::baldr::GraphReader& reader,
                 const nodelayout& nodes,
                 const std::string& begin_node_name,

--- a/test/gurka/test_graphreader.cc
+++ b/test/gurka/test_graphreader.cc
@@ -1,0 +1,169 @@
+#include "gurka.h"
+#include <gtest/gtest.h>
+
+using namespace valhalla;
+
+TEST(GraphReader, ModifyTilePointerByReference) {
+  // 2km long way crosses a tile boundary at the prime meridian due to 1km offset from null island
+  const std::string ascii_map = R"(A------------------B)";
+  const gurka::ways ways = {{"AB", {{"highway", "motorway"}, {"name", "81"}}}};
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100, {-.01, -.01});
+  const auto map =
+      gurka::buildtiles(layout, ways, {}, {}, "test/data/graphreader_tileboundary",
+                        {
+                            {"mjolnir.incident_dir", "test/data/graphreader_tileboundary"},
+                            {"mjolnir.incident_log", "test/data/graphreader_tileboundary/log"},
+                        });
+
+  // both sets of edges that cross the tile boundary from left to right and right to left
+  baldr::GraphReader reader(map.config.get_child("mjolnir"));
+  auto ltr = gurka::findEdgeByNodes(reader, layout, "A", "B");
+  auto rtl = gurka::findEdgeByNodes(reader, layout, "B", "A");
+  auto l = gurka::findNode(reader, layout, "A");
+  auto r = gurka::findNode(reader, layout, "B");
+
+  // all methods that use/modify a reference to tile pointer with two calls for cache miss and hit
+  for (size_t i = 0; i < 2; ++i) {
+    baldr::GraphId edge_id, opp_edge_id;
+    const baldr::DirectedEdge *edge, *opp_edge;
+    std::tie(edge_id, edge) = ltr;
+    std::tie(opp_edge_id, opp_edge) = rtl;
+    auto begin_node_id = l;
+    auto end_node_id = r;
+
+    {
+      baldr::graph_tile_ptr tile;
+      reader.GetGraphTile(begin_node_id, tile);
+      ASSERT_EQ(begin_node_id.Tile_Base(), tile->id());
+      reader.GetGraphTile(begin_node_id, tile);
+      ASSERT_EQ(begin_node_id.Tile_Base(), tile->id());
+    }
+
+    {
+      baldr::graph_tile_ptr tile;
+      reader.GetOpposingEdgeId(edge_id, tile);
+      ASSERT_EQ(opp_edge_id.Tile_Base(), tile->id());
+      reader.GetOpposingEdgeId(edge_id, tile);
+      ASSERT_EQ(opp_edge_id.Tile_Base(), tile->id());
+    }
+
+    {
+      baldr::graph_tile_ptr tile;
+      const baldr::DirectedEdge* actual_op_edge;
+      reader.GetOpposingEdgeId(edge_id, actual_op_edge, tile);
+      ASSERT_EQ(opp_edge_id.Tile_Base(), tile->id());
+      ASSERT_EQ(opp_edge, actual_op_edge);
+      reader.GetOpposingEdgeId(edge_id, tile);
+      ASSERT_EQ(opp_edge_id.Tile_Base(), tile->id());
+      ASSERT_EQ(opp_edge, actual_op_edge);
+    }
+
+    {
+      baldr::graph_tile_ptr tile;
+      reader.GetOpposingEdge(edge_id, tile);
+      ASSERT_EQ(opp_edge_id.Tile_Base(), tile->id());
+      reader.GetOpposingEdge(edge_id, tile);
+      ASSERT_EQ(opp_edge_id.Tile_Base(), tile->id());
+    }
+
+    {
+      baldr::graph_tile_ptr tile;
+      reader.GetOpposingEdge(edge, tile);
+      ASSERT_EQ(opp_edge_id.Tile_Base(), tile->id());
+      reader.GetOpposingEdge(edge, tile);
+      ASSERT_EQ(opp_edge_id.Tile_Base(), tile->id());
+    }
+
+    {
+      baldr::graph_tile_ptr tile;
+      reader.GetEndNode(edge, tile);
+      ASSERT_EQ(end_node_id.Tile_Base(), tile->id());
+      reader.GetEndNode(edge, tile);
+      ASSERT_EQ(end_node_id.Tile_Base(), tile->id());
+    }
+
+    {
+      baldr::graph_tile_ptr tile;
+      reader.GetBeginNodeId(edge, tile);
+      ASSERT_EQ(begin_node_id.Tile_Base(), tile->id());
+      reader.GetBeginNodeId(edge, tile);
+      ASSERT_EQ(begin_node_id.Tile_Base(), tile->id());
+    }
+
+    {
+      baldr::graph_tile_ptr tile;
+      reader.AreEdgesConnectedForward(edge_id, opp_edge_id, tile);
+      ASSERT_EQ(end_node_id.Tile_Base(), tile->id());
+      reader.AreEdgesConnectedForward(edge_id, opp_edge_id, tile);
+      ASSERT_EQ(end_node_id.Tile_Base(), tile->id());
+    }
+
+    {
+      baldr::graph_tile_ptr tile;
+      reader.nodeinfo(begin_node_id, tile);
+      ASSERT_EQ(begin_node_id.Tile_Base(), tile->id());
+      reader.nodeinfo(begin_node_id, tile);
+      ASSERT_EQ(begin_node_id.Tile_Base(), tile->id());
+    }
+
+    {
+      baldr::graph_tile_ptr tile;
+      reader.directededge(edge_id, tile);
+      ASSERT_EQ(begin_node_id.Tile_Base(), tile->id());
+      reader.directededge(edge_id, tile);
+      ASSERT_EQ(begin_node_id.Tile_Base(), tile->id());
+    }
+
+    {
+      baldr::graph_tile_ptr tile;
+      reader.GetDirectedEdgeNodes(edge_id, tile);
+      ASSERT_EQ(begin_node_id.Tile_Base(), tile->id());
+      reader.GetDirectedEdgeNodes(edge_id, tile);
+      ASSERT_EQ(begin_node_id.Tile_Base(), tile->id());
+    }
+
+    {
+      baldr::graph_tile_ptr tile;
+      reader.edge_endnode(edge_id, tile);
+      ASSERT_EQ(begin_node_id.Tile_Base(), tile->id());
+      reader.edge_endnode(edge_id, tile);
+      ASSERT_EQ(begin_node_id.Tile_Base(), tile->id());
+    }
+
+    {
+      baldr::graph_tile_ptr tile;
+      reader.edge_startnode(edge_id, tile);
+      ASSERT_EQ(end_node_id.Tile_Base(), tile->id());
+      reader.edge_startnode(edge_id, tile);
+      ASSERT_EQ(end_node_id.Tile_Base(), tile->id());
+    }
+
+    {
+      baldr::graph_tile_ptr tile;
+      reader.edgeinfo(edge_id, tile);
+      ASSERT_EQ(begin_node_id.Tile_Base(), tile->id());
+      reader.edgeinfo(edge_id, tile);
+      ASSERT_EQ(begin_node_id.Tile_Base(), tile->id());
+    }
+
+    {
+      baldr::graph_tile_ptr tile;
+      reader.GetTimezone(begin_node_id, tile);
+      ASSERT_EQ(begin_node_id.Tile_Base(), tile->id());
+      reader.GetTimezone(begin_node_id, tile);
+      ASSERT_EQ(begin_node_id.Tile_Base(), tile->id());
+    }
+
+    {
+      baldr::graph_tile_ptr tile;
+      reader.GetIncidents(begin_node_id, tile);
+      ASSERT_EQ(begin_node_id.Tile_Base(), tile->id());
+      reader.GetIncidents(begin_node_id, tile);
+      ASSERT_EQ(begin_node_id.Tile_Base(), tile->id());
+    }
+
+    // swap left and right
+    std::swap(ltr, rtl);
+    std::swap(l, r);
+  }
+}

--- a/valhalla/baldr/graphreader.h
+++ b/valhalla/baldr/graphreader.h
@@ -669,7 +669,8 @@ public:
    * @param   edge2  GraphId of second directed edge.
    * @param   tile    Reference to a pointer to a const tile.
    * @return  Returns true if the directed edges are directly connected
-   *          at a node, false if not.
+   *          at a node, false if not. If successful the tile will be set
+   *          to the one containing the end node of edge1
    */
   bool AreEdgesConnectedForward(const GraphId& edge1, const GraphId& edge2, graph_tile_ptr& tile);
 
@@ -768,7 +769,8 @@ public:
    * @return Returns a pair of GraphIds: the first is the start node
    *         and the second is the end node. An invalid start node
    *         can occur in regional extracts (where the end node tile
-   *         is not available).
+   *         is not available). If successful tile will be set to
+   *         the one containing edgeid
    */
   std::pair<GraphId, GraphId> GetDirectedEdgeNodes(const GraphId& edgeid, graph_tile_ptr& tile) {
     if (tile && tile->id().Tile_Base() == edgeid.Tile_Base()) {
@@ -795,7 +797,8 @@ public:
    * Get the end node of an edge. The current tile is accepted as an
    * argiment.
    * @param  edgeid  Edge Id.
-   * @return  Returns the end node of the edge.
+   * @return  Returns the end node of the edge. If successful tile will point to the one
+   *          containing edgeid
    */
   GraphId edge_endnode(const GraphId& edgeid, graph_tile_ptr& tile) {
     const DirectedEdge* de = directededge(edgeid, tile);

--- a/valhalla/baldr/graphreader.h
+++ b/valhalla/baldr/graphreader.h
@@ -637,10 +637,10 @@ public:
   /**
    * Method to get the begin node of an edge by using its opposing edges end node
    * @param edge    the edge whose begin node you want
-   * @param tile    reference to a pointer to a const tile
+   * @param tile    a const tile to speed up lookups
    * @return        returns GraphId of begin node of the edge (empty if couldn't find)
    */
-  GraphId GetBeginNodeId(const DirectedEdge* edge, graph_tile_ptr& tile) {
+  GraphId GetBeginNodeId(const DirectedEdge* edge, graph_tile_ptr tile) {
     // grab the node
     if (!GetGraphTile(edge->endnode(), tile))
       return {};

--- a/valhalla/baldr/graphreader.h
+++ b/valhalla/baldr/graphreader.h
@@ -561,7 +561,8 @@ public:
    * @return  Returns the graph Id of the opposing directed edge. An
    *          invalid graph Id is returned if the opposing edge does not
    *          exist (can occur with a regional extract where adjacent tile
-   *          is missing).
+   *          is missing). If successful the opp_tile will point to the
+   *          tile containing the opp_edge
    */
   GraphId GetOpposingEdgeId(const GraphId& edgeid, graph_tile_ptr& opp_tile);
 
@@ -573,13 +574,14 @@ public:
    * @return  Returns the graph Id of the opposing directed edge. An
    *          invalid graph Id is returned if the opposing edge does not
    *          exist (can occur with a regional extract where adjacent tile
-   *          is missing).
+   *          is missing). If successful the opp_tile will point to the
+   *          tile containing the opp_edge
    */
   GraphId
-  GetOpposingEdgeId(const GraphId& edgeid, const DirectedEdge*& opp_edge, graph_tile_ptr& tile) {
-    GraphId opp_edgeid = GetOpposingEdgeId(edgeid, tile);
+  GetOpposingEdgeId(const GraphId& edgeid, const DirectedEdge*& opp_edge, graph_tile_ptr& opp_tile) {
+    GraphId opp_edgeid = GetOpposingEdgeId(edgeid, opp_tile);
     if (opp_edgeid)
-      opp_edge = tile->directededge(opp_edgeid);
+      opp_edge = opp_tile->directededge(opp_edgeid);
     return opp_edgeid;
   }
 
@@ -601,11 +603,12 @@ public:
    * @param  tile    Reference to a pointer to a const tile.
    * @return  Returns the opposing directed edge or nullptr if the
    *          opposing edge does not exist (can occur with a regional extract
-   *          where the adjacent tile is missing)
+   *          where the adjacent tile is missing). If successful the opp_tile
+   *          will point to the tile containing the opp_edge
    */
-  const DirectedEdge* GetOpposingEdge(const GraphId& edgeid, graph_tile_ptr& tile) {
-    GraphId oppedgeid = GetOpposingEdgeId(edgeid, tile);
-    return oppedgeid.Is_Valid() ? tile->directededge(oppedgeid) : nullptr;
+  const DirectedEdge* GetOpposingEdge(const GraphId& edgeid, graph_tile_ptr& opp_tile) {
+    GraphId oppedgeid = GetOpposingEdgeId(edgeid, opp_tile);
+    return oppedgeid.Is_Valid() ? opp_tile->directededge(oppedgeid) : nullptr;
   }
 
   /**
@@ -614,12 +617,13 @@ public:
    * @param  tile    Reference to a pointer to a const tile.
    * @return  Returns the opposing directed edge or nullptr if the
    *          opposing edge does not exist (can occur with a regional extract
-   *          where the adjacent tile is missing)
+   *          where the adjacent tile is missing). If successful the opp_tile
+   *             will point to the tile containing the opp_edge
    */
-  const DirectedEdge* GetOpposingEdge(const DirectedEdge* edge, graph_tile_ptr& tile) {
-    if (GetGraphTile(edge->endnode(), tile)) {
-      const auto* node = tile->node(edge->endnode());
-      return tile->directededge(node->edge_index() + edge->opp_index());
+  const DirectedEdge* GetOpposingEdge(const DirectedEdge* edge, graph_tile_ptr& opp_tile) {
+    if (GetGraphTile(edge->endnode(), opp_tile)) {
+      const auto* node = opp_tile->node(edge->endnode());
+      return opp_tile->directededge(node->edge_index() + edge->opp_index());
     }
     return nullptr;
   }
@@ -628,28 +632,32 @@ public:
    * Convenience method to get an end node.
    * @param edge  the edge whose end node you want
    * @param  tile    Reference to a pointer to a const tile.
-   * @return returns the end node of edge or nullptr if it couldn't
+   * @return returns the end node of edge or nullptr if it couldn't. if successful the end_node_tile
+   *                 will point to the tile containing the end_node of edge
    */
-  const NodeInfo* GetEndNode(const DirectedEdge* edge, graph_tile_ptr& tile) {
-    return GetGraphTile(edge->endnode(), tile) ? tile->node(edge->endnode()) : nullptr;
+  const NodeInfo* GetEndNode(const DirectedEdge* edge, graph_tile_ptr& end_node_tile) {
+    return GetGraphTile(edge->endnode(), end_node_tile) ? end_node_tile->node(edge->endnode())
+                                                        : nullptr;
   }
 
   /**
    * Method to get the begin node of an edge by using its opposing edges end node
    * @param edge    the edge whose begin node you want
    * @param tile    reference to a pointer to a const tile containing the begin node
-   * @return        returns GraphId of begin node of the edge (empty if couldn't find)
+   * @return        returns GraphId of begin node of the edge (empty if couldn't find).
+   *                if successful begin_node_tile will point to the tile containing the
+   *                begin_node of edge
    */
-  GraphId GetBeginNodeId(const DirectedEdge* edge, graph_tile_ptr& tile) {
+  GraphId GetBeginNodeId(const DirectedEdge* edge, graph_tile_ptr& begin_node_tile) {
     // grab the end node maybe in an adjacent tile
-    graph_tile_ptr maybe_other_tile = tile;
+    graph_tile_ptr maybe_other_tile = begin_node_tile;
     if (!GetGraphTile(edge->endnode(), maybe_other_tile))
       return {};
     const auto* node = maybe_other_tile->node(edge->endnode());
     // grab the opp edge also could be in this adjacent tile
     const auto* opp_edge = maybe_other_tile->directededge(node->edge_index() + edge->opp_index());
-    // grab the end node of the opp_edge should be in the original tile
-    GetGraphTile(opp_edge->endnode(), tile); // no-op if original tile is already correct
+    // grab the end node of the opp_edge, it should be in the original tile
+    GetGraphTile(opp_edge->endnode(), begin_node_tile); // no-op if original tile is already correct
     return opp_edge->endnode();
   }
 
@@ -669,10 +677,12 @@ public:
    * @param   edge2  GraphId of second directed edge.
    * @param   tile    Reference to a pointer to a const tile.
    * @return  Returns true if the directed edges are directly connected
-   *          at a node, false if not. If successful the tile will be set
-   *          to the one containing the end node of edge1
+   *          at a node, false if not. If successful the edge1_end_node_tile will point
+   *          to the tile containing the end node of edge1
    */
-  bool AreEdgesConnectedForward(const GraphId& edge1, const GraphId& edge2, graph_tile_ptr& tile);
+  bool AreEdgesConnectedForward(const GraphId& edge1,
+                                const GraphId& edge2,
+                                graph_tile_ptr& edge1_end_node_tile);
 
   /**
    * Convenience method to determine if 2 directed edges are connected from
@@ -715,10 +725,11 @@ public:
    * Get node information for the specified node.
    * @param  nodeid  Node Id (GraphId)
    * @param  tile    Reference to a pointer to a const tile.
-   * @return Returns a pointer to the node information.
+   * @return Returns a pointer to the node information. If successful node_tile will
+   *                 point to the tile containing nodeid
    */
-  const NodeInfo* nodeinfo(const GraphId& nodeid, graph_tile_ptr& tile) {
-    return GetGraphTile(nodeid, tile) ? tile->node(nodeid) : nullptr;
+  const NodeInfo* nodeinfo(const GraphId& nodeid, graph_tile_ptr& node_tile) {
+    return GetGraphTile(nodeid, node_tile) ? node_tile->node(nodeid) : nullptr;
   }
 
   /**
@@ -735,10 +746,11 @@ public:
    * Get the directed edge given its GraphId.
    * @param  edgeid  Directed edge Id.
    * @param  tile    Reference to a pointer to a const tile.
-   * @return Returns a pointer to the directed edge.
+   * @return Returns a pointer to the directed edge. If successful edge_tile will point to the tile
+   *                 which contains edgeid
    */
-  const DirectedEdge* directededge(const GraphId& edgeid, graph_tile_ptr& tile) {
-    return GetGraphTile(edgeid, tile) ? tile->directededge(edgeid) : nullptr;
+  const DirectedEdge* directededge(const GraphId& edgeid, graph_tile_ptr& edge_tile) {
+    return GetGraphTile(edgeid, edge_tile) ? edge_tile->directededge(edgeid) : nullptr;
   }
 
   /**
@@ -769,17 +781,17 @@ public:
    * @return Returns a pair of GraphIds: the first is the start node
    *         and the second is the end node. An invalid start node
    *         can occur in regional extracts (where the end node tile
-   *         is not available). If successful tile will be set to
+   *         is not available). If successful edge_tile will point to
    *         the one containing edgeid
    */
-  std::pair<GraphId, GraphId> GetDirectedEdgeNodes(const GraphId& edgeid, graph_tile_ptr& tile) {
-    if (tile && tile->id().Tile_Base() == edgeid.Tile_Base()) {
-      return GetDirectedEdgeNodes(tile, tile->directededge(edgeid));
+  std::pair<GraphId, GraphId> GetDirectedEdgeNodes(const GraphId& edgeid, graph_tile_ptr& edge_tile) {
+    if (edge_tile && edge_tile->id().Tile_Base() == edgeid.Tile_Base()) {
+      return GetDirectedEdgeNodes(edge_tile, edge_tile->directededge(edgeid));
     } else {
-      tile = GetGraphTile(edgeid);
-      if (!tile)
+      edge_tile = GetGraphTile(edgeid);
+      if (!edge_tile)
         return {};
-      return GetDirectedEdgeNodes(tile, tile->directededge(edgeid));
+      return GetDirectedEdgeNodes(edge_tile, edge_tile->directededge(edgeid));
     }
   }
 
@@ -797,11 +809,11 @@ public:
    * Get the end node of an edge. The current tile is accepted as an
    * argiment.
    * @param  edgeid  Edge Id.
-   * @return  Returns the end node of the edge. If successful tile will point to the one
+   * @return  Returns the end node of the edge. If successful edge_tile will point to the one
    *          containing edgeid
    */
-  GraphId edge_endnode(const GraphId& edgeid, graph_tile_ptr& tile) {
-    const DirectedEdge* de = directededge(edgeid, tile);
+  GraphId edge_endnode(const GraphId& edgeid, graph_tile_ptr& edge_tile) {
+    const DirectedEdge* de = directededge(edgeid, edge_tile);
     if (de) {
       return de->endnode();
     } else {
@@ -813,7 +825,8 @@ public:
    * Get the start node of an edge.
    * @param edgeid Edge Id (Graph Id)
    * @param tile   Current tile.
-   * @return  Returns the start node of the edge.
+   * @return  Returns the start node of the edge. If successful end_node_tile will point to the tile
+   *                  containing the end_node of the input edge
    */
   GraphId edge_startnode(const GraphId& edgeid, graph_tile_ptr& tile) {
     GraphId opp_edgeid = GetOpposingEdgeId(edgeid, tile);
@@ -840,14 +853,15 @@ public:
    * Get the edgeinfo of an edge
    * @param edgeid Edge Id (Graph Id)
    * @param tile   Current tile.
-   * @returns Returns the edgeinfo for the specified id.
+   * @returns Returns the edgeinfo for the specified id. If successful edge_tile will point to the
+   *                  tile containing edgeid
    */
-  EdgeInfo edgeinfo(const GraphId& edgeid, graph_tile_ptr& tile) {
-    auto* edge = directededge(edgeid, tile);
+  EdgeInfo edgeinfo(const GraphId& edgeid, graph_tile_ptr& edge_tile) {
+    auto* edge = directededge(edgeid, edge_tile);
     if (edge == nullptr) {
       throw std::runtime_error("Cannot find edgeinfo for edge: " + std::to_string(edgeid));
     }
-    return tile->edgeinfo(edge);
+    return edge_tile->edgeinfo(edge);
   }
 
   /**
@@ -944,9 +958,9 @@ public:
    * Returns a vector of incidents for the given edge
    * @param edge_id   which edge you need incidents for
    * @param tile      which tile the edge lives in, is updated if not correct
-   * @return IncidentResult
+   * @return IncidentResult. If successful edge_tile will point to the tile containing the edge_id
    */
-  IncidentResult GetIncidents(const GraphId& edge_id, graph_tile_ptr& tile);
+  IncidentResult GetIncidents(const GraphId& edge_id, graph_tile_ptr& edge_tile);
 
 protected:
   // (Tar) extract of tiles - the contents are empty if not being used

--- a/valhalla/baldr/graphreader.h
+++ b/valhalla/baldr/graphreader.h
@@ -637,16 +637,19 @@ public:
   /**
    * Method to get the begin node of an edge by using its opposing edges end node
    * @param edge    the edge whose begin node you want
-   * @param tile    a const tile to speed up lookups
+   * @param tile    reference to a pointer to a const tile containing the begin node
    * @return        returns GraphId of begin node of the edge (empty if couldn't find)
    */
-  GraphId GetBeginNodeId(const DirectedEdge* edge, graph_tile_ptr tile) {
-    // grab the node
-    if (!GetGraphTile(edge->endnode(), tile))
+  GraphId GetBeginNodeId(const DirectedEdge* edge, graph_tile_ptr& tile) {
+    // grab the end node maybe in an adjacent tile
+    graph_tile_ptr maybe_other_tile = tile;
+    if (!GetGraphTile(edge->endnode(), maybe_other_tile))
       return {};
-    const auto* node = tile->node(edge->endnode());
-    // grab the opp edges end node
-    const auto* opp_edge = tile->directededge(node->edge_index() + edge->opp_index());
+    const auto* node = maybe_other_tile->node(edge->endnode());
+    // grab the opp edge also could be in this adjacent tile
+    const auto* opp_edge = maybe_other_tile->directededge(node->edge_index() + edge->opp_index());
+    // grab the end node of the opp_edge should be in the original tile
+    GetGraphTile(opp_edge->endnode(), tile); // no-op if original tile is already correct
     return opp_edge->endnode();
   }
 


### PR DESCRIPTION
this method, like all the other methods takes a graphtile pointer so that it can speed up lookups if the tile is (likely) already loaded. The problem is it takes this as a reference and then may mutate it to an adjacent tile if the edge in question leaves the tile. The problem with this is that its unintuitive because the begin node which you get back, by definition should be in the same tile as the edge you passed in. There should then, be no need to mutate the tile if it was already the right one. An argument could be made that we want to set it in case the person passed in an uninitialized one so. Perhaps its best to make it do this, especially since this would match all the rest of the functions that work like this. i'll do that