### PR TITLE
fix build_elevation script help string

### DIFF
--- a/scripts/valhalla_build_elevation
+++ b/scripts/valhalla_build_elevation
@@ -116,7 +116,7 @@ group.add_argument(
     "-z",
     "--lz4",
     help="If set, downloaded files will be recompressed with LZ4. Requires lz4. "
-    "Requires ~12% more disk space (216GB total) vs gzip. While you pay upfront in extra CPU and space on the "
+    "Requires ~12%% more disk space (216GB total) vs gzip. While you pay upfront in extra CPU and space on the "
     "initial download, tiles will be several times faster to decompress vz gzip.",
     action="store_true",
 )


### PR DESCRIPTION
The help message wasn't working, Python's string formatting didn't like the percent symbol
