### PR TITLE
fix: `-Wdefaulted-function-deleted` warning/error in `NarrativeBuilder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
    * FIXED: All logging in `valhalla_export_edges` now goes to stderr [#4892](https://github.com/valhalla/valhalla/pull/4892)
    * FIXED: Iterate over only `kLandmark` tagged values in `AddLandmarks()` [#4873](https://github.com/valhalla/valhalla/pull/4873)
    * FIXED: `walk_or_snap` mode edge case with loop routes [#4895](https://github.com/valhalla/valhalla/pull/4895)
+   * FIXED: `-Wdefaulted-function-deleted` compilation warning/error in `NarrativeBuilder` [#4877](https://github.com/valhalla/valhalla/pull/4877)
 * **Enhancement**
    * CHANGED: voice instructions for OSRM serializer to work better in real-world environment [#4756](https://github.com/valhalla/valhalla/pull/4756)
    * ADDED: Add option `edge.forward` to trace attributes [#4876](https://github.com/valhalla/valhalla/pull/4876)

--- a/valhalla/odin/narrativebuilder.h
+++ b/valhalla/odin/narrativebuilder.h
@@ -27,10 +27,10 @@ public:
   virtual ~NarrativeBuilder() = default;
 
   NarrativeBuilder(NarrativeBuilder&&) = default;
-  NarrativeBuilder& operator=(NarrativeBuilder&&) = default;
+  NarrativeBuilder& operator=(NarrativeBuilder&&) = delete;
 
   NarrativeBuilder(const NarrativeBuilder&) = default;
-  NarrativeBuilder& operator=(const NarrativeBuilder&) = default;
+  NarrativeBuilder& operator=(const NarrativeBuilder&) = delete;
 
   void Build(std::list<Maneuver>& maneuvers);
 


### PR DESCRIPTION
# Issue

This PR fixes the following compilation error on MacOS caused by `NarrativeBuilder` that has `default` copy/move assignment operators that are implicitly deleted because of `NarrativeBuilder::options_` which is a const ref, that definitely cannot be assigned. See the full error below:
```
[ 91%] Building CXX object src/tyr/CMakeFiles/valhalla-tyr.dir/trace_serializer.cc.o
In file included from /Users/kinkard/Developer/valhalla/src/tyr/route_serializer_osrm.cc:14:
In file included from /Users/kinkard/Developer/valhalla/valhalla/odin/narrative_builder_factory.h:8:
/Users/kinkard/Developer/valhalla/valhalla/odin/narrativebuilder.h:30:21: error: explicitly defaulted move assignment operator is implicitly deleted [-Werror,-Wdefaulted-function-deleted]
  NarrativeBuilder& operator=(NarrativeBuilder&&) = default;
                    ^
/Users/kinkard/Developer/valhalla/valhalla/odin/narrativebuilder.h:659:18: note: move assignment operator of 'NarrativeBuilder' is implicitly deleted because field 'options_' is of reference type 'const Options &'
  const Options& options_;
                 ^
/Users/kinkard/Developer/valhalla/valhalla/odin/narrativebuilder.h:30:53: note: replace 'default' with 'delete'
  NarrativeBuilder& operator=(NarrativeBuilder&&) = default;
                                                    ^~~~~~~
                                                    delete
/Users/kinkard/Developer/valhalla/valhalla/odin/narrativebuilder.h:33:21: error: explicitly defaulted copy assignment operator is implicitly deleted [-Werror,-Wdefaulted-function-deleted]
  NarrativeBuilder& operator=(const NarrativeBuilder&) = default;
                    ^
/Users/kinkard/Developer/valhalla/valhalla/odin/narrativebuilder.h:659:18: note: copy assignment operator of 'NarrativeBuilder' is implicitly deleted because field 'options_' is of reference type 'const Options &'
  const Options& options_;
                 ^
/Users/kinkard/Developer/valhalla/valhalla/odin/narrativebuilder.h:33:58: note: replace 'default' with 'delete'
  NarrativeBuilder& operator=(const NarrativeBuilder&) = default;
                                                         ^~~~~~~
                                                         delete
2 errors generated.
```

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
