### PR TITLE
update vpckg due to xz having a compromised release in previous version

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -31,7 +31,7 @@ on:
 env:
   BUILD_TYPE: Release
   MSVC_VERSION: '2022'
-  VCPKG_VERSION: '8040303'
+  VCPKG_VERSION: 'a164ace'
   VCPKG_INSTALL_OPTIONS: --x-abi-tools-use-exact-versions
   VCPKG_DISABLE_COMPILER_TRACKING: ON
 


### PR DESCRIPTION
ref https://github.com/microsoft/vcpkg/issues/37893

reading further it seems github actually disabled the whole repo! might not even work with this newer version.. in worst case win builds will be broken for a few days/weeks..