### PR TITLE
Look for `allow_second_pass` in CostMatrix at new location in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
    * FIXED: More trivial cases in `CostMatrix` [#5001](https://github.com/valhalla/valhalla/pull/5001)
    * FIXED: Tag smoothness=impassable breaks pedestrian routing [#5023](https://github.com/valhalla/valhalla/pull/5023)
    * FIXED: Make isochrone geotiff serialization use "north up" geotransform [#5019](https://github.com/valhalla/valhalla/pull/5019)
+   * FIXED: Get CostMatrix allow second pass option from new location in config []()
 * **Enhancement**
    * ADDED: Consider smoothness in all profiles that use surface [#4949](https://github.com/valhalla/valhalla/pull/4949)
    * ADDED: `admin_crossings` request parameter for `/route` [#4941](https://github.com/valhalla/valhalla/pull/4941)

--- a/src/thor/worker.cc
+++ b/src/thor/worker.cc
@@ -101,7 +101,7 @@ thor_worker_t::thor_worker_t(const boost::property_tree::ptree& config,
     source_to_target_algorithm = SELECT_OPTIMAL;
   }
 
-  costmatrix_allow_second_pass = config.get<bool>("thor.costmatrix_allow_second_pass", false);
+  costmatrix_allow_second_pass = config.get<bool>("thor.costmatrix.allow_second_pass", false);
 
   max_timedep_distance =
       config.get<float>("service_limits.max_timedep_distance", kDefaultMaxTimeDependentDistance);

--- a/test/gurka/test_matrix.cc
+++ b/test/gurka/test_matrix.cc
@@ -693,7 +693,7 @@ TEST(StandAlone, MatrixSecondPass) {
 
   const auto layout = gurka::detail::map_to_coordinates(ascii_map, 50);
   const auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/matrix_second_pass",
-                                     {{"thor.costmatrix_allow_second_pass", "1"}});
+                                     {{"thor.costmatrix.allow_second_pass", "1"}});
   baldr::GraphReader graph_reader(map.config.get_child("mjolnir"));
 
   // Make sure the relevant edges are actually built as no-thru


### PR DESCRIPTION
I moved this option to the new `costmatrix` section in #5010 but forgot to also actually get it from there in the worker instantiation.