### PR TITLE
Fix bug in thor_worker_t::build_trace on wrong edge_index assignment

### DIFF
--- a/src/thor/trace_route_action.cc
+++ b/src/thor/trace_route_action.cc
@@ -273,7 +273,9 @@ void thor_worker_t::build_trace(
                high = (segment->last_match_idx >= 0 ? segment->last_match_idx
                                                     : segment->first_match_idx);
            low >= 0 && low <= high; ++low) {
-        match_results[low].edge_index = edge_index;
+        // assign edge_index if edgeid is correct
+        if (match_results[low].edgeid == segment->edgeid)
+          match_results[low].edge_index = edge_index;
       }
       if (last_id != segment->edgeid) {
         ++edge_index;


### PR DESCRIPTION
# Issue
#fixes 3633

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
