### PR TITLE
Increase precision for leg/maneuver lengths in `/route` JSON serializer 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
    * ADDED: include level change info in `/route` response [#4942](https://github.com/valhalla/valhalla/pull/4942)
    * ADDED: steps maneuver improvements [#4960](https://github.com/valhalla/valhalla/pull/4960)
    * ADDED: instruction improvements for node-based elevators [#4988](https://github.com/valhalla/valhalla/pull/4988)
+   * ADDED: increased precision in route lengths [#5020](https://github.com/valhalla/valhalla/pull/5020)
 
 ## Release Date: 2024-10-10 Valhalla 3.5.1
 * **Removed**

--- a/src/tyr/route_serializer_valhalla.cc
+++ b/src/tyr/route_serializer_valhalla.cc
@@ -142,7 +142,9 @@ void summary(const valhalla::Api& api, int route_index, rapidjson::writer_wrappe
   writer("max_lon", bbox.maxx());
   writer.set_precision(3);
   writer("time", route_time);
+  writer.set_precision(api.options().units() == Options::miles ? 4 : 3);
   writer("length", route_length);
+  writer.set_precision(3);
   writer("cost", route_cost);
   auto recost_itr = api.options().recostings().begin();
   for (auto recost : recost_times) {
@@ -220,6 +222,7 @@ void locations(const valhalla::Api& api, int route_index, rapidjson::writer_wrap
 void legs(const valhalla::Api& api, int route_index, rapidjson::writer_wrapper_t& writer) {
   writer.start_array("legs");
   const auto& directions_legs = api.directions().routes(route_index).legs();
+  unsigned int length_prec = api.options().units() == Options::miles ? 4 : 3;
   auto trip_leg_itr = api.trip().routes(route_index).legs().begin();
   for (const auto& directions_leg : directions_legs) {
     writer.start_object(); // leg
@@ -278,7 +281,9 @@ void legs(const valhalla::Api& api, int route_index, rapidjson::writer_wrapper_t
 
       writer.set_precision(3);
       writer("time", maneuver.time());
+      writer.set_precision(length_prec);
       writer("length", maneuver.length());
+      writer.set_precision(3);
       writer("cost", cost);
       writer("begin_shape_index", static_cast<uint64_t>(maneuver.begin_shape_index()));
       writer("end_shape_index", static_cast<uint64_t>(maneuver.end_shape_index()));
@@ -594,7 +599,9 @@ void legs(const valhalla::Api& api, int route_index, rapidjson::writer_wrapper_t
     writer("max_lon", directions_leg.summary().bbox().max_ll().lng());
     writer.set_precision(3);
     writer("time", directions_leg.summary().time());
+    writer.set_precision(length_prec);
     writer("length", directions_leg.summary().length());
+    writer.set_precision(3);
     writer("cost", trip_leg_itr->node().rbegin()->cost().elapsed_cost().cost());
     auto recost_itr = api.options().recostings().begin();
     for (const auto& recost : trip_leg_itr->node().rbegin()->recosts()) {


### PR DESCRIPTION
# Issue

When the unit option is miles, increase the leg/maneuver length precision to 4, so that lengths are precise down to 1 foot. Doesn't matter much in outdoor scenarios, but distances are usually much shorter in indoor scenarios. 