### PR TITLE
Remove tile_extract from config when creating stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
    * FIXED: Fix segfault in costmatrix (date_time and time zone always added). [#4530](https://github.com/valhalla/valhalla/pull/4530)
    * FIXED: Fixed roundoff issue in Tiles Row and Col methods [#4585](https://github.com/valhalla/valhalla/pull/4585)
    * FIXED: Fix for assigning attributes has_(highway, ferry, toll) if directions_type is none [#4465](https://github.com/valhalla/valhalla/issues/4465)
+   * FIXED: Have the `valhalla_add_predicted_speeds` summary always be created from `mjolnir.tile_dir` [#4722](https://github.com/valhalla/valhalla/pull/4722) 
 * **Enhancement**
    * UPDATED: French translations, thanks to @xlqian [#4159](https://github.com/valhalla/valhalla/pull/4159)
    * CHANGED: -j flag for multithreaded executables to override mjolnir.concurrency [#4168](https://github.com/valhalla/valhalla/pull/4168)

--- a/src/mjolnir/valhalla_add_predicted_traffic.cc
+++ b/src/mjolnir/valhalla_add_predicted_traffic.cc
@@ -351,6 +351,9 @@ int main(int argc, char** argv) {
   if (!summary)
     return EXIT_SUCCESS;
 
+  // don't use the .tar for stats
+  config.get_child("mjolnir").erase("tile_extract");
+
   GraphReader reader(config.get_child("mjolnir"));
   // Iterate through the tiles
   int shortcuts_with_speed = 0;


### PR DESCRIPTION
# Issue

When running `valhalla_add_predicted_traffic` using a config that has an entry for both `mjolnir.tile_dir` and `mjolnir.tile_extract`, the summary (if requested) will be created from the tar, not the tile directory.  The predicted traffic is added to the tile directory though, so according to the summary, no speeds were added. This PR just removes the `mjolnir.tile_extract` before creating the summary, so it reads from the tile directory instead.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

