### PR TITLE
fix: warning: unqualified call to `std::move` [-Wunqualified-std-cast-call]

### DIFF
--- a/src/meili/viterbi_search.cc
+++ b/src/meili/viterbi_search.cc
@@ -252,7 +252,7 @@ template <bool Maximize> StateId NaiveViterbiSearch<Maximize>::SearchWinner(Stat
       winner = FindWinner(labels);
     }
     winner_by_time.push_back(winner);
-    history_.push_back(move(labels));
+    history_.push_back(std::move(labels));
   }
 
   return winner_by_time[target];


### PR DESCRIPTION
The PR fixes this compilation warning on MacOS:

```
valhalla/src/meili/viterbi_search.cc:255:24: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
  255 |     history_.push_back(move(labels));
      |                        ^
      |                        std::
valhalla/src/meili/viterbi_search.cc:255:24: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
  255 |     history_.push_back(move(labels));
      |                        ^
      |                        std::
valhalla/src/meili/viterbi_search.cc:350:16: note: in instantiation of member function 'valhalla::meili::NaiveViterbiSearch<true>::SearchWinner' requested here
  350 | template class NaiveViterbiSearch<true>;
      |                ^
valhalla/src/meili/viterbi_search.cc:255:24: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
  255 |     history_.push_back(move(labels));
      |                        ^
      |                        std::
valhalla/src/meili/viterbi_search.cc:351:16: note: in instantiation of member function 'valhalla::meili::NaiveViterbiSearch<false>::SearchWinner' requested here
  351 | template class NaiveViterbiSearch<false>;
      |                ^
3 warnings generated.
```

# Issue

What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
