### PR TITLE
dont use static_cast for negative varint encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
    * FIXED: Iterate over only `kLandmark` tagged values in `AddLandmarks()` [#4873](https://github.com/valhalla/valhalla/pull/4873)
    * FIXED: `walk_or_snap` mode edge case with loop routes [#4895](https://github.com/valhalla/valhalla/pull/4895)
    * FIXED: `-Wdefaulted-function-deleted` compilation warning/error in `NarrativeBuilder` [#4877](https://github.com/valhalla/valhalla/pull/4877)
+   * FIXED: For a long time we were potentially wrongly encoding varints by using `static_cast` vs `reinterpret_cast` [#4877]https://github.com/valhalla/valhalla/pull/4925
 * **Enhancement**
    * CHANGED: voice instructions for OSRM serializer to work better in real-world environment [#4756](https://github.com/valhalla/valhalla/pull/4756)
    * ADDED: Add option `edge.forward` to trace attributes [#4876](https://github.com/valhalla/valhalla/pull/4876)

--- a/valhalla/midgard/encoded.h
+++ b/valhalla/midgard/encoded.h
@@ -177,7 +177,7 @@ std::string encode(const container_t& points, const int precision = ENCODE_PRECI
   // handy lambda to turn an integer into an encoded string
   auto serialize = [&output](int number) {
     // move the bits left 1 position and flip all the bits if it was a negative number
-    number = number < 0 ? ~(static_cast<unsigned int>(number) << 1) : (number << 1);
+    number = number < 0 ? ~(*reinterpret_cast<unsigned int*>(&number) << 1) : (number << 1);
     // write 5 bit chunks of the number
     while (number >= 0x20) {
       int nextValue = (0x20 | (number & 0x1f)) + 63;
@@ -224,7 +224,7 @@ std::string encode7(const container_t& points, const int precision = ENCODE_PREC
   auto serialize = [&output](int number) {
     // get the sign bit down on the least significant end to
     // make the most significant bits mostly zeros
-    number = number < 0 ? ~(static_cast<unsigned int>(number) << 1) : number << 1;
+    number = number < 0 ? ~(*reinterpret_cast<unsigned int*>(&number) << 1) : number << 1;
     // we take 7 bits of this at a time
     while (number > 0x7f) {
       // marking the most significant bit means there are more pieces to come


### PR DESCRIPTION
over in #4879 @chrstnbwnkl noticed that when varint encoding negative values certain values fail the tests. this turned out to be a result of how we handle the movement of the sign bit to do the encoding for negative values. the main issue with my initial implementation was that to get the integer into something that we could reliably bitshift i `static_cast`ed it to unsigned. `static_cast` is meant really to do a conversion in the human sense of understanding numbers and for negatives it wraps around which isnt what we want. what we want is to treat it like a blob of bytes that we can do bitwise operations on, hence `reinterpret_cast` is the right tool for the job