### PR TITLE
fix: blocked route reclassification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
    * FIXED: wrong index used in CostMatrix expansion callback inside reverse connection check [#4821](https://github.com/valhalla/valhalla/pull/4821)
    * FIXED: oneway ferry connections classification [#4828](https://github.com/valhalla/valhalla/pull/4828)
    * FIXED: location search_filter ignored in certain cases [#4835](https://github.com/valhalla/valhalla/pull/4835)
+   * FIXED: Ferry reclassification finds shortest path that is blocked by inaccessible node [#4854](https://github.com/valhalla/valhalla/pull/4854)
 
 * **Enhancement**
    * UPDATED: French translations, thanks to @xlqian [#4159](https://github.com/valhalla/valhalla/pull/4159)

--- a/src/mjolnir/ferry_connections.cc
+++ b/src/mjolnir/ferry_connections.cc
@@ -114,6 +114,9 @@ std::pair<uint32_t, bool> ShortestPath(const uint32_t start_node_idx,
       // Expand all edges from this node
       auto expand_node_itr = nodes[expand_node_idx];
       auto expanded_bundle = collect_node_edges(expand_node_itr, nodes, edges);
+      if (!(expanded_bundle.node.access() & access_filter)) {
+        continue;
+      }
 
       // We are finished if node has RC <= rc and beyond first several edges.
       // Have seen cases where the immediate connections are high class roads


### PR DESCRIPTION
# Issue

This PR fixes ferry connected edges reclassification in case if the shortest path is blocked by some node like here - https://www.openstreetmap.org/node/6613737974
In such cases `ShortestPath` ends earlier without reclassifying the real shortest path, accessible for cars. And because of the hierarchy limits, Valhalla fails to use this ferry and takes much longer path:
https://valhalla.openstreetmap.de/directions?profile=car&wps=16.369628906250004%2C56.84897198026975%2C18.32150459289551%2C57.6248168745992
<img width="641" alt="image" src="https://github.com/user-attachments/assets/5ef37a54-a84a-49b8-8b80-bf6c2f0fa81c">

## Tasklist

 - [x] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
