### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Release Date: 2024-??-?? Valhalla 3.4.1
+## Unreleased
 * **Removed**
    * REMOVED: needs_ci_run script [#4423](https://github.com/valhalla/valhalla/pull/4423)
    * REMOVED: unused vehicle types in AutoCost and segway; renamed kTruck to "truck" instead of "tractor_trailer" [#4430](https://github.com/valhalla/valhalla/pull/4430)


### PR DESCRIPTION
was just about to comment on this, but then figured I'll try my luck right now:) 

removes the "crystal bowl" from the changelog and just puts "Unreleased" which IMO is more to the point.