### PR TITLE
Remove manual timeouts of Loki and Skadi service tests

### DIFF
--- a/test/loki_service.cc
+++ b/test/loki_service.cc
@@ -607,9 +607,6 @@ public:
 
 // Elevation service
 int main(int argc, char* argv[]) {
-  // make this whole thing bail if it doesnt finish fast
-  alarm(180);
-
   testing::AddGlobalTestEnvironment(new LokiServiceEnv);
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/test/skadi_service.cc
+++ b/test/skadi_service.cc
@@ -241,9 +241,6 @@ TEST(SkadiService, test_requests) {
       },
       1);
 
-  // make this whole thing bail if it doesnt finish fast
-  alarm(120);
-
   // request and receive
   client.batch();
 }


### PR DESCRIPTION
# Issue

This PR removes manual signals in Loki and Skadi service tests that are not necessary anymore as https://github.com/kevinkreiser/prime_server/pull/134 is merged.

Previously, we had a timing issue where HTTP requests into the Valhalla cluster disappears if the HTTP server is not ready to accept loopback messages but has already started accepting HTTP requests.

## Tasklist

- [x] Add tests
- [ ] Add #fixes with the issue number that this PR addresses
- [x] Update the docs with any new request parameters or changes to behavior described
- [ ] Update the [changelog](CHANGELOG.md)
- [x] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

- https://github.com/kevinkreiser/prime_server/pull/134
