### PR TITLE
Fix out-of-range linestrings in expansion results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -253,6 +253,7 @@
    * FIXED: Building Valhalla as a submodule [#3781](https://github.com/valhalla/valhalla/issues/3781)
    * FIXED: Fixed invalid time detection in GetSpeed [#3800](https://github.com/valhalla/valhalla/pull/3800)
    * FIXED: Osmway struct update: added up to 33 and not 32 [#3808](https://github.com/valhalla/valhalla/pull/3808)
+   * FIXED: Fix out-of-range linestrings in expansion [#4603](https://github.com/valhalla/valhalla/pull/4603)
 
 * **Enhancement**
    * CHANGED: Pronunciation for names and destinations [#3132](https://github.com/valhalla/valhalla/pull/3132)

--- a/src/thor/isochrone.cc
+++ b/src/thor/isochrone.cc
@@ -323,7 +323,7 @@ ExpansionRecommendation Isochrone::ShouldExpand(baldr::GraphReader& /*graphreade
   // updating or pushing the label back
   // prune the edge if its start is above max contour
 
-  ExpansionRecommendation recommendation = time > max_seconds_ && dist > max_meters_
+  ExpansionRecommendation recommendation = (time > max_seconds_ && dist > max_meters_)
                                                ? ExpansionRecommendation::prune_expansion
                                                : ExpansionRecommendation::continue_expansion;
 

--- a/src/thor/isochrone.cc
+++ b/src/thor/isochrone.cc
@@ -322,8 +322,10 @@ ExpansionRecommendation Isochrone::ShouldExpand(baldr::GraphReader& /*graphreade
   // max but need to consider others so we just continue here. Tells MMExpand function to skip
   // updating or pushing the label back
   // prune the edge if its start is above max contour
-  if (time > max_seconds_ && dist > max_meters_)
-    return ExpansionRecommendation::prune_expansion;
+
+  ExpansionRecommendation recommendation = time > max_seconds_ && dist > max_meters_
+                                               ? ExpansionRecommendation::prune_expansion
+                                               : ExpansionRecommendation::continue_expansion;
 
   // track expansion
   if (inner_expansion_callback_ && (time <= (max_seconds_ - METRIC_PADDING * kSecondsPerMinute) ||
@@ -334,8 +336,7 @@ ExpansionRecommendation Isochrone::ShouldExpand(baldr::GraphReader& /*graphreade
   } else if (expansion_callback_) {
     expansion_callback_ = nullptr;
   }
-
-  return ExpansionRecommendation::continue_expansion;
+  return recommendation;
 };
 
 void Isochrone::GetExpansionHints(uint32_t& bucket_count, uint32_t& edge_label_reservation) const {


### PR DESCRIPTION
# Issue

Fixes #3869. The early return caused the callback not be set to null, so it was called even though the current edge was outside of the expansion tracking thresholds.

Hard to produce a test case with gurka, the ascii map would need to be quite big to account for the metric padding :smile: If deemed necessary, I can add a test on the Utrecht tiles and make sure all the returned edges are connected to their pred edge. 
 
## Tasklist

 - [ ] Add tests
 - [x] Add #fixes with the issue number that this PR addresses
 - [x] Update the [changelog](CHANGELOG.md)

