### PR TITLE
Fix logging properly in valhalla_export_edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## UNRELEASED
 * **Removed**
 * **Bug Fix**
+   * FIXED: All logging in `valhalla_export_edges` now goes to stderr [#4892](https://github.com/valhalla/valhalla/pull/4892)
 * **Enhancement**
    * CHANGED: voice instructions for OSRM serializer to work better in real-world environment [#4756](https://github.com/valhalla/valhalla/pull/4756)
    * ADDED: Add option `edge.forward` to trace attributes [#4876](https://github.com/valhalla/valhalla/pull/4876)

--- a/src/valhalla_export_edges.cc
+++ b/src/valhalla_export_edges.cc
@@ -177,11 +177,11 @@ int main(int argc, char* argv[]) {
     return EXIT_FAILURE;
   }
 
-  // get something we can use to fetch tiles
-  valhalla::baldr::GraphReader reader(config.get_child("mjolnir"));
-
   // configure logging here, we want it to go to stderr
   valhalla::midgard::logging::Configure({{"type", "std_err"}, {"color", "true"}});
+
+  // get something we can use to fetch tiles
+  valhalla::baldr::GraphReader reader(config.get_child("mjolnir"));
 
   // keep the global number of edges encountered at the point we encounter each tile
   // this allows an edge to have a sequential global id and makes storing it very small


### PR DESCRIPTION
# Issue

Fixes #4891.

## Tasklist

 - [ ] Add tests
 - [X] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described 
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

Related to https://github.com/valhalla/valhalla/pull/4498/files (just moves the logging up before the graph reader init).