### PR TITLE
fix `-j` for executables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
    * FIXED: retry elevation tile download if the download failed for some reason or the downloaded tile was corrupt [#4461](https://github.com/valhalla/valhalla/pull/4461)
    * FIXED: base transition costs were getting overridden by osrm car turn duration [#4463](https://github.com/valhalla/valhalla/pull/4463)
    * FIXED: insane ETAs for `motor_scooter` on `track`s [#4468](https://github.com/valhalla/valhalla/pull/4468)
+   * FIXED: -j wasn't taken into account anymore [#4483](https://github.com/valhalla/valhalla/pull/4483)
 * **Enhancement**
    * UPDATED: French translations, thanks to @xlqian [#4159](https://github.com/valhalla/valhalla/pull/4159)
    * CHANGED: -j flag for multithreaded executables to override mjolnir.concurrency [#4168](https://github.com/valhalla/valhalla/pull/4168)

--- a/src/argparse_utils.h
+++ b/src/argparse_utils.h
@@ -16,7 +16,7 @@
  * @param program The executable's name
  * @param opts    The command line options
  * @param result  The parsed result
- * @param pt      The config which will be populated here
+ * @param config  The config which will be populated here
  * @param log     The logging config node's key
  * @param use_threads Whether this program multi-threads
  *
@@ -26,6 +26,7 @@
 bool parse_common_args(const std::string& program,
                        const cxxopts::Options& opts,
                        const cxxopts::ParseResult& result,
+                       boost::property_tree::ptree& conf,
                        const std::string& log,
                        const bool use_threads = false) {
   if (result.count("help")) {
@@ -39,7 +40,6 @@ bool parse_common_args(const std::string& program,
   }
 
   // Read the config file
-  boost::property_tree::ptree conf;
   if (result.count("inline-config")) {
     conf = valhalla::config(result["inline-config"].as<std::string>());
   } else if (result.count("config") &&

--- a/src/mjolnir/valhalla_add_elevation.cc
+++ b/src/mjolnir/valhalla_add_elevation.cc
@@ -10,7 +10,6 @@
 #include "baldr/graphreader.h"
 #include "baldr/graphtile.h"
 #include "baldr/rapidjson_utils.h"
-#include "config.h"
 #include "mjolnir/elevationbuilder.h"
 
 #include "argparse_utils.h"
@@ -66,6 +65,7 @@ int main(int argc, char** argv) {
   const auto program = filesystem::path(__FILE__).stem().string();
   // args
   std::vector<std::string> tiles;
+  boost::property_tree::ptree config;
 
   try {
     // clang-format off
@@ -87,7 +87,7 @@ int main(int argc, char** argv) {
     // clang-format on
 
     const auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, "mjolnir.logging", true))
+    if (!parse_common_args(program, options, result, config, "mjolnir.logging", true))
       return EXIT_SUCCESS;
 
     if (!result.count("tiles")) {
@@ -111,13 +111,12 @@ int main(int argc, char** argv) {
   }
 
   // pass the deduplicated tiles
-  auto tile_ids =
-      get_tile_ids(valhalla::config(), std::unordered_set<std::string>(tiles.begin(), tiles.end()));
+  auto tile_ids = get_tile_ids(config, std::unordered_set<std::string>(tiles.begin(), tiles.end()));
   if (tile_ids.empty()) {
     std::cerr << "Failed to load tiles\n\n";
     return EXIT_FAILURE;
   }
 
-  ElevationBuilder::Build(valhalla::config(), tile_ids);
+  ElevationBuilder::Build(config, tile_ids);
   return EXIT_SUCCESS;
 }

--- a/src/mjolnir/valhalla_add_landmarks.cc
+++ b/src/mjolnir/valhalla_add_landmarks.cc
@@ -1,6 +1,5 @@
 #include "argparse_utils.h"
 #include "baldr/rapidjson_utils.h"
-#include "config.h"
 #include "filesystem.h"
 #include "midgard/logging.h"
 #include "mjolnir/landmarks.h"
@@ -8,6 +7,8 @@
 
 int main(int argc, char** argv) {
   const auto program = filesystem::path(__FILE__).stem().string();
+  // args
+  boost::property_tree::ptree config;
 
   try {
     // clang-format off
@@ -29,7 +30,7 @@ int main(int argc, char** argv) {
     options.parse_positional({"input_files"});
     options.positional_help("OSM PBF file(s)");
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, "mjolnir.logging", true))
+    if (!parse_common_args(program, options, result, config, "mjolnir.logging", true))
       return EXIT_SUCCESS;
   } catch (cxxopts::OptionException& e) {
     std::cerr << e.what() << std::endl;
@@ -40,18 +41,7 @@ int main(int argc, char** argv) {
     return EXIT_FAILURE;
   }
 
-  auto pt = valhalla::config();
-
-  // configure logging
-  auto logging_subtree = pt.get_child_optional("mjolnir.logging");
-  if (logging_subtree) {
-    auto logging_config =
-        valhalla::midgard::ToMap<const boost::property_tree::ptree&,
-                                 std::unordered_map<std::string, std::string>>(logging_subtree.get());
-    valhalla::midgard::logging::Configure(logging_config);
-  }
-
-  if (!valhalla::mjolnir::AddLandmarks(pt.get_child("mjolnir"))) {
+  if (!valhalla::mjolnir::AddLandmarks(config.get_child("mjolnir"))) {
     return EXIT_FAILURE;
   };
 

--- a/src/mjolnir/valhalla_add_predicted_traffic.cc
+++ b/src/mjolnir/valhalla_add_predicted_traffic.cc
@@ -19,7 +19,6 @@
 #include "baldr/graphreader.h"
 #include "baldr/predictedspeeds.h"
 #include "baldr/rapidjson_utils.h"
-#include "config.h"
 #include "filesystem.h"
 #include "midgard/logging.h"
 #include "midgard/util.h"
@@ -242,6 +241,7 @@ int main(int argc, char** argv) {
   // args
   filesystem::path traffic_tile_dir;
   bool summary = false;
+  boost::property_tree::ptree config;
 
   try {
     // clang-format off
@@ -263,7 +263,7 @@ int main(int argc, char** argv) {
     options.parse_positional({"traffic-tile-dir"});
     options.positional_help("Traffic tile dir");
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, "mjolnir.logging", true))
+    if (!parse_common_args(program, options, result, config, "mjolnir.logging", true))
       return EXIT_SUCCESS;
 
     if (!result.count("traffic-tile-dir")) {
@@ -278,17 +278,6 @@ int main(int argc, char** argv) {
     std::cerr << "Unable to parse command line options because: " << e.what() << "\n"
               << "This is a bug, please report it at " PACKAGE_BUGREPORT << "\n";
     return EXIT_FAILURE;
-  }
-
-  auto config = valhalla::config();
-
-  // configure logging
-  auto logging_subtree = config.get_child_optional("mjolnir.logging");
-  if (logging_subtree) {
-    auto logging_config =
-        valhalla::midgard::ToMap<const boost::property_tree::ptree&,
-                                 std::unordered_map<std::string, std::string>>(logging_subtree.get());
-    valhalla::midgard::logging::Configure(logging_config);
   }
 
   // queue up all the work we'll be doing

--- a/src/mjolnir/valhalla_assign_speeds.cc
+++ b/src/mjolnir/valhalla_assign_speeds.cc
@@ -78,6 +78,8 @@ void assign(const boost::property_tree::ptree& config,
 
 int main(int argc, char** argv) {
   const auto program = filesystem::path(__FILE__).stem().string();
+  // args
+  bpt::ptree config;
 
   try {
     // clang-format off
@@ -95,7 +97,7 @@ int main(int argc, char** argv) {
     // clang-format on
 
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, "mjolnir.logging", true))
+    if (!parse_common_args(program, options, result, config, "mjolnir.logging", true))
       return EXIT_SUCCESS;
   } catch (cxxopts::OptionException& e) {
     std::cerr << e.what() << std::endl;
@@ -106,19 +108,9 @@ int main(int argc, char** argv) {
     return EXIT_FAILURE;
   }
 
-  auto config = valhalla::config();
-
-  // configure logging
   config.get_child("mjolnir").erase("tile_extract");
   config.get_child("mjolnir").erase("tile_url");
   config.get_child("mjolnir").erase("traffic_extract");
-  auto logging_subtree = config.get_child_optional("mjolnir.logging");
-  if (logging_subtree) {
-    auto logging_config =
-        valhalla::midgard::ToMap<const boost::property_tree::ptree&,
-                                 std::unordered_map<std::string, std::string>>(logging_subtree.get());
-    valhalla::midgard::logging::Configure(logging_config);
-  }
 
   // queue some tiles up to modify
   std::deque<GraphId> tilequeue;

--- a/src/mjolnir/valhalla_benchmark_admins.cc
+++ b/src/mjolnir/valhalla_benchmark_admins.cc
@@ -26,7 +26,6 @@
 #include "baldr/graphtile.h"
 #include "baldr/rapidjson_utils.h"
 #include "baldr/tilehierarchy.h"
-#include "config.h"
 #include "filesystem.h"
 #include "midgard/aabb2.h"
 #include "midgard/constants.h"
@@ -201,6 +200,7 @@ int main(int argc, char** argv) {
   const auto program = filesystem::path(__FILE__).stem().string();
   // args
   std::vector<std::string> input_files;
+  boost::property_tree::ptree config;
 
   try {
     // clang-format off
@@ -217,7 +217,7 @@ int main(int argc, char** argv) {
     // clang-format on
 
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, "mjolnir.logging"))
+    if (!parse_common_args(program, options, result, config, "mjolnir.logging"))
       return EXIT_SUCCESS;
 
     if (result.count("version")) {
@@ -231,17 +231,6 @@ int main(int argc, char** argv) {
     std::cerr << "Unable to parse command line options because: " << e.what() << "\n"
               << "This is a bug, please report it at " PACKAGE_BUGREPORT << "\n";
     return EXIT_FAILURE;
-  }
-
-  auto config = valhalla::config();
-
-  // Configure logging
-  auto logging_subtree = config.get_child_optional("mjolnir.logging");
-  if (logging_subtree) {
-    auto logging_config =
-        valhalla::midgard::ToMap<const boost::property_tree::ptree&,
-                                 std::unordered_map<std::string, std::string>>(logging_subtree.get());
-    valhalla::midgard::logging::Configure(logging_config);
   }
 
   auto t1 = std::chrono::high_resolution_clock::now();

--- a/src/mjolnir/valhalla_build_admins.cc
+++ b/src/mjolnir/valhalla_build_admins.cc
@@ -3,7 +3,6 @@
 #include <cxxopts.hpp>
 
 #include "baldr/rapidjson_utils.h"
-#include "config.h"
 #include "midgard/logging.h"
 #include "midgard/util.h"
 #include "mjolnir/adminbuilder.h"
@@ -14,6 +13,7 @@ int main(int argc, char** argv) {
   const auto program = filesystem::path(__FILE__).stem().string();
   // args
   std::vector<std::string> input_files;
+  boost::property_tree::ptree config;
 
   try {
     // clang-format off
@@ -36,7 +36,7 @@ int main(int argc, char** argv) {
     options.parse_positional({"input_files"});
     options.positional_help("OSM PBF file(s)");
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, "mjolnir.logging"))
+    if (!parse_common_args(program, options, result, config, "mjolnir.logging"))
       return EXIT_SUCCESS;
 
     // input files are positional
@@ -52,16 +52,7 @@ int main(int argc, char** argv) {
     return EXIT_FAILURE;
   }
 
-  // configure logging
-  auto logging_subtree = valhalla::config().get_child_optional("mjolnir.logging");
-  if (logging_subtree) {
-    auto logging_config =
-        valhalla::midgard::ToMap<const boost::property_tree::ptree&,
-                                 std::unordered_map<std::string, std::string>>(logging_subtree.get());
-    valhalla::midgard::logging::Configure(logging_config);
-  }
-
-  if (!valhalla::mjolnir::BuildAdminFromPBF(valhalla::config().get_child("mjolnir"), input_files)) {
+  if (!valhalla::mjolnir::BuildAdminFromPBF(config.get_child("mjolnir"), input_files)) {
     return EXIT_FAILURE;
   };
 

--- a/src/mjolnir/valhalla_build_connectivity.cc
+++ b/src/mjolnir/valhalla_build_connectivity.cc
@@ -12,7 +12,6 @@
 #include "baldr/connectivity_map.h"
 #include "baldr/rapidjson_utils.h"
 #include "baldr/tilehierarchy.h"
-#include "config.h"
 #include "filesystem.h"
 
 #include "argparse_utils.h"
@@ -46,6 +45,9 @@ struct RGB {
 // Main application to create a ppm image file of connectivity.
 int main(int argc, char** argv) {
   const auto program = filesystem::path(__FILE__).stem().string();
+  // args
+  boost::property_tree::ptree config;
+
   try {
     // clang-format off
     cxxopts::Options options(
@@ -62,7 +64,7 @@ int main(int argc, char** argv) {
     // clang-format on
 
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, "mjolnir.logging"))
+    if (!parse_common_args(program, options, result, config, "mjolnir.logging"))
       return EXIT_SUCCESS;
   } catch (cxxopts::OptionException& e) {
     std::cerr << e.what() << std::endl;
@@ -74,7 +76,7 @@ int main(int argc, char** argv) {
   }
 
   // Get something we can use to fetch tiles
-  valhalla::baldr::connectivity_map_t connectivity_map(valhalla::config().get_child("mjolnir"));
+  valhalla::baldr::connectivity_map_t connectivity_map(config.get_child("mjolnir"));
 
   uint32_t transit_level = TileHierarchy::levels().back().level + 1;
   for (uint32_t level = 0; level <= transit_level; level++) {

--- a/src/mjolnir/valhalla_build_landmarks.cc
+++ b/src/mjolnir/valhalla_build_landmarks.cc
@@ -1,6 +1,5 @@
 #include "argparse_utils.h"
 #include "baldr/rapidjson_utils.h"
-#include "config.h"
 #include "filesystem.h"
 #include "midgard/logging.h"
 #include "mjolnir/landmarks.h"
@@ -10,6 +9,7 @@ int main(int argc, char** argv) {
   const auto program = filesystem::path(__FILE__).stem().string();
   // args
   std::vector<std::string> input_files;
+  boost::property_tree::ptree config;
 
   try {
     // clang-format off
@@ -31,7 +31,7 @@ int main(int argc, char** argv) {
     options.parse_positional({"input_files"});
     options.positional_help("OSM PBF file(s)");
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, "mjolnir.logging"))
+    if (!parse_common_args(program, options, result, config, "mjolnir.logging"))
       return EXIT_SUCCESS;
 
     // input files are positional
@@ -47,17 +47,7 @@ int main(int argc, char** argv) {
     return EXIT_FAILURE;
   }
 
-  // configure logging
-  auto logging_subtree = valhalla::config().get_child_optional("mjolnir.logging");
-  if (logging_subtree) {
-    auto logging_config =
-        valhalla::midgard::ToMap<const boost::property_tree::ptree&,
-                                 std::unordered_map<std::string, std::string>>(logging_subtree.get());
-    valhalla::midgard::logging::Configure(logging_config);
-  }
-
-  if (!valhalla::mjolnir::BuildLandmarkFromPBF(valhalla::config().get_child("mjolnir"),
-                                               input_files)) {
+  if (!valhalla::mjolnir::BuildLandmarkFromPBF(config.get_child("mjolnir"), input_files)) {
     return EXIT_FAILURE;
   };
 

--- a/src/mjolnir/valhalla_build_statistics.cc
+++ b/src/mjolnir/valhalla_build_statistics.cc
@@ -23,7 +23,6 @@
 #include "baldr/graphreader.h"
 #include "baldr/nodeinfo.h"
 #include "baldr/tilehierarchy.h"
-#include "config.h"
 #include "filesystem.h"
 #include "midgard/aabb2.h"
 #include "midgard/distanceapproximator.h"
@@ -572,6 +571,8 @@ void BuildStatistics(const boost::property_tree::ptree& pt) {
 
 int main(int argc, char** argv) {
   const auto program = filesystem::path(__FILE__).stem().string();
+  // args
+  boost::property_tree::ptree config;
 
   try {
     // clang-format off
@@ -589,7 +590,7 @@ int main(int argc, char** argv) {
     // clang-format on
 
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, "mjolnir.logging", true))
+    if (!parse_common_args(program, options, result, config, "mjolnir.logging", true))
       return EXIT_SUCCESS;
   } catch (cxxopts::OptionException& e) {
     std::cerr << e.what() << std::endl;
@@ -600,7 +601,7 @@ int main(int argc, char** argv) {
     return EXIT_FAILURE;
   }
 
-  BuildStatistics(valhalla::config());
+  BuildStatistics(config);
 
   return EXIT_SUCCESS;
 }

--- a/src/mjolnir/valhalla_build_tiles.cc
+++ b/src/mjolnir/valhalla_build_tiles.cc
@@ -6,7 +6,6 @@
 #include <cxxopts.hpp>
 
 #include "baldr/rapidjson_utils.h"
-#include "config.h"
 #include "filesystem.h"
 #include "midgard/logging.h"
 #include "midgard/util.h"
@@ -31,6 +30,7 @@ int main(int argc, char** argv) {
   std::vector<std::string> input_files;
   BuildStage start_stage = BuildStage::kInitialize;
   BuildStage end_stage = BuildStage::kCleanup;
+  boost::property_tree::ptree config;
 
   try {
 
@@ -57,7 +57,7 @@ int main(int argc, char** argv) {
     options.parse_positional({"input_files"});
     options.positional_help("OSM PBF file(s)");
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, "mjolnir.logging", true))
+    if (!parse_common_args(program, options, result, config, "mjolnir.logging", true))
       return EXIT_SUCCESS;
 
     // Convert stage strings to BuildStage
@@ -98,7 +98,7 @@ int main(int argc, char** argv) {
   }
 
   // Build some tiles!
-  if (build_tile_set(valhalla::config(), input_files, start_stage, end_stage)) {
+  if (build_tile_set(config, input_files, start_stage, end_stage)) {
     return EXIT_SUCCESS;
   } else {
     return EXIT_FAILURE;

--- a/src/mjolnir/valhalla_convert_transit.cc
+++ b/src/mjolnir/valhalla_convert_transit.cc
@@ -1,7 +1,6 @@
 #include <cxxopts.hpp>
 
 #include "baldr/rapidjson_utils.h"
-#include "config.h"
 #include "filesystem.h"
 #include "mjolnir/convert_transit.h"
 #include "mjolnir/validatetransit.h"
@@ -13,6 +12,7 @@ int main(int argc, char** argv) {
   // args
   boost::property_tree::ptree pt;
   std::vector<valhalla::mjolnir::OneStopTest> onestoptests;
+  boost::property_tree::ptree config;
 
   try {
     // clang-format off
@@ -35,14 +35,12 @@ int main(int argc, char** argv) {
     // clang-format on
 
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, "mjolnir.logging", true))
+    if (!parse_common_args(program, options, result, config, "mjolnir.logging", true))
       return EXIT_SUCCESS;
 
-    pt = valhalla::config();
-
     if (result.count("target_directory")) {
-      pt.get_child("mjolnir").erase("transit_dir");
-      pt.add("mjolnir.transit_dir", result["target_directory"].as<std::string>());
+      config.get_child("mjolnir").erase("transit_dir");
+      config.add("mjolnir.transit_dir", result["target_directory"].as<std::string>());
     }
 
     if (result.count("test_file")) {
@@ -61,7 +59,7 @@ int main(int argc, char** argv) {
     return EXIT_FAILURE;
   }
 
-  auto all_tiles = valhalla::mjolnir::convert_transit(pt);
-  valhalla::mjolnir::ValidateTransit::Validate(pt, all_tiles, onestoptests);
+  auto all_tiles = valhalla::mjolnir::convert_transit(config);
+  valhalla::mjolnir::ValidateTransit::Validate(config, all_tiles, onestoptests);
   return 0;
 }

--- a/src/mjolnir/valhalla_ingest_transit.cc
+++ b/src/mjolnir/valhalla_ingest_transit.cc
@@ -1,13 +1,14 @@
 #include <cxxopts.hpp>
 
 #include "baldr/rapidjson_utils.h"
-#include "config.h"
 #include "mjolnir/ingest_transit.h"
 
 #include "argparse_utils.h"
 
 int main(int argc, char** argv) {
   const auto program = filesystem::path(__FILE__).stem().string();
+  // args
+  boost::property_tree::ptree config;
 
   try {
     // clang-format off
@@ -25,7 +26,7 @@ int main(int argc, char** argv) {
     // clang-format on
 
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, "mjolnir.logging", true))
+    if (!parse_common_args(program, options, result, config, "mjolnir.logging", true))
       return EXIT_SUCCESS;
   } catch (cxxopts::OptionException& e) {
     std::cerr << e.what() << std::endl;
@@ -36,14 +37,12 @@ int main(int argc, char** argv) {
     return EXIT_FAILURE;
   }
 
-  const auto& pt = valhalla::config();
-
   // spawn threads to download all the tiles returning a list of
   // tiles that ended up having dangling stop pairs
-  auto dangling_tiles = valhalla::mjolnir::ingest_transit(pt);
+  auto dangling_tiles = valhalla::mjolnir::ingest_transit(config);
 
   // spawn threads to connect dangling stop pairs to adjacent tiles' stops
-  valhalla::mjolnir::stitch_transit(pt, dangling_tiles);
+  valhalla::mjolnir::stitch_transit(config, dangling_tiles);
 
   return 0;
 }

--- a/src/mjolnir/valhalla_query_transit.cc
+++ b/src/mjolnir/valhalla_query_transit.cc
@@ -16,7 +16,6 @@
 
 #include "baldr/graphreader.h"
 #include "baldr/tilehierarchy.h"
-#include "config.h"
 #include "filesystem.h"
 #include "midgard/logging.h"
 #include "midgard/util.h"
@@ -368,6 +367,7 @@ int main(int argc, char* argv[]) {
   double o_lng, o_lat, d_lng, d_lat;
   std::string o_onestop_id, d_onestop_id, time;
   int tripid;
+  boost::property_tree::ptree config;
 
   try {
     // clang-format off
@@ -391,7 +391,7 @@ int main(int argc, char* argv[]) {
     // clang-format on
 
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, "mjolnir.logging", true))
+    if (!parse_common_args(program, options, result, config, "mjolnir.logging", true))
       return EXIT_SUCCESS;
 
     for (const auto& arg : std::vector<std::string>{"o_onestop_id", "o_lat", "o_lng"}) {
@@ -412,7 +412,7 @@ int main(int argc, char* argv[]) {
   LOG_INFO("Read config");
 
   // Bail if no transit dir
-  auto transit_dir = valhalla::config().get_optional<std::string>("mjolnir.transit_dir");
+  auto transit_dir = config.get_optional<std::string>("mjolnir.transit_dir");
   if (!transit_dir || !filesystem::exists(*transit_dir) || !filesystem::is_directory(*transit_dir)) {
     LOG_INFO("Transit directory not found.");
     return 0;

--- a/src/mjolnir/valhalla_validate_transit.cc
+++ b/src/mjolnir/valhalla_validate_transit.cc
@@ -7,7 +7,6 @@
 
 #include "baldr/graphid.h"
 #include "baldr/rapidjson_utils.h"
-#include "config.h"
 #include "filesystem.h"
 #include "midgard/aabb2.h"
 #include "midgard/logging.h"
@@ -22,6 +21,8 @@ using namespace valhalla::mjolnir;
 
 int main(int argc, char** argv) {
   const auto program = filesystem::path(__FILE__).stem().string();
+  // args
+  boost::property_tree::ptree config;
 
   try {
     // clang-format off
@@ -41,7 +42,7 @@ int main(int argc, char** argv) {
     // clang-format on
 
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, "mjolnir.logging", true))
+    if (!parse_common_args(program, options, result, config, "mjolnir.logging", true))
       return EXIT_SUCCESS;
   } catch (cxxopts::OptionException& e) {
     std::cerr << e.what() << std::endl;
@@ -67,7 +68,7 @@ int main(int argc, char** argv) {
       std::sort(onestoptests.begin(), onestoptests.end());
       // Validate transit
       std::unordered_set<valhalla::baldr::GraphId> all_tiles;
-      if (!ValidateTransit::Validate(valhalla::config(), all_tiles, onestoptests)) {
+      if (!ValidateTransit::Validate(config, all_tiles, onestoptests)) {
         return EXIT_FAILURE;
       }
     } else if (build_validate == "build") {

--- a/src/mjolnir/valhalla_ways_to_edges.cc
+++ b/src/mjolnir/valhalla_ways_to_edges.cc
@@ -15,7 +15,6 @@
 #include "baldr/graphtile.h"
 #include "baldr/rapidjson_utils.h"
 #include "baldr/tilehierarchy.h"
-#include "config.h"
 #include "filesystem.h"
 #include "midgard/logging.h"
 
@@ -37,6 +36,8 @@ struct EdgeAndDirection {
 // to ways that are drivable.
 int main(int argc, char** argv) {
   const auto program = filesystem::path(__FILE__).stem().string();
+  // args
+  boost::property_tree::ptree config;
 
   try {
     // clang-format off
@@ -53,7 +54,7 @@ int main(int argc, char** argv) {
     // clang-format on
 
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, "mjolnir.logging"))
+    if (!parse_common_args(program, options, result, config, "mjolnir.logging"))
       return EXIT_SUCCESS;
 
   } catch (cxxopts::OptionException& e) {
@@ -68,7 +69,7 @@ int main(int argc, char** argv) {
   // Create an unordered map of OSM ways Ids and their associated graph edges
   std::unordered_map<uint64_t, std::vector<EdgeAndDirection>> ways_edges;
 
-  GraphReader reader(valhalla::config().get_child("mjolnir"));
+  GraphReader reader(config.get_child("mjolnir"));
   // Iterate through all tiles
   for (auto edge_id : reader.GetTileSet()) {
     // If tile exists add it to the queue
@@ -100,7 +101,7 @@ int main(int argc, char** argv) {
   }
 
   std::ofstream ways_file;
-  std::string fname = valhalla::config().get<std::string>("mjolnir.tile_dir") +
+  std::string fname = config.get<std::string>("mjolnir.tile_dir") +
                       filesystem::path::preferred_separator + "way_edges.txt";
   ways_file.open(fname, std::ofstream::out | std::ofstream::trunc);
   for (const auto& way : ways_edges) {

--- a/src/valhalla_benchmark_adjacency_list.cc
+++ b/src/valhalla_benchmark_adjacency_list.cc
@@ -6,7 +6,6 @@
 #include <string>
 #include <vector>
 
-#include "config.h"
 #include "midgard/logging.h"
 #include "midgard/util.h"
 #include "sif/edgelabel.h"
@@ -106,6 +105,8 @@ int Benchmark(const uint32_t n, const float maxcost, const float bucketsize) {
 
 int main(int argc, char* argv[]) {
   const auto program = filesystem::path(__FILE__).stem().string();
+  // args
+  boost::property_tree::ptree config;
 
   try {
     // clang-format off
@@ -120,7 +121,7 @@ int main(int argc, char* argv[]) {
       ("v,version", "Print the version of this software.");
 
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, "mjolnir.logging"))
+    if (!parse_common_args(program, options, result, config, "mjolnir.logging"))
       return EXIT_SUCCESS;
   } catch (cxxopts::OptionException& e) {
     std::cerr << e.what() << std::endl;

--- a/src/valhalla_benchmark_loki.cc
+++ b/src/valhalla_benchmark_loki.cc
@@ -13,7 +13,6 @@
 #include <cxxopts.hpp>
 
 #include "baldr/rapidjson_utils.h"
-#include "config.h"
 #include "filesystem.h"
 #include "loki/search.h"
 #include "midgard/logging.h"
@@ -128,6 +127,7 @@ int main(int argc, char** argv) {
   size_t batch, isolated, radius;
   bool extrema = false;
   std::vector<std::string> input_files;
+  boost::property_tree::ptree config;
 
   try {
     // clang-format off
@@ -155,7 +155,7 @@ int main(int argc, char** argv) {
     options.parse_positional({"input_files"});
     options.positional_help("LOCATIONS.TXT");
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, "loki.logging"))
+    if (!parse_common_args(program, options, result, config, "loki.logging"))
       return EXIT_SUCCESS;
 
     if (!result.count("input_files")) {
@@ -206,10 +206,10 @@ int main(int argc, char** argv) {
 
   // start up the threads
   std::list<std::thread> pool;
-  const auto num_threads = valhalla::config().get<uint32_t>("mjolnir.concurrency");
+  const auto num_threads = config.get<uint32_t>("mjolnir.concurrency");
   std::vector<std::promise<results_t>> pool_results(num_threads);
   for (size_t i = 0; i < num_threads; ++i) {
-    pool.emplace_back(work, std::cref(valhalla::config()), std::ref(pool_results[i]));
+    pool.emplace_back(work, std::cref(config), std::ref(pool_results[i]));
   }
 
   // let the threads finish up

--- a/src/valhalla_expand_bounding_box.cc
+++ b/src/valhalla_expand_bounding_box.cc
@@ -16,6 +16,7 @@ int main(int argc, char** argv) {
   const auto program = filesystem::path(__FILE__).stem().string();
   // args
   std::string bbox;
+  boost::property_tree::ptree config;
 
   try {
     // clang-format off
@@ -34,7 +35,7 @@ int main(int argc, char** argv) {
     // clang-format on
 
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, "mjolnir.logging"))
+    if (!parse_common_args(program, options, result, config, "mjolnir.logging"))
       return EXIT_SUCCESS;
 
     if (!result.count("bounding-box")) {
@@ -67,7 +68,7 @@ int main(int argc, char** argv) {
 
   valhalla::midgard::AABB2<valhalla::midgard::PointLL> bb{{result[0], result[1]},
                                                           {result[2], result[3]}};
-  valhalla::baldr::GraphReader reader(valhalla::config().get_child("mjolnir"));
+  valhalla::baldr::GraphReader reader(config.get_child("mjolnir"));
   bb = reader.GetMinimumBoundingBox(bb);
 
   std::cout << std::fixed << std::setprecision(6) << bb.minx() << "," << bb.miny() << "," << bb.maxx()

--- a/src/valhalla_export_edges.cc
+++ b/src/valhalla_export_edges.cc
@@ -8,7 +8,6 @@
 #include "midgard/encoded.h"
 #include "midgard/logging.h"
 
-#include "config.h"
 #include <algorithm>
 #include <cxxopts.hpp>
 #include <iostream>
@@ -145,6 +144,7 @@ int main(int argc, char* argv[]) {
   const auto program = filesystem::path(__FILE__).stem().string();
   // args
   std::string bbox;
+  boost::property_tree::ptree config;
 
   try {
     // clang-format off
@@ -158,17 +158,16 @@ int main(int argc, char* argv[]) {
     options.add_options()
       ("h,help", "Print this help message.")
       ("v,version", "Print the version of this software.")
-      ("c,column", "What separator to use between columns [default=\\0].", cxxopts::value<std::string>(column_separator)->default_value("\0"s))
+      ("c,config", "Path to the json configuration file.", cxxopts::value<std::string>())
+      ("i,inline-config", "Inline json config.", cxxopts::value<std::string>())
+      ("x,column", "What separator to use between columns [default=\\0].", cxxopts::value<std::string>(column_separator)->default_value("\0"s))
       ("r,row", "What separator to use between row [default=\\n].", cxxopts::value<std::string>(row_separator)->default_value("\n"))
       ("f,ferries", "Export ferries as well [default=false]", cxxopts::value<bool>(ferries)->default_value("false"))
-      ("u,unnamed", "Export unnamed edges as well [default=false]", cxxopts::value<bool>(unnamed)->default_value("false"))
-      ("config", "positional argument", cxxopts::value<std::string>());
+      ("u,unnamed", "Export unnamed edges as well [default=false]", cxxopts::value<bool>(unnamed)->default_value("false"));
     // clang-format on
 
-    options.parse_positional({"config"});
-    options.positional_help("Config file path");
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, "mjolnir.logging"))
+    if (!parse_common_args(program, options, result, config, "mjolnir.logging"))
       return EXIT_SUCCESS;
   } catch (cxxopts::OptionException& e) {
     std::cerr << e.what() << std::endl;
@@ -180,7 +179,7 @@ int main(int argc, char* argv[]) {
   }
 
   // get something we can use to fetch tiles
-  valhalla::baldr::GraphReader reader(valhalla::config().get_child("mjolnir"));
+  valhalla::baldr::GraphReader reader(config.get_child("mjolnir"));
 
   // keep the global number of edges encountered at the point we encounter each tile
   // this allows an edge to have a sequential global id and makes storing it very small

--- a/src/valhalla_run_isochrone.cc
+++ b/src/valhalla_run_isochrone.cc
@@ -11,7 +11,6 @@
 #include "argparse_utils.h"
 #include "baldr/graphreader.h"
 #include "baldr/pathlocation.h"
-#include "config.h"
 #include "loki/search.h"
 #include "midgard/logging.h"
 #include "proto/options.pb.h"
@@ -34,6 +33,7 @@ int main(int argc, char* argv[]) {
   // args
   std::string json_str;
   std::string filename = "";
+  boost::property_tree::ptree config;
 
   try {
     // clang-format off
@@ -55,7 +55,7 @@ int main(int argc, char* argv[]) {
     // clang-format on
 
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, "mjolnir.logging"))
+    if (!parse_common_args(program, options, result, config, "mjolnir.logging"))
       return EXIT_SUCCESS;
 
     if (!result.count("json")) {
@@ -129,7 +129,7 @@ int main(int argc, char* argv[]) {
   }
 
   // Get something we can use to fetch tiles
-  valhalla::baldr::GraphReader reader(config().get_child("mjolnir"));
+  valhalla::baldr::GraphReader reader(config.get_child("mjolnir"));
 
   // Construct costing
   CostFactory factory;

--- a/src/valhalla_run_matrix.cc
+++ b/src/valhalla_run_matrix.cc
@@ -13,7 +13,6 @@
 #include "argparse_utils.h"
 #include "baldr/graphreader.h"
 #include "baldr/pathlocation.h"
-#include "config.h"
 #include "loki/worker.h"
 #include "midgard/logging.h"
 #include "odin/directionsbuilder.h"
@@ -93,6 +92,7 @@ int main(int argc, char* argv[]) {
   uint32_t iterations;
   bool log_details;
   bool optimize;
+  boost::property_tree::ptree config;
 
   try {
     // clang-format off
@@ -121,7 +121,7 @@ int main(int argc, char* argv[]) {
     // clang-format on
 
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, "mjolnir.logging"))
+    if (!parse_common_args(program, options, result, config, "mjolnir.logging"))
       return EXIT_SUCCESS;
 
     if (!result.count("json")) {
@@ -146,7 +146,7 @@ int main(int argc, char* argv[]) {
   auto& options = *request.mutable_options();
 
   // Get something we can use to fetch tiles
-  valhalla::baldr::GraphReader reader(config().get_child("mjolnir"));
+  valhalla::baldr::GraphReader reader(config.get_child("mjolnir"));
 
   // Construct costing
   CostFactory factory;
@@ -161,7 +161,7 @@ int main(int argc, char* argv[]) {
 
   // Find path locations (loki) for sources and targets
   auto t0 = std::chrono::high_resolution_clock::now();
-  loki_worker_t lw(config());
+  loki_worker_t lw(config);
   lw.matrix(request);
   auto t1 = std::chrono::high_resolution_clock::now();
   uint32_t ms = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
@@ -169,7 +169,7 @@ int main(int argc, char* argv[]) {
 
   // Get the max matrix distances for construction of the CostMatrix and TimeDistanceMatrix classes
   std::unordered_map<std::string, float> max_matrix_distance;
-  for (const auto& kv : config().get_child("service_limits")) {
+  for (const auto& kv : config.get_child("service_limits")) {
     // Skip over any service limits that are not for a costing method
     if (kv.first == "max_exclude_locations" || kv.first == "max_reachability" ||
         kv.first == "max_radius" || kv.first == "max_timedep_distance" || kv.first == "skadi" ||
@@ -179,8 +179,8 @@ int main(int argc, char* argv[]) {
         kv.first == "max_distance_disable_hierarchy_culling") {
       continue;
     }
-    max_matrix_distance.emplace(kv.first, config().get<float>("service_limits." + kv.first +
-                                                              ".max_matrix_distance"));
+    max_matrix_distance.emplace(kv.first, config.get<float>("service_limits." + kv.first +
+                                                            ".max_matrix_distance"));
   }
 
   if (max_matrix_distance.empty()) {

--- a/src/valhalla_run_route.cc
+++ b/src/valhalla_run_route.cc
@@ -40,7 +40,6 @@
 #include "proto/trip.pb.h"
 
 #include "argparse_utils.h"
-#include "config.h"
 
 using namespace valhalla::midgard;
 using namespace valhalla::baldr;
@@ -467,6 +466,7 @@ int main(int argc, char* argv[]) {
   const auto program = filesystem::path(__FILE__).stem().string();
   // args
   std::string json_str, json_file;
+  boost::property_tree::ptree config;
 
   bool match_test, verbose_lanes;
   bool multi_run = false;
@@ -500,7 +500,7 @@ int main(int argc, char* argv[]) {
     // clang-format on
 
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, "mjolnir.logging"))
+    if (!parse_common_args(program, options, result, config, "mjolnir.logging"))
       return EXIT_SUCCESS;
 
     if (iterations > 1) {
@@ -541,9 +541,6 @@ int main(int argc, char* argv[]) {
     throw;
   }
 
-  // Get the config
-  boost::property_tree::ptree pt = valhalla::config();
-
   // Something to hold the statistics
   uint32_t n = locations.size() - 1;
   PathStatistics data({locations[0].latlng_.lat(), locations[0].latlng_.lng()},
@@ -554,11 +551,11 @@ int main(int argc, char* argv[]) {
     d1 += locations[i].latlng_.Distance(locations[i + 1].latlng_) * kKmPerMeter;
   }
   // Get something we can use to fetch tiles
-  valhalla::baldr::GraphReader reader(pt.get_child("mjolnir"));
+  valhalla::baldr::GraphReader reader(config.get_child("mjolnir"));
 
   // Get the maximum distance for time dependent routes
   float max_timedep_distance =
-      pt.get<float>("service_limits.max_timedep_distance", kDefaultMaxTimeDependentDistance);
+      config.get<float>("service_limits.max_timedep_distance", kDefaultMaxTimeDependentDistance);
 
   auto t0 = std::chrono::high_resolution_clock::now();
 
@@ -570,7 +567,7 @@ int main(int argc, char* argv[]) {
 
   // Find path locations (loki) for sources and targets
   auto tw0 = std::chrono::high_resolution_clock::now();
-  loki_worker_t lw(pt);
+  loki_worker_t lw(config);
   auto tw1 = std::chrono::high_resolution_clock::now();
   auto msw = std::chrono::duration_cast<std::chrono::milliseconds>(tw1 - tw0).count();
   LOG_INFO("Location Worker construction took " + std::to_string(msw) + " ms");
@@ -582,11 +579,11 @@ int main(int argc, char* argv[]) {
   LOG_INFO("Location Processing took " + std::to_string(ms) + " ms");
 
   // Get the route
-  BidirectionalAStar bd(pt.get_child("thor"));
-  MultiModalPathAlgorithm mm(pt.get_child("thor"));
-  TimeDepForward timedep_forward(pt.get_child("thor"));
-  TimeDepReverse timedep_reverse(pt.get_child("thor"));
-  MarkupFormatter markup_formatter(pt);
+  BidirectionalAStar bd(config.get_child("thor"));
+  MultiModalPathAlgorithm mm(config.get_child("thor"));
+  TimeDepForward timedep_forward(config.get_child("thor"));
+  TimeDepReverse timedep_reverse(config.get_child("thor"));
+  MarkupFormatter markup_formatter(config);
   for (uint32_t i = 0; i < n; i++) {
     // Set origin and destination for this segment
     valhalla::Location origin = options.locations(i);


### PR DESCRIPTION
We messed up on https://github.com/valhalla/valhalla/pull/4220, which removed the ability to change anything in the config for the `argparse_utils.h`. This fixes it.