### PR TITLE
log to stderr in valhalla_export_edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
    * FIXED: base transition costs were getting overridden by osrm car turn duration [#4463](https://github.com/valhalla/valhalla/pull/4463)
    * FIXED: insane ETAs for `motor_scooter` on `track`s [#4468](https://github.com/valhalla/valhalla/pull/4468)
    * FIXED: -j wasn't taken into account anymore [#4483](https://github.com/valhalla/valhalla/pull/4483)
+   * FIXED: log to stderr in valhalla_export_edges [#4498](https://github.com/valhalla/valhalla/pull/4498)
 * **Enhancement**
    * UPDATED: French translations, thanks to @xlqian [#4159](https://github.com/valhalla/valhalla/pull/4159)
    * CHANGED: -j flag for multithreaded executables to override mjolnir.concurrency [#4168](https://github.com/valhalla/valhalla/pull/4168)

--- a/src/argparse_utils.h
+++ b/src/argparse_utils.h
@@ -51,7 +51,7 @@ bool parse_common_args(const std::string& program,
 
   // configure logging
   auto logging_subtree = conf.get_child_optional(log);
-  if (logging_subtree) {
+  if (!log.empty() && logging_subtree) {
     auto logging_config =
         valhalla::midgard::ToMap<const boost::property_tree::ptree&,
                                  std::unordered_map<std::string, std::string>>(logging_subtree.get());

--- a/src/argparse_utils.h
+++ b/src/argparse_utils.h
@@ -17,7 +17,7 @@
  * @param opts    The command line options
  * @param result  The parsed result
  * @param config  The config which will be populated here
- * @param log     The logging config node's key
+ * @param log     The logging config node's key. If empty, logging will not be configured.
  * @param use_threads Whether this program multi-threads
  *
  * @returns true if the program should continue, false if we should EXIT_SUCCESS

--- a/src/valhalla_export_edges.cc
+++ b/src/valhalla_export_edges.cc
@@ -167,7 +167,7 @@ int main(int argc, char* argv[]) {
     // clang-format on
 
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, config, "mjolnir.logging"))
+    if (!parse_common_args(program, options, result, config, ""))
       return EXIT_SUCCESS;
   } catch (cxxopts::OptionException& e) {
     std::cerr << e.what() << std::endl;
@@ -180,6 +180,9 @@ int main(int argc, char* argv[]) {
 
   // get something we can use to fetch tiles
   valhalla::baldr::GraphReader reader(config.get_child("mjolnir"));
+
+  // configure logging here, we want it to go to stderr
+  valhalla::midgard::logging::Configure({{"type", "std_err"}, {"color", "true"}});
 
   // keep the global number of edges encountered at the point we encounter each tile
   // this allows an edge to have a sequential global id and makes storing it very small


### PR DESCRIPTION
fixes #4496 

should've been the only script needing this. `valhalla_service` also does smth like this conditionally, but it's not using the arg parser.