### PR TITLE
allow multi arch builds in manual docker build

### DIFF
--- a/.github/workflows/docker_build_branch.yml
+++ b/.github/workflows/docker_build_branch.yml
@@ -22,4 +22,10 @@ jobs:
 
       - name: Build latest image for given branch
         run: |
+          sudo apt update --yes
+          sudo apt install --yes --quiet binfmt-support qemu-user-static qemu-system
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          docker buildx create --name mybuilder
+          docker buildx use mybuilder
+          docker buildx inspect --bootstrap
           docker buildx build --push --platform linux/amd64,linux/arm64 --tag ghcr.io/valhalla/valhalla:branch-${{ github.ref_name }} .


### PR DESCRIPTION
Just like we do in the main docker build action when building from latest master