### PR TITLE
fix maneuver bearing_before in valhalla response

### DIFF
--- a/src/tyr/route_serializer_valhalla.cc
+++ b/src/tyr/route_serializer_valhalla.cc
@@ -282,7 +282,8 @@ void legs(valhalla::Api& api, int route_index, rapidjson::writer_wrapper_t& writ
       bool depart_maneuver = (maneuver_index == 0);
       bool arrive_maneuver = (maneuver_index == directions_leg.maneuver_size() - 1);
       if (!depart_maneuver) {
-        uint32_t in_brg = etp.GetPrevEdge(maneuver_index)->end_heading();
+        uint32_t node_index = maneuver.begin_path_index();
+        uint32_t in_brg = etp.GetPrevEdge(node_index)->end_heading();
         writer("bearing_before", static_cast<uint64_t>(in_brg));
       }
       if (!arrive_maneuver) {


### PR DESCRIPTION
use the correct index to get previous edge end heading

# Issue

Didn't open an issue for that simple fix but let me know if relevant.

When I introduced maneuver bearings into json response format in #5024 I somehow messed up something with the `bearing_before` calculation. Using the maneuver index to get the previous edge was not ok, instead we need to use the node index of the current maneuver.

In some situations the two are the same and everything looks fine, in some other it doesn't.

example:

https://valhalla.openstreetmap.de/directions?profile=pedestrian&wps=2.341643571853638%2C48.84337433623694%2C2.341520190238953%2C48.84313779693215

The third maneuver ("Turn left onto the walkway.") has

- `bearing_before`: 197
- `bearing_after: 197

Which is obviously wrong for a left turn.

The OSRM response format give the good answer which is:

- `bearing_before`: 289
- `bearing_after`: 197

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
