### PR TITLE
Turn lane information for valhalla serializer. Fixes #3435

### DIFF
--- a/proto/options.proto
+++ b/proto/options.proto
@@ -524,5 +524,6 @@ message Options {
   bool voice_instructions = 57;                                    // Whether to return voiceInstructions in the OSRM serializer response
   bool dedupe = 58;                                                // Keep track of edges and override their properties during expansion,
                                                                    // ensuring that each edge appears in the output only once. [default = false]
-  bool admin_crossings = 59;                                     // Include administrative boundary crossings
+  bool admin_crossings = 59;                                       // Include administrative boundary crossings
+  bool turn_lane_info = 60;                                        // Include turn lane information into Valhalla serializer response.
 }

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -1250,6 +1250,9 @@ void from_json(rapidjson::Document& doc, Options::Action action, Api& api) {
   options.set_voice_instructions(
       rapidjson::get<bool>(doc, "/voice_instructions", options.voice_instructions()));
 
+  options.set_turn_lane_info(
+      rapidjson::get<bool>(doc, "/turn_lane_info", options.turn_lane_info()));
+
   // whether to include roundabout_exit maneuvers, default true
   auto roundabout_exits =
       rapidjson::get<bool>(doc, "/roundabout_exits",


### PR DESCRIPTION
# Issue

Default valhalla json answer lacks turn lane information. I suggest this is minimal solution. What do you think?

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
