### PR TITLE
feat: Add functions to get tile ID and traffic directory for a given way id.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,7 +259,7 @@ endif()
 ## Valhalla programs
 set(valhalla_programs valhalla_run_map_match valhalla_benchmark_loki valhalla_benchmark_skadi
   valhalla_run_isochrone valhalla_run_route valhalla_benchmark_adjacency_list valhalla_run_matrix
-  valhalla_path_comparison valhalla_export_edges valhalla_expand_bounding_box valhalla_service)
+  valhalla_path_comparison valhalla_export_edges valhalla_expand_bounding_box valhalla_service valhalla_tile_utils )
 
 ## Valhalla data tools
 set(valhalla_data_tools valhalla_build_statistics valhalla_ways_to_edges valhalla_validate_transit

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -157,7 +157,8 @@ endif()
 
 if (ENABLE_SERVICES)
   set(valhalla_hdrs ${valhalla_hdrs} ${VALHALLA_SOURCE_DIR}/valhalla/tile_server.h)
-  set(valhalla_src ${valhalla_src} tile_server.cc)
+  set(valhalla_src ${valhalla_src} tile_server.cc
+          mjolnir/valhalla_tile_utils.cc)
 endif()
 
 add_library(valhalla ${valhalla_src})

--- a/src/mjolnir/valhalla_tile_utils.cc
+++ b/src/mjolnir/valhalla_tile_utils.cc
@@ -1,0 +1,80 @@
+#include "baldr/graphreader.h"
+#include "baldr/graphtile.h"
+#include <filesystem>
+namespace fs = std::filesystem;
+
+#include <boost/algorithm/string/replace.hpp>
+#include <iostream>
+#include <vector>
+
+// Function to get the traffic directory for a given edge ID
+int handle_get_traffic_dir(uint64_t edge_id) {
+  try {
+    valhalla::baldr::GraphId graph_id(edge_id);
+    auto tile_path = valhalla::baldr::GraphTile::FileSuffix(graph_id);
+    auto dir = fs::path(tile_path);
+    auto dir_str = dir.string();
+    boost::replace_all(dir_str, ".gph", ".csv");
+    std::cout << edge_id << ": " << dir_str << std::endl;
+  } catch (const std::exception& e) {
+    std::cerr << "Error in handle_get_traffic_dir: " << e.what() << std::endl;
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}
+
+// Function to get the tile ID for a given edge ID
+int handle_get_tile_id(uint64_t edge_id) {
+  try {
+    valhalla::baldr::GraphId graph_id(edge_id);
+    std::cout << edge_id << ": " << graph_id << std::endl;
+  } catch (const std::exception& e) {
+    std::cerr << "Error in handle_get_tile_id: " << e.what() << std::endl;
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}
+
+// Function to get traffic directories for multiple edge IDs
+void handle_get_traffic_dirs(const std::vector<uint64_t>& edge_ids) {
+  for (const auto& edge_id : edge_ids) {
+    handle_get_traffic_dir(edge_id);
+  }
+}
+
+// Function to get tile IDs for multiple edge IDs
+void handle_get_tile_ids(const std::vector<uint64_t>& edge_ids) {
+  for (const auto& edge_id : edge_ids) {
+    handle_get_tile_id(edge_id);
+  }
+}
+
+// Main function to demonstrate usage
+int main(int argc, char** argv) {
+  if (argc < 3) {
+    std::cerr << "Usage: " << argv[0] << " <operation> <edge_id(s)> " << std::endl;
+    std::cerr << "Operations: get-traffic-dir | get-tile-id | get-traffic-dirs | get-tile-ids" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  std::string operation = argv[1];
+  std::vector<uint64_t> edge_ids;
+  for (int i = 2; i < argc; ++i) {
+    edge_ids.push_back(std::stoull(argv[i]));
+  }
+
+  if (operation == "get-traffic-dir" && edge_ids.size() == 1) {
+    return handle_get_traffic_dir(edge_ids[0]);
+  } else if (operation == "get-tile-id" && edge_ids.size() == 1) {
+    return handle_get_tile_id(edge_ids[0]);
+  } else if (operation == "get-traffic-dirs") {
+    handle_get_traffic_dirs(edge_ids);
+  } else if (operation == "get-tile-ids") {
+    handle_get_tile_ids(edge_ids);
+  } else {
+    std::cerr << "Unknown operation: " << operation << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This PR introduces a utility named valhalla_tile_utils, which helps users determine the tile ID associated with a given way ID. Additionally, it provides the correct traffic CSV file path where traffic data should be dumped.

🔗 Reference Issue: [valhalla/valhalla#5015](https://github.com/valhalla/valhalla/issues/5015) (This issue was closed, but since it can be helpful to others, I have added this utility to address the need.)
What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.

## Tasklist

 - [Y]  Implement valhalla_tile_utils to retrieve the tile ID for a given way ID.
 - [Y]Implement logic to determine the traffic CSV file path based on the tile ID.
 - [Y ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
