### PR TITLE
restore ignoring hierarchy limits for bike/ped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
    * FIXED: Make isochrone geotiff serialization use "north up" geotransform [#5019](https://github.com/valhalla/valhalla/pull/5019)
    * FIXED: Get CostMatrix allow second pass option from new location in config [#5055](https://github.com/valhalla/valhalla/pull/5055/)
    * FIXED: Slim down Matrix PBF response [#5066](https://github.com/valhalla/valhalla/pull/5066)
+   * FIXED: restore ignoring hierarchy limits for bicycle and pedestrian [#5080](https://github.com/valhalla/valhalla/pull/5080)
 * **Enhancement**
    * ADDED: Consider smoothness in all profiles that use surface [#4949](https://github.com/valhalla/valhalla/pull/4949)
    * ADDED: `admin_crossings` request parameter for `/route` [#4941](https://github.com/valhalla/valhalla/pull/4941)

--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -540,6 +540,8 @@ BicycleCost::BicycleCost(const Costing& costing)
   for (uint32_t i = 0; i <= kMaxGradeFactor; i++) {
     grade_penalty[i] = avoid_hills * kAvoidHillsStrength[i];
   }
+
+  use_hierarchy_limits = false;
 }
 
 // Check if access is allowed on the specified edge.

--- a/src/sif/pedestriancost.cc
+++ b/src/sif/pedestriancost.cc
@@ -639,6 +639,8 @@ PedestrianCost::PedestrianCost(const Costing& costing)
   for (uint32_t i = 0; i <= kMaxGradeFactor; i++) {
     grade_penalty[i] = avoid_hills * kAvoidHillsStrength[i];
   }
+
+  use_hierarchy_limits = false;
 }
 
 // Check if access is allowed on the specified edge. Disallow if no

--- a/src/thor/matrix_action.cc
+++ b/src/thor/matrix_action.cc
@@ -114,8 +114,8 @@ std::string thor_worker_t::matrix(Api& request) {
   auto* algo = get_matrix_algorithm(request, has_time, costing);
   if (check_hierarchy_limits(mode_costing[int(mode)]->GetHierarchyLimits(), mode_costing[int(mode)],
                              options.costings().find(options.costing_type())->second.options(),
-                             hierarchy_limits_config_costmatrix,
-                             allow_hierarchy_limits_modifications)) {
+                             hierarchy_limits_config_costmatrix, allow_hierarchy_limits_modifications,
+                             mode_costing[int(mode)]->UseHierarchyLimits())) {
     // maybe warn if we needed to change user provided hierarchy limits
     add_warning(request, allow_hierarchy_limits_modifications ? 210 : 209);
   }

--- a/src/thor/route_action.cc
+++ b/src/thor/route_action.cc
@@ -397,7 +397,8 @@ void thor_worker_t::path_arrive_by(Api& api, const std::string& costing) {
                                 path_algorithm == &bidir_astar
                                     ? hierarchy_limits_config_bidirectional_astar
                                     : hierarchy_limits_config_astar,
-                                allow_hierarchy_limits_modifications)) ||
+                                allow_hierarchy_limits_modifications,
+                                mode_costing[int(mode)]->UseHierarchyLimits())) ||
         add_hierarchy_limits_warning;
 
     // ..and mark hierarchy limits for this algorithm as checked
@@ -621,7 +622,8 @@ void thor_worker_t::path_depart_at(Api& api, const std::string& costing) {
                                 path_algorithm == &bidir_astar
                                     ? hierarchy_limits_config_bidirectional_astar
                                     : hierarchy_limits_config_astar,
-                                allow_hierarchy_limits_modifications)) ||
+                                allow_hierarchy_limits_modifications,
+                                mode_costing[static_cast<uint32_t>(mode)]->UseHierarchyLimits())) ||
         add_hierarchy_limits_warning;
     // ..and mark hierarchy limits for this algorithm as checked
     is_bidir ? (used_bidir = true) : (used_unidir = true);

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -1424,7 +1424,8 @@ bool check_hierarchy_limits(std::vector<HierarchyLimits>& hierarchy_limits,
                             sif::cost_ptr_t& cost,
                             const valhalla::Costing_Options& options,
                             const hierarchy_limits_config_t& config,
-                            const bool allow_modifications) {
+                            const bool allow_modifications,
+                            const bool use_hierarchy_limits) {
 
   // keep track whether we need to mess with user provided limits
   bool add_warning = false;
@@ -1447,8 +1448,10 @@ bool check_hierarchy_limits(std::vector<HierarchyLimits>& hierarchy_limits,
                                  limits.expand_within_dist() == kMaxDistance)) {
       add_warning = add_warning || (limits.max_up_transitions() != kUnlimitedTransitions ||
                                     limits.expand_within_dist() != kMaxDistance);
-      limits.set_max_up_transitions(config.default_limits[i].max_up_transitions());
-      limits.set_expand_within_dist(config.default_limits[i].expand_within_dist());
+      if (use_hierarchy_limits) {
+        limits.set_max_up_transitions(config.default_limits[i].max_up_transitions());
+        limits.set_expand_within_dist(config.default_limits[i].expand_within_dist());
+      }
       continue;
     }
     default_limits = false;

--- a/test/astar.cc
+++ b/test/astar.cc
@@ -142,7 +142,7 @@ const auto hl_config_bd = parse_hierarchy_limits_from_config(fake_conf, "bidirec
 void set_hierarchy_limits(vs::cost_ptr_t cost, bool bdir) {
   Costing_Options opts;
   check_hierarchy_limits(cost->GetHierarchyLimits(), cost, opts, bdir ? hl_config_bd : hl_config,
-                         false);
+                         false, true);
 }
 void make_tile() {
 

--- a/test/hierarchylimits.cc
+++ b/test/hierarchylimits.cc
@@ -191,7 +191,7 @@ TEST(StandAlone, ClampHierarchyLimitsMatrix) {
       parse_hierarchy_limits_from_config(test_params.cfg, "costmatrix", false);
 
   EXPECT_TRUE(check_hierarchy_limits(mode_costing[0]->GetHierarchyLimits(), mode_costing[0], opts,
-                                     config_matrix, true));
+                                     config_matrix, true, true));
 
   EXPECT_FALSE(mode_costing[0]->DefaultHierarchyLimits());
 
@@ -221,7 +221,7 @@ TEST(StandAlone, ClampHierarchyLimitsBidirAStar) {
       parse_hierarchy_limits_from_config(test_params.cfg, "bidirectional_astar", true);
 
   EXPECT_TRUE(check_hierarchy_limits(mode_costing[0]->GetHierarchyLimits(), mode_costing[0], opts,
-                                     config_bidir, true));
+                                     config_bidir, true, true));
 
   EXPECT_FALSE(mode_costing[0]->DefaultHierarchyLimits());
 
@@ -252,7 +252,7 @@ TEST(StandAlone, ClampHierarchyLimitsUnidirAStar) {
       parse_hierarchy_limits_from_config(test_params.cfg, "unidirectional_astar", true);
 
   EXPECT_TRUE(check_hierarchy_limits(mode_costing[0]->GetHierarchyLimits(), mode_costing[0], opts,
-                                     config_bidir, true));
+                                     config_bidir, true, true));
 
   EXPECT_FALSE(mode_costing[0]->DefaultHierarchyLimits());
 

--- a/test/matrix.cc
+++ b/test/matrix.cc
@@ -149,7 +149,7 @@ const auto hl_config = parse_hierarchy_limits_from_config(cfg, "costmatrix", tru
 // we have to do this manually
 void set_hierarchy_limits(sif::cost_ptr_t cost) {
   Costing_Options opts;
-  check_hierarchy_limits(cost->GetHierarchyLimits(), cost, opts, hl_config, false);
+  check_hierarchy_limits(cost->GetHierarchyLimits(), cost, opts, hl_config, false, true);
 }
 
 const auto test_request = R"({

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -1000,6 +1000,10 @@ public:
     default_hierarchy_limits = default_;
   }
 
+  bool UseHierarchyLimits() {
+    return use_hierarchy_limits;
+  }
+
 protected:
   /**
    * Calculate `track` costs based on tracks preference.
@@ -1105,6 +1109,7 @@ protected:
   bool exclude_ferries_{false};
   bool has_excludes_{false};
   bool default_hierarchy_limits{true};
+  bool use_hierarchy_limits{true};
 
   bool exclude_cash_only_tolls_{false};
 

--- a/valhalla/worker.h
+++ b/valhalla/worker.h
@@ -94,7 +94,8 @@ bool check_hierarchy_limits(std::vector<HierarchyLimits>& hierarchy_limits,
                             sif::cost_ptr_t& cost,
                             const valhalla::Costing_Options& options,
                             const hierarchy_limits_config_t& config,
-                            const bool allow_modifications);
+                            const bool allow_modifications,
+                            const bool use_hierarchy_limits);
 #ifdef ENABLE_SERVICES
 /**
  * Take the json OR pbf request and parse/validate it. If you pass a protobuf mime type in the request


### PR DESCRIPTION
# Issue

Fixes an oversight from #5010 (and should fix #5075). This must have gotten lost in the last refactor of the hierarchy limits customization... 

