### PR TITLE
less aggressive logging for nodes' headings & ferry connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
    * ADDED: Update the street name and sign data processing include language and pronunciations [#4268](https://github.com/valhalla/valhalla/pull/4268)
    * CHANGED: more sustainable way to work with protobuf in cmake [#4334](https://github.com/valhalla/valhalla/pull/4334)
    * CHANGED: use date_time API to retrieve timezone aliases instead of our own curated list [#4382](https://github.com/valhalla/valhalla/pull/4382)
+   * CHANGED: less aggressive logging for nodes' headings & ferry connections [#4420][https://github.com/valhalla/valhalla/pull/4420]
 
 ## Release Date: 2023-05-11 Valhalla 3.4.0
 * **Removed**

--- a/src/mjolnir/ferry_connections.cc
+++ b/src/mjolnir/ferry_connections.cc
@@ -328,6 +328,7 @@ void ReclassifyFerryConnections(const std::string& ways_file,
   // regular (non-ferry) edge. Skip short ferry edges (river crossing?)
   uint32_t ferry_endpoint_count = 0;
   uint32_t total_count = 0;
+  uint32_t missed_both = 0;
   sequence<Node>::iterator node_itr = nodes.begin();
   while (node_itr != nodes.end()) {
     auto bundle = collect_node_edges(node_itr, nodes, edges);
@@ -411,15 +412,14 @@ void ReclassifyFerryConnections(const std::string& ways_file,
 
       // Log cases where reclassification fails
       if (!inbound_path_found && !outbound_path_found) {
-        LOG_INFO("Reclassification fails both directions to ferry at LL =" +
-                 std::to_string(ll.lat()) + "," + std::to_string(ll.lng()));
+        missed_both++;
       } else {
         if (!inbound_path_found) {
-          LOG_INFO("Reclassification fails inbound to ferry at LL =" + std::to_string(ll.lat()) +
+          LOG_WARN("Reclassification fails inbound to ferry at LL =" + std::to_string(ll.lat()) +
                    "," + std::to_string(ll.lng()));
         }
         if (!outbound_path_found) {
-          LOG_INFO("Reclassification fails outbound from ferry at LL =" + std::to_string(ll.lat()) +
+          LOG_WARN("Reclassification fails outbound from ferry at LL =" + std::to_string(ll.lat()) +
                    "," + std::to_string(ll.lng()));
         }
       }
@@ -431,7 +431,8 @@ void ReclassifyFerryConnections(const std::string& ways_file,
 
   LOG_INFO("Finished ReclassifyFerryEdges: ferry_endpoint_count = " +
            std::to_string(ferry_endpoint_count) + ", " + std::to_string(total_count) +
-           " edges reclassified.");
+           " edges reclassified. Failed both directions for " + std::to_string(missed_both) +
+           " connections.");
 }
 
 } // namespace mjolnir

--- a/valhalla/baldr/nodeinfo.h
+++ b/valhalla/baldr/nodeinfo.h
@@ -430,8 +430,8 @@ public:
    */
   inline uint32_t heading(const uint32_t localidx) const {
     if (localidx > kMaxLocalEdgeIndex) {
-      LOG_WARN("Local index " + std::to_string(localidx) + " exceeds max value of " +
-               std::to_string(kMaxLocalEdgeIndex) + ", returning heading of 0");
+      LOG_DEBUG("Local index " + std::to_string(localidx) + " exceeds max value of " +
+                std::to_string(kMaxLocalEdgeIndex) + ", returning heading of 0");
       return 0;
     }
     // Make sure everything is 64 bit!


### PR DESCRIPTION
 fixes #4396 

also moves around some logs in the ferry reclassification code.