### PR TITLE
perf: Move encoded elevation to avoid redundant allocation

### DIFF
--- a/src/mjolnir/edgeinfobuilder.cc
+++ b/src/mjolnir/edgeinfobuilder.cc
@@ -85,7 +85,7 @@ void EdgeInfoBuilder::set_encoded_shape(const std::string& encoded_shape) {
 }
 
 // Set the encoded elevation vector.
-void EdgeInfoBuilder::set_encoded_elevation(const std::vector<int8_t>& encoded_elevation) {
+void EdgeInfoBuilder::set_encoded_elevation(std::vector<int8_t> encoded_elevation) {
   if (!encoded_elevation.empty()) {
     encoded_elevation_ = std::move(encoded_elevation);
   }

--- a/src/mjolnir/elevationbuilder.cc
+++ b/src/mjolnir/elevationbuilder.cc
@@ -225,7 +225,7 @@ void add_elevations_to_single_tile(GraphReader& graphreader,
       } else {
         encoded = encode_edge_elevation(sample, shape, length, wayid);
       }
-      ei_offset += tilebuilder.set_elevation(edge_info_offset, mean_elevation, encoded);
+      ei_offset += tilebuilder.set_elevation(edge_info_offset, mean_elevation, std::move(encoded));
     }
 
     // Edge elevation information. If the edge is forward (with respect to the shape)

--- a/src/mjolnir/graphtilebuilder.cc
+++ b/src/mjolnir/graphtilebuilder.cc
@@ -866,7 +866,7 @@ void GraphTileBuilder::set_mean_elevation(const float elev) {
 // info offset. This requires a serialized tile builder.
 uint32_t GraphTileBuilder::set_elevation(const uint32_t offset,
                                          const float mean_elevation,
-                                         const std::vector<int8_t>& encoded_elevation) {
+                                         std::vector<int8_t> encoded_elevation) {
   auto e = edgeinfo_offset_map_.find(offset);
   if (e == edgeinfo_offset_map_.end()) {
     LOG_ERROR("set_elevation - could not find the EdgeInfo index given the offset");
@@ -874,7 +874,7 @@ uint32_t GraphTileBuilder::set_elevation(const uint32_t offset,
   }
   e->second->set_mean_elevation(mean_elevation);
   if (!encoded_elevation.empty()) {
-    e->second->set_encoded_elevation(encoded_elevation);
+    e->second->set_encoded_elevation(std::move(encoded_elevation));
     e->second->set_has_elevation(true);
   }
   return e->second->SizeOf();

--- a/valhalla/mjolnir/edgeinfobuilder.h
+++ b/valhalla/mjolnir/edgeinfobuilder.h
@@ -98,7 +98,7 @@ public:
    * Set encoded elevation.
    * @param  encoded_elevation  Encoded elevation
    */
-  void set_encoded_elevation(const std::vector<int8_t>& encoded_elevation);
+  void set_encoded_elevation(std::vector<int8_t> encoded_elevation);
 
   /**
    * Get the size of this edge info (without padding).

--- a/valhalla/mjolnir/graphtilebuilder.h
+++ b/valhalla/mjolnir/graphtilebuilder.h
@@ -301,7 +301,7 @@ public:
    */
   uint32_t set_elevation(const uint32_t offset,
                          const float mean_elevation,
-                         const std::vector<int8_t>& encoded_elevation);
+                         std::vector<int8_t> encoded_elevation);
 
   /**
    * Add a name to the text list.


### PR DESCRIPTION
# Issue

Basically this PR fixes `performance-move-const-arg` in this function and thus avoids redundant allocation during the setting elevation data into EdgeInfo.
```cpp
// Set the encoded elevation vector.
void EdgeInfoBuilder::set_encoded_elevation(const std::vector<int8_t>& encoded_elevation) {
  if (!encoded_elevation.empty()) {
    encoded_elevation_ = std::move(encoded_elevation);
  }
}
```

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
