### PR TITLE
`clear_reserved_memory_` uninitialized in TD Matrix

### DIFF
--- a/valhalla/thor/timedistancematrix.h
+++ b/valhalla/thor/timedistancematrix.h
@@ -94,7 +94,6 @@ protected:
   float current_cost_threshold_;
 
   uint32_t max_reserved_labels_count_;
-  bool clear_reserved_memory_;
 
   // List of destinations
   std::vector<Destination> destinations_;


### PR DESCRIPTION
# Issue

Probably just an oversight in #4535, where the member was moved to the `MatrixAlgorithm` base class.
