### PR TITLE
Add missing `break` to graphconstants.h

### DIFF
--- a/valhalla/baldr/graphconstants.h
+++ b/valhalla/baldr/graphconstants.h
@@ -764,6 +764,7 @@ inline float GetOffsetForHeading(RoadClass road_class, Use use) {
     case Use::kPedestrian:
     case Use::kBridleway: {
       offset *= 0.5f;
+      break;
     }
     default:
       break;


### PR DESCRIPTION
Adding this break allows the code to compile with `-Wimplicit-fallthrough` enabled as `-Werror`.

This has prevented many bugs in our codebase, so it's useful to have upstream code able to compile with the same flags enabled.

# Issue

#4576 

## Tasklist

 - [ X ] Add tests
 - [ X ] Add #fixes with the issue number that this PR addresses
 - [ X ] Update the docs with any new request parameters or changes to behavior described
 - [ X ] Update the [changelog](CHANGELOG.md) - likely unnecessary
 - [ X ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

N/A
