### PR TITLE
Restructure top speeds for truck

### DIFF
--- a/src/mjolnir/shortcutbuilder.cc
+++ b/src/mjolnir/shortcutbuilder.cc
@@ -330,7 +330,7 @@ void ConnectEdges(GraphReader& reader,
   total_truck_duration += turn_duration;
   auto const truck_speed =
       std::min(tile->GetSpeed(directededge, kNoFlowMask, kInvalidSecondsOfWeek, true),
-               directededge->truck_speed() ? directededge->truck_speed() : kMaxAssumedTruckSpeed);
+               directededge->truck_speed() ? directededge->truck_speed() : directededge->speed());
 
   assert(truck_speed != 0);
   auto const edge_duration_truck = directededge->length() / (truck_speed * kKPHtoMetersPerSec);

--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -79,6 +79,8 @@ constexpr ranged_default_t<float> kUseDistanceRange{0, kDefaultUseDistance, 1.0f
 constexpr ranged_default_t<float> kAutoHeightRange{0, kDefaultAutoHeight, 10.0f};
 constexpr ranged_default_t<float> kAutoWidthRange{0, kDefaultAutoWidth, 10.0f};
 constexpr ranged_default_t<uint32_t> kProbabilityRange{0, kDefaultRestrictionProbability, 100};
+constexpr ranged_default_t<uint32_t> kVehicleSpeedRange{10, baldr::kMaxAssumedSpeed,
+                                                        baldr::kMaxSpeedKph};
 
 constexpr float kHighwayFactor[] = {
     1.0f, // Motorway
@@ -694,6 +696,7 @@ void ParseAutoCostOptions(const rapidjson::Document& doc,
   JSON_PBF_DEFAULT(co, false, json, "/include_hot", include_hot);
   JSON_PBF_DEFAULT(co, false, json, "/include_hov2", include_hov2);
   JSON_PBF_DEFAULT(co, false, json, "/include_hov3", include_hov3);
+  JSON_PBF_RANGED_DEFAULT(co, kVehicleSpeedRange, json, "/top_speed", top_speed);
 }
 
 cost_ptr_t CreateAutoCost(const Costing& costing_options) {

--- a/src/sif/dynamiccost.cc
+++ b/src/sif/dynamiccost.cc
@@ -108,10 +108,10 @@ constexpr float kDefaultClosureFactor = 9.0f;
 // non-closure end
 constexpr ranged_default_t<float> kClosureFactorRange{1.0f, kDefaultClosureFactor, 10.0f};
 
-constexpr ranged_default_t<uint32_t> kVehicleSpeedRange{10, baldr::kMaxAssumedSpeed,
-                                                        baldr::kMaxSpeedKph};
 constexpr ranged_default_t<uint32_t> kFixedSpeedRange{0, baldr::kDisableFixedSpeed,
                                                       baldr::kMaxSpeedKph};
+constexpr ranged_default_t<uint32_t> kVehicleSpeedRange{10, baldr::kMaxAssumedSpeed,
+                                                        baldr::kMaxSpeedKph};
 } // namespace
 
 /*
@@ -122,8 +122,8 @@ BaseCostingOptionsConfig::BaseCostingOptionsConfig()
     : dest_only_penalty_{0.f, kDefaultDestinationOnlyPenalty, kMaxPenalty},
       maneuver_penalty_{0.f, kDefaultManeuverPenalty, kMaxPenalty},
       alley_penalty_{0.f, kDefaultAlleyPenalty, kMaxPenalty},
-      gate_cost_{0.f, kDefaultGateCost, kMaxPenalty}, gate_penalty_{0.f, kDefaultGatePenalty,
-                                                                    kMaxPenalty},
+      gate_cost_{0.f, kDefaultGateCost, kMaxPenalty},
+      gate_penalty_{0.f, kDefaultGatePenalty, kMaxPenalty},
       private_access_penalty_{0.f, kDefaultPrivateAccessPenalty, kMaxPenalty},
       country_crossing_cost_{0.f, kDefaultCountryCrossingCost, kMaxPenalty},
       country_crossing_penalty_{0.f, kDefaultCountryCrossingPenalty, kMaxPenalty},
@@ -131,15 +131,13 @@ BaseCostingOptionsConfig::BaseCostingOptionsConfig()
       toll_booth_penalty_{0.f, kDefaultTollBoothPenalty, kMaxPenalty},
       ferry_cost_{0.f, kDefaultFerryCost, kMaxPenalty}, use_ferry_{0.f, kDefaultUseFerry, 1.f},
       rail_ferry_cost_{0.f, kDefaultRailFerryCost, kMaxPenalty},
-      use_rail_ferry_{0.f, kDefaultUseRailFerry, 1.f}, service_penalty_{0.f, kDefaultServicePenalty,
-                                                                        kMaxPenalty},
-      service_factor_{kMinFactor, kDefaultServiceFactor, kMaxFactor}, use_tracks_{0.f,
-                                                                                  kDefaultUseTracks,
-                                                                                  1.f},
+      use_rail_ferry_{0.f, kDefaultUseRailFerry, 1.f},
+      service_penalty_{0.f, kDefaultServicePenalty, kMaxPenalty},
+      service_factor_{kMinFactor, kDefaultServiceFactor, kMaxFactor},
+      use_tracks_{0.f, kDefaultUseTracks, 1.f},
       use_living_streets_{0.f, kDefaultUseLivingStreets, 1.f}, use_lit_{0.f, kDefaultUseLit, 1.f},
-      closure_factor_{kClosureFactorRange}, exclude_unpaved_(false),
-      exclude_cash_only_tolls_(false), include_hot_{false}, include_hov2_{false}, include_hov3_{
-                                                                                      false} {
+      closure_factor_{kClosureFactorRange}, exclude_unpaved_(false), exclude_cash_only_tolls_(false),
+      include_hot_{false}, include_hov2_{false}, include_hov3_{false} {
 }
 
 DynamicCost::DynamicCost(const Costing& costing,
@@ -402,9 +400,6 @@ void ParseBaseCostOptions(const rapidjson::Value& json,
   co->set_disable_hierarchy_pruning(
       rapidjson::get<bool>(json, "/disable_hierarchy_pruning", co->disable_hierarchy_pruning()));
 
-  // top speed
-  JSON_PBF_RANGED_DEFAULT(co, kVehicleSpeedRange, json, "/top_speed", top_speed);
-
   // destination only penalty
   JSON_PBF_RANGED_DEFAULT(co, cfg.dest_only_penalty_, json, "/destination_only_penalty",
                           destination_only_penalty);
@@ -432,6 +427,9 @@ void ParseBaseCostOptions(const rapidjson::Value& json,
   // country_crossing_penalty
   JSON_PBF_RANGED_DEFAULT(co, cfg.country_crossing_penalty_, json, "/country_crossing_penalty",
                           country_crossing_penalty);
+
+  // // top_speed
+  // JSON_PBF_RANGED_DEFAULT(co, kVehicleSpeedRange, json, "/top_speed", top_speed);
 
   if (!cfg.disable_toll_booth_) {
     // toll_booth_cost

--- a/src/sif/truckcost.cc
+++ b/src/sif/truckcost.cc
@@ -495,9 +495,9 @@ Cost TruckCost::EdgeCost(const baldr::DirectedEdge* edge,
                                          &flow_sources, time_info.seconds_from_now)
                         : fixed_speed_;
 
-  auto final_speed = std::min(std::min(edge_speed, edge->truck_speed() ? edge->truck_speed()
-                                                                       : kMaxAssumedTruckSpeed),
-                              top_speed_);
+  auto final_speed =
+      std::min(edge_speed,
+               edge->truck_speed() ? std::min(edge->truck_speed(), top_speed_) : top_speed_);
 
   float sec = edge->length() * speedfactor_[final_speed];
 


### PR DESCRIPTION
# Issue
Fixes #4789. 

This properly enabled `top_speed` for trucks. Until now, the option was a ranged default, but even the allowed range was [10,252], the parameter was always clamped to the default value, 90. This PR addresses that with the following changes:

  - top speed now is clamped to the edge speed instead of `kMaxAssumedTruckSpeed`
  - when a `truck_speed` is set, choose the minimum of `truck_speed`, edge speed or `top_speed` 
  - `kMaxAssumedTruckSpeed` (and hence, `top_speed` default for truck) is now raised from 90 to 120 KPH. This is more in line with `kMaxAssumedSpeed` which at 140 kph is set at the higher end of how fast cars will actually go. I have gotten frequent feedback about 90 sometimes being to low, and in this case is really just necessary for build time estimation of truck durations for shortcuts to play well with run time dynamic costing
  - in shortcutbuilder, we previously set `truck_speed` to `kMaxAssumedTruckSpeed` i.e. 90KPH where no truck speed is set, but with `top_speed` now fully controllable, this really needs to be the edge's `speed` as the fallback

Thinking about it, though, I think #4493 and this PR really are just band aids for a bigger problem, which is trying to get good ETA's for truck routes... IMO this PR would improve the situation a bit by extending the flexibility of `top_speed`, but also worsen the default situation again. Anyway, leaving it here to be tried out and contested :smile:  

## Tasklist

 - [x] Add tests
 - [x] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
