### PR TITLE
auto-update the fossgis instances

### DIFF
--- a/.github/workflows/update_public_servers.yml
+++ b/.github/workflows/update_public_servers.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - nn-update-fossgis-gha
     paths:
+      - .github/workflows
       - 'src'
       - 'valhalla'
       - 'proto'

--- a/.github/workflows/update_public_servers.yml
+++ b/.github/workflows/update_public_servers.yml
@@ -1,0 +1,31 @@
+name: Update public FOSSGIS servers
+
+on:
+  push:
+    branches:
+      - nn-update-fossgis-gha
+    paths:
+      - 'src'
+      - 'valhalla'
+      - 'proto'
+      - 'scripts'
+      - 'lua'
+  workflow_dispatch:
+
+jobs:
+  update_servers:
+    name: Update servers
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run script
+        run: |
+          eval $(ssh-agent -s)
+          ssh-add - <<< "${{ secrets.SSH_SECRET }}"
+          # first the build server
+          ssh -p 23432 -o StrictHostKeyChecking=no valhalla@162.55.2.221 'sudo bash -s builder' < scripts/update_public_server.sh
+          # then the services
+          ssh -p 23432 -o StrictHostKeyChecking=no valhalla@162.55.2.221 'sudo bash -s service' < scripts/update_public_server.sh

--- a/scripts/update_public_server.sh
+++ b/scripts/update_public_server.sh
@@ -1,0 +1,35 @@
+# updates Valhalla on the FOSSGIS servers
+
+set -e
+
+server=$1
+src_dir="/src/valhalla"
+
+git -C "${src_dir}" checkout master
+git -C "${src_dir}" pull
+
+if [[ $server == "builder" ]]; then
+    cmake -S "${src_dir}" -B "${src_dir}/build" \
+        -DENABLE_TOOLS=OFF \
+        -DENABLE_SERVICES=OFF \
+        -DENABLE_HTTP=OFF \
+        -DENABLE_PYTHON_BINDINGS=OFF \
+        -DENABLE_TESTS=OFF \
+        -DENABLE_SINGLE_FILES_WERROR=OFF \
+        -DENABLE_GDAL=OFF
+
+    sudo make -C "${src_dir}/build" -j$(nproc) install
+    # config is updated by 
+else
+    cmake -S "${src_dir}" -B "${src_dir}/build" \
+    -DENABLE_DATA_TOOLS=OFF \
+    -DENABLE_SERVICES=ON \
+    -DENABLE_HTTP=ON \
+    -DENABLE_PYTHON_BINDINGS=OFF \
+    -DENABLE_TESTS=OFF \
+    -DENABLE_SINGLE_FILES_WERROR=OFF
+
+    sudo make -C "${src_dir}/build" -j$(nproc) install
+    # Update the configs
+    /opt/valhalla/runner_build_config.sh 8000 && /opt/valhalla/runner_build_config.sh 8001
+fi


### PR DESCRIPTION
adds a github action workflow to update the fossgis instances automatically whenever smth interesting was pushed to master. things can still go wrong, but really shouldn't very often. I didn't touch the servers in quite a while, other than installing gdal a while back.

just a general note how I set it up back then:
- one server has two sets of valhalla servers "installed", controlled by supervisor, where only one service is online at all times. once a new graph is pushed we start/stop the supervisor instances so we don't have any outages
- builder server has a supervisord process running on `while true` (until eternity) building the planet graph, updating the planet PBF right after incrementally and pushing the new tarred graph to the services server via ssh and starting/stopping its supervisor processes remotely
