### PR TITLE
improved elevator instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
    * ADDED: Consider smoothness in all profiles that use surface [#4949](https://github.com/valhalla/valhalla/pull/4949)
    * ADDED: `admin_crossings` request parameter for `/route` [#4941](https://github.com/valhalla/valhalla/pull/4941)
    * ADDED: include level change info in `/route` response [#4942](https://github.com/valhalla/valhalla/pull/4942)
-   * ADDED: steps and elevator maneuver improvements [#4960](https://github.com/valhalla/valhalla/pull/4960)
+   * ADDED: steps maneuver improvements [#4960](https://github.com/valhalla/valhalla/pull/4960)
+   * ADDED: instruction improvements for node-based elevators [#](https://github.com/valhalla/valhalla/pull/)
 
 ## Release Date: 2024-10-10 Valhalla 3.5.1
 * **Removed**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
    * ADDED: `admin_crossings` request parameter for `/route` [#4941](https://github.com/valhalla/valhalla/pull/4941)
    * ADDED: include level change info in `/route` response [#4942](https://github.com/valhalla/valhalla/pull/4942)
    * ADDED: steps maneuver improvements [#4960](https://github.com/valhalla/valhalla/pull/4960)
-   * ADDED: instruction improvements for node-based elevators [#](https://github.com/valhalla/valhalla/pull/)
+   * ADDED: instruction improvements for node-based elevators [#4988](https://github.com/valhalla/valhalla/pull/4988)
 
 ## Release Date: 2024-10-10 Valhalla 3.5.1
 * **Removed**

--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -1459,6 +1459,7 @@ void ManeuversBuilder::FinalizeManeuver(Maneuver& maneuver, int node_index) {
   // Set elevator
   if (node->IsElevator()) {
     maneuver.set_elevator(true);
+    maneuver.set_node_type(node->type());
     // Set the end level ref
     if (curr_edge && !curr_edge->GetLevelRef().empty()) {
       if (curr_edge->GetLevelRef().size() > 1) {

--- a/src/odin/narrativebuilder.cc
+++ b/src/odin/narrativebuilder.cc
@@ -465,7 +465,19 @@ void NarrativeBuilder::Build(std::list<Maneuver>& maneuvers) {
       }
       case DirectionsLeg_Maneuver_Type_kElevatorEnter: {
         // Set instruction
-        maneuver.set_instruction(FormElevatorInstruction(maneuver));
+        auto instr = FormElevatorInstruction(maneuver);
+        maneuver.set_instruction(instr);
+
+        if (maneuver.has_node_type() && maneuver.node_type() == TripLeg_Node_Type_kElevator) {
+          maneuver.set_verbal_transition_alert_instruction(instr);
+
+          // Set verbal pre transition instruction
+          maneuver.set_verbal_pre_transition_instruction(instr);
+
+          // Set verbal post transition instruction
+          maneuver.set_verbal_post_transition_instruction(
+              FormVerbalPostTransitionInstruction(maneuver));
+        }
         break;
       }
       case DirectionsLeg_Maneuver_Type_kStepsEnter: {


### PR DESCRIPTION
# Issue

Currently, only the instruction is set for node-based elevators. This PR sets the pre/post transtion and alert instructions, which also enables multi-cue instructions.  

## Tasklist

 - [x] Add tests
 - [x] Update the [changelog](CHANGELOG.md)
