### PR TITLE
feat: loop on stop times with cache

### DIFF
--- a/src/mjolnir/ingest_transit.cc
+++ b/src/mjolnir/ingest_transit.cc
@@ -222,24 +222,46 @@ std::priority_queue<tile_transit_info_t> select_transit_tiles(const std::string&
           tile_info.stations.insert({stop.stop_id, feed_name});
           tile_info.station_children.insert({{stop.stop_id, feed_name}, stop.stop_id});
         }
+      }
 
-        for (const auto& stopTime : feed.get_stop_times_for_stop(stop.stop_id)) {
-          // add trip, route, agency and service_id from stop_time, it's the only place with that info
-          // TODO: should we throw here?
-          auto trip = feed.get_trip(stopTime.trip_id);
+      // Process stop times efficiently
+      std::unordered_map<std::string, gtfs::Trip> trip_cache;
+      std::unordered_map<std::string, gtfs::Route> route_cache;
+
+      for (const auto& stop_time : feed.get_stop_times()) {
+        const auto& trip_id = stop_time.trip_id;
+
+        // Check trip cache first
+        auto trip_it = trip_cache.find(trip_id);
+        if (trip_it == trip_cache.end()) {
+          auto trip = feed.get_trip(trip_id);
+          if (!gtfs::valid(trip))
+            continue; // Skip invalid trips
+          trip_it = trip_cache.emplace(trip_id, std::move(trip)).first;
+        }
+        const auto& trip = trip_it->second;
+
+        // Check route cache
+        auto route_it = route_cache.find(trip.route_id);
+        if (route_it == route_cache.end()) {
           auto route = feed.get_route(trip.route_id);
-          if (!gtfs::valid(trip) || !gtfs::valid(route) || trip.service_id.empty()) {
-            LOG_ERROR("Missing trip or route or service_id for trip");
-            continue;
-          }
+          if (!gtfs::valid(route))
+            continue; // Skip invalid routes
+          route_it = route_cache.emplace(trip.route_id, std::move(route)).first;
+        }
+        const auto& route = route_it->second;
 
-          tile_info.trips.insert({trip.trip_id, feed_name});
-          tile_info.routes.insert({{route.route_id, feed_name}, tile_info.routes.size()});
+        // Now get the stop's tile info
+        const auto& stop = feed.get_stop(stop_time.stop_id);
+        auto& tile_info = get_tile_info(stop);
 
-          // shapes are optional, don't keep non-existing shapes around
-          if (!trip.shape_id.empty()) {
-            tile_info.shapes.insert({{trip.shape_id, feed_name}, tile_info.shapes.size()});
-          }
+        // Store trip, route, and shape data
+        tile_info.trips.insert({trip.trip_id, feed_name});
+        tile_info.routes.insert({{route.route_id, feed_name}, tile_info.routes.size()});
+
+        // Only add valid shapes
+        if (!trip.shape_id.empty()) {
+          tile_info.shapes.insert({{trip.shape_id, feed_name}, tile_info.shapes.size()});
         }
       }
 


### PR DESCRIPTION
# Issue

The issue is the time it take for valhalla_ingest_transit takes on large dataset of gtfs. 
SO after investigation the issue is arround :

`for (const auto& stopTime : feed.get_stop_times_for_stop(stop.stop_id)) {`

On large gtfs data searching in stop_times takes too much times to execute for every stop.

 **In this pr I propose one loop on all the stop times with a cache for the search of trip and route**

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
