### PR TITLE
update boost geometry includes

### DIFF
--- a/src/mjolnir/graphenhancer.cc
+++ b/src/mjolnir/graphenhancer.cc
@@ -22,10 +22,10 @@
 #include <vector>
 
 #include <boost/format.hpp>
+#include <boost/geometry/geometries/multi_polygon.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
 #include <boost/geometry/geometries/polygon.hpp>
 #include <boost/geometry/io/wkt/wkt.hpp>
-#include <boost/geometry/multi/geometries/multi_polygon.hpp>
 
 #include "baldr/datetime.h"
 #include "baldr/graphconstants.h"

--- a/src/mjolnir/valhalla_benchmark_admins.cc
+++ b/src/mjolnir/valhalla_benchmark_admins.cc
@@ -4,10 +4,10 @@
 #include <vector>
 
 #include <boost/geometry.hpp>
+#include <boost/geometry/geometries/multi_polygon.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
 #include <boost/geometry/geometries/polygon.hpp>
 #include <boost/geometry/io/wkt/wkt.hpp>
-#include <boost/geometry/multi/geometries/multi_polygon.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <cxxopts.hpp>
 

--- a/test/gurka/test_avoids.cc
+++ b/test/gurka/test_avoids.cc
@@ -1,8 +1,8 @@
 #include "gurka.h"
 #include <boost/format.hpp>
 #include <boost/geometry.hpp>
+#include <boost/geometry/geometries/register/multi_polygon.hpp>
 #include <boost/geometry/geometries/register/point.hpp>
-#include <boost/geometry/multi/geometries/register/multi_polygon.hpp>
 #include <gtest/gtest.h>
 #include <valhalla/proto/options.pb.h>
 

--- a/test/gurka/test_oneways.cc
+++ b/test/gurka/test_oneways.cc
@@ -1,7 +1,7 @@
 #include "gurka.h"
 #include <boost/geometry.hpp>
+#include <boost/geometry/geometries/register/multi_polygon.hpp>
 #include <boost/geometry/geometries/register/point.hpp>
-#include <boost/geometry/multi/geometries/register/multi_polygon.hpp>
 #include <gtest/gtest.h>
 #include <valhalla/proto/options.pb.h>
 

--- a/valhalla/mjolnir/admin.h
+++ b/valhalla/mjolnir/admin.h
@@ -2,10 +2,10 @@
 #define VALHALLA_MJOLNIR_ADMIN_H_
 
 #include <boost/geometry.hpp>
+#include <boost/geometry/geometries/multi_polygon.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
 #include <boost/geometry/geometries/polygon.hpp>
 #include <boost/geometry/io/wkt/wkt.hpp>
-#include <boost/geometry/multi/geometries/multi_polygon.hpp>
 
 #include <cstdint>
 #include <sqlite3.h>


### PR DESCRIPTION
Boost has been threatening to remove those headers in 1.86 for a while now (although they're still in 1.87). 