### PR TITLE
Fix crash using costmatrix (and potentially timedistancebssmatrix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
    * CHANGED: use pkg-config to find spatialite & geos and remove our cmake modules; upgraded conan's boost to 1.83.0 in the process [#4253](https://github.com/valhalla/valhalla/pull/4253)
    * ADDED: Added aggregation logic to filter stage of tile building [#4512](https://github.com/valhalla/valhalla/pull/4512)
    * UPDATED: tz to 2023d [#4519](https://github.com/valhalla/valhalla/pull/4519)
+   * FIXED: Fix segfault in costmatrix (date_time and time zone always added). [#4530](https://github.com/valhalla/valhalla/pull/4530)
 
 ## Release Date: 2023-05-11 Valhalla 3.4.0
 * **Removed**

--- a/src/thor/costmatrix.cc
+++ b/src/thor/costmatrix.cc
@@ -294,6 +294,15 @@ void CostMatrix::SourceToTarget(Api& request,
 
       auto* pbf_time_zone_name = matrix.mutable_time_zone_names()->Add();
       *pbf_time_zone_name = dt_info.time_zone_name;
+    } else {
+      // Add empty strings to make sure pbf arrays are populated (serializer
+      // requires this)
+      auto* pbf_date_time = matrix.mutable_date_times()->Add();
+      *pbf_date_time = "";
+      auto* pbf_time_zone_offset = matrix.mutable_time_zone_offsets()->Add();
+      *pbf_time_zone_offset = "";
+      auto* pbf_time_zone_name = matrix.mutable_time_zone_names()->Add();
+      *pbf_time_zone_name = "";
     }
     matrix.mutable_from_indices()->Set(count, source_idx);
     matrix.mutable_to_indices()->Set(count, target_idx);

--- a/src/thor/timedistancebssmatrix.cc
+++ b/src/thor/timedistancebssmatrix.cc
@@ -531,6 +531,15 @@ void TimeDistanceBSSMatrix::FormTimeDistanceMatrix(Api& request,
     matrix.mutable_to_indices()->Set(pbf_idx, forward ? i : origin_index);
     matrix.mutable_distances()->Set(pbf_idx, dest.distance);
     matrix.mutable_times()->Set(pbf_idx, time);
+
+    // TODO - support date_time and time zones as in timedistancematrix.
+    // For now, add empty strings (serializer requires this) to prevent crashing
+    auto* pbf_dt = matrix.mutable_date_times()->Add();
+    *pbf_dt = "";
+    auto* pbf_tz_offset = matrix.mutable_time_zone_offsets()->Add();
+    *pbf_tz_offset = "";
+    auto* pbf_tz_names = matrix.mutable_time_zone_names()->Add();
+    *pbf_tz_names = "";
   }
 }
 


### PR DESCRIPTION
Add empty strings for date_time, time_zone_offset, and time_zone_name. The matrix serializer expects these arrays to have same size as the time and distance arrays.

#fixes #4526 (note - to test the default limits for pedestrian matrix need to be increased to handle the request listed in the issue).

Note: I left a TODO comment in timedistancebssmatrix as a reminder to set date_time and timezone info (as is done in timedistancematrix).

# Issue

What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
