### PR TITLE
Fix spurious bear left/right maneuvers

### DIFF
--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -3136,7 +3136,7 @@ bool ManeuversBuilder::IsNextManeuverObvious(const std::list<Maneuver>& maneuver
   if (next_man->type() == DirectionsLeg_Maneuver_Type_kContinue ||
       next_man->type() == DirectionsLeg_Maneuver_Type_kSlightLeft ||
       next_man->type() == DirectionsLeg_Maneuver_Type_kSlightRight) {
-    // Get the node between the the current and next maneuver
+    // Get the node between the current and next maneuver
     auto node = trip_path_->GetEnhancedNode(next_man->begin_node_index());
 
     // Slight turn maneuvers may be obvious ONLY if there are no other forward intersecting edges.

--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -3144,8 +3144,7 @@ bool ManeuversBuilder::IsNextManeuverObvious(const std::list<Maneuver>& maneuver
     // multiple forward paths of travel are not obvious
     // (e.g. a slight left to stay on a road,
     // when another "straight" road from the intersection is one way or otherwise non-traversable).
-    if (node &&
-        next_man->type() != DirectionsLeg_Maneuver_Type_kContinue &&
+    if (node && next_man->type() != DirectionsLeg_Maneuver_Type_kContinue &&
         node->HasForwardIntersectingEdge(curr_man->end_heading())) {
       return false;
     }

--- a/test/astar_bikeshare.cc
+++ b/test/astar_bikeshare.cc
@@ -147,13 +147,13 @@ TEST(AstarBss, test_With_Mode_Changes) {
   std::vector<std::string> expected_route{"Rue Gabriel Vicaire", "Rue Perrée",
                                           "Rue Perrée",          "Rue Caffarelli",
                                           "Rue de Bretagne",     "Rue de Turenne",
-                                          "Rue du Parc Royal",   "Place de Thorigny",
-                                          "Rue de la Perle",     "Rue de la Perle"};
+                                          "Rue du Parc Royal",   "Rue de la Perle",
+                                          "Rue de la Perle"};
 
   const std::map<size_t, BssManeuverType>&
       expected_bss_maneuver{{2, DirectionsLeg_Maneuver_BssManeuverType_kRentBikeAtBikeShare},
-                            {9, DirectionsLeg_Maneuver_BssManeuverType_kReturnBikeAtBikeShare}};
-  const std::map<size_t, std::string>& expected_bss_ref{{2, "3006"}, {9, "3008"}};
+                            {8, DirectionsLeg_Maneuver_BssManeuverType_kReturnBikeAtBikeShare}};
+  const std::map<size_t, std::string>& expected_bss_ref{{2, "3006"}, {8, "3008"}};
 
   test_request(request, expected_travel_modes, expected_route, expected_bss_maneuver,
                expected_bss_ref);
@@ -226,14 +226,13 @@ TEST(AstarBss, test_With_Mode_Changes_2) {
                                           "Rue du Pont aux Choux",
                                           "Rue de Turenne",
                                           "Rue du Parc Royal",
-                                          "Place de Thorigny",
                                           "Rue de la Perle",
                                           "Rue de la Perle",
                                           "Rue Vieille du Temple"};
   const std::map<size_t, BssManeuverType>&
       expected_bss_maneuver{{1, DirectionsLeg_Maneuver_BssManeuverType_kRentBikeAtBikeShare},
-                            {10, DirectionsLeg_Maneuver_BssManeuverType_kReturnBikeAtBikeShare}};
-  const std::map<size_t, std::string>& expected_bss_ref{{1, "11103"}, {10, "3008"}};
+                            {9, DirectionsLeg_Maneuver_BssManeuverType_kReturnBikeAtBikeShare}};
+  const std::map<size_t, std::string>& expected_bss_ref{{1, "11103"}, {9, "3008"}};
 
   test_request(request, expected_travel_modes, expected_route, expected_bss_maneuver,
                expected_bss_ref);
@@ -244,7 +243,7 @@ TEST(AstarBss, test_Pedestrian) {
   std::string request =
       R"({"locations":[{"lat":48.859895,"lon":2.3610976338},{"lat":48.86271911,"lon":2.367111146}],"costing":"pedestrian"})";
   std::vector<TravelMode> expected_travel_modes{TravelMode::kPedestrian};
-  std::vector<std::string> expected_route{"Rue de la Perle", "Rue Vieille du Temple", "Rue Froissart",
+  std::vector<std::string> expected_route{"Rue de la Perle", "Rue Vieille du Temple",
                                           "Rue Commines", "Rue Amelot"};
   // There shouldn't be any bss maneuvers
   const std::map<size_t, BssManeuverType>& expected_bss_maneuver{};

--- a/test/gurka/test_conditional_restrictions.cc
+++ b/test/gurka/test_conditional_restrictions.cc
@@ -114,7 +114,7 @@ gurka::map ConditionalRestrictions::map = {};
 
 TEST_F(ConditionalRestrictions, NoRestrictionAutoNoDate) {
   auto result = gurka::do_action(valhalla::Options::route, map, {"A", "E"}, "auto");
-  gurka::assert::osrm::expect_steps(result, {"AB", "BC", "CE"});
+  gurka::assert::osrm::expect_steps(result, {"AB", "BC"});
   gurka::assert::raw::expect_path(result, {"AB", "BC", "CE"});
 }
 
@@ -122,7 +122,7 @@ TEST_F(ConditionalRestrictions, NoRestrictionAuto) {
   auto result =
       gurka::do_action(valhalla::Options::route, map, {"A", "E"}, "auto",
                        {{"/date_time/type", "1"}, {"/date_time/value", "2020-04-15T06:00"}});
-  gurka::assert::osrm::expect_steps(result, {"AB", "BC", "CE"});
+  gurka::assert::osrm::expect_steps(result, {"AB", "BC"});
   gurka::assert::raw::expect_path(result, {"AB", "BC", "CE"});
 }
 
@@ -130,13 +130,13 @@ TEST_F(ConditionalRestrictions, RestrictionAuto) {
   auto result =
       gurka::do_action(valhalla::Options::route, map, {"A", "E"}, "auto",
                        {{"/date_time/type", "1"}, {"/date_time/value", "2020-04-02T12:00"}});
-  gurka::assert::osrm::expect_steps(result, {"AB", "BC", "CE"});
+  gurka::assert::osrm::expect_steps(result, {"AB", "BC"});
   gurka::assert::raw::expect_path(result, {"AB", "BC", "CE"});
 }
 
 TEST_F(ConditionalRestrictions, NoRestrictionBikeNoDate) {
   auto result = gurka::do_action(valhalla::Options::route, map, {"A", "E"}, "bicycle");
-  gurka::assert::osrm::expect_steps(result, {"AD", "DE"});
+  gurka::assert::osrm::expect_steps(result, {"AD"});
   gurka::assert::raw::expect_path(result, {"AD", "DE"});
 }
 
@@ -144,7 +144,7 @@ TEST_F(ConditionalRestrictions, NoRestrictionBike) {
   auto result =
       gurka::do_action(valhalla::Options::route, map, {"A", "E"}, "bicycle",
                        {{"/date_time/type", "1"}, {"/date_time/value", "2020-04-02T12:00"}});
-  gurka::assert::osrm::expect_steps(result, {"AD", "DE"});
+  gurka::assert::osrm::expect_steps(result, {"AD"});
   gurka::assert::raw::expect_path(result, {"AD", "DE"});
 }
 
@@ -167,7 +167,7 @@ TEST_F(ConditionalRestrictions, RestrictionBike) {
 
 TEST_F(ConditionalRestrictions, NoRestrictionPedestrianNoDate) {
   auto result = gurka::do_action(valhalla::Options::route, map, {"A", "E"}, "pedestrian");
-  gurka::assert::osrm::expect_steps(result, {"AD", "DE"});
+  gurka::assert::osrm::expect_steps(result, {"AD"});
   gurka::assert::raw::expect_path(result, {"AD", "DE"});
 }
 
@@ -175,7 +175,7 @@ TEST_F(ConditionalRestrictions, NoRestrictionPedestrian) {
   auto result =
       gurka::do_action(valhalla::Options::route, map, {"A", "E"}, "pedestrian",
                        {{"/date_time/type", "1"}, {"/date_time/value", "2020-04-02T20:00"}});
-  gurka::assert::osrm::expect_steps(result, {"AD", "DE"});
+  gurka::assert::osrm::expect_steps(result, {"AD"});
   gurka::assert::raw::expect_path(result, {"AD", "DE"});
 }
 

--- a/test/gurka/test_route_summary.cc
+++ b/test/gurka/test_route_summary.cc
@@ -51,7 +51,7 @@ TEST(TestRouteSummary, GetSummary) {
   valhalla::Api result0 = gurka::do_action(valhalla::Options::route, map, {"A", "F"}, "auto");
   EXPECT_EQ(result0.trip().routes_size(), 1);
   EXPECT_EQ(result0.trip().routes(0).legs_size(), 1);
-  gurka::assert::osrm::expect_steps(result0, {"RT 1", "RT 2", "RT 5"});
+  gurka::assert::osrm::expect_steps(result0, {"RT 1", "RT 5"});
   gurka::assert::osrm::expect_summaries(result0, {"RT 1, RT 5"});
 
   // Bikes avoid motorways, so the shortest route is not an option.
@@ -105,7 +105,7 @@ TEST(TestRouteSummary, GetSummary) {
   directions = result.mutable_directions()->mutable_routes()->Add();
   *directions = result2.directions().routes(0);
 
-  const std::string expected_route_summary0 = "RT 1, RT 2, RT 5";
+  const std::string expected_route_summary0 = "RT 1, RT 5";
   const std::string expected_route_summary1 = "RT 1, RT 4, RT 5";
   const std::string expected_route_summary2 = "RT 1, RT 3, RT 5";
   gurka::assert::osrm::expect_summaries(result, {expected_route_summary0, expected_route_summary1,

--- a/test/gurka/test_tagged_values.cc
+++ b/test/gurka/test_tagged_values.cc
@@ -123,7 +123,7 @@ TEST_F(TaggedValues, test_taking_tunnel) {
   rapidjson::Document d = gurka::convert_to_json(result, valhalla::Options_Format_osrm);
 
   auto steps = d["routes"][0]["legs"][0]["steps"].GetArray();
-  EXPECT_EQ(steps.Size(), 6);
+  EXPECT_EQ(steps.Size(), 5);
 
   int step_index = 0;
   // First step AB has no tunnels
@@ -141,7 +141,7 @@ TEST_F(TaggedValues, test_taking_tunnel) {
     EXPECT_STREQ(intersection["classes"][1].GetString(), "motorway");
   }
 
-  // Third step CD is tunnel
+  // Third step CE is tunnel
   step_index++;
   for (const auto& intersection : steps[step_index]["intersections"].GetArray()) {
     EXPECT_TRUE(intersection.HasMember("tunnel_name"));
@@ -150,23 +150,14 @@ TEST_F(TaggedValues, test_taking_tunnel) {
     EXPECT_STREQ(intersection["classes"][1].GetString(), "motorway");
   }
 
-  // Fourth step DE is tunnel
-  step_index++;
-  for (const auto& intersection : steps[step_index]["intersections"].GetArray()) {
-    EXPECT_TRUE(intersection.HasMember("tunnel_name"));
-    EXPECT_STREQ(intersection["tunnel_name"].GetString(), "Fort McHenry Tunnel");
-    EXPECT_STREQ(intersection["classes"][0].GetString(), "tunnel");
-    EXPECT_STREQ(intersection["classes"][1].GetString(), "motorway");
-  }
-
-  // Fifth step EF is not tunnel
+  // Fourth step EF is not tunnel
   step_index++;
   for (const auto& intersection : steps[step_index]["intersections"].GetArray()) {
     EXPECT_FALSE(intersection.HasMember("tunnel_name"));
     EXPECT_STREQ(intersection["classes"][0].GetString(), "motorway");
   }
 
-  // Sixth step is arrival
+  // Fifth step is arrival
   step_index++;
   for (const auto& intersection : steps[step_index]["intersections"].GetArray()) {
     EXPECT_FALSE(intersection.HasMember("tunnel_name"));

--- a/test/turnlanes.cc
+++ b/test/turnlanes.cc
@@ -178,9 +178,11 @@ TEST(Turnlanes, validate_turn_lanes) {
                   "[ *slight_left* VALID | *slight_left* ACTIVE | slight_right | right ]");
 
   // Test slight right active
+  // NOTE: This used to trigger a slight right maneuver, but this is not super useful to a driver to be honest.
+  // See discussion in https://github.com/valhalla/valhalla/pull/5095
   test_turn_lanes({VALHALLA_SOURCE_DIR "test/pinpoints/turn_lanes/slight_right_active_pinpoint.pbf"},
-                  expected_routes_size, expected_legs_size, expected_maneuvers_size, maneuver_index,
-                  "[ slight_left | slight_left | *slight_right* ACTIVE | right ]");
+                  expected_routes_size, expected_legs_size, expected_maneuvers_size - 1, maneuver_index,
+                  "");
 
   // Test left most left u-turn active
   test_turn_lanes({VALHALLA_SOURCE_DIR


### PR DESCRIPTION
# Issue

Fixes #5094 (or at least substantially mitigates it; can open separate issues for other edge cases as needed)

## Tasklist

 - [ ] Add tests
 - [X] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

N/A

This doesn't appear to break any existing tests, and improves handling of the edge cases that I've tested from real world experience. If maintainers think this is the right approach, I can add some tests and a CHANGELOG.