### PR TITLE
Fix #5089: Add expansion callback support for multimodal isochrones

### DIFF
--- a/src/thor/dijkstras.cc
+++ b/src/thor/dijkstras.cc
@@ -753,6 +753,16 @@ void Dijkstras::ComputeMultiModal(
     // Check if we should stop
     cb_decision = ShouldExpand(graphreader, pred, ExpansionType::multimodal);
     if (cb_decision != ExpansionRecommendation::prune_expansion) {
+      if (expansion_callback_) {
+        GraphId pred_edge = pred.predecessor() == kInvalidLabel ? 
+                          GraphId() : 
+                          mmedgelabels_[pred.predecessor()].edgeid();
+        expansion_callback_(graphreader, pred.edgeid(), pred_edge, 
+                          "multimodal", 
+                          valhalla::Expansion_EdgeStatus_reached,
+                          pred.cost().secs, pred.path_distance(), pred.cost().cost,
+                          valhalla::Expansion_ExpansionType_forward);
+      }
       // Expand from the end node of the predecessor edge.
       ExpandForwardMultiModal(graphreader, pred.endnode(), pred, predindex, false, pc, tc,
                               mode_costing, time_infos.front());


### PR DESCRIPTION
# Issue
Fixes #5089

This PR adds expansion callback support for multimodal isochrones. Currently, the /expansion API endpoint doesn't work properly with multimodal isochrones because ComputeMultiModal doesn't implement the expansion callback logic, unlike the forward and reverse expansion types.

The issue causes multimodal isochrones to not be visualizable through the expansion endpoint, making it impossible to debug or visualize the algorithm's behavior for multimodal routing scenarios.
## Tasklist

 - [ ] Add tests
 - [x] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

This PR follows the same pattern used in the forward and reverse expansion callbacks in the `Compute` template method. It adds the callback at the point after a node is popped from the queue and marked as permanently settled, but before expanding from that node using `ExpandForwardMultiModal`.

No lua file changes were required for this fix.
