### PR TITLE
fix: Continious driwevay ferry connection reclassification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## UNRELEASED
 * **Removed**
 * **Bug Fix**
+   * FIXED: Continious driwevay ferry connection reclassification [#4863](https://github.com/valhalla/valhalla/pull/4863)
 * **Enhancement**
 
 ## Release Date: 2024-08-21 Valhalla 3.5.0

--- a/src/mjolnir/ferry_connections.cc
+++ b/src/mjolnir/ferry_connections.cc
@@ -147,9 +147,12 @@ std::pair<uint32_t, bool> ShortestPath(const uint32_t start_node_idx,
           continue;
         }
 
-        // Skip uses other than road / other (service?)
+        // Skip uses other than road / other (service?) and driveways.
+        // Note about driveways - additional penalty to the driveways is added below in the destonly
+        // penalty handling (driveways always have destonly flag) if they are not continious.
         const OSMWay w = *ways[edge.wayindex_];
         if (w.use() != baldr::Use::kOther && w.use() != baldr::Use::kServiceRoad &&
+            w.use() != baldr::Use::kDriveway &&
             static_cast<int>(w.use()) > static_cast<int>(baldr::Use::kTurnChannel)) {
           continue;
         }


### PR DESCRIPTION
# Issue

This PR fixes ferry connection reclassification if there are no other way than follow driveways to access ferry.
<img width="1197" alt="image" src="https://github.com/user-attachments/assets/c29c62d5-13d0-4b1f-afd1-b518ade2680c">

Here the example where because of such issue the wrong ferry is suggested instead of taking the direct ferry Klaipėda - Karlshamn - https://valhalla.openstreetmap.de/directions?profile=car&wps=21.149110794067386%2C55.68394791018847%2C14.798583984375002%2C56.18225387824834

See the previous discussion about this problem for more context - https://github.com/valhalla/valhalla/pull/2933#discussion_r595409031

## Tasklist

 - [x] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
