### PR TITLE
auto tz updates in GHA

### DIFF
--- a/.github/workflows/check_tz_releases.yml
+++ b/.github/workflows/check_tz_releases.yml
@@ -25,7 +25,46 @@ jobs:
 
           if [[ $latest_tag_commit != $current_commit ]]; then 
               echo "New tz release available: ${latest_tag}"
+              new_branch="gha-bump-tz-${latest_tag}"
+              git checkout -b $new_branch
+
+              # update the submodule 
+              git -C third_party/tz checkout "${latest_tag}"
+              git add third_party/tz
+
+              # update the url in valhalla_build_timezones 
+              url_old=$(grep -oP "url=\"\Khttps://github.com/.*(?=\")" scripts/valhalla_build_timezones)
+              url_new=$(echo ${url_old} | sed -E "s/download\/[0-9]{4}[a-z]/download\/${latest_tag}/")
+
+              # first make sure the file is actually available
+
+              set +e
+              curl -Is --fail-with-body ${url_new} >/dev/null
+
+              if [[ $? -eq 0 ]]; then 
+                  # only replace if it's available
+                  url_old_escaped=$(echo "${url_old}" | sed 's/[\&/]/\\&/g')
+                  url_new_escaped=$(echo "${url_new}" | sed 's/[\&/]/\\&/g')
+                  sed -i -e "s/${url_old_escaped}/${url_new_escaped}/" scripts/valhalla_build_timezones
+                  git add scripts/valhalla_build_timezones
+
+                  echo "Updated timezone shapefile download URL:"
+                  git diff scripts/valhalla_build_timezones
+              fi
+
+              set -e
+              # commit and push 
+              git commit -m "bumped tz to ${latest_tag}"
+              git push origin 
+
+              # open new PR 
+              gh pr create --base master --head $new_branch --title "Bump tz to ${latest_tag}" --body "Created by workflow run [#${WORKFLOW_RUN_ID}](https://github.com/valhalla/valhalla/actions/runs/$WORKFLOW_RUN_ID/job/${WORKFLOW_JOB_ID})"
+
               exit 1
           fi
 
           echo "tz up to date"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_RUN_ID: ${{ github.run_id }}
+          WORKFLOW_JOB_ID: ${{ github.job }}

--- a/.github/workflows/check_tz_releases.yml
+++ b/.github/workflows/check_tz_releases.yml
@@ -3,6 +3,7 @@ name: Check if tz git submodule is up to date
 on:
   schedule:
     - cron: "0 0 * * 0"
+  workflow_dispatch:
 
 jobs:
   check_tz:
@@ -58,7 +59,10 @@ jobs:
               git push origin 
 
               # open new PR 
-              gh pr create --base master --head $new_branch --title "Bump tz to ${latest_tag}" --body "Created by workflow run [#${WORKFLOW_RUN_ID}](https://github.com/valhalla/valhalla/actions/runs/$WORKFLOW_RUN_ID/job/${WORKFLOW_JOB_ID})"
+              body=$(echo "See [here](https://github.com/eggert/tz/blob/main/NEWS) for the latest changes made to tz.\
+              Created by workflow run [#${WORKFLOW_RUN_ID}](https://github.com/valhalla/valhalla/actions/runs/${WORKFLOW_RUN_ID}/job/${WORKFLOW_JOB_ID})." | xargs)
+
+              gh pr create --base master --head $new_branch --title "Bump tz to ${latest_tag}" --body "${body}"
 
               exit 1
           fi


### PR DESCRIPTION
# Issue
Extends #4510 by checking out the new tz release, possibly updating the URL used in `scripts/valhalla_build_elevation`, committing and ppushing everything and opening a new PR. Not very experienced with using the GitHub CLI inside GHA, but if `GITHUB_TOKEN` has the necessary privileges, we should be able to pull this off.   

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
