### PR TITLE
fix wrong time zones in time distance matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,16 +20,11 @@ commands:
   linux_lint_deps:
     steps:
       - run: |
-            apt-get update --assume-yes
-            env DEBIAN_FRONTEND=noninteractive apt install --yes --quiet sudo python3-pip python3-requests git curl file
+          apt-get update --assume-yes
+          env DEBIAN_FRONTEND=noninteractive apt install --yes --quiet sudo python3-pip python3-requests git curl file
   check_ci_lint:
     steps:
-      - run: |
-            if [[ $(./scripts/needs_ci_run) == "skip CI" ]]; then
-                echo "Changes in last commit do not need CI. Skipping step"
-                circleci-agent step halt
-            fi
-            ./scripts/format.sh && ./scripts/error_on_dirty.sh
+      - run: ./scripts/format.sh && ./scripts/error_on_dirty.sh
 
 jobs:
   lint-build-debug:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
    * FIXED: base transition costs were getting overridden by osrm car turn duration [#4463](https://github.com/valhalla/valhalla/pull/4463)
    * FIXED: insane ETAs for `motor_scooter` on `track`s [#4468](https://github.com/valhalla/valhalla/pull/4468)
    * FIXED: -j wasn't taken into account anymore [#4483](https://github.com/valhalla/valhalla/pull/4483)
+   * FIXED: time distance matrix was always using time zone of last settled edge id []()
 * **Enhancement**
    * UPDATED: French translations, thanks to @xlqian [#4159](https://github.com/valhalla/valhalla/pull/4159)
    * CHANGED: -j flag for multithreaded executables to override mjolnir.concurrency [#4168](https://github.com/valhalla/valhalla/pull/4168)

--- a/src/thor/timedistancematrix.cc
+++ b/src/thor/timedistancematrix.cc
@@ -230,6 +230,9 @@ void TimeDistanceMatrix::ComputeMatrix(Api& request,
     SetOrigin<expansion_direction>(graphreader, origin, time_info);
     SetDestinationEdges();
 
+    // Collect edge_ids used for settling a location
+    std::unordered_map<u_int32_t, baldr::GraphId> dest_edge_ids;
+
     // Find shortest path
     graph_tile_ptr tile;
     while (true) {
@@ -239,7 +242,7 @@ void TimeDistanceMatrix::ComputeMatrix(Api& request,
       if (predindex == kInvalidLabel) {
         // Can not expand any further...
         FormTimeDistanceMatrix(request, graphreader, FORWARD, origin_index, origin.date_time(),
-                               time_info.timezone_index, GraphId{}, out_date_times);
+                               time_info.timezone_index, dest_edge_ids, out_date_times);
         break;
       }
 
@@ -261,10 +264,14 @@ void TimeDistanceMatrix::ComputeMatrix(Api& request,
         // have been settled or the requested amount of destinations has been found
         tile = graphreader.GetGraphTile(pred.edgeid());
         const DirectedEdge* edge = tile->directededge(pred.edgeid());
+
+        for (auto& dest_id : destedge->second) {
+          dest_edge_ids[dest_id] = pred.edgeid();
+        }
         if (UpdateDestinations(origin, destinations, destedge->second, edge, tile, pred, time_info,
                                matrix_locations)) {
           FormTimeDistanceMatrix(request, graphreader, FORWARD, origin_index, origin.date_time(),
-                                 time_info.timezone_index, pred.edgeid(), out_date_times);
+                                 time_info.timezone_index, dest_edge_ids, out_date_times);
           break;
         }
       }
@@ -272,7 +279,7 @@ void TimeDistanceMatrix::ComputeMatrix(Api& request,
       // Terminate when we are beyond the cost threshold
       if (pred.cost().cost > current_cost_threshold_) {
         FormTimeDistanceMatrix(request, graphreader, FORWARD, origin_index, origin.date_time(),
-                               time_info.timezone_index, pred.edgeid(), out_date_times);
+                               time_info.timezone_index, dest_edge_ids, out_date_times);
         break;
       }
 
@@ -564,7 +571,7 @@ void TimeDistanceMatrix::FormTimeDistanceMatrix(Api& request,
                                                 const uint32_t origin_index,
                                                 const std::string& origin_dt,
                                                 const uint64_t& origin_tz,
-                                                const GraphId& pred_id,
+                                                std::unordered_map<uint32_t, GraphId>& edge_ids,
                                                 std::vector<std::string>& out_date_times) {
   // when it's forward, origin_index will be the source_index
   // when it's reverse, origin_index will be the target_index
@@ -583,7 +590,7 @@ void TimeDistanceMatrix::FormTimeDistanceMatrix(Api& request,
     // this logic doesn't work with string repeated fields, gotta collect them
     // and process them later
     auto date_time =
-        DateTime::offset_date(origin_dt, origin_tz, reader.GetTimezoneFromEdge(pred_id, tile),
+        DateTime::offset_date(origin_dt, origin_tz, reader.GetTimezoneFromEdge(edge_ids[i], tile),
                               static_cast<uint64_t>(time));
     out_date_times[pbf_idx] = date_time;
   }

--- a/src/thor/timedistancematrix.cc
+++ b/src/thor/timedistancematrix.cc
@@ -230,7 +230,7 @@ void TimeDistanceMatrix::ComputeMatrix(Api& request,
     SetOrigin<expansion_direction>(graphreader, origin, time_info);
     SetDestinationEdges();
 
-    // Collect edge_ids used for settling a location
+    // Collect edge_ids used for settling a location to determine its time zone
     std::unordered_map<uint32_t, baldr::GraphId> dest_edge_ids;
 
     // Find shortest path

--- a/src/thor/timedistancematrix.cc
+++ b/src/thor/timedistancematrix.cc
@@ -233,7 +233,7 @@ void TimeDistanceMatrix::ComputeMatrix(Api& request,
     // Collect edge_ids used for settling a location to determine its time zone
     std::unordered_map<uint32_t, baldr::GraphId> dest_edge_ids;
     dest_edge_ids.reserve(destinations.size());
-    
+
     // Find shortest path
     graph_tile_ptr tile;
     while (true) {

--- a/src/thor/timedistancematrix.cc
+++ b/src/thor/timedistancematrix.cc
@@ -232,7 +232,8 @@ void TimeDistanceMatrix::ComputeMatrix(Api& request,
 
     // Collect edge_ids used for settling a location to determine its time zone
     std::unordered_map<uint32_t, baldr::GraphId> dest_edge_ids;
-
+    dest_edge_ids.reserve(destinations.size());
+    
     // Find shortest path
     graph_tile_ptr tile;
     while (true) {

--- a/src/thor/timedistancematrix.cc
+++ b/src/thor/timedistancematrix.cc
@@ -231,7 +231,7 @@ void TimeDistanceMatrix::ComputeMatrix(Api& request,
     SetDestinationEdges();
 
     // Collect edge_ids used for settling a location
-    std::unordered_map<u_int32_t, baldr::GraphId> dest_edge_ids;
+    std::unordered_map<uint32_t, baldr::GraphId> dest_edge_ids;
 
     // Find shortest path
     graph_tile_ptr tile;

--- a/valhalla/thor/timedistancematrix.h
+++ b/valhalla/thor/timedistancematrix.h
@@ -275,7 +275,7 @@ protected:
                               const uint32_t origin_index,
                               const std::string& origin_dt,
                               const uint64_t& origin_tz,
-                              const baldr::GraphId& pred_id,
+                              std::unordered_map<u_int32_t, valhalla::baldr::GraphId>& edge_ids,
                               std::vector<std::string>& out_date_times);
 };
 

--- a/valhalla/thor/timedistancematrix.h
+++ b/valhalla/thor/timedistancematrix.h
@@ -275,7 +275,7 @@ protected:
                               const uint32_t origin_index,
                               const std::string& origin_dt,
                               const uint64_t& origin_tz,
-                              std::unordered_map<u_int32_t, valhalla::baldr::GraphId>& edge_ids,
+                              std::unordered_map<u_int32_t, baldr::GraphId>& edge_ids,
                               std::vector<std::string>& out_date_times);
 };
 

--- a/valhalla/thor/timedistancematrix.h
+++ b/valhalla/thor/timedistancematrix.h
@@ -275,7 +275,7 @@ protected:
                               const uint32_t origin_index,
                               const std::string& origin_dt,
                               const uint64_t& origin_tz,
-                              std::unordered_map<u_int32_t, baldr::GraphId>& edge_ids,
+                              std::unordered_map<uint32_t, baldr::GraphId>& edge_ids,
                               std::vector<std::string>& out_date_times);
 };
 


### PR DESCRIPTION
# Issue

In time distance matrix, the time zone of the edge id used to settle the last location was used for getting the date time for all locations (there's no issue for this, found out while writing tests for #4491).

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
