### PR TITLE
fix location search_filter for node snaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
    * FIXED: Reset `not_thru_pruning` in CostMatrix after second pass was used [#4817](https://github.com/valhalla/valhalla/pull/4817)  
    * FIXED: wrong index used in CostMatrix expansion callback inside reverse connection check [#4821](https://github.com/valhalla/valhalla/pull/4821)
    * FIXED: oneway ferry connections classification [#4828](https://github.com/valhalla/valhalla/pull/4828)
+   * FIXED: location search_filter ignored in certain cases [#4835](https://github.com/valhalla/valhalla/pull/4835)
 
 * **Enhancement**
    * UPDATED: French translations, thanks to @xlqian [#4159](https://github.com/valhalla/valhalla/pull/4159)

--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -22,23 +22,22 @@ template <typename T> inline T square(T v) {
   return v * v;
 }
 
-bool is_search_filter_triggered(const DirectedEdge* edge,
-                                const DynamicCost& costing,
-                                const graph_tile_ptr& tile,
-                                const Location::SearchFilter& search_filter) {
+bool search_filter(const DirectedEdge* edge,
+                   const DynamicCost& costing,
+                   const graph_tile_ptr& tile,
+                   const Location::SearchFilter& filter) {
   // check if this edge matches any of the exclusion filters
   uint32_t road_class = static_cast<uint32_t>(edge->classification());
-  uint32_t min_road_class = static_cast<uint32_t>(search_filter.min_road_class_);
-  uint32_t max_road_class = static_cast<uint32_t>(search_filter.max_road_class_);
+  uint32_t min_road_class = static_cast<uint32_t>(filter.min_road_class_);
+  uint32_t max_road_class = static_cast<uint32_t>(filter.max_road_class_);
 
   // Note that min_ and max_road_class are integers where, by default, max_road_class
   // is 0 and min_road_class is 7. This filter rejects roads where the functional
   // road class is outside of the min to max range.
   return (road_class > min_road_class || road_class < max_road_class) ||
-         (search_filter.exclude_tunnel_ && edge->tunnel()) ||
-         (search_filter.exclude_bridge_ && edge->bridge()) ||
-         (search_filter.exclude_ramp_ && (edge->use() == Use::kRamp)) ||
-         (search_filter.exclude_closures_ && (costing.flow_mask() & kCurrentFlowMask) &&
+         (filter.exclude_tunnel_ && edge->tunnel()) || (filter.exclude_bridge_ && edge->bridge()) ||
+         (filter.exclude_ramp_ && (edge->use() == Use::kRamp)) ||
+         (filter.exclude_closures_ && (costing.flow_mask() & kCurrentFlowMask) &&
           tile->IsClosed(edge));
 }
 
@@ -323,7 +322,7 @@ struct bin_handler_t {
         // do we want this edge, note we have to re-evaluate the filter check because we may be
         // seeing these edges a second time (filtered out before)
         if (costing->Allowed(edge, tile, kDisallowShortcut) &&
-            !is_search_filter_triggered(edge, *costing, tile, location.search_filter_)) {
+            !search_filter(edge, *costing, tile, location.search_filter_)) {
           auto reach = get_reach(id, edge);
           PathLocation::PathEdge
               path_edge{id,   0, node_ll, distance, PathLocation::NONE, reach.outbound, reach.inbound,
@@ -343,7 +342,7 @@ struct bin_handler_t {
           continue;
 
         if (costing->Allowed(other_edge, other_tile, kDisallowShortcut) &&
-            !is_search_filter_triggered(other_edge, *costing, other_tile, location.search_filter_)) {
+            !search_filter(other_edge, *costing, other_tile, location.search_filter_)) {
           auto opp_angle = std::fmod(angle + 180.f, 360.f);
           auto reach = get_reach(other_id, other_edge);
           PathLocation::PathEdge path_edge{other_id,
@@ -421,11 +420,13 @@ struct bin_handler_t {
       PathLocation::PathEdge path_edge{candidate.edge_id, length_ratio, candidate.point,
                                        distance,          side,         reach.outbound,
                                        reach.inbound,     angle};
-      // correlate the edge we found
-      if (side_filter(path_edge, location, reader) || heading_filter(location, angle) ||
-          layer_filter(location, layer)) {
+      // correlate the edge we found if its not filtered out
+      bool hard_filtered =
+          search_filter(candidate.edge, *costing, candidate.tile, location.search_filter_);
+      if (!hard_filtered && (side_filter(path_edge, location, reader) ||
+                             heading_filter(location, angle) || layer_filter(location, layer))) {
         filtered.push_back(std::move(path_edge));
-      } else if (correlated_edges.insert(candidate.edge_id).second) {
+      } else if (!hard_filtered && correlated_edges.insert(candidate.edge_id).second) {
         correlated.edges.push_back(std::move(path_edge));
       }
       // correlate its evil twin
@@ -433,7 +434,8 @@ struct bin_handler_t {
       graph_tile_ptr other_tile;
       auto opposing_edge_id = reader.GetOpposingEdgeId(candidate.edge_id, other_edge, other_tile);
 
-      if (other_edge && costing->Allowed(other_edge, other_tile, kDisallowShortcut)) {
+      if (other_edge && costing->Allowed(other_edge, other_tile, kDisallowShortcut) &&
+          !search_filter(other_edge, *costing, other_tile, location.search_filter_)) {
         auto opp_angle = std::fmod(angle + 180.f, 360.f);
         reach = get_reach(opposing_edge_id, other_edge);
         PathLocation::PathEdge other_path_edge{opposing_edge_id, 1 - length_ratio, candidate.point,
@@ -517,14 +519,22 @@ struct bin_handler_t {
         continue;
       }
 
+      // lots of places below where we might like to know about the opp edge
+      const DirectedEdge* opp_edge = nullptr;
+      graph_tile_ptr opp_tile = tile;
+      GraphId opp_edgeid;
+
       // if this edge is filtered
       const auto* edge = tile->directededge(edge_id);
       if (!costing->Allowed(edge, tile, kDisallowShortcut)) {
-        // then we try its opposing edge
-        edge_id = reader.GetOpposingEdgeId(edge_id, edge, tile);
         // but if we couldnt get it or its filtered too then we move on
-        if (!edge_id.Is_Valid() || !costing->Allowed(edge, tile, kDisallowShortcut))
+        if (!(opp_edgeid = reader.GetOpposingEdgeId(edge_id, opp_edge, opp_tile)) ||
+            !costing->Allowed(opp_edge, opp_tile, kDisallowShortcut))
           continue;
+        // if we will continue with the opposing edge lets swap it in
+        std::swap(edge, opp_edge);
+        std::swap(tile, opp_tile);
+        std::swap(edge_id, opp_edgeid);
       }
 
       // initialize candidates vector:
@@ -535,15 +545,12 @@ struct bin_handler_t {
       bool all_prefiltered = true;
       for (p_itr = begin; p_itr != end; ++p_itr, ++c_itr) {
         c_itr->sq_distance = std::numeric_limits<double>::max();
-        // TODO: for closings its possible that we could use the opposing edge if edge is filtered
-        //  need to do something like is done above with the allowed check filtering or below when we
-        //  switch to the opposing when the reach check fails. one concrete option is to make a little
-        //  lambda or anon namespace function that will check the edge and if is filtered it will pull
-        //  opposing edge to check it as well. that way if the opposing isnt filtered we'll let the
-        //  candidate through and then in correlate_edge we can check the filter once more and get the
-        //  one thats allowed.
+        // for traffic closures we may have only one direction disabled so we must also check opp
+        // before we can be sure that we can completely filter this edge pair for this location
         c_itr->prefiltered =
-            is_search_filter_triggered(edge, *costing, tile, p_itr->location.search_filter_);
+            search_filter(edge, *costing, tile, p_itr->location.search_filter_) &&
+            (opp_edgeid = reader.GetOpposingEdgeId(edge_id, opp_edge, opp_tile)) &&
+            search_filter(opp_edge, *costing, opp_tile, p_itr->location.search_filter_);
         // set to false if even one candidate was not filtered
         all_prefiltered = all_prefiltered && c_itr->prefiltered;
       }
@@ -605,12 +612,10 @@ struct bin_handler_t {
         // is this edge reachable in the right way
         bool reachable = reach.outbound >= p_itr->location.min_outbound_reach_ &&
                          reach.inbound >= p_itr->location.min_inbound_reach_;
-        const DirectedEdge* opp_edge = nullptr;
-        graph_tile_ptr opp_tile = tile;
-        GraphId opp_edgeid;
         // it's possible that it isnt reachable but the opposing is, switch to that if so
         if (!reachable && (opp_edgeid = reader.GetOpposingEdgeId(edge_id, opp_edge, opp_tile)) &&
-            costing->Allowed(opp_edge, opp_tile, kDisallowShortcut)) {
+            costing->Allowed(opp_edge, opp_tile, kDisallowShortcut) &&
+            !search_filter(opp_edge, *costing, opp_tile, p_itr->location.search_filter_)) {
           auto opp_reach = check_reachability(begin, end, opp_tile, opp_edge, opp_edgeid);
           if (opp_reach.outbound >= p_itr->location.min_outbound_reach_ &&
               opp_reach.inbound >= p_itr->location.min_inbound_reach_) {

--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -309,6 +309,13 @@ struct bin_handler_t {
         distance = node_ll.Distance(location.latlng_);
       // add edges entering/leaving this node
       for (const auto* edge = start_edge; edge < end_edge; ++edge) {
+        // the edge candidate that we got this node from we know is not filtered so it will get pass
+        // but some of these edges attached to the node could have been already filtered out as edge
+        // candidates. now that we are re-evaluating these edges because of the node-snap, we must
+        // also re-evaluate whether they are filtered
+        if (is_search_filter_triggered(edge, *costing, tile, location.search_filter_))
+          continue;
+
         // get some info about this edge and the opposing
         GraphId id = tile->id();
         id.set_id(node->edge_index() + (edge - start_edge));

--- a/test/gurka/test_search_filter.cc
+++ b/test/gurka/test_search_filter.cc
@@ -61,6 +61,23 @@ TEST_F(SearchFilter, Unfiltered) {
   gurka::assert::osrm::expect_steps(result, {"AB", "BC"});
   gurka::assert::raw::expect_path(result, {"AB", "BC"});
 }
+TEST_F(SearchFilter, NodeSnapped) {
+  auto from = "B";
+  auto to = "C";
+
+  const std::string& request =
+      (boost::format(
+           R"({"locations":[{"lat":%s,"lon":%s,"search_filter":{"exclude_tunnel":true}},{"lat":%s,"lon":%s}],"costing":"auto"})") %
+       std::to_string(map.nodes.at(from).lat()) % std::to_string(map.nodes.at(from).lng()) %
+       std::to_string(map.nodes.at(to).lat()) % std::to_string(map.nodes.at(to).lng()))
+          .str();
+
+  auto result = gurka::do_action(valhalla::Options::route, map, request);
+
+  // should take the shortest path
+  gurka::assert::osrm::expect_steps(result, {"AB", "AD", "CD"});
+  gurka::assert::raw::expect_path(result, {"AB", "AD", "CD"});
+}
 TEST_F(SearchFilter, Heading) {
   auto from = "1";
   auto to = "2";

--- a/test/gurka/test_traffic.cc
+++ b/test/gurka/test_traffic.cc
@@ -110,7 +110,6 @@ TEST(Traffic, BasicUpdates) {
                "it's noticed the changes in the live traffic file"
             << std::endl;
   {
-
     auto result = gurka::do_action(valhalla::Options::route, map, {"B", "D"}, "auto",
                                    {{"/date_time/type", "0"}}, clean_reader);
     gurka::assert::osrm::expect_steps(result, {"BC", "CE", "DE"});


### PR DESCRIPTION
this morning @chrstnbwnkl and i debugged an issue with another pr that is currently open. we found that the search filter was not always filtering out candidate edges that should be.

after a few minutes of looking we quickly noticed that indeed, we use the search filter when deciding the initial candidates to use but if a candidate becomes a node snap, the other edges connected at the node (which were likely already filtered) are not checked a second time, instead they are simply included.

this pr fixes that by again checking if an edge should be filtered before including it.

more info here: https://github.com/valhalla/valhalla/pull/4524#issuecomment-2269095092

also it seems that we found this issue in testing before but werent able to debug to find out what was going wrong. so it seems another test breaks and we'll need to patch that up before merging this.