### PR TITLE
CostMatrix: check for empty edgelabels when building date time info

### DIFF
--- a/src/thor/costmatrix.cc
+++ b/src/thor/costmatrix.cc
@@ -270,10 +270,13 @@ bool CostMatrix::SourceToTarget(Api& request,
       auto dt_info =
           DateTime::offset_date(source_location_list[source_idx].date_time(),
                                 time_infos[source_idx].timezone_index,
-                                graphreader.GetTimezoneFromEdge(edgelabel_[MATRIX_REV][target_idx]
-                                                                    .front()
-                                                                    .edgeid(),
-                                                                tile),
+                                edgelabel_[MATRIX_REV][target_idx].empty()
+                                    ? 0
+                                    : graphreader
+                                          .GetTimezoneFromEdge(edgelabel_[MATRIX_REV][target_idx]
+                                                                   .front()
+                                                                   .edgeid(),
+                                                               tile),
                                 time);
       *matrix.mutable_date_times(connection_idx) = dt_info.date_time;
       *matrix.mutable_time_zone_offsets(connection_idx) = dt_info.time_zone_offset;


### PR DESCRIPTION
# Issue

Previously, for super trivial location pairs (i.e. source ll == target ll), we got the target edge label to get the time zone. There are cases though when these might be empty (e.g. the target is inside an exclude polygon, so we end up with no edges to expand from). 

This leads to UB, so the least we can do is check the container is not empty.  

