### PR TITLE
`use_truck_route` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@
    * ADDED: Dedupe option for expansion, significantly reducing the response size. [#4601](https://github.com/valhalla/valhalla/issues/4601)
    * FIXED: remove old code that allows bicycle access on hiking trails. [#4781](https://github.com/valhalla/valhalla/pull/4781)
    * ADDED: inline config arg for `valhalla_build_elevation` script [#4787](https://github.com/valhalla/valhalla/pull/4787)
+   * ADDED: `use_truck_route` [#4809](https://github.com/valhalla/valhalla/pull/4809)
 
 ## Release Date: 2023-05-11 Valhalla 3.4.0
 * **Removed**

--- a/docs/docs/api/turn-by-turn/api-reference.md
+++ b/docs/docs/api/turn-by-turn/api-reference.md
@@ -163,6 +163,7 @@ The following options are available for `truck` costing.
 | `hazmat` | A value indicating if the truck is carrying hazardous materials. Default false. |
 | `hgv_no_access_penalty` | A penalty applied to roads with no HGV/truck access. If set to a value less than 43200 seconds, HGV will be allowed on these roads and the penalty applies. Default 43200, i.e. trucks are not allowed. |
 | `low_class_penalty` | A penalty (in seconds) which is applied when going to residential or service roads. Default is 30 seconds. |
+| `use_truck_route` | This value is a range of values from 0 to 1, where 0 indicates a light preference for streets marked as truck routes, and 1 indicates that streets not marked as truck routes should be avoided. This information is derived from the `hgv=designated` tag. Note that even with values near 1, there is no guarantee the returned route will include streets marked as truck routes. The default value is 0. | 
 
 
 ##### Bicycle costing options

--- a/proto/options.proto
+++ b/proto/options.proto
@@ -316,6 +316,7 @@ message Costing {
     oneof has_hgv_no_access_penalty {
       float hgv_no_access_penalty = 85;
     }
+    float use_truck_route = 86;
   }
 
   oneof has_options {


### PR DESCRIPTION
# Issue

Fixes  #4797 

I decided to implement this the way `use_lit` works: instead of letting `use_truck_route` control preference of edges marked with `truck_route`, this does the inverse by applying high factors to edges *not* marked with `truck_route`. The existing logic for `truck_route` edges does not change though: a constant factor of 0.85 is still applied in that case, and by default the "inverse" factor is 1, so no change here. 


## Tasklist

 - [x] Add tests
 - [x] Add #fixes with the issue number that this PR addresses
 - [x] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)

