### PR TITLE
rm unused import fixes building tests without prime_server

### DIFF
--- a/test/gurka/test_elevation.cc
+++ b/test/gurka/test_elevation.cc
@@ -8,12 +8,9 @@
 #include <filesystem>
 
 #include <gtest/gtest.h>
-#include <prime_server/http_protocol.hpp>
-#include <prime_server/prime_server.hpp>
 
 using namespace valhalla;
 using namespace valhalla::gurka;
-using namespace prime_server;
 
 const std::string workdir = "test/data/gurka_elevation";
 


### PR DESCRIPTION
# Issue

The tests fail to build without prime_server, even with `-DENABLE_SERVICES=OFF -DENABLE_HTTP=OFF`.

I was going to do something fancier with cmake including different tests depending on the config, but it actually looks like this import was unused anyway.

## Context

I'm trying to build valhalla for use as a library (really I'm only looking at using `odin` at the moment), so I don't need the service integration. Further, prime_server is failing to build for me, but that's for another issue.

## Tasklist

I don't think any of these are relevant to this PR, but LMK:

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.
