### PR TITLE
warning for multiple level nodes when splitting

### DIFF
--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -235,10 +235,11 @@ void ConstructEdges(const std::string& ways_file,
         edge.attributes.way_end = current_way_node_index == last_way_node_index;
 
         // We should add the previous edge now that we know its done
-        if (prev_edge.is_valid()){
+        if (prev_edge.is_valid()) {
           edges.push_back(prev_edge);
           if (way.multiple_levels()) {
-            LOG_WARN("Multilevel Way [ID:" + std::to_string(way.way_id()) +"] - Split at intersection");
+            LOG_WARN("Multilevel Way [ID:" + std::to_string(way.way_id()) +
+                     "] - Split at intersection");
           }
         }
 
@@ -270,7 +271,8 @@ void ConstructEdges(const std::string& ways_file,
           node.start_of = edges.size() + 1; // + 1 because the edge has not been added yet
           element = node;
           if (way.multiple_levels()) {
-            LOG_WARN("Multilevel Way [ID:"+std::to_string(way.way_id()) +"] - Additional edge created");
+            LOG_WARN("Multilevel Way [ID:" + std::to_string(way.way_id()) +
+                     "] - Additional edge created");
           }
         }
       } // If this edge has a signal not at a intersection

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -235,8 +235,12 @@ void ConstructEdges(const std::string& ways_file,
         edge.attributes.way_end = current_way_node_index == last_way_node_index;
 
         // We should add the previous edge now that we know its done
-        if (prev_edge.is_valid())
+        if (prev_edge.is_valid()){
           edges.push_back(prev_edge);
+          if (way.multiple_levels()) {
+            LOG_WARN("Multilevel Way [ID:" + std::to_string(way.way_id()) +"] - Split at intersection");
+          }
+        }
 
         // Finish this edge
         prev_edge = edge;
@@ -265,6 +269,9 @@ void ConstructEdges(const std::string& ways_file,
           auto node = *element;
           node.start_of = edges.size() + 1; // + 1 because the edge has not been added yet
           element = node;
+          if (way.multiple_levels()) {
+            LOG_WARN("Multilevel Way [ID:"+std::to_string(way.way_id()) +"] - Additional edge created");
+          }
         }
       } // If this edge has a signal not at a intersection
       else if (way_node.node.traffic_signal()) {

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -526,8 +526,15 @@ struct graph_parser {
         tunnel_name_right_ = tag_.second;
     };
     tag_handlers_["level"] = [this]() {
-      if (!tag_.second.empty())
-        way_.set_level_index(osmdata_.name_offset_map.index(tag_.second));
+      if (tag_.second.empty())
+        return;
+
+      way_.set_level_index(osmdata_.name_offset_map.index(tag_.second));
+
+      bool has_multiple_levels =
+          tag_.second.find_first_of(";,-") != std::string::npos &&
+          (tag_.second.find('-') == std::string::npos || tag_.second.find('-') > 0);
+      way_.set_multiple_levels(has_multiple_levels);
     };
     tag_handlers_["level:ref"] = [this]() {
       if (!tag_.second.empty())

--- a/valhalla/mjolnir/osmway.h
+++ b/valhalla/mjolnir/osmway.h
@@ -2181,19 +2181,19 @@ struct OSMWay {
   bool drive_on_right() const {
     return drive_on_right_;
   }
-   /**
-   * Set multiple_levels flag. 
+  /**
+   * Set multiple_levels flag.
    * @param multiple_levels Is there a multiple levels?
    */
-  void set_multiple_levels(const bool multiple_levels){
+  void set_multiple_levels(const bool multiple_levels) {
     multiple_levels_ = multiple_levels;
   }
 
   /**
    * Get the multiple levels flag.
-   * @return Returns drive on right flag. 
+   * @return Returns drive on right flag.
    */
-  bool multiple_levels() const{
+  bool multiple_levels() const {
     return multiple_levels_;
   }
 

--- a/valhalla/mjolnir/osmway.h
+++ b/valhalla/mjolnir/osmway.h
@@ -2181,6 +2181,21 @@ struct OSMWay {
   bool drive_on_right() const {
     return drive_on_right_;
   }
+   /**
+   * Set multiple_levels flag. 
+   * @param multiple_levels Is there a multiple levels?
+   */
+  void set_multiple_levels(const bool multiple_levels){
+    multiple_levels_ = multiple_levels;
+  }
+
+  /**
+   * Get the multiple levels flag.
+   * @return Returns drive on right flag. 
+   */
+  bool multiple_levels() const{
+    return multiple_levels_;
+  }
 
   /**
    * Sets the bike network.
@@ -2658,6 +2673,7 @@ struct OSMWay {
   uint32_t truck_route_ : 1;
   uint32_t sidewalk_right_ : 1;
   uint32_t sidewalk_left_ : 1;
+  uint32_t multiple_levels_ : 1;
   uint32_t sac_scale_ : 3;
 
   // Classification


### PR DESCRIPTION
warning when multilevel ways are split into multiple edges during graph construction
by setting a bit while parsing(multiple levels) and then check later while graph constructing 

## Tasklist

 - [ ] Add tests
 - [x] Add #5105 


