### PR TITLE
Fix roundoff issue in Tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@
    * UPDATED: cxxopts to 3.1.1 [#4541](https://github.com/valhalla/valhalla/pull/4541)
    * CHANGED: make use of vendored libraries optional (other than libraries which are not commonly in package managers or only used for testing) [#4544](https://github.com/valhalla/valhalla/pull/4544)
    * ADDED: Improved instructions for blind users [#3694](https://github.com/valhalla/valhalla/pull/3694)
+   * FIXED: Fixed roundoff issue in Tiles Row and Col methods [#4585](https://github.com/valhalla/valhalla/pull/4585)
 
 ## Release Date: 2023-05-11 Valhalla 3.4.0
 * **Removed**

--- a/test/tiles.cc
+++ b/test/tiles.cc
@@ -569,6 +569,18 @@ TEST(Tiles, test_intersect_bbox_rounding) {
   EXPECT_EQ(bin_id, 0);
 }
 
+TEST(Tiles, float_roundoff_issue) {
+  AABB2<PointLL> world_box{-180, -90, 180, 90};
+  Tiles<PointLL> t(world_box, 0.25, 5);
+
+  PointLL ll(179.999978, -16.805363);
+  auto tile_id = t.TileId(ll);
+  EXPECT_EQ(tile_id, 421919);
+  auto base_ll = t.Base(tile_id);
+  EXPECT_EQ(base_ll.lat(), -17.0);
+  EXPECT_EQ(base_ll.lng(), 179.75);
+}
+
 } // namespace
 
 int main(int argc, char* argv[]) {

--- a/valhalla/midgard/tiles.h
+++ b/valhalla/midgard/tiles.h
@@ -123,7 +123,7 @@ public:
    * @param   y   y coordinate
    * @return  Returns the tile row. Returns -1 if outside the tile system bounds.
    */
-  int32_t Row(const float y) const {
+  int32_t Row(const double y) const {
     // Return -1 if outside the tile system bounds
     if (y < tilebounds_.miny() || y > tilebounds_.maxy()) {
       return -1;
@@ -139,7 +139,7 @@ public:
    * @param   x   x coordinate
    * @return  Returns the tile column. Returns -1 if outside the tile system bounds.
    */
-  int32_t Col(const float x) const {
+  int32_t Col(const double x) const {
     // Return -1 if outside the tile system bounds
     if (x < tilebounds_.minx() || x > tilebounds_.maxx()) {
       return -1;

--- a/valhalla/midgard/tiles.h
+++ b/valhalla/midgard/tiles.h
@@ -123,7 +123,7 @@ public:
    * @param   y   y coordinate
    * @return  Returns the tile row. Returns -1 if outside the tile system bounds.
    */
-  int32_t Row(const double y) const {
+  int32_t Row(const typename coord_t::value_type y) const {
     // Return -1 if outside the tile system bounds
     if (y < tilebounds_.miny() || y > tilebounds_.maxy()) {
       return -1;
@@ -139,7 +139,7 @@ public:
    * @param   x   x coordinate
    * @return  Returns the tile column. Returns -1 if outside the tile system bounds.
    */
-  int32_t Col(const double x) const {
+  int32_t Col(const typename coord_t::value_type x) const {
     // Return -1 if outside the tile system bounds
     if (x < tilebounds_.minx() || x > tilebounds_.maxx()) {
       return -1;


### PR DESCRIPTION
# Issue

#fixes #4584
Using float in the Tiles Row and Col methods can lead to an incorrect tile id being computed (along with incorrect base lat, lng). Using double as the argument to these methods fixes the issue.
For discussion - will this change cause any compatibility issues?
## Tasklist

 - [x] Add tests
 - [x] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
