### PR TITLE
costmatrix cleanup was not resetting properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
    * FIXED: Handle list type arguments correctly when overriding config with valhalla_build_config [#4799](https://github.com/valhalla/valhalla/pull/4799)
    * FIXED: `top_speed` range not fully allowed for trucks [#4793](https://github.com/valhalla/valhalla/pull/4793)
    * FIXED: Trivial routes for CostMatrix [#4634](https://github.com/valhalla/valhalla/pull/4634)
+   * FIXED: Reset `not_thru_pruning` in CostMatrix after second pass was used [#4817](https://github.com/valhalla/valhalla/pull/4817)  
 
 * **Enhancement**
    * UPDATED: French translations, thanks to @xlqian [#4159](https://github.com/valhalla/valhalla/pull/4159)

--- a/src/thor/costmatrix.cc
+++ b/src/thor/costmatrix.cc
@@ -71,7 +71,7 @@ void CostMatrix::Clear() {
   if (check_reverse_connections_)
     sources_->clear();
 
-  // Clear all source adjacency lists, edge labels, and edge status
+  // Clear all adjacency lists, edge labels, and edge status
   // Resize and shrink_to_fit so all capacity is reduced.
   auto label_reservation = clear_reserved_memory_ ? 0 : max_reserved_labels_count_;
   auto locs_reservation = clear_reserved_memory_ ? 0 : max_reserved_locations_count_;
@@ -105,6 +105,7 @@ void CostMatrix::Clear() {
     astar_heuristics_[is_fwd].clear();
   }
   best_connection_.clear();
+  set_not_thru_pruning(true);
   ignore_hierarchy_limits_ = false;
 }
 


### PR DESCRIPTION
# Issue

In `CostMatrix`, when second pass is used, `not_thru_pruning` is set to false to increase the chances of finding a route, but the reset was missing afterwards. 
