### PR TITLE
Removed old traffic docs

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -110,7 +110,6 @@ nav:
       - thor.md
       - thor/isochrones.md
       - thor/path-algorithm.md
-      - thor/simple_traffic.md 
       - incidents.md
   - Data sources:
     - Data sources: mjolnir/data_sources.md


### PR DESCRIPTION
#4259 broke the documentation pipeline. The simple_traffic.md was removed, but it was still listed in the make file of the docs.
