### PR TITLE
TODOs to create longer shortcuts

### DIFF
--- a/src/mjolnir/shortcutbuilder.cc
+++ b/src/mjolnir/shortcutbuilder.cc
@@ -29,7 +29,7 @@ using namespace valhalla::mjolnir;
 
 namespace {
 
-// total_shortcut_count and avg_edge_per_shortcut
+// total_shortcut_count and total_superseded_edges
 using shortcut_stats = std::pair<uint32_t, uint32_t>;
 
 // Simple structure to hold the 2 pair of directed edges at a node.
@@ -341,12 +341,12 @@ bool IsEnteringEdgeOfContractedNode(GraphReader& reader, const GraphId& nodeid, 
 
 // Add shortcut edges (if they should exist) from the specified node
 shortcut_stats AddShortcutEdges(GraphReader& reader,
-                          const graph_tile_ptr& tile,
-                          GraphTileBuilder& tilebuilder,
-                          const GraphId& start_node,
-                          const uint32_t edge_index,
-                          const uint32_t edge_count,
-                          std::unordered_map<uint32_t, uint32_t>& shortcuts) {
+                                const graph_tile_ptr& tile,
+                                GraphTileBuilder& tilebuilder,
+                                const GraphId& start_node,
+                                const uint32_t edge_index,
+                                const uint32_t edge_count,
+                                std::unordered_map<uint32_t, uint32_t>& shortcuts) {
   // Shortcut edges have to start at a node that is not contracted - return if
   // this node can be contracted.
   EdgePairs edgepairs;
@@ -613,7 +613,7 @@ shortcut_stats FormShortcuts(GraphReader& reader, const TileLevel& level) {
       // Add shortcut edges first.
       std::unordered_map<uint32_t, uint32_t> shortcuts;
       auto stats = AddShortcutEdges(reader, tile, tilebuilder, node_id, old_edge_index,
-                                         old_edge_count, shortcuts);
+                                    old_edge_count, shortcuts);
       shortcut_count += stats.first;
       total_edge_count += stats.second;
 
@@ -746,7 +746,7 @@ void ShortcutBuilder::Build(const boost::property_tree::ptree& pt) {
     // Create shortcuts on this level
     LOG_INFO("Creating shortcuts on level " + std::to_string(tile_level->level));
     [[maybe_unused]] shortcut_stats stats = FormShortcuts(reader, *tile_level);
-    uint32_t avg = stats.first ? avg = stats.second / stats.first : 0;
+    [[maybe_unused]] uint32_t avg = stats.first ? (stats.second / stats.first) : 0;
     LOG_INFO("Finished with " + std::to_string(stats.first) + " shortcuts superseding " +
              std::to_string(stats.second) + " edges, average ~" + std::to_string(avg) +
              " edges per shortcut");

--- a/test/astar.cc
+++ b/test/astar.cc
@@ -1570,9 +1570,8 @@ TEST(BiDiAstar, test_recost_path) {
            3  4        5
   )";
   const gurka::ways ways = {
-      // make ABC to be a shortcut
+      // make ABCDE to be a shortcut
       {"ABC", {{"highway", "primary"}, {"maxspeed", "80"}}},
-      // make CDE to be a shortcut
       {"CDE", {{"highway", "primary"}, {"maxspeed", "80"}}},
       {"1A", {{"highway", "secondary"}}},
       {"B3", {{"highway", "secondary"}}},
@@ -1586,7 +1585,7 @@ TEST(BiDiAstar, test_recost_path) {
       {"E2", {{"highway", "secondary"}}},
   };
 
-  auto nodes = gurka::detail::map_to_coordinates(ascii_map, 500);
+  auto nodes = gurka::detail::map_to_coordinates(ascii_map, 5);
 
   const std::string test_dir = "test/data/astar_shortcuts_recosting";
   const auto map = gurka::buildtiles(nodes, ways, {}, {}, test_dir);
@@ -1594,11 +1593,8 @@ TEST(BiDiAstar, test_recost_path) {
   vb::GraphReader graphreader(map.config.get_child("mjolnir"));
 
   // before continue check that ABC is actually a shortcut
-  const auto ABC = gurka::findEdgeByNodes(graphreader, nodes, "A", "C");
-  ASSERT_TRUE(std::get<1>(ABC)->is_shortcut()) << "Expected ABC to be a shortcut";
-  // before continue check that CDE is actually a shortcut
-  const auto CDE = gurka::findEdgeByNodes(graphreader, nodes, "C", "E");
-  ASSERT_TRUE(std::get<1>(CDE)->is_shortcut()) << "Expected CDE to be a shortcut";
+  const auto ABCDE = gurka::findEdgeByNodes(graphreader, nodes, "A", "E");
+  ASSERT_TRUE(std::get<1>(ABCDE)->is_shortcut()) << "Expected ABCDE to be a shortcut";
 
   auto const set_constrained_speed = [&graphreader, &test_dir](const std::vector<GraphId>& edge_ids) {
     for (const auto& edgeid : edge_ids) {
@@ -1618,8 +1614,7 @@ TEST(BiDiAstar, test_recost_path) {
   };
   // set constrained speed for all superseded edges;
   // this speed will be used for them in costing model
-  set_constrained_speed(graphreader.RecoverShortcut(std::get<0>(ABC)));
-  set_constrained_speed(graphreader.RecoverShortcut(std::get<0>(CDE)));
+  set_constrained_speed(graphreader.RecoverShortcut(std::get<0>(ABCDE)));
   // reset cache to see updated speeds
   graphreader.Clear();
 


### PR DESCRIPTION
EDIT: I'll leave this open as draft, it contains all potential todos I could think of. I'll open another PR with the changes to remove names and speed.

relates to #4599 but goes much wider in scope.

for now, I just left a few TODOs in places which I think could be re-investigated. I might miss a few important concepts downstream of creating shortcuts, e.g. I find the `shortcuts` mask and `superseded` still a bit hard to make full sense of.

I'd like to discuss those TODOs before I jump in to work on it. but I think (and hope) we can create quite a few less and quite a bit longer shortcuts in the future.

I should expand on my thoughts a bit though:

it seems we only contract a node when it has **2 outbound edges** on the same hierarchy, but also we even only allow those 2 edges to have the same FRC (for costing purposes). that's the key to most TODOs. 

consider these 2 shortcuts we produce today:
```
A--------------B-------------C
```
where AB and BC differ in access modes and/or access restrictions and/or tolls and/or most other attributes. 

note that for an algorithm it doesn't matter what B is connected to otherwise. if it's connected to another edge of the same hierarchy, B wouldn't ever be contracted. so an algorithm would need to traverse BOTH AB and BC in any case, it has no way of turning anywhere from B. hence it doesn't matter if break up the shortcut and we might as well not and assign the most restrictive attributes to the full thing ABC and contract B away.

does that make any sense?