### PR TITLE
Fix manual docker GHA 

### DIFF
--- a/.github/workflows/docker_build_branch.yml
+++ b/.github/workflows/docker_build_branch.yml
@@ -22,4 +22,4 @@ jobs:
 
       - name: Build latest image for given branch
         run: |
-          docker buildx build --push --platform linux/amd64,linux/arm64 --tag ghcr.io/valhalla/valhalla:branch-${{ github.ref }} .
+          docker buildx build --push --platform linux/amd64,linux/arm64 --tag ghcr.io/valhalla/valhalla:branch-${{ github.ref_name }} .


### PR DESCRIPTION
Accidentally got the wrong variable (should be `ref_name` instead of `ref` to avoid getting the full reference path).