### PR TITLE
fix echo statement for linux/macos in building.md

### DIFF
--- a/docs/docs/building.md
+++ b/docs/docs/building.md
@@ -42,9 +42,9 @@ git clone https://github.com/microsoft/vcpkg && git -C vcpkg checkout <some-tag>
 ./vcpkg/bootstrap-vcpkg.sh
 # windows: cmd.exe /c bootstrap-vcpkg.bat
 # only build Release versions of dependencies, not Debug
-echo "VCPKG_BUILD_TYPE release" >> vcpkg/triplets/x64-linux.cmake
+echo "set(VCPKG_BUILD_TYPE release)" >> vcpkg/triplets/x64-linux.cmake
 # windows: echo.set(VCPKG_BUILD_TYPE release)>> .\vcpkg\triplets\x64-windows.cmake
-# osx: echo "VCPKG_BUILD_TYPE release" >> vcpkg/triplets/arm64-osx.cmake
+# osx: echo "set(VCPKG_BUILD_TYPE release)" >> vcpkg/triplets/arm64-osx.cmake
 
 # vcpkg will install everything during cmake configuration
 # if you want to ENABLE_SERVICES=ON, install https://github.com/kevinkreiser/prime_server#build-and-install (no Windows)


### PR DESCRIPTION
# Issue

I tried to build valhalla from source and followed the [vcpkg example](https://valhalla.github.io/valhalla/building/#building-with-vcpkg-any-platform) but got a syntax error:

```lang=bash
$ cmake -B build -DCMAKE_TOOLCHAIN_FILE=$PWD/vcpkg/scripts/buildsystems/vcpkg.cmake -DENABLE_SERVICE=OFF
-- Running vcpkg install
command:
/usr/bin/cmake -DVCPKG_ROOT_DIR=/root/valhalla/vcpkg -DPACKAGES_DIR=/root/valhalla/vcpkg/packages -DBUILDTREES_DIR=/root/valhalla/vcpkg/buildtrees -D_VCPKG_INSTALLED_DIR=/root/valhalla/build/vcpkg_installed -DDOWNLOADS=/root/valhalla/vcpkg/downloads -DVCPKG_MANIFEST_INSTALL=OFF -P /root/valhalla/vcpkg/buildtrees/0.vcpkg_dep_info.cmake
failed with the following output:
CMake Error at buildtrees/0.vcpkg_dep_info.cmake:13:,   Parse error.  Expected "(", got identifier with text "release"., , , CMake Error: Error processing file: /root/valhalla/vcpkg/buildtrees/0.vcpkg_dep_info.cmake
-- Running vcpkg install - failed
CMake Error at vcpkg/scripts/buildsystems/vcpkg.cmake:899 (message):
  vcpkg install failed.  See logs for more information:
  /root/valhalla/build/vcpkg-manifest-install.log
Call Stack (most recent call first):
  /usr/share/cmake-3.29/Modules/CMakeDetermineSystem.cmake:146 (include)
  CMakeLists.txt:11 (project)


CMake Error: CMake was unable to find a build program corresponding to "Unix Makefiles".  CMAKE_MAKE_PROGRAM is not set.  You probably need to select a different build tool.
CMake Error: CMAKE_CXX_COMPILER not set, after EnableLanguage
CMake Error: CMAKE_C_COMPILER not set, after EnableLanguage
-- Configuring incomplete, errors occurred!
``` 

I think it should be `set(VCPKG_BUILD_TYPE release)` and not ` VCPKG_BUILD_TYPE release`.
