### PR TITLE
fix: Double free crash during tiles build inside libxml2 on concurrent `spatialite_cleanup_ex()` calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
    * FIXED: `incremental_build_tiles` script works again [#4909](https://github.com/valhalla/valhalla/pull/4909)
    * FIXED: Fix ability to use Valhalla via cmake `add_subdirectory` [#4930](https://github.com/valhalla/valhalla/pull/4930)
    * FIXED: Fix valhalla_benchmark_loki benchmark application. [#4981](https://github.com/valhalla/valhalla/pull/4981)
+   * FIXED: Double free crash during tiles build inside libxml2 on concurrent `spatialite_cleanup_ex()` calls [#5005](https://github.com/valhalla/valhalla/pull/5005)
 * **Enhancement**
    * ADDED: Consider smoothness in all profiles that use surface [#4949](https://github.com/valhalla/valhalla/pull/4949)
    * ADDED: `admin_crossings` request parameter for `/route` [#4941](https://github.com/valhalla/valhalla/pull/4941)

--- a/src/mjolnir/util.cc
+++ b/src/mjolnir/util.cc
@@ -217,13 +217,16 @@ std::shared_ptr<void> make_spatialite_cache(sqlite3* handle) {
   void* conn = spatialite_alloc_connection();
   spatialite_init_ex(handle, conn, 0);
 
-  // Sadly, `spatialite_cleanup_ex` calls `xmlCleanupParser()` (from `free_internal_cache()`) which is
+  // Sadly, `spatialite_cleanup_ex` calls `xmlCleanupParser()` (via `free_internal_cache()`) which is
   // not thread-safe and may cause a crash on double-free if called from multiple threads.
+  // This static mutex works around the issue until the spatialite library is fixed:
+  // - https://www.gaia-gis.it/fossil/libspatialite/tktview/855ef62a68b9ac6e500b54883707b2876c390c01
+  // For full "double free" issue details follow https://github.com/valhalla/valhalla/issues/4904
   static std::mutex spatialite_mutex;
-  return {conn, [](void* c) {
-            std::lock_guard<std::mutex> lock(spatialite_mutex);
-            spatialite_cleanup_ex(c);
-          }};
+  return std::shared_ptr<void>(conn, [](void* c) {
+    std::lock_guard<std::mutex> lock(spatialite_mutex);
+    spatialite_cleanup_ex(c);
+  });
 }
 
 bool build_tile_set(const boost::property_tree::ptree& original_config,

--- a/src/mjolnir/util.cc
+++ b/src/mjolnir/util.cc
@@ -216,7 +216,14 @@ std::shared_ptr<void> make_spatialite_cache(sqlite3* handle) {
   spatialite_singleton_t::get_instance();
   void* conn = spatialite_alloc_connection();
   spatialite_init_ex(handle, conn, 0);
-  return {conn, [](void* c) { spatialite_cleanup_ex(c); }};
+
+  // Sadly, `spatialite_cleanup_ex` calls `xmlCleanupParser()` (from `free_internal_cache()`) which is
+  // not thread-safe and may cause a crash on double-free if called from multiple threads.
+  static std::mutex spatialite_mutex;
+  return {conn, [](void* c) {
+            std::lock_guard<std::mutex> lock(spatialite_mutex);
+            spatialite_cleanup_ex(c);
+          }};
 }
 
 bool build_tile_set(const boost::property_tree::ptree& original_config,


### PR DESCRIPTION
# Issue

Fixes https://github.com/valhalla/valhalla/issues/4904

Sadly, [`spatialite_cleanup_ex()` calls](https://www.gaia-gis.it/fossil/libspatialite/file?name=src/spatialite/spatialite.c) ([via `free_internal_cache()`](https://www.gaia-gis.it/fossil/libspatialite/file?name=src/connection_cache/alloc_cache.c)) the `xmlCleanupParser()`, which is [not thread-safe](https://github.com/GNOME/libxml2/blob/3b38f19b406951a5eedf71776d3864d7f2e03265/encoding.c#L700-L720).

This PR introduces a static mutex that guarantees that all `spatialite_cleanup_ex()` are called sequentially.

## Tasklist

 - [ ] Add tests
 - [x] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
