### PR TITLE
 Fix macOS CI – homebrew links two versions of pkg-config

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -40,6 +40,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          brew unlink pkg-config@0.29.2 # todo(chris): remove once GH deploys https://github.com/actions/runner-images/pull/11015
           HOMEBREW_NO_AUTO_UPDATE=1 brew install python autoconf automake protobuf cmake ccache libtool sqlite3 libspatialite luajit curl wget czmq lz4 spatialite-tools unzip boost gdal
           export PATH="$(brew --prefix python)/libexec/bin:$PATH"
           sudo python -m pip install --break-system-packages requests shapely


### PR DESCRIPTION
Seems like the issue is fixed upstream but hasn't been deployed yet.
