### PR TITLE
no need to search for GDAL when building data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
    * FIXED: some entry points to creating geotiff isochrones output did not register the geotiff driver before attempting to use it [#4628](https://github.com/valhalla/valhalla/pull/4628)
    * FIXED: libgdal wasn't installed in docker image, so it never worked in docker [#4629](https://github.com/valhalla/valhalla/pull/4629)
    * FIXED: CostMatrix shapes for routes against trivial oneways [#4633](https://github.com/valhalla/valhalla/pull/4633)
+   * FIXED: no need to search for GDAL when building data [#4651](https://github.com/valhalla/valhalla/pull/4651)
 * **Enhancement**
    * UPDATED: French translations, thanks to @xlqian [#4159](https://github.com/valhalla/valhalla/pull/4159)
    * CHANGED: -j flag for multithreaded executables to override mjolnir.concurrency [#4168](https://github.com/valhalla/valhalla/pull/4168)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,8 +192,9 @@ else()
 endif()
 
 # unless you said you didnt want gdal we try to turn it on, if we cant we tell you
+# we don't need it to build tiles (yet)
 set(GDAL_TARGET "")
-if (ENABLE_GDAL)
+if (ENABLE_GDAL AND (ENABLE_SERVICES OR ENABLE_TOOLS OR ENABLE_PYTHON_BINDINGS))
   find_package(GDAL QUIET)
   if (GDAL_FOUND)
     set(GDAL_TARGET GDAL::GDAL)


### PR DESCRIPTION
just a small cleanup: don't even look for gdal if the installation will only be used for building data. even I just installed gdal on the building server when I saw the warning :smile: then I thought "why?".