### PR TITLE
properly use defined source and build dirs for testing

### DIFF
--- a/test/alternates.cc
+++ b/test/alternates.cc
@@ -21,7 +21,7 @@ using namespace valhalla::midgard;
 
 namespace {
 
-const auto conf = test::make_config("test/data/utrecht_tiles");
+const auto conf = test::make_config(VALHALLA_BUILD_DIR "test/data/utrecht_tiles");
 
 struct route_tester {
   route_tester()

--- a/test/astar.cc
+++ b/test/astar.cc
@@ -127,7 +127,7 @@ const gurka::relations relations3 = {{{gurka::relation_member{gurka::way_member,
 
 const vb::GraphId tile_id = vb::TileHierarchy::GetGraphId({.125, .125}, 2);
 gurka::nodelayout node_locations;
-const std::string test_dir = "test/data/fake_tiles_astar";
+const std::string test_dir = VALHALLA_BUILD_DIR "test/data/fake_tiles_astar";
 const auto fake_conf =
     test::make_config(test_dir,
                       {{"mjolnir.admin", VALHALLA_SOURCE_DIR "test/data/netherlands_admin.sqlite"},

--- a/test/astar_bikeshare.cc
+++ b/test/astar_bikeshare.cc
@@ -28,7 +28,7 @@ namespace {
 // avoid that we set a radius here to get both sets of edges and let the algorithm take the cheaper
 // one. this only worked before by luck
 const auto conf =
-    test::make_config("test/data/paris_bss_tiles", {{"loki.service_defaults.radius", "10"}});
+    test::make_config(VALHALLA_BUILD_DIR "test/data/paris_bss_tiles", {{"loki.service_defaults.radius", "10"}});
 
 struct route_tester {
   route_tester()

--- a/test/countryaccess.cc
+++ b/test/countryaccess.cc
@@ -20,16 +20,12 @@
 
 #include "test.h"
 
-#if !defined(VALHALLA_SOURCE_DIR)
-#define VALHALLA_SOURCE_DIR
-#endif
-
 using namespace valhalla::mjolnir;
 using namespace valhalla::baldr;
 
 namespace {
 
-const std::string config_file = "test/test_config_country";
+const std::string config_file = VALHALLA_BUILD_DIR "test/test_config_country";
 
 // Remove a temporary file if it exists
 void remove_temp_file(const std::string& fname) {

--- a/test/graphbuilder.cc
+++ b/test/graphbuilder.cc
@@ -22,14 +22,6 @@ using valhalla::baldr::GraphReader;
 using valhalla::mjolnir::build_tile_set;
 using valhalla::mjolnir::TileManifest;
 
-#if !defined(VALHALLA_SOURCE_DIR)
-#define VALHALLA_SOURCE_DIR
-#endif
-
-#if !defined(VALHALLA_BINARY_DIR)
-#define VALHALLA_BINARY_DIR
-#endif
-
 namespace {
 
 const std::string pbf_file = {VALHALLA_SOURCE_DIR "test/data/harrisburg.osm.pbf"};

--- a/test/graphparser.cc
+++ b/test/graphparser.cc
@@ -16,17 +16,13 @@
 #include "baldr/directededge.h"
 #include "baldr/graphconstants.h"
 
-#if !defined(VALHALLA_SOURCE_DIR)
-#define VALHALLA_SOURCE_DIR
-#endif
-
 using namespace valhalla::midgard;
 using namespace valhalla::mjolnir;
 using namespace valhalla::baldr;
 
 namespace {
 
-const std::string config_file = "test/test_config_gp";
+const std::string config_file = VALHALLA_BUILD_DIR "test/test_config_gp";
 
 const auto node_predicate = [](const OSMWayNode& a, const OSMWayNode& b) {
   return a.node.osmid_ < b.node.osmid_;

--- a/test/graphtilebuilder.cc
+++ b/test/graphtilebuilder.cc
@@ -10,10 +10,6 @@
 #include <string>
 #include <vector>
 
-#if !defined(VALHALLA_SOURCE_DIR)
-#define VALHALLA_SOURCE_DIR
-#endif
-
 using namespace std;
 using namespace valhalla::mjolnir;
 
@@ -104,7 +100,7 @@ TEST(GraphTileBuilder, TestDuplicateEdgeInfo) {
   EXPECT_FALSE(success.second) << "Why on earth would it be found but then insert just fine";
 
   // load a test builder
-  std::string test_dir = "test/data/builder_tiles";
+  std::string test_dir = VALHALLA_BUILD_DIR "test/data/builder_tiles";
   test_graph_tile_builder test(test_dir, GraphId(0, 2, 0), false);
   test.directededges().emplace_back();
   // add edge info for node 0 to node 1
@@ -224,7 +220,7 @@ TEST(GraphTileBuilder, TestAddBins) {
     ASSERT_TRUE(t && t->header()) << "Couldn't load test tile";
 
     // alter the config to point to another dir
-    std::string bin_dir = "test/data/bin_tiles/bin";
+    std::string bin_dir = VALHALLA_BUILD_DIR "test/data/bin_tiles/bin";
 
     // send blank bins
     std::array<std::vector<GraphId>, kBinCount> bins;
@@ -239,7 +235,7 @@ TEST(GraphTileBuilder, TestAddBins) {
       std::string obytes((std::istreambuf_iterator<char>(o)), std::istreambuf_iterator<char>());
       ifstream n;
       n.exceptions(std::ifstream::failbit | std::ifstream::badbit);
-      n.open("test/data/bin_tiles/bin/2/000/" + test_tile.first, std::ios::binary);
+      n.open(VALHALLA_BUILD_DIR "test/data/bin_tiles/bin/2/000/" + test_tile.first, std::ios::binary);
       std::string nbytes((std::istreambuf_iterator<char>(n)), std::istreambuf_iterator<char>());
       EXPECT_EQ(obytes, nbytes) << "Old tile and new tile should be the same if not adding any bins";
     }

--- a/test/http_tiles.cc
+++ b/test/http_tiles.cc
@@ -273,7 +273,7 @@ public:
     // start a file server for utrecht tiles
     valhalla::test_tile_server_t server;
     server.set_url(tile_remote_address);
-    server.start("test/data/utrecht_tiles", context);
+    server.start(VALHALLA_BUILD_DIR "test/data/utrecht_tiles", context);
   }
 
   void TearDown() override {

--- a/test/isochrone.cc
+++ b/test/isochrone.cc
@@ -30,7 +30,7 @@ using rp = rapidjson::Pointer;
 
 namespace {
 
-const auto cfg = test::make_config("test/data/utrecht_tiles");
+const auto cfg = test::make_config(VALHALLA_BUILD_DIR "test/data/utrecht_tiles");
 
 void check_coords(const rapidjson::Value& a, const rapidjson::Value& b) {
   EXPECT_NEAR(a.GetArray()[0].GetDouble(), b.GetArray()[0].GetDouble(), 0.00002);
@@ -215,7 +215,7 @@ TEST(Isochrones, LongEdge) {
   };
 
   const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100);
-  auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/isochrones/long_edge");
+  auto map = gurka::buildtiles(layout, ways, {}, {}, VALHALLA_BUILD_DIR "test/data/isochrones/long_edge");
 
   std::string geojson;
   auto result = gurka::do_action(valhalla::Options::isochrone, map, {"a"}, "pedestrian",

--- a/test/mapmatch.cc
+++ b/test/mapmatch.cc
@@ -65,7 +65,7 @@ std::string to_locations(const std::vector<PointLL>& shape,
 }
 
 // fake config
-const auto conf = test::make_config("test/data/utrecht_tiles",
+const auto conf = test::make_config(VALHALLA_BUILD_DIR "test/data/utrecht_tiles",
                                     {
                                         {"meili.default.max_search_radius", "200"},
                                         {"meili.default.search_radius", "15.0"},

--- a/test/matrix.cc
+++ b/test/matrix.cc
@@ -138,7 +138,7 @@ const std::unordered_map<std::string, float> kMaxDistances = {
 // a scale factor to apply to the score so that we bias towards closer results more
 constexpr float kDistanceScale = 10.f;
 
-const auto cfg = test::make_config("test/data/utrecht_tiles");
+const auto cfg = test::make_config(VALHALLA_BUILD_DIR "test/data/utrecht_tiles");
 
 const auto test_request = R"({
     "sources":[

--- a/test/matrix_bss.cc
+++ b/test/matrix_bss.cc
@@ -35,7 +35,7 @@ namespace {
 // radius to 0 so that the algorithm will choose the best projection. Otherwise, the location may be
 // projected uniquely on the bss_connection.
 const auto cfg =
-    test::make_config("test/data/paris_bss_tiles", {{"loki.service_defaults.radius", "10"}});
+    test::make_config(VALHALLA_BUILD_DIR "test/data/paris_bss_tiles", {{"loki.service_defaults.radius", "10"}});
 } // namespace
 
 // The distances returned by route and matrix are not always equal to each other

--- a/test/minbb.cc
+++ b/test/minbb.cc
@@ -54,7 +54,7 @@ bool ApproxEqual(const AABB2<PointLL>& a, const AABB2<PointLL>& b) {
 }
 
 TEST(MinBB, utrecht_bb) {
-  bb_tester t("test/data/utrecht_tiles");
+  bb_tester t(VALHALLA_BUILD_DIR "test/data/utrecht_tiles");
 
   EXPECT_TRUE(t.bb.minpt().IsValid());
   EXPECT_TRUE(t.bb.maxpt().IsValid());

--- a/test/multipoint_routes.cc
+++ b/test/multipoint_routes.cc
@@ -23,7 +23,7 @@ using namespace valhalla::tyr;
 
 namespace {
 
-const auto conf = test::make_config("test/data/utrecht_tiles");
+const auto conf = test::make_config(VALHALLA_BUILD_DIR "test/data/utrecht_tiles");
 
 struct route_tester {
   route_tester()

--- a/test/predictive_traffic.cc
+++ b/test/predictive_traffic.cc
@@ -18,7 +18,7 @@ using namespace valhalla::midgard;
 namespace {
 
 const auto config = test::json_to_pt(R"({
-    "mjolnir":{"tile_dir":"test/data/utrecht_tiles", "concurrency": 1}
+    "mjolnir":{"tile_dir":")" VALHALLA_BUILD_DIR R"(test/data/utrecht_tiles", "concurrency": 1}
   })");
 
 } // namespace

--- a/test/reach.cc
+++ b/test/reach.cc
@@ -20,7 +20,7 @@ namespace vs = valhalla::sif;
 
 namespace {
 
-const auto conf = test::make_config("test/data/utrecht_tiles");
+const auto conf = test::make_config(VALHALLA_BUILD_DIR "test/data/utrecht_tiles");
 
 GraphId begin_node(GraphReader& reader, const DirectedEdge* edge) {
   // grab the node

--- a/test/recover_shortcut.cc
+++ b/test/recover_shortcut.cc
@@ -22,7 +22,7 @@ std::string to_string(const midgard::PointLL& p) {
 }
 } // namespace std
 
-const auto conf = test::make_config("test/data/utrecht_tiles");
+const auto conf = test::make_config(VALHALLA_BUILD_DIR "test/data/utrecht_tiles");
 
 // expose the constructor
 struct testable_recovery : public shortcut_recovery_t {

--- a/test/shape_attributes.cc
+++ b/test/shape_attributes.cc
@@ -19,7 +19,7 @@ using namespace valhalla::midgard;
 namespace {
 
 // fake config
-const auto conf = test::make_config("test/data/utrecht_tiles");
+const auto conf = test::make_config(VALHALLA_BUILD_DIR "test/data/utrecht_tiles");
 
 TEST(ShapeAttributes, test_shape_attributes_included) {
   tyr::actor_t actor(conf);

--- a/test/summary.cc
+++ b/test/summary.cc
@@ -21,7 +21,7 @@ using namespace valhalla::tyr;
 
 namespace {
 
-const auto conf = test::make_config("test/data/utrecht_tiles");
+const auto conf = test::make_config(VALHALLA_BUILD_DIR "test/data/utrecht_tiles");
 
 struct route_tester {
   route_tester()

--- a/test/tar_index.cc
+++ b/test/tar_index.cc
@@ -12,9 +12,9 @@ public:
   using vb::GraphReader::tile_extract_;
 };
 
-auto config_tar = test::make_config("test/data/utrecht_tiles",
-                                    {{"mjolnir.tile_extract", "test/data/utrecht_tiles/tiles.tar"}});
-auto config_dir = test::make_config("test/data/utrecht_tiles");
+auto config_tar = test::make_config(VALHALLA_BUILD_DIR "test/data/utrecht_tiles",
+                                    {{"mjolnir.tile_extract", VALHALLA_BUILD_DIR "test/data/utrecht_tiles/tiles.tar"}});
+auto config_dir = test::make_config(VALHALLA_BUILD_DIR "test/data/utrecht_tiles");
 
 TEST(TarIndexer, TestTrafficTar) {
   // read the tile headers from tar & dir tiles and memcmp them

--- a/test/thor_worker.cc
+++ b/test/thor_worker.cc
@@ -17,7 +17,7 @@ using namespace std::string_literals;
 namespace {
 
 // fake config
-const auto conf = test::make_config("test/data/utrecht_tiles");
+const auto conf = test::make_config(VALHALLA_BUILD_DIR "test/data/utrecht_tiles");
 
 TEST(ThorWorker, test_parse_filter_attributes_defaults) {
   tyr::actor_t actor(conf, true);

--- a/test/timedep_paths.cc
+++ b/test/timedep_paths.cc
@@ -37,7 +37,7 @@ const std::unordered_map<std::string, float> kMaxDistances = {
 // a scale factor to apply to the score so that we bias towards closer results more
 constexpr float kDistanceScale = 10.f;
 
-const auto cfg = test::make_config("test/data/utrecht_tiles");
+const auto cfg = test::make_config(VALHALLA_BUILD_DIR "test/data/utrecht_tiles");
 
 void try_path(GraphReader& reader,
               loki_worker_t& loki_worker,

--- a/test/trivial_paths.cc
+++ b/test/trivial_paths.cc
@@ -69,7 +69,7 @@ void adjust_scores(Options& options) {
   }
 }
 
-const auto cfg = test::make_config("test/data/utrecht_tiles");
+const auto cfg = test::make_config(VALHALLA_BUILD_DIR "test/data/utrecht_tiles");
 
 void try_path(GraphReader& reader,
               loki_worker_t& loki_worker,

--- a/test/urban.cc
+++ b/test/urban.cc
@@ -22,7 +22,7 @@ namespace {
 
 struct route_tester {
   route_tester()
-      : conf(test::make_config("test/data/utrecht_tiles")),
+      : conf(test::make_config(VALHALLA_BUILD_DIR "test/data/utrecht_tiles")),
         reader(new GraphReader(conf.get_child("mjolnir"))), loki_worker(conf, reader),
         thor_worker(conf, reader), odin_worker(conf) {
   }

--- a/test/util_mjolnir.cc
+++ b/test/util_mjolnir.cc
@@ -11,14 +11,6 @@
 
 #include "test.h"
 
-#if !defined(VALHALLA_SOURCE_DIR)
-#define VALHALLA_SOURCE_DIR
-#endif
-
-#if !defined(VALHALLA_BINARY_DIR)
-#define VALHALLA_BINARY_DIR
-#endif
-
 namespace {
 using boost::property_tree::ptree;
 using valhalla::baldr::GraphId;
@@ -30,7 +22,7 @@ using namespace valhalla::midgard;
 // Verify that this function runs
 TEST(UtilMjolnir, BuildTileSet) {
   ptree config;
-  const std::string tile_dir("test/data/util_mjolnir_test_tiles");
+  const std::string tile_dir(VALHALLA_BUILD_DIR "test/data/util_mjolnir_test_tiles");
   config.put("mjolnir.tile_dir", tile_dir);
   config.put("mjolnir.concurrency", 1);
   EXPECT_TRUE(build_tile_set(config, {VALHALLA_SOURCE_DIR "test/data/harrisburg.osm.pbf"},
@@ -84,7 +76,7 @@ TEST(UtilMjolnir, TileManifestLogToFile) {
                                          {GraphId{5970546}, 54},
                                          {GraphId{5970554}, 450}};
   TileManifest manifest{src};
-  const std::string filename(VALHALLA_BINARY_DIR "dummy_tile_manifest0.json");
+  const std::string filename(VALHALLA_BUILD_DIR "test/data/written_dummy_tile_manifest0.json");
   manifest.LogToFile(filename);
   TileManifest read = TileManifest::ReadFromFile(filename);
   EXPECT_EQ(read.tileset.size(), 3);

--- a/test/utrecht.cc
+++ b/test/utrecht.cc
@@ -12,10 +12,6 @@
 
 #include "test.h"
 
-#if !defined(VALHALLA_SOURCE_DIR)
-#define VALHALLA_SOURCE_DIR
-#endif
-
 using namespace valhalla::midgard;
 using namespace valhalla::mjolnir;
 using namespace valhalla::baldr;
@@ -51,7 +47,7 @@ OSMWay GetWay(uint32_t way_id, sequence<OSMWay>& ways) {
 
 TEST(Utrecth, TestBike) {
   boost::property_tree::ptree conf;
-  conf.put<std::string>("mjolnir.tile_dir", "test/data/parser_tiles");
+  conf.put<std::string>("mjolnir.tile_dir", VALHALLA_BUILD_DIR "test/data/parser_tiles");
   conf.put<unsigned long>("mjolnir.id_table_size", 1000);
 
   sequence<OSMWay> ways(ways_file, false);

--- a/test/worker_nullptr_tiles.cc
+++ b/test/worker_nullptr_tiles.cc
@@ -14,7 +14,7 @@ using Seed_t = std::mt19937_64::result_type;
 namespace {
 
 constexpr size_t AttemptsCount = 1000;
-const auto Config = test::make_config("test/data/whitelion_tiles");
+const auto Config = test::make_config(VALHALLA_BUILD_DIR "test/data/whitelion_tiles");
 constexpr auto TestRequest =
     R"({"locations":[{"lat":51.455768530466514,"lon":-2.5954368710517883},{"lat":51.456082740244824,"lon":-2.595050632953644}],"costing":"auto"})";
 


### PR DESCRIPTION
trivial one but in a lot of the tests we dont use directories in a CWD safe way which causes some tests to fail when you run them outside of their narrow working criteria. this pr simply fixes the tests that rely on paths to either source stuff or stuff we are building in the build directory