### PR TITLE
Clear state after time domain push

### DIFF
--- a/src/mjolnir/timeparsing.cc
+++ b/src/mjolnir/timeparsing.cc
@@ -320,6 +320,7 @@ std::vector<uint64_t> get_time_range(const std::string& str) {
             timedomain.set_end_mins(min);
 
             time_domains.push_back(timedomain.td_value());
+            timedomain = TimeDomain();
           }
         }
         return time_domains;
@@ -591,6 +592,7 @@ std::vector<uint64_t> get_time_range(const std::string& str) {
             timedomain.set_end_mins(min);
 
             time_domains.push_back(timedomain.td_value());
+            timedomain = TimeDomain();
           }
         }
       }
@@ -599,6 +601,7 @@ std::vector<uint64_t> get_time_range(const std::string& str) {
     // no time.
     if (time_domains.size() == 0 && timedomain.td_value()) {
       time_domains.push_back(timedomain.td_value());
+      timedomain = TimeDomain();
     }
   } catch (const std::invalid_argument& arg) {
     LOG_INFO("invalid_argument thrown for condition " + str);


### PR DESCRIPTION
# Issue

For string with two or more time intervals e.g. `Mo-Sa 09:00-21:00; Su 10:00-20:00` current version returns second interval for all days of week.

After push we need to reset timedomain.

What do you think?

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
