### PR TITLE
Test `valhalla_service.exe` in one shot mode on win build

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -130,6 +130,7 @@ jobs:
           set PATH=$PATH:${{ github.workspace }}/build/vcpkg_installed/$BUILD_TYPE/bin
           ./build/$BUILD_TYPE/valhalla_build_tiles.exe -c ./test/win/valhalla.json ./test/data/utrecht_netherlands.osm.pbf
           ./build/$BUILD_TYPE/valhalla_run_isochrone.exe --config ./test/win/valhalla.json -j "{\"locations\": [{\"lat\": 52.10205, \"lon\": 5.114651}], \"costing\": \"auto\", \"contours\":[{\"time\":15,\"color\":\"ff0000\"}]}"
+          ./build/$BUILD_TYPE/valhalla_service.exe ./test/win/valhalla.json isochrone "{\"locations\": [{\"lat\": 52.10205, \"lon\": 5.114651}], \"costing\": \"auto\", \"contours\":[{\"time\":15,\"color\":\"ff0000\"}]}"
 
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3

--- a/test/win/valhalla.json
+++ b/test/win/valhalla.json
@@ -194,8 +194,8 @@
       "min_resample": 10.0
     },
     "trace": {
-      "max_best_paths": 4,
-      "max_best_paths_shape": 100,
+      "max_alternates": 4,
+      "max_alternates_shape": 100,
       "max_distance": 200000.0,
       "max_gps_accuracy": 100.0,
       "max_search_radius": 100.0,


### PR DESCRIPTION
# Issue

If we don't run any tests on the windows build, we should at least do a smoke test for `valhalla_service.exe` which is more important to most users than the `valhalla_run_*` scripts. I also wonder if there's a specific reason none of the tests are run in the windows build? 

