### PR TITLE
Fix `(Nov - Mar)` condition parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
    * FIXED: oneway ferry connections classification [#4828](https://github.com/valhalla/valhalla/pull/4828)
    * FIXED: location search_filter ignored in certain cases [#4835](https://github.com/valhalla/valhalla/pull/4835)
    * FIXED: Ferry reclassification finds shortest path that is blocked by inaccessible node [#4854](https://github.com/valhalla/valhalla/pull/4854)
+   * FIXED: `(Nov - Mar)` (and similar, months with spaces) condition parsing [#4857](https://github.com/valhalla/valhalla/pull/4857)
 
 * **Enhancement**
    * UPDATED: French translations, thanks to @xlqian [#4159](https://github.com/valhalla/valhalla/pull/4159)

--- a/src/mjolnir/timeparsing.cc
+++ b/src/mjolnir/timeparsing.cc
@@ -241,6 +241,18 @@ std::vector<uint64_t> get_time_range(const std::string& str) {
 
               if (RegexFound(condition, regex)) {
                 condition = FormatCondition(condition, regex, "$1#$2-$1#$3");
+              } else {
+                // Nov - Mar => Nov-Mar
+                regex = std::regex(
+                    "(?:(January|February|March|April|May|June|July|"
+                    "August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|"
+                    "Sep|Sept|Oct|Nov|Dec)) - (?:(January|February|March|April|May|June|July|"
+                    "August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|"
+                    "Sep|Sept|Oct|Nov|Dec))",
+                    std::regex_constants::icase);
+                if (RegexFound(condition, regex)) {
+                  condition = FormatCondition(condition, regex, "$1-$2");
+                }
               }
             }
           }

--- a/src/mjolnir/timeparsing.cc
+++ b/src/mjolnir/timeparsing.cc
@@ -3,7 +3,6 @@
 #include <sstream>
 
 #include <boost/algorithm/string.hpp>
-#include <boost/algorithm/string/classification.hpp>
 #include <boost/range/algorithm/remove_if.hpp>
 
 #include "baldr/graphconstants.h"
@@ -14,8 +13,78 @@
 using namespace valhalla::baldr;
 using namespace valhalla::mjolnir;
 
-namespace valhalla {
-namespace mjolnir {
+namespace {
+// Dec Su[-1]-Mar 3 => Dec#Su#[5]-Mar#3
+const std::pair<std::regex, std::string> kBeginWeekdayOfTheMonth =
+    {std::regex(
+         "(?:(January|February|March|April|May|June|July|"
+         "August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|"
+         "Sep|Sept|Oct|Nov|Dec)) (?:(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|"
+         "Sunday|Mon|Mo|Tues|Tue|Tu|Weds|Wed|We|Thurs|Thur|Th|Fri|Fr|Sat|Sa|Sun|Su)(\\[-?[0-9]\\])-"
+         "(?:(January|February|March|April|May|June|July|August|September|October|November"
+         "|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)) (\\d{1,2}))",
+         std::regex_constants::icase),
+     "$1#$2#$3-$4#$5"};
+
+// Mar 3-Dec Su[-1] => Mar#3-Dec#Su#[5]
+const std::pair<std::regex, std::string> kEndWeedkayOfTheMonth =
+    {std::regex(
+         "(?:(January|February|March|April|May|June|July|August|"
+         "September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|"
+         "Nov|Dec)) (\\d{1,2})-(?:(January|February|March|April|May|June|July|"
+         "August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|"
+         "Sep|Sept|Oct|Nov|Dec)) (?:(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|"
+         "Sunday|Mon|Mo|Tues|Tue|Tu|Weds|Wed|We|Thurs|Thur|Th|Fri|Fr|Sat|Sa|Sun|Su)(\\[-?[0-9]\\])"
+         ")",
+         std::regex_constants::icase),
+     "$1#$2-$3#$4#$5"};
+
+// Dec Su[-1] => Dec#Su#[5]
+const std::pair<std::regex, std::string> kWeekdayOfTheMonth =
+    {std::regex("(?:(January|February|March|April|May|June|July|"
+                "August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|"
+                "Sep|Sept|Oct|Nov|Dec)) (?:(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|"
+                "Sunday|Mon|Mo|Tues|Tue|Tu|Weds|Wed|We|Thurs|Thur|Th|Fri|Fr|Sat|Sa|Sun|Su)(\\[-?[0-9]"
+                "\\]))",
+                std::regex_constants::icase),
+     "$1#$2#$3"};
+
+// Mon[-1] => Mon#[5], Tue[2] => Tue#[2]
+const std::pair<std::regex, std::string> kWeekdayOfEveryMonth =
+    {std::regex("(?:(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|"
+                "Sunday|Mon|Mo|Tues|Tue|Tu|Weds|Wed|We|Thurs|Thur|Th|Fri|Fr|Sat|Sa|Sun|"
+                "Su)(\\[-?[0-9]\\]))",
+                std::regex_constants::icase),
+     "$1#$2"};
+
+// Feb 16-Oct 15 09:00-18:30 => Feb#16-Oct#15 09:00-18:30
+const std::pair<std::regex, std::string> kMonthDay =
+    {std::regex("(?:(January|February|March|April|May|June|July|"
+                "August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|"
+                "Sep|Sept|Oct|Nov|Dec)) (\\d{1,2})",
+                std::regex_constants::icase),
+     "$1#$2"};
+
+// Feb 2-14 => Feb#2-Feb#14
+const std::pair<std::regex, std::string> kRangeWithinMonth =
+    {std::regex("(?:(January|February|March|April|May|June|July|"
+                "August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|"
+                "Sep|Sept|Oct|Nov|Dec)) (\\d{1,2})-(\\d{1,2})",
+                std::regex_constants::icase),
+     "$1#$2-$1#$3"};
+
+// Nov - Mar => Nov-Mar
+const std::pair<std::regex, std::string> kMonthRange =
+    {std::regex("(?:(January|February|March|April|May|June|July|"
+                "August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|"
+                "Sep|Sept|Oct|Nov|Dec)) - (?:(January|February|March|April|May|June|July|"
+                "August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|"
+                "Sep|Sept|Oct|Nov|Dec))",
+                std::regex_constants::icase),
+     "$1-$2"};
+
+// fifth is the equivalent of last week in month (-1)
+const std::pair<std::regex, std::string> kLastWeekday = {std::regex("\\[-1\\]"), "[5]"};
 
 std::vector<std::string> GetTokens(const std::string& tag_value, char delim) {
   std::vector<std::string> tokens;
@@ -31,10 +100,15 @@ bool RegexFound(const std::string& source, const std::regex& regex) {
   return std::distance(begin, end);
 }
 
-std::string
-FormatCondition(const std::string& source, const std::regex& regex, const std::string& pattern) {
-  return std::regex_replace(source, regex, pattern);
+std::string FormatCondition(const std::string& source,
+                            const std::pair<std::regex, std::string>& regex_pattern) {
+  return std::regex_replace(source, regex_pattern.first, regex_pattern.second);
 }
+
+} // namespace
+
+namespace valhalla {
+namespace mjolnir {
 
 // get the dow mask from the provided string.  try to handle most inputs
 uint8_t get_dow_mask(const std::string& dow) {
@@ -163,95 +237,43 @@ std::vector<uint64_t> get_time_range(const std::string& str) {
       return time_domains;
     }
 
-    // Dec Su[-1]-Mar 3
-    std::regex regex = std::regex(
-        "(?:(January|February|March|April|May|June|July|"
-        "August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|"
-        "Sep|Sept|Oct|Nov|Dec)) (?:(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|"
-        "Sunday|Mon|Mo|Tues|Tue|Tu|Weds|Wed|We|Thurs|Thur|Th|Fri|Fr|Sat|Sa|Sun|Su)(\\[-?[0-9]\\])-"
-        "(?:(January|February|March|April|May|June|July|August|September|October|November"
-        "|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)) (\\d{1,2}))",
-        std::regex_constants::icase);
-
-    if (RegexFound(condition, regex)) {
-      condition = FormatCondition(condition, regex, "$1#$2#$3-$4#$5");
-      // fifth is the equivalent of last week in month (-1)
-      condition = FormatCondition(condition, std::regex("\\[-1\\]"), "[5]");
+    // Dec Su[-1]-Mar 3 => Dec#Su#[5]-Mar#3
+    if (RegexFound(condition, kBeginWeekdayOfTheMonth.first)) {
+      condition = FormatCondition(condition, kBeginWeekdayOfTheMonth);
+      condition = FormatCondition(condition, kLastWeekday);
     } else {
 
-      // Mar 3-Dec Su[-1]
-      std::regex regex = std::regex(
-          "(?:(January|February|March|April|May|June|July|August|"
-          "September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|"
-          "Nov|Dec)) (\\d{1,2})-(?:(January|February|March|April|May|June|July|"
-          "August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|"
-          "Sep|Sept|Oct|Nov|Dec)) (?:(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|"
-          "Sunday|Mon|Mo|Tues|Tue|Tu|Weds|Wed|We|Thurs|Thur|Th|Fri|Fr|Sat|Sa|Sun|Su)(\\[-?[0-9]\\])"
-          ")",
-          std::regex_constants::icase);
-
-      if (RegexFound(condition, regex)) {
-        condition = FormatCondition(condition, regex, "$1#$2-$3#$4#$5");
-        // fifth is the equivalent of last week in month (-1)
-        condition = FormatCondition(condition, std::regex("\\[-1\\]"), "[5]");
+      // Mar 3-Dec Su[-1] => Mar#3-Dec#Su#[5]
+      if (RegexFound(condition, kEndWeedkayOfTheMonth.first)) {
+        condition = FormatCondition(condition, kEndWeedkayOfTheMonth);
+        condition = FormatCondition(condition, kLastWeekday);
       } else {
 
-        // Dec Su[-1]
-        regex = std::regex(
-            "(?:(January|February|March|April|May|June|July|"
-            "August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|"
-            "Sep|Sept|Oct|Nov|Dec)) (?:(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|"
-            "Sunday|Mon|Mo|Tues|Tue|Tu|Weds|Wed|We|Thurs|Thur|Th|Fri|Fr|Sat|Sa|Sun|Su)(\\[-?[0-9]"
-            "\\]))",
-            std::regex_constants::icase);
-
-        if (RegexFound(condition, regex)) {
-          condition = FormatCondition(condition, regex, "$1#$2#$3");
-          // fifth is the equivalent of last week in month (-1)
-          condition = FormatCondition(condition, std::regex("\\[-1\\]"), "[5]");
+        // Dec Su[-1] => Dec#Su#[5]
+        if (RegexFound(condition, kWeekdayOfTheMonth.first)) {
+          condition = FormatCondition(condition, kWeekdayOfTheMonth);
+          condition = FormatCondition(condition, kLastWeekday);
         } else {
 
-          regex = std::regex("(?:(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|"
-                             "Sunday|Mon|Mo|Tues|Tue|Tu|Weds|Wed|We|Thurs|Thur|Th|Fri|Fr|Sat|Sa|Sun|"
-                             "Su)(\\[-?[0-9]\\]))",
-                             std::regex_constants::icase);
-
-          if (RegexFound(condition, regex)) {
-            condition = FormatCondition(condition, regex, "$1#$2");
-            // fifth is the equivalent of last week in month (-1)
-            condition = FormatCondition(condition, std::regex("\\[-1\\]"), "[5]");
+          // Mon[-1] => Mon#[5], Tue[2] => Tue#[2]
+          if (RegexFound(condition, kWeekdayOfEveryMonth.first)) {
+            condition = FormatCondition(condition, kWeekdayOfEveryMonth);
+            condition = FormatCondition(condition, kLastWeekday);
           } else {
 
-            // Feb 16-Oct 15 09:00-18:30
-            regex = std::
-                regex("(?:(January|February|March|April|May|June|July|"
-                      "August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|"
-                      "Sep|Sept|Oct|Nov|Dec)) (\\d{1,2})",
-                      std::regex_constants::icase);
-
-            if (RegexFound(condition, regex)) {
-              condition = FormatCondition(condition, regex, "$1#$2");
+            // Feb 16-Oct 15 09:00-18:30 => Feb#16-Oct#15 09:00-18:30
+            if (RegexFound(condition, kMonthDay.first)) {
+              condition = FormatCondition(condition, kMonthDay);
             } else {
-              // Feb 2-14
-              regex = std::
-                  regex("(?:(January|February|March|April|May|June|July|"
-                        "August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|"
-                        "Sep|Sept|Oct|Nov|Dec)) (\\d{1,2})-(\\d{1,2})",
-                        std::regex_constants::icase);
 
-              if (RegexFound(condition, regex)) {
-                condition = FormatCondition(condition, regex, "$1#$2-$1#$3");
+              // Feb 2-14 => Feb#2-Feb#14
+              if (RegexFound(condition, kRangeWithinMonth.first)) {
+                condition = FormatCondition(condition, kRangeWithinMonth);
               } else {
+
                 // Nov - Mar => Nov-Mar
-                regex = std::regex(
-                    "(?:(January|February|March|April|May|June|July|"
-                    "August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|"
-                    "Sep|Sept|Oct|Nov|Dec)) - (?:(January|February|March|April|May|June|July|"
-                    "August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|"
-                    "Sep|Sept|Oct|Nov|Dec))",
-                    std::regex_constants::icase);
-                if (RegexFound(condition, regex)) {
-                  condition = FormatCondition(condition, regex, "$1-$2");
+                if (RegexFound(condition, kMonthRange.first)) {
+                  condition = FormatCondition(condition, kMonthRange);
                 }
               }
             }

--- a/test/datetime.cc
+++ b/test/datetime.cc
@@ -550,6 +550,16 @@ TEST(DateTime, TestIsRestricted) {
   TryIsRestricted(td, "2022-05-10T16:00", false);
   TryIsRestricted(td, "2021-02-18T16:00", false);
   TryIsRestricted(td, "2021-06-26T16:00", false);
+
+  td = TimeDomain(35184375234560); // "Jun-Aug"
+  TryIsRestricted(td, "2024-04-03T08:00", false);
+  TryIsRestricted(td, "2024-05-31T21:00", false);
+  TryIsRestricted(td, "2024-06-01T00:01", true);
+  TryIsRestricted(td, "2024-06-15T16:00", true);
+  TryIsRestricted(td, "2024-07-10T16:00", true);
+  TryIsRestricted(td, "2024-08-18T16:00", true);
+  TryIsRestricted(td, "2024-08-31T23:59", true);
+  TryIsRestricted(td, "2024-09-01T00:01", false);
 }
 
 TEST(DateTime, TestTimezoneDiff) {

--- a/test/timeparsing.cc
+++ b/test/timeparsing.cc
@@ -460,6 +460,7 @@ TEST(TimeParsing, TestConditionalRestrictions) {
   }
 }
 
+// A test case with exotic conditions extracted from `maxspeed:conditional` OSM field.
 TEST(TimeParsing, TestConditionalMaxspeed) {
   TryConditionalRestrictions("(19:00-06:00)", 0, 0, 0, {0, 0, 0, 19, 0}, {0, 0, 0, 6, 0});
   TryConditionalRestrictions("(06:00-18:00)", 0, 0, 0, {0, 0, 0, 6, 0}, {0, 0, 0, 18, 0});
@@ -527,7 +528,7 @@ TEST(TimeParsing, TestConditionalMaxspeed) {
   TryConditionalRestrictions("(Jun 1-Aug 31 00:00-24:00)", 0, 0, 0, {6, 1, 0, 0, 0},
                              {8, 31, 0, 0, 0});
 
-  // non-standart seasons that are not supported
+  // non-standard seasons that are not supported
   EXPECT_TRUE(get_time_range("summer").empty());
   EXPECT_TRUE(get_time_range("winter").empty());
 }

--- a/test/timeparsing.cc
+++ b/test/timeparsing.cc
@@ -48,20 +48,20 @@ void TryConditionalRestrictions(const std::string& condition,
   }
 }
 
+struct DateTimePoint {
+  uint32_t month;
+  uint32_t day;
+  uint32_t week;
+  uint32_t hour;
+  uint32_t minute;
+};
+
 void TryConditionalRestrictions(const std::string& condition,
                                 const uint32_t index,
                                 const uint32_t type,
                                 const uint32_t dow,
-                                const uint32_t begin_month,
-                                const uint32_t begin_day,
-                                const uint32_t begin_week,
-                                const uint32_t begin_hrs,
-                                const uint32_t begin_mins,
-                                const uint32_t end_month,
-                                const uint32_t end_day,
-                                const uint32_t end_week,
-                                const uint32_t end_hrs,
-                                const uint32_t end_mins) {
+                                const DateTimePoint begin,
+                                const DateTimePoint end) {
 
   std::vector<uint64_t> results = get_time_range(condition);
 
@@ -69,16 +69,16 @@ void TryConditionalRestrictions(const std::string& condition,
 
   EXPECT_EQ(res.type(), type);
   EXPECT_EQ(res.dow(), dow);
-  EXPECT_EQ(res.begin_month(), begin_month);
-  EXPECT_EQ(res.begin_day_dow(), begin_day);
-  EXPECT_EQ(res.begin_week(), begin_week);
-  EXPECT_EQ(res.begin_hrs(), begin_hrs);
-  EXPECT_EQ(res.begin_mins(), begin_mins);
-  EXPECT_EQ(res.end_month(), end_month);
-  EXPECT_EQ(res.end_day_dow(), end_day);
-  EXPECT_EQ(res.end_week(), end_week);
-  EXPECT_EQ(res.end_hrs(), end_hrs);
-  EXPECT_EQ(res.end_mins(), end_mins);
+  EXPECT_EQ(res.begin_month(), begin.month);
+  EXPECT_EQ(res.begin_day_dow(), begin.day);
+  EXPECT_EQ(res.begin_week(), begin.week);
+  EXPECT_EQ(res.begin_hrs(), begin.hour);
+  EXPECT_EQ(res.begin_mins(), begin.minute);
+  EXPECT_EQ(res.end_month(), end.month);
+  EXPECT_EQ(res.end_day_dow(), end.day);
+  EXPECT_EQ(res.end_week(), end.week);
+  EXPECT_EQ(res.end_hrs(), end.hour);
+  EXPECT_EQ(res.end_mins(), end.minute);
 
   if (::testing::Test::HasFailure()) {
     std::cerr << "Time domain: " << condition << std::endl;
@@ -102,15 +102,15 @@ TEST(TimeParsing, TestConditionalRestrictions) {
       TryConditionalRestrictions(conditions.at(x), expected_values);
       TryConditionalRestrictions(conditions.at(x), expected_values);
 
-      TryConditionalRestrictions(conditions.at(x), 0, 0, 62, 0, 0, 0, 6, 0, 0, 0, 0, 11, 0);
-      TryConditionalRestrictions(conditions.at(x), 1, 0, 62, 0, 0, 0, 17, 0, 0, 0, 0, 19, 0);
+      TryConditionalRestrictions(conditions.at(x), 0, 0, 62, {0, 0, 0, 6, 0}, {0, 0, 0, 11, 0});
+      TryConditionalRestrictions(conditions.at(x), 1, 0, 62, {0, 0, 0, 17, 0}, {0, 0, 0, 19, 0});
 
     } else if (x == 1) { // Sa 03:30-19:00
       std::vector<uint64_t> expected_values;
       expected_values.push_back(40802435968);
 
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 0, 64, 0, 0, 0, 3, 30, 0, 0, 0, 19, 0);
+      TryConditionalRestrictions(conditions.at(x), 0, 0, 64, {0, 0, 0, 3, 30}, {0, 0, 0, 19, 0});
     }
   }
 
@@ -123,14 +123,14 @@ TEST(TimeParsing, TestConditionalRestrictions) {
       std::vector<uint64_t> expected_values;
       expected_values.push_back(38654708852);
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 0, 58, 0, 0, 0, 12, 0, 0, 0, 0, 18, 0);
+      TryConditionalRestrictions(conditions.at(x), 0, 0, 58, {0, 0, 0, 12, 0}, {0, 0, 0, 18, 0});
 
     } else if (x == 1) { // Sa-Su 12:00-17:00
       std::vector<uint64_t> expected_values;
       expected_values.push_back(36507225218);
 
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 0, 65, 0, 0, 0, 12, 0, 0, 0, 0, 17, 0);
+      TryConditionalRestrictions(conditions.at(x), 0, 0, 65, {0, 0, 0, 12, 0}, {0, 0, 0, 17, 0});
     }
   }
 
@@ -144,14 +144,14 @@ TEST(TimeParsing, TestConditionalRestrictions) {
       expected_values.push_back(1512971146104448);
 
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 0, 64, 7, 23, 0, 14, 0, 8, 21, 0, 20, 0);
+      TryConditionalRestrictions(conditions.at(x), 0, 0, 64, {7, 23, 0, 14, 0}, {8, 21, 0, 20, 0});
 
     } else if (x == 1) { // JUL 23-jUl 28 Fr,PH 10:00-20:00
       std::vector<uint64_t> expected_values;
       expected_values.push_back(2001154308835904);
 
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 0, 32, 7, 23, 0, 10, 0, 7, 28, 0, 20, 0);
+      TryConditionalRestrictions(conditions.at(x), 0, 0, 32, {7, 23, 0, 10, 0}, {7, 28, 0, 20, 0});
     }
   }
 
@@ -171,7 +171,7 @@ TEST(TimeParsing, TestConditionalRestrictions) {
       expected_values.push_back(39610337987200);
 
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 0, 64, 4, 0, 0, 10, 0, 9, 0, 0, 13, 0);
+      TryConditionalRestrictions(conditions.at(x), 0, 0, 64, {4, 0, 0, 10, 0}, {9, 0, 0, 13, 0});
     }
   }
 
@@ -191,7 +191,7 @@ TEST(TimeParsing, TestConditionalRestrictions) {
       expected_values.push_back(39610337987200);
 
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 0, 64, 4, 0, 0, 10, 0, 9, 0, 0, 13, 0);
+      TryConditionalRestrictions(conditions.at(x), 0, 0, 64, {4, 0, 0, 10, 0}, {9, 0, 0, 13, 0});
     }
   }
 
@@ -205,8 +205,8 @@ TEST(TimeParsing, TestConditionalRestrictions) {
       expected_values.push_back(23622321664);
       expected_values.push_back(3133178646784);
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 11, 0);
-      TryConditionalRestrictions(conditions.at(x), 1, 0, 0, 0, 0, 0, 17, 0, 0, 0, 0, 19, 45);
+      TryConditionalRestrictions(conditions.at(x), 0, 0, 0, {0, 0, 0, 6, 0}, {0, 0, 0, 11, 0});
+      TryConditionalRestrictions(conditions.at(x), 1, 0, 0, {0, 0, 0, 17, 0}, {0, 0, 0, 19, 45});
     }
   }
 
@@ -222,13 +222,13 @@ TEST(TimeParsing, TestConditionalRestrictions) {
       std::vector<uint64_t> expected_values;
       expected_values.push_back(1106007905274112);
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 0, 0, 10, 16, 0, 9, 0, 11, 15, 0, 17, 30);
+      TryConditionalRestrictions(conditions.at(x), 0, 0, 0, {10, 16, 0, 9, 0}, {11, 15, 0, 17, 30});
 
     } else if (x == 2) { // Nov 16-Feb 15: 09:00-16:30
       std::vector<uint64_t> expected_values;
       expected_values.push_back(1066423339714816);
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 0, 0, 11, 16, 0, 9, 0, 02, 15, 0, 16, 30);
+      TryConditionalRestrictions(conditions.at(x), 0, 0, 0, {11, 16, 0, 9, 0}, {02, 15, 0, 16, 30});
     }
   }
 
@@ -241,27 +241,27 @@ TEST(TimeParsing, TestConditionalRestrictions) {
       std::vector<uint64_t> expected_values;
       expected_values.push_back(2078764173088);
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 0, 16, 0, 0, 0, 7, 0, 0, 0, 0, 8, 30);
+      TryConditionalRestrictions(conditions.at(x), 0, 0, 16, {0, 0, 0, 7, 0}, {0, 0, 0, 8, 30});
     } else if (x == 1) { // th-friday 06:00-09:30
       std::vector<uint64_t> expected_values;
       expected_values.push_back(2080911656544);
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 0, 48, 0, 0, 0, 6, 0, 0, 0, 0, 9, 30);
+      TryConditionalRestrictions(conditions.at(x), 0, 0, 48, {0, 0, 0, 6, 0}, {0, 0, 0, 9, 30});
     } else if (x == 2) { // May 15 09:00-11:30
       std::vector<uint64_t> expected_values;
       expected_values.push_back(1079606730295552);
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 0, 0, 5, 15, 0, 9, 0, 5, 15, 0, 11, 30);
+      TryConditionalRestrictions(conditions.at(x), 0, 0, 0, {5, 15, 0, 9, 0}, {5, 15, 0, 11, 30});
     } else if (x == 3) { // May 07:00-08:30
       std::vector<uint64_t> expected_values;
       expected_values.push_back(24068999350016);
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 0, 0, 5, 0, 0, 7, 0, 5, 0, 0, 8, 30);
+      TryConditionalRestrictions(conditions.at(x), 0, 0, 0, {5, 0, 0, 7, 0}, {5, 0, 0, 8, 30});
     } else if (x == 4) { // May 16-31 11:00-13:30
       std::vector<uint64_t> expected_values;
       expected_values.push_back(2205510940494592);
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 0, 0, 5, 16, 0, 11, 0, 5, 31, 0, 13, 30);
+      TryConditionalRestrictions(conditions.at(x), 0, 0, 0, {5, 16, 0, 11, 0}, {5, 31, 0, 13, 30});
     }
   }
 
@@ -274,16 +274,16 @@ TEST(TimeParsing, TestConditionalRestrictions) {
       expected_values.push_back(29856470044524);
 
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 0, 54, 9, 0, 0, 8, 15, 6, 0, 0, 8, 45);
-      TryConditionalRestrictions(conditions.at(x), 1, 0, 54, 9, 0, 0, 15, 20, 6, 0, 0, 15, 50);
+      TryConditionalRestrictions(conditions.at(x), 0, 0, 54, {9, 0, 0, 8, 15}, {6, 0, 0, 8, 45});
+      TryConditionalRestrictions(conditions.at(x), 1, 0, 54, {9, 0, 0, 15, 20}, {6, 0, 0, 15, 50});
     } else if (x == 1) { // Sep-Jun We 08:15-08:45,11:55-12:35
       std::vector<uint64_t> expected_values;
       expected_values.push_back(29497840232464);
       expected_values.push_back(28819235728144);
 
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 0, 8, 9, 0, 0, 8, 15, 6, 0, 0, 8, 45);
-      TryConditionalRestrictions(conditions.at(x), 1, 0, 8, 9, 0, 0, 11, 55, 6, 0, 0, 12, 35);
+      TryConditionalRestrictions(conditions.at(x), 0, 0, 8, {9, 0, 0, 8, 15}, {6, 0, 0, 8, 45});
+      TryConditionalRestrictions(conditions.at(x), 1, 0, 8, {9, 0, 0, 11, 55}, {6, 0, 0, 12, 35});
     }
   }
 
@@ -296,7 +296,7 @@ TEST(TimeParsing, TestConditionalRestrictions) {
       std::vector<uint64_t> expected_values;
       expected_values.push_back(9372272830712067);
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 1, 1, 10, 1, 5, 9, 0, 3, 5, 4, 16, 0);
+      TryConditionalRestrictions(conditions.at(x), 0, 1, 1, {10, 1, 5, 9, 0}, {3, 5, 4, 16, 0});
     } else if (x == 1) { // PH 09:00-16:00  Holidays are tossed for now
       std::vector<uint64_t> expected_values;
       expected_values.push_back(0);
@@ -305,7 +305,7 @@ TEST(TimeParsing, TestConditionalRestrictions) {
       std::vector<uint64_t> expected_values;
       expected_values.push_back(11373388284561667);
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 1, 1, 3, 1, 5, 9, 0, 10, 1, 5, 18, 0);
+      TryConditionalRestrictions(conditions.at(x), 0, 1, 1, {3, 1, 5, 9, 0}, {10, 1, 5, 18, 0});
     } else if (x == 3) { // PH 09:00-18:00  Holidays are tossed for now
       std::vector<uint64_t> expected_values;
       expected_values.push_back(0);
@@ -322,14 +322,14 @@ TEST(TimeParsing, TestConditionalRestrictions) {
       expected_values.push_back(7252416602836867);
 
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 1, 65, 12, 6, 5, 9, 0, 1, 7, 3, 16, 0);
-      TryConditionalRestrictions(conditions.at(x), 1, 1, 65, 12, 6, 5, 15, 0, 1, 7, 3, 17, 0);
+      TryConditionalRestrictions(conditions.at(x), 0, 1, 65, {12, 6, 5, 9, 0}, {1, 7, 3, 16, 0});
+      TryConditionalRestrictions(conditions.at(x), 1, 1, 65, {12, 6, 5, 15, 0}, {1, 7, 3, 17, 0});
     } else if (x == 1) { // Dec Su[-1] Su-Sa 15:00-17:00
       std::vector<uint64_t> expected_values;
       expected_values.push_back(11311813490642943);
 
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 1, 127, 12, 1, 5, 15, 0, 12, 0, 5, 17, 0);
+      TryConditionalRestrictions(conditions.at(x), 0, 1, 127, {12, 1, 5, 15, 0}, {12, 0, 5, 17, 0});
     }
   }
 
@@ -343,62 +343,62 @@ TEST(TimeParsing, TestConditionalRestrictions) {
       std::vector<uint64_t> expected_values;
       expected_values.push_back(34359740674);
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 0, 1, 0, 0, 0, 9, 0, 0, 0, 0, 16, 0);
+      TryConditionalRestrictions(conditions.at(x), 0, 0, 1, {0, 0, 0, 9, 0}, {0, 0, 0, 16, 0});
     } else if (x == 1) { // Su[1]
       std::vector<uint64_t> expected_values;
       expected_values.push_back(268435459);
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 1, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0);
+      TryConditionalRestrictions(conditions.at(x), 0, 1, 1, {0, 0, 1, 0, 0}, {0, 0, 0, 0, 0});
     } else if (x == 2) { // Dec
       std::vector<uint64_t> expected_values;
       expected_values.push_back(52776564424704);
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 0, 0, 12, 0, 0, 0, 0, 12, 0, 0, 0, 0);
+      TryConditionalRestrictions(conditions.at(x), 0, 0, 0, {12, 0, 0, 0, 0}, {12, 0, 0, 0, 0});
     } else if (x == 3) { // Dec Su[-1] 15:00-17:00
       std::vector<uint64_t> expected_values;
       expected_values.push_back(11311813490642943);
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 1, 127, 12, 1, 5, 15, 0, 12, 0, 5, 17, 0);
+      TryConditionalRestrictions(conditions.at(x), 0, 1, 127, {12, 1, 5, 15, 0}, {12, 0, 5, 17, 0});
     } else if (x == 4) { // Dec Su[-1] Th 15:00-17:00
       std::vector<uint64_t> expected_values;
       expected_values.push_back(11311813490642721);
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 1, 16, 12, 1, 5, 15, 0, 12, 0, 5, 17, 0);
+      TryConditionalRestrictions(conditions.at(x), 0, 1, 16, {12, 1, 5, 15, 0}, {12, 0, 5, 17, 0});
     } else if (x == 5) { // Dec Su[-1]
       std::vector<uint64_t> expected_values;
       expected_values.push_back(11311776983417087);
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 1, 127, 12, 1, 5, 0, 0, 12, 0, 5, 0, 0);
+      TryConditionalRestrictions(conditions.at(x), 0, 1, 127, {12, 1, 5, 0, 0}, {12, 0, 5, 0, 0});
     } else if (x == 6) { // Dec Su[-1]-Mar 3 Sat
       std::vector<uint64_t> expected_values;
       expected_values.push_back(224301728923777);
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 1, 64, 12, 1, 5, 0, 0, 3, 3, 0, 0, 0);
+      TryConditionalRestrictions(conditions.at(x), 0, 1, 64, {12, 1, 5, 0, 0}, {3, 3, 0, 0, 0});
     } else if (x == 7) { // Mar 3-Dec Su[-1] Sat
       std::vector<uint64_t> expected_values;
       expected_values.push_back(11382144397475969);
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 1, 64, 3, 3, 0, 0, 0, 12, 1, 5, 0, 0);
+      TryConditionalRestrictions(conditions.at(x), 0, 1, 64, {3, 3, 0, 0, 0}, {12, 1, 5, 0, 0});
     } else if (x == 8) { // Dec Su[-1]-Mar 3 Sat 15:00-17:00
       std::vector<uint64_t> expected_values;
       expected_values.push_back(224338236149633);
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 1, 64, 12, 1, 5, 15, 0, 3, 3, 0, 17, 0);
+      TryConditionalRestrictions(conditions.at(x), 0, 1, 64, {12, 1, 5, 15, 0}, {3, 3, 0, 17, 0});
     } else if (x == 9) { // Mar 3-Dec Su[-1] Sat 15:00-17:00
       std::vector<uint64_t> expected_values;
       expected_values.push_back(11382180904701825);
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 1, 64, 3, 3, 0, 15, 0, 12, 1, 5, 17, 0);
+      TryConditionalRestrictions(conditions.at(x), 0, 1, 64, {3, 3, 0, 15, 0}, {12, 1, 5, 17, 0});
     } else if (x == 10) { // Mar 3-Dec Su[-1] Sat,PH 15:00-17:00
       std::vector<uint64_t> expected_values;
       expected_values.push_back(11382180904701825);
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 1, 64, 3, 3, 0, 15, 0, 12, 1, 5, 17, 0);
+      TryConditionalRestrictions(conditions.at(x), 0, 1, 64, {3, 3, 0, 15, 0}, {12, 1, 5, 17, 0});
     } else if (x == 11) { // Mar 3-Dec Su[-1] PH,Sat 15:00-17:00
       std::vector<uint64_t> expected_values;
       expected_values.push_back(11382180904701825);
       TryConditionalRestrictions(conditions.at(x), expected_values);
-      TryConditionalRestrictions(conditions.at(x), 0, 1, 64, 3, 3, 0, 15, 0, 12, 1, 5, 17, 0);
+      TryConditionalRestrictions(conditions.at(x), 0, 1, 64, {3, 3, 0, 15, 0}, {12, 1, 5, 17, 0});
     }
   }
 
@@ -407,13 +407,13 @@ TEST(TimeParsing, TestConditionalRestrictions) {
   for (uint32_t x = 0; x < conditions.size(); x++) {
     if (x == 0) {
       TryConditionalRestrictions(conditions.at(x), {4});
-      TryConditionalRestrictions(conditions.at(x), 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+      TryConditionalRestrictions(conditions.at(x), 0, 0, 2, {0, 0, 0, 0, 0}, {0, 0, 0, 0, 0});
     } else if (x == 1) {
       TryConditionalRestrictions(conditions.at(x), {16});
-      TryConditionalRestrictions(conditions.at(x), 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+      TryConditionalRestrictions(conditions.at(x), 0, 0, 8, {0, 0, 0, 0, 0}, {0, 0, 0, 0, 0});
     } else if (x == 2 || x == 3) {
       TryConditionalRestrictions(conditions.at(x), {64});
-      TryConditionalRestrictions(conditions.at(x), 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+      TryConditionalRestrictions(conditions.at(x), 0, 0, 32, {0, 0, 0, 0, 0}, {0, 0, 0, 0, 0});
     }
   }
 
@@ -427,8 +427,8 @@ TEST(TimeParsing, TestConditionalRestrictions) {
   conditions = GetTagTokens(str, ';');
   for (uint32_t x = 0; x < conditions.size(); x++) {
     TryConditionalRestrictions(conditions.at(x), {2080911656828, 32212258172});
-    TryConditionalRestrictions(conditions.at(x), 0, 0, 62, 0, 0, 0, 7, 0, 0, 0, 0, 9, 30);
-    TryConditionalRestrictions(conditions.at(x), 1, 0, 62, 0, 0, 0, 13, 0, 0, 0, 0, 15, 0);
+    TryConditionalRestrictions(conditions.at(x), 0, 0, 62, {0, 0, 0, 7, 0}, {0, 0, 0, 9, 30});
+    TryConditionalRestrictions(conditions.at(x), 1, 0, 62, {0, 0, 0, 13, 0}, {0, 0, 0, 15, 0});
   }
 
   // includes end of year


### PR DESCRIPTION
# Issue

This PR itself is a substract from the https://github.com/valhalla/valhalla/pull/4851 into a separate PR that addresses a separate issue.

The `(Nov - Mar)` condition (with spaces) is extremely common in Lithuania. It is used to annotate 110 kph speed limit during winter (130 otherwise) - https://en.wikipedia.org/wiki/Speed_limits_in_Lithuania. Almost all A1 ways (e.g. https://www.openstreetmap.org/way/966218614) have it.

## Tasklist

 - [x] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
