### PR TITLE
log shortcuts which have the same start/end node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@
    * ADDED: isochrone proper polygon support & pbf output for isochrone [#4575](https://github.com/valhalla/valhalla/pull/4575)
    * ADDED: return isotile grid as geotiff  [#4594](https://github.com/valhalla/valhalla/pull/4594)
    * ADDED: `ignore_non_vehicular_restrictions` parameter for truck costing [#4606](https://github.com/valhalla/valhalla/pull/4606)
+   * ADDED: log shortcuts which have the same start/end node [4632](https://github.com/valhalla/valhalla/pull/4632)
 
 ## Release Date: 2023-05-11 Valhalla 3.4.0
 * **Removed**

--- a/src/mjolnir/shortcutbuilder.cc
+++ b/src/mjolnir/shortcutbuilder.cc
@@ -360,6 +360,7 @@ std::pair<uint32_t, uint32_t> AddShortcutEdges(GraphReader& reader,
   uint32_t shortcut = 0;
   uint32_t shortcut_count = 0;
   uint32_t total_edge_count = 0;
+  std::unordered_set<uint64_t> end_nodes; // detect shortcuts with same start/end node
   GraphId edge_id(start_node.tileid(), start_node.level(), edge_index);
   for (uint32_t i = 0; i < edge_count; i++, ++edge_id) {
     // Skip transit connection edges.
@@ -547,6 +548,15 @@ std::pair<uint32_t, uint32_t> AddShortcutEdges(GraphReader& reader,
       tilebuilder.directededges().emplace_back(std::move(newedge));
       shortcut_count++;
       shortcut++;
+      if (!end_nodes.insert(newedge.endnode()).second) {
+        PointLL start_ll = tile->get_node_ll(start_node);
+        PointLL end_ll = tile->get_node_ll(end_node);
+        LOG_WARN("Node " + std::to_string(start_node) +
+                 " has outbound shortcuts with same start/end nodes starting at node at LL = " +
+                 std::to_string(start_ll.lat()) + "," + std::to_string(start_ll.lng()) +
+                 " and ending at node at LL = " + std::to_string(end_ll.lat()) + "," +
+                 std::to_string(end_ll.lng()));
+      }
     }
   }
 

--- a/src/mjolnir/shortcutbuilder.cc
+++ b/src/mjolnir/shortcutbuilder.cc
@@ -550,7 +550,7 @@ std::pair<uint32_t, uint32_t> AddShortcutEdges(GraphReader& reader,
       shortcut++;
       if (!end_nodes.insert(newedge.endnode()).second) {
         [[maybe_unused]] PointLL start_ll = tile->get_node_ll(start_node);
-        [[maybe_unused]] PointLL end_ll = tile->get_node_ll(end_node);
+        [[maybe_unused]] PointLL end_ll = reader.GetGraphTile(end_node)->get_node_ll(end_node);
         LOG_WARN("Node " + std::to_string(start_node) +
                  " has outbound shortcuts with same start/end nodes starting at node at LL = " +
                  std::to_string(start_ll.lat()) + "," + std::to_string(start_ll.lng()) +

--- a/src/mjolnir/shortcutbuilder.cc
+++ b/src/mjolnir/shortcutbuilder.cc
@@ -549,8 +549,8 @@ std::pair<uint32_t, uint32_t> AddShortcutEdges(GraphReader& reader,
       shortcut_count++;
       shortcut++;
       if (!end_nodes.insert(newedge.endnode()).second) {
-        PointLL start_ll = tile->get_node_ll(start_node);
-        PointLL end_ll = tile->get_node_ll(end_node);
+        [[maybe_unused]] PointLL start_ll = tile->get_node_ll(start_node);
+        [[maybe_unused]] PointLL end_ll = tile->get_node_ll(end_node);
         LOG_WARN("Node " + std::to_string(start_node) +
                  " has outbound shortcuts with same start/end nodes starting at node at LL = " +
                  std::to_string(start_ll.lat()) + "," + std::to_string(start_ll.lng()) +
@@ -563,7 +563,7 @@ std::pair<uint32_t, uint32_t> AddShortcutEdges(GraphReader& reader,
   // Log a warning (with the node lat,lon) if the max number of shortcuts from a node
   // is exceeded. This is not serious (see NOTE above) but good to know where it occurs.
   if (shortcut_count > kMaxShortcutsFromNode) {
-    PointLL ll = tile->get_node_ll(start_node);
+    [[maybe_unused]] PointLL ll = tile->get_node_ll(start_node);
     LOG_WARN("Exceeding max shortcut edges from a node at LL = " + std::to_string(ll.lat()) + "," +
              std::to_string(ll.lng()));
   }


### PR DESCRIPTION
relates to https://github.com/valhalla/valhalla/issues/4609, but doesn't fix it. I'd first like to see if this is even happening anywhere (though I'm sure it does) and how often.