### PR TITLE
FIXED Issue #4652: src/thor/unidirectional_astar.cc doesnt work for date_time type 2, i.e. for arrival

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
    * FIXED: some entry points to creating geotiff isochrones output did not register the geotiff driver before attempting to use it [#4628](https://github.com/valhalla/valhalla/pull/4628)
    * FIXED: libgdal wasn't installed in docker image, so it never worked in docker [#4629](https://github.com/valhalla/valhalla/pull/4629)
    * FIXED: CostMatrix shapes for routes against trivial oneways [#4633](https://github.com/valhalla/valhalla/pull/4633)
+   * FIXED: unidirectional_astar.cc doesn't work for date_time type = 2 #4652(https://github.com/valhalla/valhalla/issues/4652)
 * **Enhancement**
    * UPDATED: French translations, thanks to @xlqian [#4159](https://github.com/valhalla/valhalla/pull/4159)
    * CHANGED: -j flag for multithreaded executables to override mjolnir.concurrency [#4168](https://github.com/valhalla/valhalla/pull/4168)

--- a/src/thor/unidirectional_astar.cc
+++ b/src/thor/unidirectional_astar.cc
@@ -466,7 +466,7 @@ std::vector<std::vector<PathInfo>> UnidirectionalAStar<expansion_direction, FORW
   midgard::PointLL destination_new(destination.correlation().edges(0).ll().lng(),
                                    destination.correlation().edges(0).ll().lat());
   Init(origin_new, destination_new);
-  float mindist = astarheuristic_.GetDistance(FORWARD?origin_new:destination_new);
+  float mindist = astarheuristic_.GetDistance(FORWARD ? origin_new : destination_new);
 
   auto& startpoint = FORWARD ? origin : destination;
   auto& endpoint = FORWARD ? destination : origin;


### PR DESCRIPTION
# Issue 4652 ([https://github.com/valhalla/valhalla/issues/4652])

issue : src/thor/unidirectional_astar.cc doesnt work for date_time type 2, i.e. for arrival

steps to recreate: just make any long route(idk roughly around 1500 kms) with speed_type = 2(arrival), it will say "no route found".

its a minor fix i know but its bugging me.