### PR TITLE
add libgdal to final docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
    * FIXED: Osmnode size reduction: Fixed excessive disk space for planet build [#4605](https://github.com/valhalla/valhalla/pull/4605)
    * FIXED: CostMatrix for trivial routes with oneways [#4626](https://github.com/valhalla/valhalla/pull/4626)
    * FIXED: some entry points to creating geotiff isochrones output did not register the geotiff driver before attempting to use it [#4628](https://github.com/valhalla/valhalla/pull/4628)
+   * FIXED: libgdal wasn't installed in docker image, so it never worked in docker [#4629](https://github.com/valhalla/valhalla/pull/4629)
 * **Enhancement**
    * UPDATED: French translations, thanks to @xlqian [#4159](https://github.com/valhalla/valhalla/pull/4159)
    * CHANGED: -j flag for multithreaded executables to override mjolnir.concurrency [#4168](https://github.com/valhalla/valhalla/pull/4168)

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ COPY --from=builder /usr/lib/python3/dist-packages/valhalla/* /usr/lib/python3/d
 # install all the posix locales that we support
 RUN export DEBIAN_FRONTEND=noninteractive && apt update && \
     apt install -y \
-      libcurl4 libczmq4 libluajit-5.1-2 \
+      libcurl4 libczmq4 libluajit-5.1-2 libgdal32 \
       libprotobuf-lite32 libsqlite3-0 libsqlite3-mod-spatialite libzmq5 zlib1g \
       curl gdb locales parallel python3-minimal python3-distutils python-is-python3 \
       spatialite-bin unzip wget && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
currently the docker build is failing in master when compiling the python bindings. that's pointing to a much bigger problem, where `ENABLE_GDAL=ON` would currently not even be able to run `valhalla_service`, because `libgdal32` wasn't installed in the final docker image, just in the building intermediate docker image.