### PR TITLE
feat: allow to disable storing elevation in tiles

### DIFF
--- a/src/mjolnir/elevationbuilder.cc
+++ b/src/mjolnir/elevationbuilder.cc
@@ -315,9 +315,14 @@ namespace mjolnir {
 
 void ElevationBuilder::Build(const boost::property_tree::ptree& pt,
                              std::deque<baldr::GraphId> tile_ids) {
-  auto elevation = pt.get_optional<std::string>("additional_data.elevation");
+  boost::optional<std::string> elevation = pt.get_optional<std::string>("additional_data.elevation");
+  boost::optional<bool> addElevation = pt.get_optional<bool>("additional_data.add_elevation_in_tiles");
   if (!elevation || !filesystem::exists(*elevation)) {
     LOG_WARN("Elevation storage directory does not exist");
+    return;
+  }
+  if (addElevation == false) {
+    LOG_WARN("Elevation won't be stored in tiles");
     return;
   }
 


### PR DESCRIPTION
# Issue
https://github.com/valhalla/valhalla/issues/4953

This adds  a setting `additional_data.add_elevation_in_tiles` to allow disabling tiles elevation

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
