### PR TITLE
Loop match walk or snap fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * **Removed**
 * **Bug Fix**
    * FIXED: All logging in `valhalla_export_edges` now goes to stderr [#4892](https://github.com/valhalla/valhalla/pull/4892)
+   * FIXED: `walk_or_snap` mode edge case with loop routes [#4895](https://github.com/valhalla/valhalla/pull/4895)
 * **Enhancement**
    * CHANGED: voice instructions for OSRM serializer to work better in real-world environment [#4756](https://github.com/valhalla/valhalla/pull/4756)
    * ADDED: Add option `edge.forward` to trace attributes [#4876](https://github.com/valhalla/valhalla/pull/4876)

--- a/src/thor/route_matcher.cc
+++ b/src/thor/route_matcher.cc
@@ -492,20 +492,23 @@ bool RouteMatcher::FormPath(const sif::mode_costing_t& mode_costing,
       index++;
     }
 
-    // Did not find the end of the origin edge. Check for trivial route on a single edge
-    for (const auto& end : end_nodes) {
-      if (end.second.first.graph_id() == edge.graph_id()) {
-        // Update the elapsed time based on edge cost
-        uint8_t flow_sources;
-        elapsed += mode_costing[static_cast<int>(mode)]->EdgeCost(de, end_node_tile, time_info,
-                                                                  flow_sources) *
-                   (end.second.first.percent_along() - edge.percent_along());
-        if (options.use_timestamps())
-          elapsed.secs = options.shape().rbegin()->time() - options.shape(0).time();
+    // Look for trivial cases if we didn't bail based on checking more than the edge length
+    if (length <= de_length) {
+      // Did not find the end of the origin edge. Check for trivial route on a single edge
+      for (const auto& end : end_nodes) {
+        if (end.second.first.graph_id() == edge.graph_id()) {
+          // Update the elapsed time based on edge cost
+          uint8_t flow_sources;
+          elapsed += mode_costing[static_cast<int>(mode)]->EdgeCost(de, end_node_tile, time_info,
+                                                                    flow_sources) *
+                     (end.second.first.percent_along() - edge.percent_along());
+          if (options.use_timestamps())
+            elapsed.secs = options.shape().rbegin()->time() - options.shape(0).time();
 
-        // Add end edge
-        path_infos.emplace_back(mode, elapsed, GraphId(edge.graph_id()), 0, 0.f, -1);
-        return true;
+          // Add end edge
+          path_infos.emplace_back(mode, elapsed, GraphId(edge.graph_id()), 0, 0.f, -1);
+          return true;
+        }
       }
     }
   }

--- a/test/mapmatch.cc
+++ b/test/mapmatch.cc
@@ -1232,6 +1232,33 @@ TEST(Mapmatch, test_loop_matching) {
   }
 }
 
+TEST(Mapmatch, test_loop_matching_walk_or_snap) {
+  // The walk_or_snap case sometimes incorrectly identifies trivial cases where it can optimize away.
+  // This tests loops which are not trivial.
+  std::vector<std::string> test_cases = {
+      // Simple loop around a block; incorrectly identified as trivial in such a way that
+      // it caused an exception in TripLegBuilder (no maneuvers)
+      R"({"shape_match":"walk_or_snap", "shape":[
+          {"lat": 52.11870746741026, "lon": 5.117783546447755, "type": "break", "node_snap_tolerance": 0},
+          {"lat": 52.11905661947785, "lon": 5.118234157562257, "type": "via", "node_snap_tolerance": 0},
+          {"lat": 52.11934977334695, "lon": 5.117751359939576, "type": "via", "node_snap_tolerance": 0},
+          {"lat": 52.118852398789194, "lon": 5.116935968399049, "type": "via", "node_snap_tolerance": 0},
+          {"lat": 52.11852959643748, "lon": 5.117445588111878, "type": "via", "node_snap_tolerance": 0},
+          {"lat": 52.11870746741026, "lon": 5.117783546447755, "type": "break", "node_snap_tolerance": 0}],
+          "costing":"auto"})",
+  };
+
+  api_tester tester;
+  for (size_t i = 0; i < test_cases.size(); ++i) {
+    // Verify that the map_snap output matches the walk_or_snap output.
+    // This approach is inspired by the above.
+    auto map_snap_case = R"({"shape_match":"map_snap)" + test_cases[i].substr(28);
+    auto map_snapped = tester.match(map_snap_case);
+    auto matched = tester.match(test_cases[i]);
+    compare_results(map_snapped, matched);
+  }
+}
+
 TEST(Mapmatch, test_intersection_matching) {
   std::vector<std::string> test_cases = {
       R"({"shape":[


### PR DESCRIPTION
# Issue

More fun with matching loops (#2205 and others)!

I ran into this when debugging another loop issue when map matching GTFS feeds, which are a great source of loops. I found a problem. I found _a_ fix. But I don't know if it's the correct one ;)

There is an optimization(?) for identifying trivial routes on a single edge in the walking route matcher. I assume that "trivial" in this case means "only ever traverses (some of) a single edge." This appears to be causing problems. In such cases, if you're in `walk_or_snap` mode, you'll get the following server error:

```json
{
  "error_code": 299,
  "error": "Unknown: Could not build directions for TripLeg",
  "status_code": 400,
  "status": "Bad Request"
}
```

The route successfully matches in the more expensive `map_snap` mode, but it fails in `edge_walk` mode. The curious thing is that, in `walk_or_snap` mode, the error handling around https://github.com/valhalla/valhalla/blob/3a385045919967a14d5c9cc57610b2111936ac64/src/thor/trace_route_action.cc#L111 is such that it will fall back to `map_snap` when `edge_walk` fails. Indeed, the expected warning log is printed. However, it never succeeds.

Why it does not successfully find a match, and fails with this error about building trip legs, I have not had time to uncover, but since almost all of this code appears to be dealing with mutable references, it is quite difficult to reason about.

My fix comes from observing that the "trivial" case detection is way too eager. I thought of a few ways to fix this, but also observed that it was being hit for my routes as well as a constructed example (in the unit tests now) after breaking from the preceeding while loop due to examining a distance greater than the edge length. That looks to me like a situation where the route is almost certainly *not* trivial, so I have cut out the check using the break condition.

## Tasklist

 - [x] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.
