### PR TITLE
Add missing include in `baldr/admin.h`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
    * FIXED: Fix for assigning attributes has_(highway, ferry, toll) if directions_type is none [#4465](https://github.com/valhalla/valhalla/issues/4465)
    * FIXED: Have the `valhalla_add_predicted_speeds` summary always be created from `mjolnir.tile_dir` [#4722](https://github.com/valhalla/valhalla/pull/4722) 
    * FIXED: Fix inconsistency in graph.lua for motor_vehicle_node [#4723](https://github.com/valhalla/valhalla/issues/4723)
+   * FIXED: Missing algorithm include in `baldr/admin.h` []()
 * **Enhancement**
    * UPDATED: French translations, thanks to @xlqian [#4159](https://github.com/valhalla/valhalla/pull/4159)
    * CHANGED: -j flag for multithreaded executables to override mjolnir.concurrency [#4168](https://github.com/valhalla/valhalla/pull/4168)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@
    * FIXED: Fix for assigning attributes has_(highway, ferry, toll) if directions_type is none [#4465](https://github.com/valhalla/valhalla/issues/4465)
    * FIXED: Have the `valhalla_add_predicted_speeds` summary always be created from `mjolnir.tile_dir` [#4722](https://github.com/valhalla/valhalla/pull/4722) 
    * FIXED: Fix inconsistency in graph.lua for motor_vehicle_node [#4723](https://github.com/valhalla/valhalla/issues/4723)
-   * FIXED: Missing algorithm include in `baldr/admin.h` []()
+   * FIXED: Missing algorithm include in `baldr/admin.h` [#4766](https://github.com/valhalla/valhalla/pull/4766)
 * **Enhancement**
    * UPDATED: French translations, thanks to @xlqian [#4159](https://github.com/valhalla/valhalla/pull/4159)
    * CHANGED: -j flag for multithreaded executables to override mjolnir.concurrency [#4168](https://github.com/valhalla/valhalla/pull/4168)

--- a/src/baldr/admin.cc
+++ b/src/baldr/admin.cc
@@ -1,4 +1,5 @@
 #include "baldr/admin.h"
+#include <algorithm>
 
 namespace {
 

--- a/valhalla/baldr/admin.h
+++ b/valhalla/baldr/admin.h
@@ -1,6 +1,7 @@
 #ifndef VALHALLA_BALDR_ADMIN_H_
 #define VALHALLA_BALDR_ADMIN_H_
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <cstring>

--- a/valhalla/baldr/admin.h
+++ b/valhalla/baldr/admin.h
@@ -1,7 +1,6 @@
 #ifndef VALHALLA_BALDR_ADMIN_H_
 #define VALHALLA_BALDR_ADMIN_H_
 
-#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <cstring>


### PR DESCRIPTION
# Issue

I've been starting to get compilation errors recently due the use of `std::find()` in `baldr/admin.cc`, apparently caused by a missing include:

```
[build] /home/chris/dev/github/valhalla/src/baldr/admin.cc: In member function ‘std::string valhalla::baldr::Admin::state_iso() const’:
[build] /home/chris/dev/github/valhalla/src/baldr/admin.cc:109:57: error: no matching function for call to ‘find(std::array<char, 3>::const_iterator, std::array<char, 3>::const_iterator, char)’
[build]   109 |              : std::string(state_iso_.begin(), std::find(state_iso_.begin(), state_iso_.end(), '\0'));
[build]       |                                                ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

 Not sure what's the root cause, but seems like Valhalla was just relying on it being included elsewhere? 

## Tasklist

 - [x] Update the [changelog](CHANGELOG.md)
