### PR TITLE
refactor path pruning for not_thru/destonly/closures

### DIFF
--- a/src/mjolnir/graphenhancer.cc
+++ b/src/mjolnir/graphenhancer.cc
@@ -534,6 +534,7 @@ bool IsNotThruEdge(GraphReader& reader,
 
       // Return false if we get back to the start node or hit an
       // edge with higher classification
+      // TODO(nils): why does higher classification immediately tell it's not "not_thru"?
       if (diredge->classification() < RoadClass::kTertiary || diredge->endnode() == startnode) {
         return false;
       }

--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -423,7 +423,8 @@ bool AutoCost::Allowed(const baldr::DirectedEdge* edge,
   if (!IsAccessible(edge) || (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
       ((pred.restrictions() & (1 << edge->localedgeidx())) && !ignore_turn_restrictions_) ||
       edge->surface() == Surface::kImpassable || IsUserAvoidEdge(edgeid) ||
-      (!allow_destination_only_ && !pred.destonly() && edge->destonly()) ||
+      (destination_only_pruning_ && pred.destonly_pruning() && edge->destonly()) ||
+      (not_thru_pruning_ && pred.not_thru_pruning() && edge->not_thru()) ||
       (pred.closure_pruning() && IsClosed(edge, tile)) ||
       (exclude_unpaved_ && !pred.unpaved() && edge->unpaved()) || !IsHOVAllowed(edge)) {
     return false;
@@ -448,7 +449,8 @@ bool AutoCost::AllowedReverse(const baldr::DirectedEdge* edge,
   if (!IsAccessible(opp_edge) || (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
       ((opp_edge->restrictions() & (1 << pred.opp_local_idx())) && !ignore_turn_restrictions_) ||
       opp_edge->surface() == Surface::kImpassable || IsUserAvoidEdge(opp_edgeid) ||
-      (!allow_destination_only_ && !pred.destonly() && opp_edge->destonly()) ||
+      (destination_only_pruning_ && pred.destonly_pruning() && opp_edge->destonly()) ||
+      (not_thru_pruning_ && pred.not_thru_pruning() && edge->not_thru()) ||
       (pred.closure_pruning() && IsClosed(opp_edge, tile)) ||
       (exclude_unpaved_ && !pred.unpaved() && opp_edge->unpaved()) || !IsHOVAllowed(opp_edge)) {
     return false;
@@ -785,7 +787,8 @@ bool BusCost::Allowed(const baldr::DirectedEdge* edge,
   if (!IsAccessible(edge) || (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
       ((pred.restrictions() & (1 << edge->localedgeidx())) && !ignore_restrictions_) ||
       edge->surface() == Surface::kImpassable || IsUserAvoidEdge(edgeid) ||
-      (!allow_destination_only_ && !pred.destonly() && edge->destonly()) ||
+      (destination_only_pruning_ && pred.destonly_pruning() && edge->destonly()) ||
+      (not_thru_pruning_ && pred.not_thru_pruning() && edge->not_thru()) ||
       (pred.closure_pruning() && IsClosed(edge, tile)) ||
       (exclude_unpaved_ && !pred.unpaved() && edge->unpaved())) {
     return false;
@@ -810,7 +813,8 @@ bool BusCost::AllowedReverse(const baldr::DirectedEdge* edge,
   if (!IsAccessible(opp_edge) || (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
       ((opp_edge->restrictions() & (1 << pred.opp_local_idx())) && !ignore_turn_restrictions_) ||
       opp_edge->surface() == Surface::kImpassable || IsUserAvoidEdge(opp_edgeid) ||
-      (!allow_destination_only_ && !pred.destonly() && opp_edge->destonly()) ||
+      (destination_only_pruning_ && pred.destonly_pruning() && opp_edge->destonly()) ||
+      (not_thru_pruning_ && pred.not_thru_pruning() && edge->not_thru()) ||
       (pred.closure_pruning() && IsClosed(opp_edge, tile)) ||
       (exclude_unpaved_ && !pred.unpaved() && opp_edge->unpaved())) {
     return false;
@@ -964,7 +968,8 @@ bool TaxiCost::Allowed(const baldr::DirectedEdge* edge,
   if (!IsAccessible(edge) || (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
       ((pred.restrictions() & (1 << edge->localedgeidx())) && !ignore_restrictions_) ||
       edge->surface() == Surface::kImpassable || IsUserAvoidEdge(edgeid) ||
-      (!allow_destination_only_ && !pred.destonly() && edge->destonly()) ||
+      (destination_only_pruning_ && pred.destonly_pruning() && edge->destonly()) ||
+      (not_thru_pruning_ && pred.not_thru_pruning() && edge->not_thru()) ||
       (pred.closure_pruning() && IsClosed(edge, tile)) ||
       (exclude_unpaved_ && !pred.unpaved() && edge->unpaved())) {
     return false;
@@ -989,7 +994,8 @@ bool TaxiCost::AllowedReverse(const baldr::DirectedEdge* edge,
   if (!IsAccessible(opp_edge) || (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
       ((opp_edge->restrictions() & (1 << pred.opp_local_idx())) && !ignore_turn_restrictions_) ||
       opp_edge->surface() == Surface::kImpassable || IsUserAvoidEdge(opp_edgeid) ||
-      (!allow_destination_only_ && !pred.destonly() && opp_edge->destonly()) ||
+      (destination_only_pruning_ && pred.destonly_pruning() && opp_edge->destonly()) ||
+      (not_thru_pruning_ && pred.not_thru_pruning() && edge->not_thru()) ||
       (pred.closure_pruning() && IsClosed(opp_edge, tile)) ||
       (exclude_unpaved_ && !pred.unpaved() && opp_edge->unpaved())) {
     return false;

--- a/src/sif/dynamiccost.cc
+++ b/src/sif/dynamiccost.cc
@@ -146,9 +146,9 @@ DynamicCost::DynamicCost(const Costing& costing,
                          const TravelMode mode,
                          uint32_t access_mask,
                          bool penalize_uturns)
-    : pass_(0), allow_transit_connections_(false), allow_destination_only_(true),
-      allow_conditional_destination_(false), travel_mode_(mode), access_mask_(access_mask),
-      closure_factor_(kDefaultClosureFactor), flow_mask_(kDefaultFlowMask),
+    : pass_(0), allow_transit_connections_(false), destination_only_pruning_(true),
+      conditional_destination_only_pruning_(true), not_thru_pruning_(true), travel_mode_(mode),
+      access_mask_(access_mask), closure_factor_(kDefaultClosureFactor), flow_mask_(kDefaultFlowMask),
       shortest_(costing.options().shortest()),
       ignore_restrictions_(costing.options().ignore_restrictions()),
       ignore_non_vehicular_restrictions_(costing.options().ignore_non_vehicular_restrictions()),
@@ -239,13 +239,18 @@ void DynamicCost::SetAllowTransitConnections(const bool allow) {
 }
 
 // Sets the flag indicating whether destination only edges are allowed.
-void DynamicCost::set_allow_destination_only(const bool allow) {
-  allow_destination_only_ = allow;
+void DynamicCost::set_destination_only_pruning(const bool allow) {
+  destination_only_pruning_ = allow;
 }
 
 // Sets the flag indicating whether edges with valid restriction conditional=destination are allowed.
-void DynamicCost::set_allow_conditional_destination(const bool allow) {
-  allow_conditional_destination_ = allow;
+void DynamicCost::set_conditional_destination_only_pruning(const bool allow) {
+  conditional_destination_only_pruning_ = allow;
+}
+
+// Sets the flag indicating whether we should prune paths leading into not_thru regions.
+void DynamicCost::set_not_thru_pruning(const bool allow) {
+  not_thru_pruning_ = allow;
 }
 
 // Returns the maximum transfer distance between stops that you are willing

--- a/src/sif/motorcyclecost.cc
+++ b/src/sif/motorcyclecost.cc
@@ -357,7 +357,7 @@ bool MotorcycleCost::Allowed(const baldr::DirectedEdge* edge,
   if (!IsAccessible(edge) || (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
       ((pred.restrictions() & (1 << edge->localedgeidx())) && !ignore_turn_restrictions_) ||
       (edge->surface() > kMinimumMotorcycleSurface) || IsUserAvoidEdge(edgeid) ||
-      (!allow_destination_only_ && !pred.destonly() && edge->destonly()) ||
+      (destination_only_pruning_ && pred.destonly_pruning() && edge->destonly()) ||
       (pred.closure_pruning() && IsClosed(edge, tile))) {
     return false;
   }
@@ -381,7 +381,7 @@ bool MotorcycleCost::AllowedReverse(const baldr::DirectedEdge* edge,
   if (!IsAccessible(opp_edge) || (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
       ((opp_edge->restrictions() & (1 << pred.opp_local_idx())) && !ignore_turn_restrictions_) ||
       (opp_edge->surface() > kMinimumMotorcycleSurface) || IsUserAvoidEdge(opp_edgeid) ||
-      (!allow_destination_only_ && !pred.destonly() && opp_edge->destonly()) ||
+      (destination_only_pruning_ && !pred.destonly_pruning() && opp_edge->destonly()) ||
       (pred.closure_pruning() && IsClosed(opp_edge, tile))) {
     return false;
   }

--- a/src/sif/motorscootercost.cc
+++ b/src/sif/motorscootercost.cc
@@ -378,7 +378,7 @@ bool MotorScooterCost::Allowed(const baldr::DirectedEdge* edge,
   if (!IsAccessible(edge) || (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
       ((pred.restrictions() & (1 << edge->localedgeidx())) && !ignore_turn_restrictions_) ||
       (edge->surface() > kMinimumScooterSurface) || IsUserAvoidEdge(edgeid) ||
-      (!allow_destination_only_ && !pred.destonly() && edge->destonly()) ||
+      (destination_only_pruning_ && pred.destonly_pruning() && edge->destonly()) ||
       (pred.closure_pruning() && IsClosed(edge, tile))) {
     return false;
   }
@@ -402,7 +402,7 @@ bool MotorScooterCost::AllowedReverse(const baldr::DirectedEdge* edge,
   if (!IsAccessible(opp_edge) || (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
       ((opp_edge->restrictions() & (1 << pred.opp_local_idx())) && !ignore_turn_restrictions_) ||
       (opp_edge->surface() > kMinimumScooterSurface) || IsUserAvoidEdge(opp_edgeid) ||
-      (!allow_destination_only_ && !pred.destonly() && opp_edge->destonly()) ||
+      (destination_only_pruning_ && pred.destonly_pruning() && opp_edge->destonly()) ||
       (pred.closure_pruning() && IsClosed(opp_edge, tile))) {
     return false;
   }

--- a/src/sif/pedestriancost.cc
+++ b/src/sif/pedestriancost.cc
@@ -550,7 +550,7 @@ public:
          (edge->use() == baldr::Use::kRailFerry && pred->use() != baldr::Use::kRailFerry);
 
     // Additional penalties without any time cost
-    c.cost += destination_only_penalty_ * (edge->destonly() && !pred->destonly());
+    c.cost += destination_only_penalty_ * (edge->destonly() && pred->destonly());
     c.cost +=
         alley_penalty_ * (edge->use() == baldr::Use::kAlley && pred->use() != baldr::Use::kAlley);
     c.cost +=

--- a/src/sif/recost.cc
+++ b/src/sif/recost.cc
@@ -91,7 +91,7 @@ void recost_forward(baldr::GraphReader& reader,
     // TODO: if this edge begins a restriction, we need to start popping off edges into queue
     // so that we can find if we reach the end of the restriction. then we need to replay the
     // queued edges as normal
-    uint8_t time_restrictions_TODO = -1;
+    uint8_t time_restrictions_TODO = baldr::kInvalidRestriction;
     // if its not time dependent set to 0 for Allowed method below
     const uint64_t localtime = offset_time.valid ? offset_time.local_time : 0;
     // we should call 'Allowed' method even if 'ignore_access' flag is true in order to

--- a/src/sif/truckcost.cc
+++ b/src/sif/truckcost.cc
@@ -441,7 +441,7 @@ inline bool TruckCost::Allowed(const baldr::DirectedEdge* edge,
   if (!IsAccessible(edge) || (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
       ((pred.restrictions() & (1 << edge->localedgeidx())) && (!ignore_turn_restrictions_)) ||
       edge->surface() == Surface::kImpassable || IsUserAvoidEdge(edgeid) ||
-      (!allow_destination_only_ && !pred.destonly() && edge->destonly_hgv()) ||
+      (destination_only_pruning_ && pred.destonly_pruning() && edge->destonly_hgv()) ||
       (pred.closure_pruning() && IsClosed(edge, tile)) ||
       (exclude_unpaved_ && !pred.unpaved() && edge->unpaved())) {
     return false;
@@ -465,7 +465,7 @@ bool TruckCost::AllowedReverse(const baldr::DirectedEdge* edge,
   if (!IsAccessible(opp_edge) || (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
       ((opp_edge->restrictions() & (1 << pred.opp_local_idx())) && !ignore_turn_restrictions_) ||
       opp_edge->surface() == Surface::kImpassable || IsUserAvoidEdge(opp_edgeid) ||
-      (!allow_destination_only_ && !pred.destonly() && opp_edge->destonly_hgv()) ||
+      (destination_only_pruning_ && pred.destonly_pruning() && opp_edge->destonly_hgv()) ||
       (pred.closure_pruning() && IsClosed(opp_edge, tile)) ||
       (exclude_unpaved_ && !pred.unpaved() && opp_edge->unpaved())) {
     return false;

--- a/src/thor/astar_bss.cc
+++ b/src/thor/astar_bss.cc
@@ -219,9 +219,11 @@ void AStarBSSAlgorithm::ExpandForward(GraphReader& graphreader,
     }
 
     // Add to the adjacency list and edge labels.
+    // TODO(nils): no pruning is enabled for this algo for now, needs some investigation if a second
+    // pass is possible for this algo (bike doesn't allow that)
     uint32_t idx = edgelabels_.size();
     edgelabels_.emplace_back(pred_idx, edgeid, GraphId(), directededge, newcost, sortcost, dist, mode,
-                             transition_cost, false, true, false, InternalTurn::kNoTurn,
+                             transition_cost, false, false, false, false, InternalTurn::kNoTurn,
                              baldr::kInvalidRestriction);
     *current_es = {EdgeSet::kTemporary, idx};
     adjacencylist_.add(idx);
@@ -446,8 +448,8 @@ void AStarBSSAlgorithm::SetOrigin(GraphReader& graphreader,
     // of the path.
     uint32_t d = static_cast<uint32_t>(directededge->length() * (1.0f - edge.percent_along()));
     BDEdgeLabel edge_label(kInvalidLabel, edgeid, directededge, cost, sortcost, dist,
-                           travel_mode_t::kPedestrian, baldr::kInvalidRestriction, true, false,
-                           sif::InternalTurn::kNoTurn);
+                           travel_mode_t::kPedestrian, baldr::kInvalidRestriction, false, false,
+                           false, sif::InternalTurn::kNoTurn);
     // Set the origin flag and path distance
     edge_label.set_origin();
     edge_label.set_path_distance(d);

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -1033,7 +1033,7 @@ void BidirectionalAStar::SetOrigin(GraphReader& graphreader,
 
     pruning_disabled_at_origin_ =
         pruning_disabled_at_origin_ || !edgelabels_forward_.back().closure_pruning() ||
-        directededge->not_thru() || !edgelabels_reverse_.back().destonly_pruning();
+        directededge->not_thru() || !edgelabels_forward_.back().destonly_pruning();
   }
 
   // Set the origin timezone

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -89,8 +89,6 @@ void BidirectionalAStar::Clear() {
 
   // Set the ferry flag to false
   has_ferry_ = false;
-  // Set not thru pruning to true
-  set_not_thru_pruning(true);
   // reset origin & destination pruning states
   pruning_disabled_at_origin_ = false;
   pruning_disabled_at_destination_ = false;
@@ -237,7 +235,7 @@ inline bool BidirectionalAStar::ExpandInner(baldr::GraphReader& graphreader,
   // or if a complex restriction prevents transition onto this edge.
   // if its not time dependent set to 0 for Allowed and Restricted methods below
   const uint64_t localtime = time_info.valid ? time_info.local_time : 0;
-  uint8_t restriction_idx = -1;
+  uint8_t restriction_idx = baldr::kInvalidRestriction;
   if (FORWARD) {
     // Why is is_dest false?
     // We have to consider next cases:
@@ -308,8 +306,8 @@ inline bool BidirectionalAStar::ExpandInner(baldr::GraphReader& graphreader,
                           ? astarheuristic_forward_.Get(t2->get_node_ll(meta.edge->endnode()), dist)
                           : astarheuristic_reverse_.Get(t2->get_node_ll(meta.edge->endnode()), dist));
 
-  // not_thru_pruning_ is only set to false on the 2nd pass in route_action.
-  bool thru = not_thru_pruning_ ? (pred.not_thru_pruning() || !meta.edge->not_thru()) : false;
+  // not_thru is the same for both trees
+  bool not_thru_pruning = pred.not_thru_pruning() || !meta.edge->not_thru();
 
   // Add edge label, add to the adjacency list and set edge status
   uint32_t idx = 0;
@@ -321,13 +319,12 @@ inline bool BidirectionalAStar::ExpandInner(baldr::GraphReader& graphreader,
       dist = astarheuristic_reverse_.GetDistance(t2->get_node_ll(meta.edge->endnode()));
     }
     edgelabels_forward_.emplace_back(pred_idx, meta.edge_id, opp_edge_id, meta.edge, newcost,
-                                     sortcost, dist, mode_, transition_cost, thru,
-                                     (pred.closure_pruning() || !costing_->IsClosed(meta.edge, tile)),
+                                     sortcost, dist, mode_, transition_cost, not_thru_pruning,
+                                     pred.closure_pruning() || !(costing_->IsClosed(meta.edge, tile)),
+                                     pred.destonly_pruning() || !meta.edge->destonly(),
                                      static_cast<bool>(flow_sources & kDefaultFlowMask),
                                      costing_->TurnType(pred.opp_local_idx(), nodeinfo, meta.edge),
-                                     restriction_idx, 0,
-                                     meta.edge->destonly() ||
-                                         (costing_->is_hgv() && meta.edge->destonly_hgv()));
+                                     restriction_idx, 0);
     adjacencylist_forward_.add(idx);
   } else {
     idx = edgelabels_reverse_.size();
@@ -337,14 +334,13 @@ inline bool BidirectionalAStar::ExpandInner(baldr::GraphReader& graphreader,
       dist = astarheuristic_forward_.GetDistance(t2->get_node_ll(meta.edge->endnode()));
     }
     edgelabels_reverse_.emplace_back(pred_idx, meta.edge_id, opp_edge_id, meta.edge, newcost,
-                                     sortcost, dist, mode_, transition_cost, thru,
-                                     (pred.closure_pruning() || !costing_->IsClosed(meta.edge, tile)),
+                                     sortcost, dist, mode_, transition_cost, not_thru_pruning,
+                                     pred.closure_pruning() || !(costing_->IsClosed(opp_edge, t2)),
+                                     pred.destonly_pruning() || !opp_edge->destonly(),
                                      static_cast<bool>(flow_sources & kDefaultFlowMask),
                                      costing_->TurnType(meta.edge->localedgeidx(), nodeinfo, opp_edge,
                                                         opp_pred_edge),
-                                     restriction_idx, 0,
-                                     opp_edge->destonly() ||
-                                         (costing_->is_hgv() && opp_edge->destonly_hgv()));
+                                     restriction_idx, 0);
     adjacencylist_reverse_.add(idx);
   }
 
@@ -361,9 +357,8 @@ inline bool BidirectionalAStar::ExpandInner(baldr::GraphReader& graphreader,
                         pred.path_distance() + meta.edge->length(), newcost.cost);
   }
 
-  // we've just added this edge to the queue, but we won't expand from it if it's a not-thru edge that
-  // will be pruned. In that case we want to allow uturns.
-  return !(pred.not_thru_pruning() && meta.edge->not_thru());
+  // we've just added this edge to the queue
+  return true;
 }
 
 template <const ExpansionType expansion_direction>
@@ -422,14 +417,14 @@ void BidirectionalAStar::Expand(baldr::GraphReader& graphreader,
     // If so, it means we are attempting a u-turn. In that case, lets wait with evaluating
     // this edge until last. If any other edges were emplaced, it means we should not
     // even try to evaluate a u-turn since u-turns should only happen for deadends
-    uturn_meta = pred.opp_local_idx() == meta.edge->localedgeidx() ? meta : uturn_meta;
+    bool is_uturn = pred.opp_local_idx() == meta.edge->localedgeidx();
+    uturn_meta = is_uturn ? meta : uturn_meta;
 
     // Expand but only if this isnt the uturn, we'll try that later if nothing else works out
-    disable_uturn =
-        (pred.opp_local_idx() != meta.edge->localedgeidx() &&
-         ExpandInner<expansion_direction>(graphreader, pred, opp_pred_edge, nodeinfo, pred_idx, meta,
-                                          shortcuts, tile, offset_time)) ||
-        disable_uturn;
+    disable_uturn = (!is_uturn && ExpandInner<expansion_direction>(graphreader, pred, opp_pred_edge,
+                                                                   nodeinfo, pred_idx, meta,
+                                                                   shortcuts, tile, offset_time)) ||
+                    disable_uturn;
   }
 
   // Handle transitions - expand from the end node of each transition
@@ -709,8 +704,7 @@ BidirectionalAStar::GetBestPath(valhalla::Location& origin,
 
       // Prune path if predecessor is not a through edge or if the maximum
       // number of upward transitions has been exceeded on this hierarchy level.
-      if ((fwd_pred.not_thru() && fwd_pred.not_thru_pruning()) ||
-          (!ignore_hierarchy_limits_ &&
+      if ((!ignore_hierarchy_limits_ &&
            hierarchy_limits_forward_[fwd_pred.endnode().level()].StopExpanding(
                fwd_pred.distance()))) {
         continue;
@@ -755,8 +749,7 @@ BidirectionalAStar::GetBestPath(valhalla::Location& origin,
       }
 
       // Prune path if predecessor is not a through edge
-      if ((rev_pred.not_thru() && rev_pred.not_thru_pruning()) ||
-          (!ignore_hierarchy_limits_ &&
+      if ((!ignore_hierarchy_limits_ &&
            hierarchy_limits_reverse_[rev_pred.endnode().level()].StopExpanding(
                rev_pred.distance()))) {
         continue;
@@ -1011,11 +1004,12 @@ void BidirectionalAStar::SetOrigin(GraphReader& graphreader,
       dist = astarheuristic_reverse_.GetDistance(nodeinfo->latlng(endtile->header()->base_ll()));
     }
     edgelabels_forward_.emplace_back(kInvalidLabel, edgeid, directededge, cost, sortcost, dist, mode_,
-                                     -1, !(costing_->IsClosed(directededge, tile)),
+                                     baldr::kInvalidRestriction,
+                                     !(costing_->IsClosed(directededge, tile)),
+                                     !directededge->destonly() &&
+                                         !(costing_->is_hgv() && directededge->destonly_hgv()),
                                      static_cast<bool>(flow_sources & kDefaultFlowMask),
-                                     sif::InternalTurn::kNoTurn, 0,
-                                     directededge->destonly() ||
-                                         (costing_->is_hgv() && directededge->destonly_hgv()));
+                                     sif::InternalTurn::kNoTurn);
     adjacencylist_forward_.add(idx);
 
     // setting this edge as reached
@@ -1024,13 +1018,18 @@ void BidirectionalAStar::SetOrigin(GraphReader& graphreader,
                           static_cast<uint32_t>(edge.distance() + 0.5), cost.cost);
     }
 
-    // Set the initial not_thru flag to false. There is an issue with not_thru
-    // flags on small loops. Set this to false here to override this for now.
-    edgelabels_forward_.back().set_not_thru(false);
+    // TODO(nils): is this really still necessary? could imagine it's a problem when we snap on
+    // a oneway road leading only to a not-thru edge and a restricted edge and we'd HAVE TO take
+    // that not_thru edge, go the full circle inside the not_thru region and come back on the
+    // not_thru's opposite to take the now allowed turn. easily tested!
 
-    pruning_disabled_at_origin_ = pruning_disabled_at_origin_ ||
-                                  !edgelabels_forward_.back().closure_pruning() ||
-                                  !edgelabels_forward_.back().not_thru_pruning();
+    // Set the initial not_thru_pruning to false. There is an issue with not_thru
+    // flags on small loops. Set this to false here to override this for now.
+    edgelabels_forward_.back().set_not_thru_pruning(false);
+
+    pruning_disabled_at_origin_ =
+        pruning_disabled_at_origin_ || !edgelabels_forward_.back().closure_pruning() ||
+        directededge->not_thru() || !edgelabels_reverse_.back().destonly_pruning();
   }
 
   // Set the origin timezone
@@ -1106,12 +1105,11 @@ void BidirectionalAStar::SetDestination(GraphReader& graphreader,
       dist = astarheuristic_forward_.GetDistance(tile->get_node_ll(opp_dir_edge->endnode()));
     }
     edgelabels_reverse_.emplace_back(kInvalidLabel, opp_edge_id, edgeid, opp_dir_edge, cost, sortcost,
-                                     dist, mode_, c, !opp_dir_edge->not_thru(),
-                                     !(costing_->IsClosed(directededge, tile)),
+                                     dist, mode_, c, false, !(costing_->IsClosed(directededge, tile)),
+                                     !opp_dir_edge->destonly() &&
+                                         !(costing_->is_hgv() && opp_dir_edge->destonly_hgv()),
                                      static_cast<bool>(flow_sources & kDefaultFlowMask),
-                                     sif::InternalTurn::kNoTurn, -1,
-                                     opp_dir_edge->destonly() ||
-                                         (costing_->is_hgv() && opp_dir_edge->destonly_hgv()));
+                                     sif::InternalTurn::kNoTurn, baldr::kInvalidRestriction);
     adjacencylist_reverse_.add(idx);
 
     // setting this edge as reached, sending the opposing because this is the reverse tree
@@ -1120,13 +1118,9 @@ void BidirectionalAStar::SetDestination(GraphReader& graphreader,
                           static_cast<uint32_t>(edge.distance() + 0.5), cost.cost);
     }
 
-    // Set the initial not_thru flag to false. There is an issue with not_thru
-    // flags on small loops. Set this to false here to override this for now.
-    edgelabels_reverse_.back().set_not_thru(false);
-
-    pruning_disabled_at_destination_ = pruning_disabled_at_destination_ ||
-                                       !edgelabels_reverse_.back().closure_pruning() ||
-                                       !edgelabels_reverse_.back().not_thru_pruning();
+    pruning_disabled_at_destination_ =
+        pruning_disabled_at_destination_ || !edgelabels_reverse_.back().closure_pruning() ||
+        opp_dir_edge->not_thru() || !edgelabels_reverse_.back().destonly_pruning();
   }
 }
 

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -321,7 +321,9 @@ inline bool BidirectionalAStar::ExpandInner(baldr::GraphReader& graphreader,
     edgelabels_forward_.emplace_back(pred_idx, meta.edge_id, opp_edge_id, meta.edge, newcost,
                                      sortcost, dist, mode_, transition_cost, not_thru_pruning,
                                      pred.closure_pruning() || !(costing_->IsClosed(meta.edge, tile)),
-                                     pred.destonly_pruning() || !meta.edge->destonly(),
+                                     pred.destonly_pruning() ||
+                                         !(meta.edge->destonly() ||
+                                           (costing_->is_hgv() && meta.edge->destonly_hgv())),
                                      static_cast<bool>(flow_sources & kDefaultFlowMask),
                                      costing_->TurnType(pred.opp_local_idx(), nodeinfo, meta.edge),
                                      restriction_idx, 0);
@@ -336,7 +338,9 @@ inline bool BidirectionalAStar::ExpandInner(baldr::GraphReader& graphreader,
     edgelabels_reverse_.emplace_back(pred_idx, meta.edge_id, opp_edge_id, meta.edge, newcost,
                                      sortcost, dist, mode_, transition_cost, not_thru_pruning,
                                      pred.closure_pruning() || !(costing_->IsClosed(opp_edge, t2)),
-                                     pred.destonly_pruning() || !opp_edge->destonly(),
+                                     pred.destonly_pruning() ||
+                                         !(opp_edge->destonly() ||
+                                           (costing_->is_hgv() && opp_edge->destonly_hgv())),
                                      static_cast<bool>(flow_sources & kDefaultFlowMask),
                                      costing_->TurnType(meta.edge->localedgeidx(), nodeinfo, opp_edge,
                                                         opp_pred_edge),
@@ -1006,8 +1010,8 @@ void BidirectionalAStar::SetOrigin(GraphReader& graphreader,
     edgelabels_forward_.emplace_back(kInvalidLabel, edgeid, directededge, cost, sortcost, dist, mode_,
                                      baldr::kInvalidRestriction,
                                      !(costing_->IsClosed(directededge, tile)),
-                                     !directededge->destonly() &&
-                                         !(costing_->is_hgv() && directededge->destonly_hgv()),
+                                     !(directededge->destonly() ||
+                                       (costing_->is_hgv() && directededge->destonly_hgv())),
                                      static_cast<bool>(flow_sources & kDefaultFlowMask),
                                      sif::InternalTurn::kNoTurn);
     adjacencylist_forward_.add(idx);
@@ -1106,8 +1110,8 @@ void BidirectionalAStar::SetDestination(GraphReader& graphreader,
     }
     edgelabels_reverse_.emplace_back(kInvalidLabel, opp_edge_id, edgeid, opp_dir_edge, cost, sortcost,
                                      dist, mode_, c, false, !(costing_->IsClosed(directededge, tile)),
-                                     !opp_dir_edge->destonly() &&
-                                         !(costing_->is_hgv() && opp_dir_edge->destonly_hgv()),
+                                     !(directededge->destonly() ||
+                                       (costing_->is_hgv() && directededge->destonly_hgv())),
                                      static_cast<bool>(flow_sources & kDefaultFlowMask),
                                      sif::InternalTurn::kNoTurn, baldr::kInvalidRestriction);
     adjacencylist_reverse_.add(idx);

--- a/src/thor/costmatrix.cc
+++ b/src/thor/costmatrix.cc
@@ -521,7 +521,9 @@ bool CostMatrix::ExpandInner(baldr::GraphReader& graphreader,
     edgelabels.emplace_back(pred_idx, meta.edge_id, opp_edge_id, meta.edge, newcost, mode_, tc,
                             pred_dist, not_thru_pruning,
                             pred.closure_pruning() || !(costing_->IsClosed(meta.edge, tile)),
-                            pred.destonly_pruning() || !meta.edge->destonly(),
+                            pred.destonly_pruning() ||
+                                !(meta.edge->destonly() ||
+                                  (costing_->is_hgv() && meta.edge->destonly_hgv())),
                             static_cast<bool>(flow_sources & kDefaultFlowMask),
                             costing_->TurnType(pred.opp_local_idx(), nodeinfo, meta.edge),
                             restriction_idx, 0);
@@ -529,7 +531,9 @@ bool CostMatrix::ExpandInner(baldr::GraphReader& graphreader,
     edgelabels.emplace_back(pred_idx, meta.edge_id, opp_edge_id, meta.edge, newcost, mode_, tc,
                             pred_dist, not_thru_pruning,
                             pred.closure_pruning() || !(costing_->IsClosed(opp_edge, t2)),
-                            pred.destonly_pruning() || !opp_edge->destonly(),
+                            pred.destonly_pruning() ||
+                                !(opp_edge->destonly() ||
+                                  (costing_->is_hgv() && opp_edge->destonly_hgv())),
                             static_cast<bool>(flow_sources & kDefaultFlowMask),
                             costing_->TurnType(meta.edge->localedgeidx(), nodeinfo, opp_edge,
                                                opp_pred_edge),
@@ -1021,8 +1025,8 @@ void CostMatrix::SetSources(GraphReader& graphreader,
       Cost ec(std::round(edgecost.secs), static_cast<uint32_t>(directededge->length()));
       BDEdgeLabel edge_label(kInvalidLabel, edgeid, oppedge, directededge, cost, mode_, ec, d, false,
                              !(costing_->IsClosed(directededge, tile)),
-                             !directededge->destonly() &&
-                                 !(costing_->is_hgv() && directededge->destonly_hgv()),
+                             !(directededge->destonly() ||
+                               (costing_->is_hgv() && directededge->destonly_hgv())),
                              static_cast<bool>(flow_sources & kDefaultFlowMask),
                              InternalTurn::kNoTurn, baldr::kInvalidRestriction,
                              static_cast<uint8_t>(costing_->Allowed(directededge, tile)));
@@ -1104,8 +1108,8 @@ void CostMatrix::SetTargets(baldr::GraphReader& graphreader,
       Cost ec(std::round(edgecost.secs), static_cast<uint32_t>(directededge->length()));
       BDEdgeLabel edge_label(kInvalidLabel, opp_edge_id, edgeid, opp_dir_edge, cost, mode_, ec, d,
                              false, !(costing_->IsClosed(directededge, tile)),
-                             !opp_dir_edge->destonly() &&
-                                 !(costing_->is_hgv() && opp_dir_edge->destonly_hgv()),
+                             !(directededge->destonly() ||
+                               (costing_->is_hgv() && directededge->destonly_hgv())),
                              static_cast<bool>(flow_sources & kDefaultFlowMask),
                              InternalTurn::kNoTurn, baldr::kInvalidRestriction,
                              static_cast<uint8_t>(costing_->Allowed(opp_dir_edge, opp_tile)));

--- a/src/thor/costmatrix.cc
+++ b/src/thor/costmatrix.cc
@@ -461,7 +461,7 @@ bool CostMatrix::ExpandInner(baldr::GraphReader& graphreader,
   auto& edgelabels = edgelabel_[FORWARD][index];
   // Skip this edge if no access is allowed (based on costing method)
   // or if a complex restriction prevents transition onto this edge.
-  uint8_t restriction_idx = -1;
+  uint8_t restriction_idx = baldr::kInvalidRestriction;
   if (FORWARD) {
     if (!costing_->Allowed(meta.edge, false, pred, tile, meta.edge_id, time_info.local_time,
                            time_info.timezone_index, restriction_idx) ||
@@ -511,32 +511,29 @@ bool CostMatrix::ExpandInner(baldr::GraphReader& graphreader,
     return false;
   }
 
-  // not_thru_pruning_ is only set to false on the 2nd pass in matrix_action.
-  // TODO(nils): one of these cases where I think reverse tree should look at the opposing edge,
-  //   not the expanding one, same for quite some attributes below (and same in bidir a*)
-  bool thru = not_thru_pruning_ ? (pred.not_thru_pruning() || !meta.edge->not_thru()) : false;
+  // not_thru is the same for both trees
+  bool not_thru_pruning = pred.not_thru_pruning() || !meta.edge->not_thru();
 
   // Add edge label, add to the adjacency list and set edge status
   uint32_t idx = edgelabels.size();
   *meta.edge_status = {EdgeSet::kTemporary, idx};
   if (FORWARD) {
     edgelabels.emplace_back(pred_idx, meta.edge_id, opp_edge_id, meta.edge, newcost, mode_, tc,
-                            pred_dist, thru,
-                            (pred.closure_pruning() || !costing_->IsClosed(meta.edge, tile)),
+                            pred_dist, not_thru_pruning,
+                            pred.closure_pruning() || !(costing_->IsClosed(meta.edge, tile)),
+                            pred.destonly_pruning() || !meta.edge->destonly(),
                             static_cast<bool>(flow_sources & kDefaultFlowMask),
                             costing_->TurnType(pred.opp_local_idx(), nodeinfo, meta.edge),
-                            restriction_idx, 0,
-                            meta.edge->destonly() ||
-                                (costing_->is_hgv() && meta.edge->destonly_hgv()));
+                            restriction_idx, 0);
   } else {
     edgelabels.emplace_back(pred_idx, meta.edge_id, opp_edge_id, meta.edge, newcost, mode_, tc,
-                            pred_dist, thru,
-                            (pred.closure_pruning() || !costing_->IsClosed(meta.edge, tile)),
+                            pred_dist, not_thru_pruning,
+                            pred.closure_pruning() || !(costing_->IsClosed(opp_edge, t2)),
+                            pred.destonly_pruning() || !opp_edge->destonly(),
                             static_cast<bool>(flow_sources & kDefaultFlowMask),
                             costing_->TurnType(meta.edge->localedgeidx(), nodeinfo, opp_edge,
                                                opp_pred_edge),
-                            restriction_idx, 0,
-                            opp_edge->destonly() || (costing_->is_hgv() && opp_edge->destonly_hgv()));
+                            restriction_idx, 0);
   }
   adj.add(idx);
   // mark the edge as settled for the connection check
@@ -552,7 +549,7 @@ bool CostMatrix::ExpandInner(baldr::GraphReader& graphreader,
                         pred_dist, newcost.cost);
   }
 
-  return !(pred.not_thru_pruning() && meta.edge->not_thru());
+  return true;
 }
 
 template <const MatrixExpansionType expansion_direction, const bool FORWARD>
@@ -603,10 +600,8 @@ bool CostMatrix::Expand(const uint32_t index,
   }
 
   GraphId node = pred.endnode();
-  // Prune path if predecessor is not a through edge or if the maximum
-  // number of upward transitions has been exceeded on this hierarchy level.
-  if ((pred.not_thru() && pred.not_thru_pruning()) ||
-      (!ignore_hierarchy_limits_ &&
+  // Prune path if the maximum number of upward transitions has been exceeded on this hierarchy level.
+  if ((!ignore_hierarchy_limits_ &&
        hierarchy_limits_[FORWARD][index][node.level()].StopExpanding())) {
     return false;
   }
@@ -1025,12 +1020,12 @@ void CostMatrix::SetSources(GraphReader& graphreader,
       //   - "path_id" is used to store whether the edge is even allowed (e.g. no oneway)
       Cost ec(std::round(edgecost.secs), static_cast<uint32_t>(directededge->length()));
       BDEdgeLabel edge_label(kInvalidLabel, edgeid, oppedge, directededge, cost, mode_, ec, d, false,
-                             true, static_cast<bool>(flow_sources & kDefaultFlowMask),
-                             InternalTurn::kNoTurn, -1,
-                             static_cast<uint8_t>(costing_->Allowed(directededge, tile)),
-                             directededge->destonly() ||
-                                 (costing_->is_hgv() && directededge->destonly_hgv()));
-      edge_label.set_not_thru(false);
+                             !(costing_->IsClosed(directededge, tile)),
+                             !directededge->destonly() &&
+                                 !(costing_->is_hgv() && directededge->destonly_hgv()),
+                             static_cast<bool>(flow_sources & kDefaultFlowMask),
+                             InternalTurn::kNoTurn, baldr::kInvalidRestriction,
+                             static_cast<uint8_t>(costing_->Allowed(directededge, tile)));
 
       // Add EdgeLabel to the adjacency list (but do not set its status).
       // Set the predecessor edge index to invalid to indicate the origin
@@ -1108,12 +1103,12 @@ void CostMatrix::SetTargets(baldr::GraphReader& graphreader,
       //   - "path_id" is used to store whether the opp edge is even allowed (e.g. no oneway)
       Cost ec(std::round(edgecost.secs), static_cast<uint32_t>(directededge->length()));
       BDEdgeLabel edge_label(kInvalidLabel, opp_edge_id, edgeid, opp_dir_edge, cost, mode_, ec, d,
-                             false, true, static_cast<bool>(flow_sources & kDefaultFlowMask),
-                             InternalTurn::kNoTurn, -1,
-                             static_cast<uint8_t>(costing_->Allowed(opp_dir_edge, opp_tile)),
-                             opp_dir_edge->destonly() ||
-                                 (costing_->is_hgv() && opp_dir_edge->destonly_hgv()));
-      edge_label.set_not_thru(false);
+                             false, !(costing_->IsClosed(directededge, tile)),
+                             !opp_dir_edge->destonly() &&
+                                 !(costing_->is_hgv() && opp_dir_edge->destonly_hgv()),
+                             static_cast<bool>(flow_sources & kDefaultFlowMask),
+                             InternalTurn::kNoTurn, baldr::kInvalidRestriction,
+                             static_cast<uint8_t>(costing_->Allowed(opp_dir_edge, opp_tile)));
 
       // Add EdgeLabel to the adjacency list (but do not set its status).
       // Set the predecessor edge index to invalid to indicate the origin

--- a/src/thor/map_matcher.cc
+++ b/src/thor/map_matcher.cc
@@ -286,11 +286,12 @@ MapMatcher::FormPath(meili::MapMatcher* matcher,
             mode,
             0,
             baldr::kInvalidRestriction,
-            true,
+            false,
+            false,
+            false,
             static_cast<bool>(flow_sources & kDefaultFlowMask),
             turn,
-            0,
-            directededge->destonly() || (costing->is_hgv() && directededge->destonly_hgv())};
+            0};
     paths.back().first.emplace_back(
         PathInfo{mode, elapsed, edge_id, 0, 0, edge_segment.restriction_idx, transition_cost});
     paths.back().second.emplace_back(&edge_segment);

--- a/src/thor/matrix_action.cc
+++ b/src/thor/matrix_action.cc
@@ -123,7 +123,7 @@ std::string thor_worker_t::matrix(Api& request) {
 
   // for costmatrix try a second pass if the first didn't work out
   valhalla::sif::cost_ptr_t cost = mode_costing[static_cast<uint32_t>(mode)];
-  cost->set_allow_destination_only(false);
+  cost->set_destination_only_pruning(true);
   cost->set_pass(0);
 
   if (!algo->SourceToTarget(request, *reader, mode_costing, mode,
@@ -135,9 +135,9 @@ std::string thor_worker_t::matrix(Api& request) {
     algo->Clear();
     cost->set_pass(1);
     cost->RelaxHierarchyLimits(true);
-    cost->set_allow_destination_only(true);
-    cost->set_allow_conditional_destination(true);
-    algo->set_not_thru_pruning(false);
+    cost->set_destination_only_pruning(false);
+    cost->set_conditional_destination_only_pruning(false);
+    cost->set_not_thru_pruning(false);
     algo->SourceToTarget(request, *reader, mode_costing, mode,
                          max_matrix_distance.find(costing)->second);
 

--- a/src/thor/multimodal.cc
+++ b/src/thor/multimodal.cc
@@ -751,7 +751,7 @@ bool MultiModalPathAlgorithm::ExpandFromNode(baldr::GraphReader& graphreader,
     // Add edge label, add to the adjacency list and set edge status
     uint32_t idx = edgelabels.size();
     edgelabels.emplace_back(pred_idx, edgeid, directededge, newcost, newcost.cost, mode_,
-                            walking_distance, baldr::kInvalidRestriction, true, false,
+                            walking_distance, baldr::kInvalidRestriction, false, false, false, false,
                             InternalTurn::kNoTurn);
     *es = {EdgeSet::kTemporary, idx};
     adjlist.add(idx);
@@ -809,7 +809,8 @@ bool MultiModalPathAlgorithm::CanReachDestination(const valhalla::Location& dest
     // we cannot do transition_cost on this label yet because we have no predecessor, but when we find
     // it, we will do an update on it and set the real transition cost based on the path to it
     edgelabels.emplace_back(kInvalidLabel, oppedge, diredge, cost, cost.cost, mode_, length,
-                            baldr::kInvalidRestriction, true, false, InternalTurn::kNoTurn);
+                            baldr::kInvalidRestriction, false, false, false, false,
+                            InternalTurn::kNoTurn);
     adjlist.add(label_idx);
     edgestatus.Set(oppedge, EdgeSet::kTemporary, label_idx, tile);
     label_idx++;

--- a/src/thor/route_action.cc
+++ b/src/thor/route_action.cc
@@ -305,7 +305,8 @@ std::vector<std::vector<thor::PathInfo>> thor_worker_t::get_path(PathAlgorithm* 
   // If bidirectional A* disable use of destination-only edges on the
   // first pass. If there is a failure, we allow them on the second pass.
   // Other path algorithms can use destination-only edges on the first pass.
-  cost->set_allow_destination_only(path_algorithm == &bidir_astar ? false : true);
+  // TODO(nils): why not others with destonly pruning? it gets a 2nd pass as well
+  cost->set_destination_only_pruning(path_algorithm == &bidir_astar ? true : false);
 
   cost->set_pass(0);
   auto paths = path_algorithm->GetBestPath(origin, destination, *reader, mode_costing, mode, options);
@@ -336,9 +337,9 @@ std::vector<std::vector<thor::PathInfo>> thor_worker_t::get_path(PathAlgorithm* 
     cost->set_pass(1);
     const bool using_bd = path_algorithm == &bidir_astar;
     cost->RelaxHierarchyLimits(using_bd);
-    cost->set_allow_destination_only(true);
-    cost->set_allow_conditional_destination(true);
-    path_algorithm->set_not_thru_pruning(false);
+    cost->set_destination_only_pruning(false);
+    cost->set_conditional_destination_only_pruning(false);
+    cost->set_not_thru_pruning(false);
     // Get the best path. Return if not empty (else return the original path)
     auto relaxed_paths =
         path_algorithm->GetBestPath(origin, destination, *reader, mode_costing, mode, options);

--- a/src/thor/timedistancebssmatrix.cc
+++ b/src/thor/timedistancebssmatrix.cc
@@ -138,7 +138,9 @@ void TimeDistanceBSSMatrix::Expand(GraphReader& graphreader,
     // Add to the adjacency list and edge labels.
     uint32_t idx = edgelabels_.size();
     edgelabels_.emplace_back(pred_idx, edgeid, directededge, newcost, newcost.cost, mode,
-                             path_distance, restriction_idx, true, false, InternalTurn::kNoTurn);
+                             path_distance, restriction_idx,
+                             pred.not_thru_pruning() || !directededge->not_thru(), false, false,
+                             false, InternalTurn::kNoTurn);
     *es = {EdgeSet::kTemporary, idx};
     adjacencylist_.add(idx);
   }
@@ -330,17 +332,21 @@ void TimeDistanceBSSMatrix::SetOrigin(GraphReader& graphreader, const valhalla::
     // TODO: assumes 1m/s which is a maximum penalty this could vary per costing model
     cost.cost += edge.distance();
 
+    // not_thru is the same for both trees
+    // TODO(nils): EdgeLabel should care about not_thru_pruning
+    // bool not_thru_pruning = pred.not_thru_pruning() || !meta.edge->not_thru();
+
     // Add EdgeLabel to the adjacency list (but do not set its status).
     // Set the predecessor edge index to invalid to indicate the origin
     // of the path. Set the origin flag
     if (FORWARD) {
       edgelabels_.emplace_back(kInvalidLabel, edgeid, directededge, cost, cost.cost,
-                               travel_mode_t::kPedestrian, dist, baldr::kInvalidRestriction, true,
-                               false, InternalTurn::kNoTurn);
+                               travel_mode_t::kPedestrian, dist, baldr::kInvalidRestriction, false,
+                               false, false, false, InternalTurn::kNoTurn);
     } else {
       edgelabels_.emplace_back(kInvalidLabel, opp_edge_id, opp_dir_edge, cost, cost.cost,
-                               travel_mode_t::kPedestrian, dist, baldr::kInvalidRestriction, true,
-                               false, InternalTurn::kNoTurn);
+                               travel_mode_t::kPedestrian, dist, baldr::kInvalidRestriction, false,
+                               false, false, false, InternalTurn::kNoTurn);
     }
     edgelabels_.back().set_origin();
     adjacencylist_.add(edgelabels_.size() - 1);

--- a/src/thor/timedistancematrix.cc
+++ b/src/thor/timedistancematrix.cc
@@ -376,16 +376,16 @@ void TimeDistanceMatrix::SetOrigin(GraphReader& graphreader,
       edgelabels_.emplace_back(kInvalidLabel, edgeid, directededge, cost, cost.cost, mode_, dist,
                                baldr::kInvalidRestriction, false,
                                !costing_->IsClosed(directededge, tile),
-                               directededge->destonly() ||
-                                   (costing_->is_hgv() && directededge->destonly_hgv()),
+                               !(directededge->destonly() ||
+                                 (costing_->is_hgv() && directededge->destonly_hgv())),
                                static_cast<bool>(flow_sources & kDefaultFlowMask),
                                InternalTurn::kNoTurn, 0);
     } else {
       edgelabels_.emplace_back(kInvalidLabel, opp_edge_id, opp_dir_edge, cost, cost.cost, mode_, dist,
                                baldr::kInvalidRestriction, false,
                                !costing_->IsClosed(directededge, tile),
-                               opp_dir_edge->destonly() ||
-                                   (costing_->is_hgv() && opp_dir_edge->destonly_hgv()),
+                               !(directededge->destonly() ||
+                                 (costing_->is_hgv() && directededge->destonly_hgv())),
                                static_cast<bool>(flow_sources & kDefaultFlowMask),
                                InternalTurn::kNoTurn, 0);
     }

--- a/src/thor/unidirectional_astar.cc
+++ b/src/thor/unidirectional_astar.cc
@@ -267,27 +267,28 @@ inline bool UnidirectionalAStar<expansion_direction, FORWARD>::ExpandInner(
       best_path.second = cost.cost;
     }
 
+    // not_thru is the same for both trees
+    bool not_thru_pruning = pred.not_thru_pruning() || !meta.edge->not_thru();
+
     if (FORWARD) {
       edgelabels_.emplace_back(pred_idx, meta.edge_id, opp_edge_id, meta.edge, cost, sortcost, dist,
-                               mode_, transition_cost,
-                               (pred.not_thru_pruning() || !meta.edge->not_thru()),
+                               mode_, transition_cost, not_thru_pruning,
                                (pred.closure_pruning() || !(costing_->IsClosed(meta.edge, tile))),
+                               meta.edge->destonly() ||
+                                   (costing_->is_hgv() && meta.edge->destonly_hgv()),
                                0 != (flow_sources & kDefaultFlowMask),
                                costing_->TurnType(pred.opp_local_idx(), nodeinfo, meta.edge),
-                               restriction_idx, 0,
-                               meta.edge->destonly() ||
-                                   (costing_->is_hgv() && meta.edge->destonly_hgv()));
+                               restriction_idx, 0);
     } else {
       edgelabels_.emplace_back(pred_idx, meta.edge_id, opp_edge_id, meta.edge, cost, sortcost, dist,
-                               mode_, transition_cost,
-                               (pred.not_thru_pruning() || !meta.edge->not_thru()),
-                               (pred.closure_pruning() || !(costing_->IsClosed(meta.edge, tile))),
+                               mode_, transition_cost, not_thru_pruning,
+                               (pred.closure_pruning() || !(costing_->IsClosed(opp_edge, endtile))),
+                               opp_edge->destonly() ||
+                                   (costing_->is_hgv() && opp_edge->destonly_hgv()),
                                0 != (flow_sources & kDefaultFlowMask),
                                costing_->TurnType(meta.edge->localedgeidx(), nodeinfo, opp_edge,
                                                   opp_pred_edge),
-                               restriction_idx, 0,
-                               opp_edge->destonly() ||
-                                   (costing_->is_hgv() && opp_edge->destonly_hgv()));
+                               restriction_idx, 0);
     }
 
     auto& edge_label = edgelabels_.back();
@@ -466,7 +467,7 @@ std::vector<std::vector<PathInfo>> UnidirectionalAStar<expansion_direction, FORW
   midgard::PointLL destination_new(destination.correlation().edges(0).ll().lng(),
                                    destination.correlation().edges(0).ll().lat());
   Init(origin_new, destination_new);
-  float mindist = astarheuristic_.GetDistance(origin_new);
+  float mindist = astarheuristic_.GetDistance(FORWARD ? origin_new : destination_new);
 
   auto& startpoint = FORWARD ? origin : destination;
   auto& endpoint = FORWARD ? destination : origin;
@@ -755,27 +756,21 @@ void UnidirectionalAStar<expansion_direction, FORWARD>::SetOrigin(
       if (FORWARD) {
         edgelabels_.emplace_back(kInvalidLabel, edgeid, GraphId(), directededge, cost, sortcost, dist,
                                  mode_, Cost{}, false, !(costing_->IsClosed(directededge, tile)),
+                                 !directededge->destonly() &&
+                                     !(costing_->is_hgv() && directededge->destonly_hgv()),
                                  0 != (flow_sources & kDefaultFlowMask), sif::InternalTurn::kNoTurn,
-                                 kInvalidRestriction, 0,
-                                 directededge->destonly() ||
-                                     (costing_->is_hgv() && directededge->destonly_hgv()));
+                                 kInvalidRestriction, 0);
       } else {
         edgelabels_.emplace_back(kInvalidLabel, opp_edge_id, edgeid, opp_dir_edge, cost, sortcost,
                                  dist, mode_, Cost{}, false,
                                  !(costing_->IsClosed(directededge, tile)),
+                                 !opp_dir_edge->destonly() &&
+                                     !(costing_->is_hgv() && opp_dir_edge->destonly_hgv()),
                                  0 != (flow_sources & kDefaultFlowMask), sif::InternalTurn::kNoTurn,
-                                 kInvalidRestriction, 0,
-                                 opp_dir_edge->destonly() ||
-                                     (costing_->is_hgv() && opp_dir_edge->destonly_hgv()));
+                                 kInvalidRestriction, 0);
       }
 
       auto& edge_label = edgelabels_.back();
-
-      if (!FORWARD) {
-        // Set the initial not_thru flag to false. There is an issue with not_thru
-        // flags on small loops. Set this to false here to override this for now.
-        edge_label.set_not_thru(false);
-      }
 
       /* BDEdgeLabel doesn't have a constructor that allows you to set dist and path_distance at
        * the same time - so we need to update immediately after to set path_distance */

--- a/src/thor/unidirectional_astar.cc
+++ b/src/thor/unidirectional_astar.cc
@@ -274,8 +274,9 @@ inline bool UnidirectionalAStar<expansion_direction, FORWARD>::ExpandInner(
       edgelabels_.emplace_back(pred_idx, meta.edge_id, opp_edge_id, meta.edge, cost, sortcost, dist,
                                mode_, transition_cost, not_thru_pruning,
                                (pred.closure_pruning() || !(costing_->IsClosed(meta.edge, tile))),
-                               meta.edge->destonly() ||
-                                   (costing_->is_hgv() && meta.edge->destonly_hgv()),
+                               pred.destonly_pruning() ||
+                                   !(meta.edge->destonly() ||
+                                     (costing_->is_hgv() && meta.edge->destonly_hgv())),
                                0 != (flow_sources & kDefaultFlowMask),
                                costing_->TurnType(pred.opp_local_idx(), nodeinfo, meta.edge),
                                restriction_idx, 0);
@@ -283,8 +284,9 @@ inline bool UnidirectionalAStar<expansion_direction, FORWARD>::ExpandInner(
       edgelabels_.emplace_back(pred_idx, meta.edge_id, opp_edge_id, meta.edge, cost, sortcost, dist,
                                mode_, transition_cost, not_thru_pruning,
                                (pred.closure_pruning() || !(costing_->IsClosed(opp_edge, endtile))),
-                               opp_edge->destonly() ||
-                                   (costing_->is_hgv() && opp_edge->destonly_hgv()),
+                               pred.destonly_pruning() ||
+                                   !(opp_edge->destonly() ||
+                                     (costing_->is_hgv() && opp_edge->destonly_hgv())),
                                0 != (flow_sources & kDefaultFlowMask),
                                costing_->TurnType(meta.edge->localedgeidx(), nodeinfo, opp_edge,
                                                   opp_pred_edge),
@@ -756,16 +758,16 @@ void UnidirectionalAStar<expansion_direction, FORWARD>::SetOrigin(
       if (FORWARD) {
         edgelabels_.emplace_back(kInvalidLabel, edgeid, GraphId(), directededge, cost, sortcost, dist,
                                  mode_, Cost{}, false, !(costing_->IsClosed(directededge, tile)),
-                                 !directededge->destonly() &&
-                                     !(costing_->is_hgv() && directededge->destonly_hgv()),
+                                 !(directededge->destonly() ||
+                                   (costing_->is_hgv() && directededge->destonly_hgv())),
                                  0 != (flow_sources & kDefaultFlowMask), sif::InternalTurn::kNoTurn,
                                  kInvalidRestriction, 0);
       } else {
         edgelabels_.emplace_back(kInvalidLabel, opp_edge_id, edgeid, opp_dir_edge, cost, sortcost,
                                  dist, mode_, Cost{}, false,
                                  !(costing_->IsClosed(directededge, tile)),
-                                 !opp_dir_edge->destonly() &&
-                                     !(costing_->is_hgv() && opp_dir_edge->destonly_hgv()),
+                                 !(directededge->destonly() ||
+                                   (costing_->is_hgv() && directededge->destonly_hgv())),
                                  0 != (flow_sources & kDefaultFlowMask), sif::InternalTurn::kNoTurn,
                                  kInvalidRestriction, 0);
       }

--- a/test/matrix.cc
+++ b/test/matrix.cc
@@ -49,7 +49,7 @@ public:
     if (!IsAccessible(edge) || (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
         (pred.restrictions() & (1 << edge->localedgeidx())) ||
         edge->surface() == Surface::kImpassable || IsUserAvoidEdge(edgeid) ||
-        (!allow_destination_only_ && !pred.destonly() && edge->destonly())) {
+        (destination_only_pruning_ && !pred.destonly() && edge->destonly())) {
       return false;
     }
     return true;
@@ -67,7 +67,7 @@ public:
         (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
         (opp_edge->restrictions() & (1 << pred.opp_local_idx())) ||
         opp_edge->surface() == Surface::kImpassable || IsUserAvoidEdge(opp_edgeid) ||
-        (!allow_destination_only_ && !pred.destonly() && opp_edge->destonly())) {
+        (destination_only_pruning_ && !pred.destonly() && opp_edge->destonly())) {
       return false;
     }
     return true;

--- a/valhalla/meili/routing.h
+++ b/valhalla/meili/routing.h
@@ -59,7 +59,9 @@ public:
                        mode,
                        0,
                        restriction_idx,
+                       !edge->not_thru(),
                        true,
+                       !edge->destonly(),
                        false,
                        sif::InternalTurn::kNoTurn),
         nodeid_(nodeid), dest_(dest), source_(source), target_(target), turn_cost_(turn_cost) {

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -643,7 +643,7 @@ public:
             if (access_type == baldr::AccessType::kTimedAllowed)
               return true;
             else if (access_type == baldr::AccessType::kDestinationAllowed)
-              return allow_conditional_destination_ || is_dest;
+              return !conditional_destination_only_pruning_ || is_dest;
             else
               return false;
           }
@@ -777,7 +777,7 @@ public:
    * Sets the flag indicating whether destination only edges are allowed.
    * Bidirectional path algorithms can (usually) disable access.
    */
-  virtual void set_allow_destination_only(const bool allow);
+  virtual void set_destination_only_pruning(const bool allow);
 
   /**
    * Set to allow use of transit connections.
@@ -789,7 +789,10 @@ public:
    * Sets the flag indicating whether edges with valid restriction conditional=destination are
    * allowed.
    */
-  void set_allow_conditional_destination(const bool allow);
+  void set_conditional_destination_only_pruning(const bool allow);
+
+  // Sets the flag indicating whether we should prune paths leading into not_thru regions.
+  void set_not_thru_pruning(const bool allow);
 
   /**
    * Set the current travel mode.
@@ -969,9 +972,12 @@ protected:
   // Allow entrance onto destination only edges. Bidirectional A* can (usually)
   // disable access onto destination only edges for driving routes. Pedestrian
   // and bicycle generally allow access (with small penalties).
-  bool allow_destination_only_;
+  bool destination_only_pruning_;
 
-  bool allow_conditional_destination_;
+  bool conditional_destination_only_pruning_;
+
+  // Prune edges which lead into not_thru regions
+  bool not_thru_pruning_;
 
   // Travel mode
   TravelMode travel_mode_;


### PR DESCRIPTION
as preparation for https://github.com/valhalla/valhalla/issues/4568

in that issue I promised to look into the current path pruning conditions which we apply to origin/destination correlated edges to allow closed/destonly/not_thru, but otherwise prohibit them (and enable some again on a 2nd pass). this is what I did:
- I realized `not_thru` is handled differently than the others and the special handling didn't make sense to me, so I refactored it to be consistent with the others
- checking all the logic there led me down a serious rabbit hole of refactoring `*EdgeLabel` a bit and making sure all algos & costings use those things properly and consistently

however, eventually, after I refactored everything and made sure it's all sound, I ran a few existing tests and one particular one kinda makes my first refactor moot (treating `not_thru` the same as the others). the particular test that's failing is a quite a rare case but was added particularly to avoid the scenario where it's breaking on in this PR. however, we might be able to solve this in a different way rather than reverting my refactor (which does help a lot understanding things IMO). more comments on that test.
