### PR TITLE
always save vcpkg cache

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -109,8 +109,7 @@ jobs:
             -DPREFER_EXTERNAL_DEPS=ON \
             -DENABLE_GDAL=ON
 
-      - if: ${{ steps.vcpkg-restore.outputs.cache-hit != 'true' }}
-        name: Save vcpkg packages (if cache miss)
+      - name: Save vcpkg packages (always, to avoid redundant rebuilds)
         uses: actions/cache/save@v3
         with:
           key: ${{ steps.vcpkg-restore.outputs.cache-primary-key }}


### PR DESCRIPTION
let's try to always overwrite the vcpkg binary cache.. vcpkg is very annoying to configure for caching it seems, it (very) regularly invalidates a cache when smth in the build toolchain updates and then it decides to rebuild all packages which takes 45 mins.. I quickly looked for a solution but all I could find were very very long Github issues.. I _think_ most of the invalidations are caused by vcpkg's own copy of cmake which updates quite often..