### PR TITLE
Fix misleading map matching documentation

### DIFF
--- a/docs/docs/api/map-matching/api-reference.md
+++ b/docs/docs/api/map-matching/api-reference.md
@@ -39,9 +39,7 @@ Note that the attributes that are returned are Valhalla routing attributes, not 
 
 ### Costing models and other options
 
-Valhalla Map Matching uses the `auto`, `auto_shorter`, `bicycle`, `bus`, and `pedestrian` costing models available in the Valhalla route service. Refer to the [route costing models](../turn-by-turn/api-reference.md#costing-models) and [costing options](../turn-by-turn/api-reference.md#costing-options) documentation for more on how to specify this input.
-
-Costing for `multimodal` is not supported for map matching because it would be difficult to get favorable GPS traces.
+Valhalla Map Matching can use any costing model available in the Valhalla route service except for `multimodal` (it would be difficult to get a GPS trace and detect certain mode changes). Refer to the [route costing models](../turn-by-turn/api-reference.md#costing-models) and [costing options](../turn-by-turn/api-reference.md#costing-options) documentation for more on how to specify this input.
 
 You can also set `directions_options` to specify output units, language, and whether or not to return directions in a narrative form. Refer to the [route options](../turn-by-turn/api-reference.md#directions-options) documentation for examples.
 


### PR DESCRIPTION
Just a quick ninja edit since these docs are obviously wrong (and I'm pretty sure the revised description of things is correct based on [Loki source](https://github.com/valhalla/valhalla/blob/7be6e23712ae06cb8fc7a41462529f10e662d7b4/src/loki/trace_route_action.cc#L169)).