### PR TITLE
Tag smoothness=impassable breaks pedestrian routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
    * FIXED: update CircleCI runners to Ubuntu 24.04 [#5002](https://github.com/valhalla/valhalla/pull/5002)
    * FIXED: Fixed a typo in the (previously undocumented) matrix-APIs responses `algorithm` field: `timedistancbssematrix` is now `timedistancebssmatrix` [#5000](https://github.com/valhalla/valhalla/pull/5000).
    * FIXED: More trivial cases in `CostMatrix` [#5001](https://github.com/valhalla/valhalla/pull/5001)
+   * FIXED: Tag smoothness=impassable breaks pedestrian routing [#5023](https://github.com/valhalla/valhalla/pull/5023)
 * **Enhancement**
    * ADDED: Consider smoothness in all profiles that use surface [#4949](https://github.com/valhalla/valhalla/pull/4949)
    * ADDED: `admin_crossings` request parameter for `/route` [#4941](https://github.com/valhalla/valhalla/pull/4941)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
    * ADDED: include level change info in `/route` response [#4942](https://github.com/valhalla/valhalla/pull/4942)
    * ADDED: steps maneuver improvements [#4960](https://github.com/valhalla/valhalla/pull/4960)
    * ADDED: instruction improvements for node-based elevators [#4988](https://github.com/valhalla/valhalla/pull/4988)
+   * ADDED: increased precision in route lengths [#5020](https://github.com/valhalla/valhalla/pull/5020)
 
 ## Release Date: 2024-10-10 Valhalla 3.5.1
 * **Removed**

--- a/lua/graph.lua
+++ b/lua/graph.lua
@@ -907,7 +907,7 @@ function filter_tags_generic(kv)
       kv[k] = v
     end
 
-    if kv["impassable"] == "yes" or kv["smoothness"] == "impassable" or access == "false" or (kv["access"] == "private" and (kv["emergency"] == "yes" or kv["service"] == "emergency_access")) then
+    if kv["impassable"] == "yes" or access == "false" or (kv["access"] == "private" and (kv["emergency"] == "yes" or kv["service"] == "emergency_access")) then
 
       kv["auto_forward"] = "false"
       kv["truck_forward"] = "false"
@@ -926,7 +926,7 @@ function filter_tags_generic(kv)
       kv["motorcycle_backward"] = "false"
       kv["pedestrian_backward"] = "false"
       kv["bike_backward"] = "false"
-    elseif kv["vehicle"] == "no" then --don't change ped access.
+    elseif kv["smoothness"] == "impassable" or kv["vehicle"] == "no" then --don't change ped access.
       kv["auto_forward"] = "false"
       kv["truck_forward"] = "false"
       kv["bus_forward"] = "false"
@@ -996,7 +996,7 @@ function filter_tags_generic(kv)
       default_val = tostring(rail)
     end
 
-    if ((ferry == false and rail == false) or kv["impassable"] == "yes" or kv["smoothness"] == "impassable" or access == "false" or (kv["access"] == "private" and (kv["emergency"] == "yes" or kv["service"] == "emergency_access"))) then
+    if ((ferry == false and rail == false) or kv["impassable"] == "yes" or access == "false" or (kv["access"] == "private" and (kv["emergency"] == "yes" or kv["service"] == "emergency_access"))) then
 
       kv["auto_forward"] = "false"
       kv["truck_forward"] = "false"
@@ -1018,7 +1018,7 @@ function filter_tags_generic(kv)
 
     else
       local ped_val = default_val
-      if kv["vehicle"] == "no" then --don't change ped access.
+      if kv["smoothness"] == "impassable" or kv["vehicle"] == "no" then --don't change ped access.
         default_val = "false"
       end
       --check for auto_forward overrides
@@ -1931,7 +1931,7 @@ function nodes_proc (kv, nokeys)
   local initial_access = access[kv["access"]]
   local access = initial_access or "true"
 
-  if (kv["impassable"] == "yes" or kv["smoothness"] == "impassable" or (kv["access"] == "private" and (kv["emergency"] == "yes" or kv["service"] == "emergency_access"))) then
+  if (kv["impassable"] == "yes" or (kv["access"] == "private" and (kv["emergency"] == "yes" or kv["service"] == "emergency_access"))) then
     access = "false"
   end
 
@@ -2029,7 +2029,7 @@ function nodes_proc (kv, nokeys)
   local motorcycle = motorcycle_tag or 1024
 
   --if access = false use tag if exists, otherwise no access for that mode.
-  if (access == "false" or kv["vehicle"] == "no" or kv["hov"] == "designated") then
+  if (access == "false" or kv["vehicle"] == "no" or kv["smoothness"] == "impassable" or kv["hov"] == "designated") then
     auto = auto_tag or 0
     truck = truck_tag or 0
     bus = bus_tag or 0

--- a/src/mjolnir/directededgebuilder.cc
+++ b/src/mjolnir/directededgebuilder.cc
@@ -153,7 +153,7 @@ DirectedEdgeBuilder::DirectedEdgeBuilder(const OSMWay& way,
   if ((way.pedestrian_forward() && !forward) || (way.pedestrian_backward() && forward)) {
     reverse_access |= kPedestrianAccess;
   }
-  if (way.use() != Use::kSteps && way.use() != Use::kConstruction) {
+  if (way.use() != Use::kSteps && way.use() != Use::kConstruction && way.surface() != Surface::kImpassable) {
     if (way.wheelchair_tag() && way.wheelchair()) {
       forward_access |= kWheelchairAccess;
       reverse_access |= kWheelchairAccess;

--- a/src/mjolnir/directededgebuilder.cc
+++ b/src/mjolnir/directededgebuilder.cc
@@ -153,7 +153,8 @@ DirectedEdgeBuilder::DirectedEdgeBuilder(const OSMWay& way,
   if ((way.pedestrian_forward() && !forward) || (way.pedestrian_backward() && forward)) {
     reverse_access |= kPedestrianAccess;
   }
-  if (way.use() != Use::kSteps && way.use() != Use::kConstruction && way.surface() != Surface::kImpassable) {
+  if (way.use() != Use::kSteps && way.use() != Use::kConstruction &&
+      way.surface() != Surface::kImpassable) {
     if (way.wheelchair_tag() && way.wheelchair()) {
       forward_access |= kWheelchairAccess;
       reverse_access |= kWheelchairAccess;

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -1498,6 +1498,8 @@ public:
           way_.set_surface(Surface::kGravel);
         } else if (tag_.second == "very_horrible") {
           way_.set_surface(Surface::kPath);
+        } else if (tag_.second == "impassable") {
+          way_.set_surface(Surface::kImpassable);
         } else {
           has_surface_ = false;
         }

--- a/src/tyr/route_serializer_valhalla.cc
+++ b/src/tyr/route_serializer_valhalla.cc
@@ -142,7 +142,9 @@ void summary(const valhalla::Api& api, int route_index, rapidjson::writer_wrappe
   writer("max_lon", bbox.maxx());
   writer.set_precision(3);
   writer("time", route_time);
+  writer.set_precision(api.options().units() == Options::miles ? 4 : 3);
   writer("length", route_length);
+  writer.set_precision(3);
   writer("cost", route_cost);
   auto recost_itr = api.options().recostings().begin();
   for (auto recost : recost_times) {
@@ -220,6 +222,7 @@ void locations(const valhalla::Api& api, int route_index, rapidjson::writer_wrap
 void legs(const valhalla::Api& api, int route_index, rapidjson::writer_wrapper_t& writer) {
   writer.start_array("legs");
   const auto& directions_legs = api.directions().routes(route_index).legs();
+  unsigned int length_prec = api.options().units() == Options::miles ? 4 : 3;
   auto trip_leg_itr = api.trip().routes(route_index).legs().begin();
   for (const auto& directions_leg : directions_legs) {
     writer.start_object(); // leg
@@ -278,7 +281,9 @@ void legs(const valhalla::Api& api, int route_index, rapidjson::writer_wrapper_t
 
       writer.set_precision(3);
       writer("time", maneuver.time());
+      writer.set_precision(length_prec);
       writer("length", maneuver.length());
+      writer.set_precision(3);
       writer("cost", cost);
       writer("begin_shape_index", static_cast<uint64_t>(maneuver.begin_shape_index()));
       writer("end_shape_index", static_cast<uint64_t>(maneuver.end_shape_index()));
@@ -594,7 +599,9 @@ void legs(const valhalla::Api& api, int route_index, rapidjson::writer_wrapper_t
     writer("max_lon", directions_leg.summary().bbox().max_ll().lng());
     writer.set_precision(3);
     writer("time", directions_leg.summary().time());
+    writer.set_precision(length_prec);
     writer("length", directions_leg.summary().length());
+    writer.set_precision(3);
     writer("cost", trip_leg_itr->node().rbegin()->cost().elapsed_cost().cost());
     auto recost_itr = api.options().recostings().begin();
     for (const auto& recost : trip_leg_itr->node().rbegin()->recosts()) {

--- a/test/gurka/test_exclude_unpaved_smoothness.cc
+++ b/test/gurka/test_exclude_unpaved_smoothness.cc
@@ -205,7 +205,7 @@ TEST(Standalone, SmoothnessAccess) {
     auto node_id = gurka::findNode(*graph_reader, map.nodes, "1");
     const auto* node = graph_reader->nodeinfo(node_id);
     // ped only access due to smoothness = impassable
-    EXPECT_EQ(node->access(),baldr::kPedestrianAccess);
+    EXPECT_EQ(node->access(), baldr::kPedestrianAccess);
   }
 }
 

--- a/test/gurka/test_exclude_unpaved_smoothness.cc
+++ b/test/gurka/test_exclude_unpaved_smoothness.cc
@@ -182,10 +182,10 @@ TEST(Standalone, SmoothnessAccess) {
     // ped only access due to smoothness = impassable.
     // edge_1 = AB
     // edge_2 = BA
-    EXPECT_EQ(edge_1->forwardaccess(), (baldr::kWheelchairAccess | baldr::kPedestrianAccess));
-    EXPECT_EQ(edge_1->reverseaccess(), (baldr::kWheelchairAccess | baldr::kPedestrianAccess));
-    EXPECT_EQ(edge_2->forwardaccess(), (baldr::kWheelchairAccess | baldr::kPedestrianAccess));
-    EXPECT_EQ(edge_2->reverseaccess(), (baldr::kWheelchairAccess | baldr::kPedestrianAccess));
+    EXPECT_EQ(edge_1->forwardaccess(), baldr::kPedestrianAccess);
+    EXPECT_EQ(edge_1->reverseaccess(), baldr::kPedestrianAccess);
+    EXPECT_EQ(edge_2->forwardaccess(), baldr::kPedestrianAccess);
+    EXPECT_EQ(edge_2->reverseaccess(), baldr::kPedestrianAccess);
 
     EXPECT_EQ(edge_1->surface(), baldr::Surface::kImpassable);
     EXPECT_EQ(edge_2->surface(), baldr::Surface::kImpassable);

--- a/test/gurka/test_exclude_unpaved_smoothness.cc
+++ b/test/gurka/test_exclude_unpaved_smoothness.cc
@@ -182,13 +182,13 @@ TEST(Standalone, SmoothnessAccess) {
     // ped only access due to smoothness = impassable.
     // edge_1 = AB
     // edge_2 = BA
-    EXPECT_NE(edge_1->forwardaccess(), baldr::kPedestrianAccess);
-    EXPECT_NE(edge_1->reverseaccess(), baldr::kPedestrianAccess);
-    EXPECT_NE(edge_2->forwardaccess(), baldr::kPedestrianAccess);
-    EXPECT_NE(edge_2->reverseaccess(), baldr::kPedestrianAccess);
+    EXPECT_EQ(edge_1->forwardaccess(), (baldr::kWheelchairAccess | baldr::kPedestrianAccess));
+    EXPECT_EQ(edge_1->reverseaccess(), (baldr::kWheelchairAccess | baldr::kPedestrianAccess));
+    EXPECT_EQ(edge_2->forwardaccess(), (baldr::kWheelchairAccess | baldr::kPedestrianAccess));
+    EXPECT_EQ(edge_2->reverseaccess(), (baldr::kWheelchairAccess | baldr::kPedestrianAccess));
 
-    EXPECT_NE(edge_1->surface(), baldr::Surface::kPavedSmooth);
-    EXPECT_NE(edge_2->surface(), baldr::Surface::kPavedSmooth);
+    EXPECT_EQ(edge_1->surface(), baldr::Surface::kImpassable);
+    EXPECT_EQ(edge_2->surface(), baldr::Surface::kImpassable);
 
     std::tie(edge_id_1, edge_1, edge_id_2, edge_2) = findEdge(*graph_reader, map.nodes, "B1C", "C");
     // edge_1 = B1C
@@ -199,8 +199,8 @@ TEST(Standalone, SmoothnessAccess) {
     EXPECT_NE(edge_2->forwardaccess(), 0);
     EXPECT_NE(edge_2->reverseaccess(), 0);
 
-    EXPECT_NE(edge_1->surface(), baldr::Surface::kImpassable);
-    EXPECT_NE(edge_2->surface(), baldr::Surface::kImpassable);
+    EXPECT_EQ(edge_1->surface(), baldr::Surface::kPavedSmooth);
+    EXPECT_EQ(edge_2->surface(), baldr::Surface::kPavedSmooth);
 
     auto node_id = gurka::findNode(*graph_reader, map.nodes, "1");
     const auto* node = graph_reader->nodeinfo(node_id);

--- a/test/gurka/test_exclude_unpaved_smoothness.cc
+++ b/test/gurka/test_exclude_unpaved_smoothness.cc
@@ -179,11 +179,16 @@ TEST(Standalone, SmoothnessAccess) {
     const DirectedEdge* edge_2 = nullptr;
 
     std::tie(edge_id_1, edge_1, edge_id_2, edge_2) = findEdge(*graph_reader, map.nodes, "AB", "B");
-    // no access due to smoothness = impassable and are therefore tossed.
+    // ped only access due to smoothness = impassable.
     // edge_1 = AB
     // edge_2 = BA
-    EXPECT_EQ(edge_1, nullptr);
-    EXPECT_EQ(edge_2, nullptr);
+    EXPECT_NE(edge_1->forwardaccess(), baldr::kPedestrianAccess);
+    EXPECT_NE(edge_1->reverseaccess(), baldr::kPedestrianAccess);
+    EXPECT_NE(edge_2->forwardaccess(), baldr::kPedestrianAccess);
+    EXPECT_NE(edge_2->reverseaccess(), baldr::kPedestrianAccess);
+
+    EXPECT_NE(edge_1->surface(), baldr::Surface::kPavedSmooth);
+    EXPECT_NE(edge_2->surface(), baldr::Surface::kPavedSmooth);
 
     std::tie(edge_id_1, edge_1, edge_id_2, edge_2) = findEdge(*graph_reader, map.nodes, "B1C", "C");
     // edge_1 = B1C
@@ -194,10 +199,13 @@ TEST(Standalone, SmoothnessAccess) {
     EXPECT_NE(edge_2->forwardaccess(), 0);
     EXPECT_NE(edge_2->reverseaccess(), 0);
 
+    EXPECT_NE(edge_1->surface(), baldr::Surface::kImpassable);
+    EXPECT_NE(edge_2->surface(), baldr::Surface::kImpassable);
+
     auto node_id = gurka::findNode(*graph_reader, map.nodes, "1");
     const auto* node = graph_reader->nodeinfo(node_id);
-    // no access due to smoothness = impassable
-    EXPECT_EQ(node->access(), 0);
+    // ped only access due to smoothness = impassable
+    EXPECT_EQ(node->access(),baldr::kPedestrianAccess);
   }
 }
 


### PR DESCRIPTION
# Issue

Smoothness tag should not delete the edge in general.  The smoothness tag is for the physical usability of a way for wheeled vehicles as defined in the [wiki](https://wiki.openstreetmap.org/wiki/Key:smoothness) and pedestrian access should not be removed.  

## Tasklist

 - [x] Updated tests
 - [x] Add fixes #4967
 - [x] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
