### PR TITLE
Support multiple levels and level ranges

### DIFF
--- a/lua/graph.lua
+++ b/lua/graph.lua
@@ -1870,11 +1870,6 @@ function filter_tags_generic(kv)
   kv["bike_local_ref"] = lref
   kv["bike_network_mask"] = bike_mask
 
-  -- turn semicolon into colon due to challenges to store ";" in string
-  if kv["level"] ~= nil then
-    kv["level"] = kv["level"]:gsub(";", ":")
-  end
-
   -- Explicitly turn off access for construction type. It's done for backward compatibility
   -- of valhalla tiles and valhalla routing. In case we allow non-zero access then older
   -- versions of router will work with new tiles incorrectly. They would start to route

--- a/src/baldr/edgeinfo.cc
+++ b/src/baldr/edgeinfo.cc
@@ -404,11 +404,13 @@ int8_t EdgeInfo::layer() const {
   return static_cast<int8_t>(value.front());
 }
 
-std::vector<std::string> EdgeInfo::level() const {
+std::vector<int16_t> EdgeInfo::level() const {
   const auto& tags = GetTags();
-  std::vector<std::string> values;
+  std::vector<int16_t> values;
   for (auto [itr, range_end] = tags.equal_range(TaggedValue::kLevel); itr != range_end; ++itr) {
-    values.emplace_back(itr->second);
+    try {
+      values.emplace_back(static_cast<uint16_t>(std::stoi(itr->second)));
+    } catch (...) { LOG_ERROR("Unable to parse numerical level value " + itr->second); }
   }
   return values;
 }

--- a/src/baldr/edgeinfo.cc
+++ b/src/baldr/edgeinfo.cc
@@ -404,24 +404,22 @@ int8_t EdgeInfo::layer() const {
   return static_cast<int8_t>(value.front());
 }
 
-std::string EdgeInfo::level() const {
+std::vector<std::string> EdgeInfo::level() const {
   const auto& tags = GetTags();
-  auto itr = tags.find(TaggedValue::kLevel);
-  if (itr == tags.end()) {
-    return "";
+  std::vector<std::string> values;
+  for (auto [itr, range_end] = tags.equal_range(TaggedValue::kLevel); itr != range_end; ++itr) {
+    values.emplace_back(itr->second);
   }
-  const std::string& value = itr->second;
-  return value;
+  return values;
 }
 
-std::string EdgeInfo::level_ref() const {
+std::vector<std::string> EdgeInfo::level_ref() const {
   const auto& tags = GetTags();
-  auto itr = tags.find(TaggedValue::kLevelRef);
-  if (itr == tags.end()) {
-    return "";
+  std::vector<std::string> values;
+  for (auto [itr, range_end] = tags.equal_range(TaggedValue::kLevelRef); itr != range_end; ++itr) {
+    values.emplace_back(itr->second);
   }
-  const std::string& value = itr->second;
-  return value;
+  return values;
 }
 
 json::MapPtr EdgeInfo::json() const {

--- a/src/odin/enhancedtrippath.cc
+++ b/src/odin/enhancedtrippath.cc
@@ -525,17 +525,19 @@ std::vector<std::pair<std::string, bool>> EnhancedTripLeg_Edge::GetNameList() co
 
 std::vector<std::string> EnhancedTripLeg_Edge::GetLevelRef() const {
   std::vector<std::string> level_refs;
+  std::vector<std::string> levels;
+
+  // try to get level_refs, else create some from levels as fallback
   if (!tagged_value().empty()) {
     for (int t = 0; t < tagged_value().size(); ++t) {
       if (tagged_value().Get(t).type() == TaggedValue_Type_kLevelRef) {
         level_refs.emplace_back(tagged_value().Get(t).value());
-        break;
       } else if (tagged_value().Get(t).type() == TaggedValue_Type_kLevel) {
-        level_refs.emplace_back("Level " + tagged_value().Get(t).value());
+        levels.emplace_back("Level " + tagged_value().Get(t).value());
       }
     }
   }
-  return level_refs;
+  return level_refs.empty() ? levels : level_refs;
 }
 
 float EnhancedTripLeg_Edge::GetLength(const Options::Units& units) {

--- a/src/odin/enhancedtrippath.cc
+++ b/src/odin/enhancedtrippath.cc
@@ -523,19 +523,19 @@ std::vector<std::pair<std::string, bool>> EnhancedTripLeg_Edge::GetNameList() co
   return name_list;
 }
 
-std::string EnhancedTripLeg_Edge::GetLevelRef() const {
-  std::string level_ref;
+std::vector<std::string> EnhancedTripLeg_Edge::GetLevelRef() const {
+  std::vector<std::string> level_refs;
   if (!tagged_value().empty()) {
     for (int t = 0; t < tagged_value().size(); ++t) {
       if (tagged_value().Get(t).type() == TaggedValue_Type_kLevelRef) {
-        level_ref = tagged_value().Get(t).value();
+        level_refs.emplace_back(tagged_value().Get(t).value());
         break;
       } else if (tagged_value().Get(t).type() == TaggedValue_Type_kLevel) {
-        level_ref = "Level " + tagged_value().Get(t).value();
+        level_refs.emplace_back("Level " + tagged_value().Get(t).value());
       }
     }
   }
-  return level_ref;
+  return level_refs;
 }
 
 float EnhancedTripLeg_Edge::GetLength(const Options::Units& units) {

--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -1157,7 +1157,11 @@ void ManeuversBuilder::InitializeManeuver(Maneuver& maneuver, int node_index) {
 
   // Set the end level ref
   if (curr_edge && !curr_edge->GetLevelRef().empty()) {
-    maneuver.set_end_level_ref(curr_edge->GetLevelRef());
+    if (curr_edge->GetLevelRef().size() > 1) {
+      maneuver.set_end_level_ref("");
+    } else {
+      maneuver.set_end_level_ref(curr_edge->GetLevelRef()[0]);
+    }
   }
 
   // Elevator
@@ -1452,7 +1456,11 @@ void ManeuversBuilder::FinalizeManeuver(Maneuver& maneuver, int node_index) {
     maneuver.set_elevator(true);
     // Set the end level ref
     if (curr_edge && !curr_edge->GetLevelRef().empty()) {
-      maneuver.set_end_level_ref(curr_edge->GetLevelRef());
+      if (curr_edge->GetLevelRef().size() > 1) {
+        maneuver.set_end_level_ref("");
+      } else {
+        maneuver.set_end_level_ref(curr_edge->GetLevelRef()[0]);
+      }
     }
   }
 
@@ -4006,10 +4014,12 @@ void ManeuversBuilder::AddLandmarksFromTripLegToManeuvers(std::list<Maneuver>& m
 
     for (auto node = man->begin_node_index(); node < man->end_node_index(); ++node) {
       auto curr_edge = trip_path_->GetCurrEdge(node);
-      // multipoint routes with `through` or `via` types can have consecutive copies of the same edge
+      // multipoint routes with `through` or `via` types can have consecutive copies of the same
+      // edge
       if (curr_edge != trip_path_->GetCurrEdge(node + 1)) {
         // every time we are about to leave an edge, collect all landmarks in it
-        // and reset distance of each landmark to the distance from the landmark to the maneuver point
+        // and reset distance of each landmark to the distance from the landmark to the maneuver
+        // point
         auto curr_landmarks = curr_edge->landmarks();
         for (auto& l : curr_landmarks) {
           double new_distance =

--- a/test/gurka/test_indoor.cc
+++ b/test/gurka/test_indoor.cc
@@ -55,7 +55,7 @@ protected:
         {"DN", {{"highway", "steps"}}},
         {"NO", {{"highway", "footway"}}},
 
-        {"Cx", {{"highway", "steps"}, {"indoor", "yes"}, {"level", "1;2"}}},
+        {"Cx", {{"highway", "steps"}, {"indoor", "yes"}, {"level", "-1;0-2"}}},
         {"xy", {{"highway", "steps"}, {"indoor", "yes"}, {"level", "2;3"}}},
         {"yJ", {{"highway", "corridor"}, {"indoor", "yes"}, {"level", "3"}}},
     };
@@ -125,9 +125,11 @@ TEST_F(Indoor, EdgeInfo) {
     auto edgeId = std::get<0>(gurka::findEdgeByNodes(graphreader, layout, from, to));
     return graphreader.edgeinfo(edgeId).level();
   };
-  EXPECT_THAT(get_level("A", "B"), ::testing::ElementsAre("0"));
-  EXPECT_THAT(get_level("B", "C"), ::testing::ElementsAre("0", "1"));
-  EXPECT_THAT(get_level("C", "F"), ::testing::ElementsAre("1"));
+  EXPECT_THAT(get_level("A", "B"), ::testing::ElementsAre(0));
+  EXPECT_THAT(get_level("B", "C"), ::testing::ElementsAre(0, 1));
+  EXPECT_THAT(get_level("C", "F"), ::testing::ElementsAre(1));
+  EXPECT_THAT(get_level("C", "x"), ::testing::ElementsAre(-1, 0, 1, 2));
+  EXPECT_THAT(get_level("x", "y"), ::testing::ElementsAre(2, 3));
 
   auto get_level_ref = [&](auto from, auto to) {
     auto edge_id = std::get<0>(gurka::findEdgeByNodes(graphreader, layout, from, to));

--- a/test/gurka/test_indoor.cc
+++ b/test/gurka/test_indoor.cc
@@ -1,4 +1,5 @@
 #include "gurka.h"
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #if !defined(VALHALLA_SOURCE_DIR)
@@ -124,17 +125,17 @@ TEST_F(Indoor, EdgeInfo) {
     auto edgeId = std::get<0>(gurka::findEdgeByNodes(graphreader, layout, from, to));
     return graphreader.edgeinfo(edgeId).level();
   };
-  EXPECT_EQ(get_level("A", "B"), "0");
-  EXPECT_EQ(get_level("B", "C"), "0:1");
-  EXPECT_EQ(get_level("C", "F"), "1");
+  EXPECT_THAT(get_level("A", "B"), ::testing::ElementsAre("0"));
+  EXPECT_THAT(get_level("B", "C"), ::testing::ElementsAre("0", "1"));
+  EXPECT_THAT(get_level("C", "F"), ::testing::ElementsAre("1"));
 
   auto get_level_ref = [&](auto from, auto to) {
     auto edge_id = std::get<0>(gurka::findEdgeByNodes(graphreader, layout, from, to));
     return graphreader.edgeinfo(edge_id).level_ref();
   };
-  EXPECT_EQ(get_level_ref("A", "B"), "Parking");
-  EXPECT_EQ(get_level_ref("B", "C"), "");
-  EXPECT_EQ(get_level_ref("C", "F"), "Lobby");
+  EXPECT_THAT(get_level_ref("A", "B"), ::testing::ElementsAre("Parking"));
+  EXPECT_THAT(get_level_ref("B", "C"), ::testing::ElementsAre());
+  EXPECT_THAT(get_level_ref("C", "F"), ::testing::ElementsAre("Lobby"));
 }
 
 TEST_F(Indoor, ElevatorPenalty) {

--- a/valhalla/baldr/edgeinfo.h
+++ b/valhalla/baldr/edgeinfo.h
@@ -264,13 +264,13 @@ public:
    * @return layer index of the edge
    */
 
-  std::string level() const;
+  std::vector<std::string> level() const;
   /**
    * Get layer:ref of the edge.
    * @see https://wiki.openstreetmap.org/wiki/Key:level:ref
    * @return layer index of the edge
    */
-  std::string level_ref() const;
+  std::vector<std::string> level_ref() const;
 
   /**
    * Returns json representing this object

--- a/valhalla/baldr/edgeinfo.h
+++ b/valhalla/baldr/edgeinfo.h
@@ -264,7 +264,7 @@ public:
    * @return layer index of the edge
    */
 
-  std::vector<std::string> level() const;
+  std::vector<int16_t> level() const;
   /**
    * Get layer:ref of the edge.
    * @see https://wiki.openstreetmap.org/wiki/Key:level:ref

--- a/valhalla/odin/enhancedtrippath.h
+++ b/valhalla/odin/enhancedtrippath.h
@@ -422,7 +422,7 @@ public:
 
   std::vector<std::pair<std::string, bool>> GetNameList() const;
 
-  std::string GetLevelRef() const;
+  std::vector<std::string> GetLevelRef() const;
 
   float GetLength(const Options::Units& units);
 


### PR DESCRIPTION
# Issue

Precursor to #4878. 

Adds proper parsing of integer values stored in the `level` tag, including ranges. This is in accordance with the [osm wiki](https://wiki.openstreetmap.org/wiki/Key:level) and the [Simple Indoor Tagging](https://wiki.openstreetmap.org/wiki/Indoor_Mapping) scheme. 

Also adds suppoprt for multiple, semicolon separated `level_ref` values. 


## Tasklist

 - [x] Add tests
 - [x] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)

