### PR TITLE
Fix macOS CI 

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -59,15 +59,15 @@ jobs:
             ccache-osx-
 
       - name: Configure CMake
-        run: cmake -B build -DENABLE_SINGLE_FILES_WERROR=OFF -DENABLE_GDAL=ON
+        run: |
+          source .venv/bin/activate
+          cmake -B build -DENABLE_SINGLE_FILES_WERROR=OFF -DENABLE_GDAL=ON
 
       - name: Build Valhalla
         run: make -C build -j$(sysctl -n hw.logicalcpu)
 
       - name: Build Tests
-        run: |
-          source .venv/bin/activate
-          make -C build -j$(sysctl -n hw.logicalcpu) tests
+        run: make -C build -j$(sysctl -n hw.logicalcpu) tests
 
       - name: Save ccache
         uses: actions/cache/save@v4

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -40,26 +40,32 @@ jobs:
 
       - name: Install dependencies
         run: |
-          HOMEBREW_NO_AUTO_UPDATE=1 brew install autoconf automake protobuf cmake ccache libtool sqlite3 libspatialite luajit curl wget czmq lz4 spatialite-tools unzip boost gdal
-          sudo python -m venv .venv && source .venv/bin/activate
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install python autoconf automake protobuf cmake ccache libtool sqlite3 libspatialite luajit curl wget czmq lz4 spatialite-tools unzip boost gdal
+          export PATH="$(brew --prefix python)/libexec/bin:$PATH"
           sudo python -m pip install requests shapely
           git clone https://github.com/kevinkreiser/prime_server --recurse-submodules && cd prime_server && ./autogen.sh && ./configure && make -j$(sysctl -n hw.logicalcpu) && sudo make install
 
       - name: Get branch name
         run: echo "VALHALLA_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_ENV
 
+      - name: Restore ccache
+        id: cache-ccache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/Library/Caches/ccache
+          key: ccache-osx-${{ env.VALHALLA_BRANCH }}
+          restore-keys: |
+            ccache-osx-master
+            ccache-osx-
+
       - name: Configure CMake
-        run: |
-          source .venv/bin/activate
-          cmake -B build -DENABLE_SINGLE_FILES_WERROR=OFF -DENABLE_GDAL=ON
+        run: cmake -B build -DENABLE_SINGLE_FILES_WERROR=OFF -DENABLE_GDAL=ON
 
       - name: Build Valhalla
         run: make -C build -j$(sysctl -n hw.logicalcpu)
 
       - name: Build Tests
-        run: |
-          source .venv/bin/activate
-          make -C build -j$(sysctl -n hw.logicalcpu) tests
+        run: make -C build -j$(sysctl -n hw.logicalcpu) tests
 
       - name: Save ccache
         uses: actions/cache/save@v4
@@ -68,9 +74,7 @@ jobs:
           key: ${{ steps.cache-ccache-restore.outputs.cache-primary-key }}
 
       - name: Run Tests
-        run: |
-          source .venv/bin/activate
-          make -C build -j$(sysctl -n hw.logicalcpu) check
+        run: make -C build -j$(sysctl -n hw.logicalcpu) check
 
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -48,16 +48,6 @@ jobs:
       - name: Get branch name
         run: echo "VALHALLA_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_ENV
 
-      - name: Restore ccache
-        id: cache-ccache-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/Library/Caches/ccache
-          key: ccache-osx-${{ env.VALHALLA_BRANCH }}
-          restore-keys: |
-            ccache-osx-master
-            ccache-osx-
-
       - name: Configure CMake
         run: |
           source .venv/bin/activate

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           HOMEBREW_NO_AUTO_UPDATE=1 brew install autoconf automake protobuf cmake ccache libtool sqlite3 libspatialite luajit curl wget czmq lz4 spatialite-tools unzip boost gdal
           sudo python -m venv .venv && source .venv/bin/activate
-          python -m pip install requests shapely
+          sudo python -m pip install requests shapely
           git clone https://github.com/kevinkreiser/prime_server --recurse-submodules && cd prime_server && ./autogen.sh && ./configure && make -j$(sysctl -n hw.logicalcpu) && sudo make install
 
       - name: Get branch name

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -65,7 +65,9 @@ jobs:
         run: make -C build -j$(sysctl -n hw.logicalcpu)
 
       - name: Build Tests
-        run: make -C build -j$(sysctl -n hw.logicalcpu) tests
+        run: |
+          source .venv/bin/activate
+          make -C build -j$(sysctl -n hw.logicalcpu) tests
 
       - name: Save ccache
         uses: actions/cache/save@v4
@@ -75,7 +77,6 @@ jobs:
 
       - name: Run Tests
         run: |
-          source .venv/bin/activate
           make -C build -j$(sysctl -n hw.logicalcpu) check
 
       - name: Setup tmate session

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -2,7 +2,7 @@ name: OSX CI
 on:
   push:
     paths-ignore:
-      - '*.md'
+      - "*.md"
       - .circleci/
       - docs/
       - run_route_scripts/
@@ -11,7 +11,7 @@ on:
       - master
   pull_request:
     paths-ignore:
-      - '*.md'
+      - "*.md"
       - .circleci/
       - docs/
       - run_route_scripts/
@@ -22,7 +22,7 @@ on:
     inputs:
       debug_enabled:
         type: boolean
-        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        description: "Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)"
         required: false
         default: false
 
@@ -33,15 +33,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      
+
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12' 
-      
+          python-version: "3.12"
+
       - name: Install dependencies
         run: |
           HOMEBREW_NO_AUTO_UPDATE=1 brew install autoconf automake protobuf cmake ccache libtool sqlite3 libspatialite luajit curl wget czmq lz4 spatialite-tools unzip boost gdal
-          sudo python -m pip install --break-system-packages requests shapely
+          sudo python -m venv .venv && source .venv/bin/activate
+          python -m pip install requests shapely
           git clone https://github.com/kevinkreiser/prime_server --recurse-submodules && cd prime_server && ./autogen.sh && ./configure && make -j$(sysctl -n hw.logicalcpu) && sudo make install
 
       - name: Get branch name
@@ -71,10 +72,12 @@ jobs:
         with:
           path: ~/Library/Caches/ccache
           key: ${{ steps.cache-ccache-restore.outputs.cache-primary-key }}
-          
+
       - name: Run Tests
-        run: make -C build -j$(sysctl -n hw.logicalcpu) check
-      
+        run: |
+          source .venv/bin/activate
+          make -C build -j$(sysctl -n hw.logicalcpu) check
+
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
         # only run this if manually invoked or a previous job failed
@@ -82,4 +85,3 @@ jobs:
         with:
           detached: true
           timeout-minutes: 15
-          

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -67,7 +67,9 @@ jobs:
         run: make -C build -j$(sysctl -n hw.logicalcpu)
 
       - name: Build Tests
-        run: make -C build -j$(sysctl -n hw.logicalcpu) tests
+        run: |
+          source .venv/bin/activate
+          make -C build -j$(sysctl -n hw.logicalcpu) tests
 
       - name: Save ccache
         uses: actions/cache/save@v4
@@ -77,6 +79,7 @@ jobs:
 
       - name: Run Tests
         run: |
+          source .venv/bin/activate
           make -C build -j$(sysctl -n hw.logicalcpu) check
 
       - name: Setup tmate session

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           HOMEBREW_NO_AUTO_UPDATE=1 brew install python autoconf automake protobuf cmake ccache libtool sqlite3 libspatialite luajit curl wget czmq lz4 spatialite-tools unzip boost gdal
           export PATH="$(brew --prefix python)/libexec/bin:$PATH"
-          sudo python -m pip install requests shapely
+          sudo python -m pip install --break-system-packages requests shapely
           git clone https://github.com/kevinkreiser/prime_server --recurse-submodules && cd prime_server && ./autogen.sh && ./configure && make -j$(sysctl -n hw.logicalcpu) && sudo make install
 
       - name: Get branch name

--- a/test/scripts/CMakeLists.txt
+++ b/test/scripts/CMakeLists.txt
@@ -1,10 +1,5 @@
 # be aware: the python modules that need testing, need to be symlinked to the test/scripts folder with a .py extension
 
-# FindPython should return first matching version instead of newest
-if (POLICY CMP0094)  # https://cmake.org/cmake/help/latest/policy/CMP0094.html
-        cmake_policy(SET CMP0094 NEW)  
-endif ()
-
 find_package(Python COMPONENTS Interpreter)
 if (Python_FOUND)
   add_custom_command(OUTPUT scripts.log

--- a/test/scripts/CMakeLists.txt
+++ b/test/scripts/CMakeLists.txt
@@ -1,4 +1,10 @@
 # be aware: the python modules that need testing, need to be symlinked to the test/scripts folder with a .py extension
+
+# FindPython should return first matching version instead of newest
+if (POLICY CMP0094)  # https://cmake.org/cmake/help/latest/policy/CMP0094.html
+        cmake_policy(SET CMP0094 NEW)  
+endif ()
+
 find_package(Python COMPONENTS Interpreter)
 if (Python_FOUND)
   add_custom_command(OUTPUT scripts.log

--- a/test/scripts/CMakeLists.txt
+++ b/test/scripts/CMakeLists.txt
@@ -1,5 +1,4 @@
 # be aware: the python modules that need testing, need to be symlinked to the test/scripts folder with a .py extension
-
 find_package(Python COMPONENTS Interpreter)
 if (Python_FOUND)
   add_custom_command(OUTPUT scripts.log


### PR DESCRIPTION
# Issue

CMake is picking up the wrong Python, ~~probably because the default version installed by homebrew is now 3.13, which is newer than the system one (3.12.x). See if changing the default policy to first matching instead of newest fixes this.~~

Edit: I think some package recently started depending on Python. I found out that CMake's `FindPython` always prefers non-system Python, and we did not have this issue ever before. I tried  (unsuccessfully) to force CMake to use system Python. The easiest solution seems to be to just install it directly via homebrew and use it.  