### PR TITLE
Make isochrone geotiff serialization use "north up" geotransform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
    * FIXED: update CircleCI runners to Ubuntu 24.04 [#5002](https://github.com/valhalla/valhalla/pull/5002)
    * FIXED: Fixed a typo in the (previously undocumented) matrix-APIs responses `algorithm` field: `timedistancbssematrix` is now `timedistancebssmatrix` [#5000](https://github.com/valhalla/valhalla/pull/5000).
    * FIXED: More trivial cases in `CostMatrix` [#5001](https://github.com/valhalla/valhalla/pull/5001)
+   * FIXED: Make isochrone geotiff serialization use "north up" geotransform [#5019](https://github.com/valhalla/valhalla/pull/5019)
 * **Enhancement**
    * ADDED: Consider smoothness in all profiles that use surface [#4949](https://github.com/valhalla/valhalla/pull/4949)
    * ADDED: `admin_crossings` request parameter for `/route` [#4941](https://github.com/valhalla/valhalla/pull/4941)

--- a/src/tyr/isochrone_serializer.cc
+++ b/src/tyr/isochrone_serializer.cc
@@ -197,10 +197,9 @@ std::string serializeGeoTIFF(Api& request, const std::shared_ptr<const GriddedDa
   double geo_transform[6] = {isogrid->TileBounds(isogrid->TileId(box[0], box[1])).minx(), // minx
                              isogrid->TileSize(),
                              0,
-                             isogrid->TileBounds(isogrid->TileId(box[0], box[1])).miny(), // miny
+                             isogrid->TileBounds(isogrid->TileId(box[0], box[3])).maxy(), // maxy
                              0,
-                             isogrid->TileSize()};
-
+                             -isogrid->TileSize()};
   geotiff_dataset->SetGeoTransform(geo_transform);
   geotiff_dataset->SetSpatialRef(const_cast<OGRSpatialReference*>(&spatial_ref));
 
@@ -214,10 +213,11 @@ std::string serializeGeoTIFF(Api& request, const std::shared_ptr<const GriddedDa
     for (int32_t i = 0; i < ext_y; ++i) {
       for (int32_t j = 0; j < ext_x; ++j) {
         auto tileid = isogrid->TileId(j + box[0], i + box[1]);
-        data[i * ext_x + j] =
+        data[(ext_y - 1 - i) * ext_x + j] =
             static_cast<uint16_t>(isogrid->DataAt(tileid, metric_idx) * scale_factor);
       }
     }
+
     auto band = geotiff_dataset->GetRasterBand(nbands == 2 ? (metric_idx + 1) : 1);
     band->SetNoDataValue(std::numeric_limits<uint16_t>::max());
     band->SetDescription(metric_idx == 0 ? "Time (seconds)" : "Distance (10m)");

--- a/test/isochrone.cc
+++ b/test/isochrone.cc
@@ -511,24 +511,7 @@ TEST(Isochrones, test_geotiff_vertical_orientation) {
   std::copy(geotiff.cbegin(), geotiff.cend(), buffer);
   auto handle = VSIFileFromMemBuffer(name.c_str(), buffer, static_cast<int>(geotiff.size()), 0);
   auto geotiff_dataset = GDALDataset::FromHandle(GDALOpen(name.c_str(), GA_ReadOnly));
-  int x = geotiff_dataset->GetRasterXSize();
   int y = geotiff_dataset->GetRasterYSize();
-  GDALRasterBand* band = geotiff_dataset->GetRasterBand(1);
-  uint16_t data_array[x * y];
-  CPLErr err = band->RasterIO(GF_Read, 0, 0, x, y, data_array, x, y, GDT_UInt16, 0, 0);
-  double min_max[2];
-
-  band->ComputeRasterMinMax(0, min_max);
-
-  ASSERT_EQ(err, CE_None);
-  ASSERT_NE(x, 0);
-  ASSERT_NE(y, 0);
-  ASSERT_EQ(static_cast<int>(min_max[0]), 0);
-  ASSERT_EQ(static_cast<int>(min_max[1]), 1100);
-  ASSERT_EQ(band->GetNoDataValue(), std::numeric_limits<uint16_t>::max());
-
-  check_raster_edges(x, y, data_array);
-
   double geoTransform[6];
   geotiff_dataset->GetGeoTransform(geoTransform);
   double topY = geoTransform[3] + 0 * geoTransform[4] + 0 * geoTransform[5];

--- a/test/isochrone.cc
+++ b/test/isochrone.cc
@@ -495,6 +495,48 @@ TEST(Isochrones, test_geotiff_output_time_distance) {
   }
   VSIFCloseL(handle);
 }
+TEST(Isochrones, test_geotiff_vertical_orientation) {
+  loki_worker_t loki_worker(cfg);
+  thor_worker_t thor_worker(cfg);
+
+  const auto request =
+      R"({"costing":"auto","locations":[{"lon":5.042799,"lat":52.093199}],"contours":[{"distance":1}], "format": "geotiff"})";
+  Api request_pbf;
+  ParseApi(request, Options::isochrone, request_pbf);
+  loki_worker.isochrones(request_pbf);
+  std::string geotiff = thor_worker.isochrones(request_pbf);
+
+  std::string name = "/vsimem/test_isogrid_geotiff_d.tif";
+  unsigned char buffer[geotiff.length()];
+  std::copy(geotiff.cbegin(), geotiff.cend(), buffer);
+  auto handle = VSIFileFromMemBuffer(name.c_str(), buffer, static_cast<int>(geotiff.size()), 0);
+  auto geotiff_dataset = GDALDataset::FromHandle(GDALOpen(name.c_str(), GA_ReadOnly));
+  int x = geotiff_dataset->GetRasterXSize();
+  int y = geotiff_dataset->GetRasterYSize();
+  GDALRasterBand* band = geotiff_dataset->GetRasterBand(1);
+  uint16_t data_array[x * y];
+  CPLErr err = band->RasterIO(GF_Read, 0, 0, x, y, data_array, x, y, GDT_UInt16, 0, 0);
+  double min_max[2];
+
+  band->ComputeRasterMinMax(0, min_max);
+
+  ASSERT_EQ(err, CE_None);
+  ASSERT_NE(x, 0);
+  ASSERT_NE(y, 0);
+  ASSERT_EQ(static_cast<int>(min_max[0]), 0);
+  ASSERT_EQ(static_cast<int>(min_max[1]), 1100);
+  ASSERT_EQ(band->GetNoDataValue(), std::numeric_limits<uint16_t>::max());
+
+  check_raster_edges(x, y, data_array);
+
+  double geoTransform[6];
+  geotiff_dataset->GetGeoTransform(geoTransform);
+  double topY = geoTransform[3] + 0 * geoTransform[4] + 0 * geoTransform[5];
+  double bottomY = geoTransform[3] + 0 * geoTransform[4] + y * geoTransform[5];
+  ASSERT_TRUE(topY > bottomY);
+
+  VSIFCloseL(handle);
+}
 #endif
 
 } // namespace


### PR DESCRIPTION
# Issue

The isochrone GeoTIFF serialization in Valhalla is really cool! I'm building an app that uses GeoTIFF data _without_ using gdal (or similar) libraries to post-process the data — and I noted, when playing around with this, that the vertical orientation for Valhalla isochrones is flipped ([more detail in this issue](https://github.com/valhalla/valhalla/issues/5018)).

To get the output TIFF rendering with the correct axis, on this branch I ended up:
- Making the last element of the Geotransform negative — I looked at the serialization code, and noted in the [gdal docs for "Geotransform"](https://gdal.org/en/stable/tutorials/geotransforms_tut.html) that north-south imagery expects to have a negative value for the last number in the Geotransform, which I think matches the data produced by the Isochrone tiles. 
- Assembling the "y" data passed into the gdal raster method from bottom-to-top, rather than top-to-bottom, which seemed to be required in order to actually render the raster data in the right projected location ([based on this stack exchange post](https://gis.stackexchange.com/questions/114978/raster-created-by-python-gdal-interpreted-upside-down))
- Using the bounding box's "maximum" column and "maximum Y" as the 5th element in the Geotransform, which also seemed to be required in order to project the raster in the right place.

I'm not totally confident that my understanding of the min/max for the Isochrone tiles, or tile extents, is correct here — e.g. it's possible this logic might not be safe across the meridian or the equator? — but I figured I'd get a PR going and make sure I'm on the right track and that this issue is worth solving this way before getting deeper into the coordinate math. I'm also extremely green to C++, and very happy for this code (or the unit test) to work differently!

On this branch, I'm finding that the Isochrone described in the linked issue correctly renders with north-south vertical orientation (and still projects in the correct place within software like qgis);

<img width="1055" alt="Screenshot 2024-12-14 at 9 22 47 PM" src="https://github.com/user-attachments/assets/918a2d35-b7bc-4e42-bab9-6b6c942f39ca" />

This fixes https://github.com/valhalla/valhalla/issues/5018

## Tasklist

 - [x] Add tests
 - [x] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

