### PR TITLE
Revive `max_distance` for pedestrian costing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
    * FIXED: Missing algorithm include in `baldr/admin.h` [#4766](https://github.com/valhalla/valhalla/pull/4766)
    * FIXED: Handle list type arguments correctly when overriding config with valhalla_build_config [#4799](https://github.com/valhalla/valhalla/pull/4799)
    * FIXED: `top_speed` range not fully allowed for trucks [#4793](https://github.com/valhalla/valhalla/pull/4793)
+   * FIXED: fix `max_distance` for pedestrian costing [#4811](https://github.com/valhalla/valhalla/pull/4811)
 
 * **Enhancement**
    * UPDATED: French translations, thanks to @xlqian [#4159](https://github.com/valhalla/valhalla/pull/4159)

--- a/src/sif/dynamiccost.cc
+++ b/src/sif/dynamiccost.cc
@@ -120,8 +120,8 @@ BaseCostingOptionsConfig::BaseCostingOptionsConfig()
     : dest_only_penalty_{0.f, kDefaultDestinationOnlyPenalty, kMaxPenalty},
       maneuver_penalty_{0.f, kDefaultManeuverPenalty, kMaxPenalty},
       alley_penalty_{0.f, kDefaultAlleyPenalty, kMaxPenalty},
-      gate_cost_{0.f, kDefaultGateCost, kMaxPenalty}, gate_penalty_{0.f, kDefaultGatePenalty,
-                                                                    kMaxPenalty},
+      gate_cost_{0.f, kDefaultGateCost, kMaxPenalty},
+      gate_penalty_{0.f, kDefaultGatePenalty, kMaxPenalty},
       private_access_penalty_{0.f, kDefaultPrivateAccessPenalty, kMaxPenalty},
       country_crossing_cost_{0.f, kDefaultCountryCrossingCost, kMaxPenalty},
       country_crossing_penalty_{0.f, kDefaultCountryCrossingPenalty, kMaxPenalty},
@@ -129,15 +129,13 @@ BaseCostingOptionsConfig::BaseCostingOptionsConfig()
       toll_booth_penalty_{0.f, kDefaultTollBoothPenalty, kMaxPenalty},
       ferry_cost_{0.f, kDefaultFerryCost, kMaxPenalty}, use_ferry_{0.f, kDefaultUseFerry, 1.f},
       rail_ferry_cost_{0.f, kDefaultRailFerryCost, kMaxPenalty},
-      use_rail_ferry_{0.f, kDefaultUseRailFerry, 1.f}, service_penalty_{0.f, kDefaultServicePenalty,
-                                                                        kMaxPenalty},
-      service_factor_{kMinFactor, kDefaultServiceFactor, kMaxFactor}, use_tracks_{0.f,
-                                                                                  kDefaultUseTracks,
-                                                                                  1.f},
+      use_rail_ferry_{0.f, kDefaultUseRailFerry, 1.f},
+      service_penalty_{0.f, kDefaultServicePenalty, kMaxPenalty},
+      service_factor_{kMinFactor, kDefaultServiceFactor, kMaxFactor},
+      use_tracks_{0.f, kDefaultUseTracks, 1.f},
       use_living_streets_{0.f, kDefaultUseLivingStreets, 1.f}, use_lit_{0.f, kDefaultUseLit, 1.f},
-      closure_factor_{kClosureFactorRange}, exclude_unpaved_(false),
-      exclude_cash_only_tolls_(false), include_hot_{false}, include_hov2_{false}, include_hov3_{
-                                                                                      false} {
+      closure_factor_{kClosureFactorRange}, exclude_unpaved_(false), exclude_cash_only_tolls_(false),
+      include_hot_{false}, include_hov2_{false}, include_hov3_{false} {
 }
 
 DynamicCost::DynamicCost(const Costing& costing,
@@ -327,6 +325,10 @@ void DynamicCost::AddUserAvoidEdges(const std::vector<AvoidEdge>& exclude_edges)
 
 Cost DynamicCost::BSSCost() const {
   return kNoCost;
+}
+
+float DynamicCost::MaxDistance() const {
+  return kMaxDistance;
 }
 
 void DynamicCost::set_use_tracks(float use_tracks) {

--- a/src/sif/dynamiccost.cc
+++ b/src/sif/dynamiccost.cc
@@ -120,8 +120,8 @@ BaseCostingOptionsConfig::BaseCostingOptionsConfig()
     : dest_only_penalty_{0.f, kDefaultDestinationOnlyPenalty, kMaxPenalty},
       maneuver_penalty_{0.f, kDefaultManeuverPenalty, kMaxPenalty},
       alley_penalty_{0.f, kDefaultAlleyPenalty, kMaxPenalty},
-      gate_cost_{0.f, kDefaultGateCost, kMaxPenalty},
-      gate_penalty_{0.f, kDefaultGatePenalty, kMaxPenalty},
+      gate_cost_{0.f, kDefaultGateCost, kMaxPenalty}, gate_penalty_{0.f, kDefaultGatePenalty,
+                                                                    kMaxPenalty},
       private_access_penalty_{0.f, kDefaultPrivateAccessPenalty, kMaxPenalty},
       country_crossing_cost_{0.f, kDefaultCountryCrossingCost, kMaxPenalty},
       country_crossing_penalty_{0.f, kDefaultCountryCrossingPenalty, kMaxPenalty},
@@ -129,13 +129,15 @@ BaseCostingOptionsConfig::BaseCostingOptionsConfig()
       toll_booth_penalty_{0.f, kDefaultTollBoothPenalty, kMaxPenalty},
       ferry_cost_{0.f, kDefaultFerryCost, kMaxPenalty}, use_ferry_{0.f, kDefaultUseFerry, 1.f},
       rail_ferry_cost_{0.f, kDefaultRailFerryCost, kMaxPenalty},
-      use_rail_ferry_{0.f, kDefaultUseRailFerry, 1.f},
-      service_penalty_{0.f, kDefaultServicePenalty, kMaxPenalty},
-      service_factor_{kMinFactor, kDefaultServiceFactor, kMaxFactor},
-      use_tracks_{0.f, kDefaultUseTracks, 1.f},
+      use_rail_ferry_{0.f, kDefaultUseRailFerry, 1.f}, service_penalty_{0.f, kDefaultServicePenalty,
+                                                                        kMaxPenalty},
+      service_factor_{kMinFactor, kDefaultServiceFactor, kMaxFactor}, use_tracks_{0.f,
+                                                                                  kDefaultUseTracks,
+                                                                                  1.f},
       use_living_streets_{0.f, kDefaultUseLivingStreets, 1.f}, use_lit_{0.f, kDefaultUseLit, 1.f},
-      closure_factor_{kClosureFactorRange}, exclude_unpaved_(false), exclude_cash_only_tolls_(false),
-      include_hot_{false}, include_hov2_{false}, include_hov3_{false} {
+      closure_factor_{kClosureFactorRange}, exclude_unpaved_(false),
+      exclude_cash_only_tolls_(false), include_hot_{false}, include_hov2_{false}, include_hov3_{
+                                                                                      false} {
 }
 
 DynamicCost::DynamicCost(const Costing& costing,

--- a/src/sif/pedestriancost.cc
+++ b/src/sif/pedestriancost.cc
@@ -652,7 +652,7 @@ bool PedestrianCost::Allowed(const baldr::DirectedEdge* edge,
        pred.mode() == TravelMode::kPedestrian) ||
       //      (edge->max_up_slope() > max_grade_ || edge->max_down_slope() > max_grade_) ||
       // path_distance for multimodal is currently checked inside the algorithm
-      (allow_transit_connections_ || ((pred.path_distance() + edge->length()) > max_distance_))) {
+      (!allow_transit_connections_ && ((pred.path_distance() + edge->length()) > max_distance_))) {
     return false;
   }
 
@@ -686,7 +686,8 @@ bool PedestrianCost::AllowedReverse(const baldr::DirectedEdge* edge,
       (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx() &&
        pred.mode() == TravelMode::kPedestrian) ||
       //      (opp_edge->max_up_slope() > max_grade_ || opp_edge->max_down_slope() > max_grade_) ||
-      (allow_transit_connections_ || ((pred.path_distance() + opp_edge->length()) > max_distance_))) {
+      (!allow_transit_connections_ &&
+       ((pred.path_distance() + opp_edge->length()) > max_distance_))) {
     return false;
   }
 

--- a/test/gurka/test_route.cc
+++ b/test/gurka/test_route.cc
@@ -1235,3 +1235,40 @@ TEST(StandAlone, HGVNoAccessPenalty) {
     }
   }
 }
+
+TEST(StandAlone, PedestrianMaxDistance) {
+  const std::string ascii_map = R"(
+    A----B----C----D----E----F----G-----H
+)";
+
+  const gurka::ways ways = {
+      {"AB", {{"highway", "residential"}}}, {"BC", {{"highway", "residential"}}},
+      {"CD", {{"highway", "residential"}}}, {"DE", {{"highway", "path"}}},
+      {"EF", {{"highway", "path"}}},        {"FG", {{"highway", "path"}}},
+      {"GH", {{"highway", "path"}}},
+  };
+
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100);
+  gurka::map map = gurka::buildtiles(layout, ways, {}, {}, "test/data/pedestrian_max_distance");
+
+  std::unordered_map<std::string, std::string> max_dist_opts = {
+      {"/costing_options/pedestrian/max_distance", "500"}};
+
+  // by default, expect a route to be found
+  {
+    auto route = gurka::do_action(valhalla::Options::route, map, {"A", "H"}, "pedestrian");
+    gurka::assert::raw::expect_path(route, {"AB", "BC", "CD", "DE", "EF", "FG", "GH"});
+  }
+
+  // with max_distance set to 500, this should throw
+  {
+    try {
+      auto route =
+          gurka::do_action(valhalla::Options::route, map, {"A", "H"}, "pedestrian", max_dist_opts);
+      const auto actual_names = gurka::detail::get_paths(route).front();
+      FAIL() << "Expected no path to be found, found ";
+    } catch (const valhalla_exception_t& err) { EXPECT_EQ(err.code, 442); } catch (...) {
+      FAIL() << "Expected valhalla_exception_t.";
+    };
+  }
+}

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -925,6 +925,11 @@ public:
 
   virtual Cost BSSCost() const;
 
+  /**
+   * Get the current max distance (currently only implemented by PedestrianCost).
+   * @return  Returns the maximum allowed path distance.
+   */
+  virtual float MaxDistance() const;
   /*
    * Determine whether an edge is currently closed due to traffic.
    * @param  edgeid         GraphId of the opposing edge.

--- a/valhalla/thor/bidirectional_astar.h
+++ b/valhalla/thor/bidirectional_astar.h
@@ -208,7 +208,10 @@ protected:
    * @param  pred  Edge label of the predecessor.
    * @return Returns true if a connection was set, false if not (if on a complex restriction).
    */
-  bool SetForwardConnection(baldr::GraphReader& graphreader, const sif::BDEdgeLabel& pred);
+  bool SetForwardConnection(baldr::GraphReader& graphreader,
+                            const sif::BDEdgeLabel& pred,
+                            const valhalla::sif::TravelMode mode,
+                            const valhalla::sif::cost_ptr_t costing);
 
   /**
    * The edge on the reverse search connects to a reached edge on the forward
@@ -217,7 +220,10 @@ protected:
    * @param  pred  Edge label of the predecessor.
    * @return Returns true if a connection was set, false if not (if on a complex restriction).
    */
-  bool SetReverseConnection(baldr::GraphReader& graphreader, const sif::BDEdgeLabel& pred);
+  bool SetReverseConnection(baldr::GraphReader& graphreader,
+                            const sif::BDEdgeLabel& pred,
+                            const valhalla::sif::TravelMode mode,
+                            const valhalla::sif::cost_ptr_t costing);
 
   /**
    * Form the path from the adjacency lists. Recovers the path from the


### PR DESCRIPTION
# Issue

Fixes #4804 . What I though was a small bug caused by an unwanted type conversion turned into a bit of a scavenger hunt :smile: I'm not sure how `max_distance` was so neglected, because it turns out that it just didn't work with bidirectional Astar, since that  algorithm doesn't properly track path distances. Did pedestrian pathfinding use a unidirectional algorithm when `max_distance` was first introduced? 

Anyway,  this is how I'm bringing it back to life:

  - allow edges on both search branches to be added to the queue unless their path distance exceeds the total max distance. Cutting that distance in half wouldn't make much sense, because search paths don't necessarily meet half way (maybe it could be set lower so the algorithm can bail earlier, but then the costing needs to be aware of which algorithm is calling it, and we need to agree on an appropriate percentage of max distance)
  - only allow a connection to be marked as found when the accumulated path distance does not exceed the allowed distance 
 


## Tasklist

 - [x] Add tests
 - [x] Add #fixes with the issue number that this PR addresses
 - [x] Update the [changelog](CHANGELOG.md)

