### PR TITLE
chore: flag 'seasonal' bit as UNUSED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## UNRELEASED
 * **Removed**
+   * REMOVED: `seasonal` bit from OSMWay & DirectedEdge [#5156](https://github.com/valhalla/valhalla/pull/5156)
 * **Bug Fix**
    * FIXED: `incremental_build_tiles` script works again [#4909](https://github.com/valhalla/valhalla/pull/4909)
    * FIXED: Fix ability to use Valhalla via cmake `add_subdirectory` [#4930](https://github.com/valhalla/valhalla/pull/4930)

--- a/lua/graph.lua
+++ b/lua/graph.lua
@@ -1718,11 +1718,6 @@ function filter_tags_generic(kv)
 
   kv["bridge"] = bridge[kv["bridge"]] or "false"
 
-  -- TODO access:conditional
-  if kv["seasonal"] and kv["seasonal"] ~= "no" then
-    kv["seasonal"] = "true"
-  end
-
   kv["hov_tag"] = "true"
   if (kv["hov"] and kv["hov"] == "no") then
     kv["hov_forward"] = "false"

--- a/src/baldr/directededge.cc
+++ b/src/baldr/directededge.cc
@@ -181,11 +181,6 @@ void DirectedEdge::set_toll(const bool toll) {
   toll_ = toll;
 }
 
-// Sets the flag indicating this edge has seasonal access
-void DirectedEdge::set_seasonal(const bool seasonal) {
-  seasonal_ = seasonal;
-}
-
 // Sets the destination only (private) flag. This indicates the edge should
 // allow access only to locations that are destinations and not allow
 // "through" traffic
@@ -608,7 +603,6 @@ json::MapPtr DirectedEdge::json() const {
       {"part_of_complex_restriction", static_cast<bool>(complex_restriction_)},
       {"has_sign", static_cast<bool>(sign_)},
       {"toll", static_cast<bool>(toll_)},
-      {"seasonal", static_cast<bool>(seasonal_)},
       {"destination_only", static_cast<bool>(dest_only_)},
       {"tunnel", static_cast<bool>(tunnel_)},
       {"bridge", static_cast<bool>(bridge_)},

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -1589,7 +1589,6 @@ struct graph_parser {
     tag_handlers_["toll"] = [this]() { way_.set_toll(tag_.second == "true" ? true : false); };
     tag_handlers_["bridge"] = [this]() { way_.set_bridge(tag_.second == "true" ? true : false); };
     tag_handlers_["indoor"] = [this]() { way_.set_indoor(tag_.second == "yes" ? true : false); };
-    tag_handlers_["seasonal"] = [this]() { way_.set_seasonal(tag_.second == "true" ? true : false); };
     tag_handlers_["bike_network_mask"] = [this]() { way_.set_bike_network(std::stoi(tag_.second)); };
     //    tag_handlers_["bike_national_ref"] = [this]() {
     //      if (!tag_.second.empty())

--- a/taginfo.json
+++ b/taginfo.json
@@ -7430,12 +7430,6 @@
       ]
     },
     {
-      "key": "seasonal",
-      "object_types": [
-        "way"
-      ]
-    },
-    {
       "key": "segregated",
       "value": "yes",
       "object_types": [

--- a/valhalla/baldr/directededge.h
+++ b/valhalla/baldr/directededge.h
@@ -268,20 +268,6 @@ public:
   void set_toll(const bool toll);
 
   /**
-   * Does this edge have a seasonal access (e.g., closed in the winter)?
-   * @return  Returns true if this edge has seasonal access, false if not.
-   */
-  bool seasonal() const {
-    return seasonal_;
-  }
-
-  /**
-   * Sets the flag indicating this edge has seasonal access.
-   * @param  seasonal  True if this edge has seasonal access, false if not.
-   */
-  void set_seasonal(const bool seasonal);
-
-  /**
    * Is this edge part of a private or no through road that allows access
    * only if required to get to a destination?
    * @return  Returns true if the edge is destination only / private access.
@@ -1232,34 +1218,34 @@ protected:
   uint64_t has_predicted_speed_ : 1;    // Does this edge have a predicted speed records?
 
   // 4th 8-byte word
-  uint64_t forwardaccess_ : 12; // Access (bit mask) in forward direction (see graphconstants.h)
-  uint64_t reverseaccess_ : 12; // Access (bit mask) in reverse direction (see graphconstants.h)
-  uint64_t max_up_slope_ : 5;   // Maximum upward slope
-  uint64_t max_down_slope_ : 5; // Maximum downward slope
-  uint64_t sac_scale_ : 3;      // Is this edge for hiking and if so how difficult is the hike?
-  uint64_t cycle_lane_ : 2;     // Does this edge have bicycle lanes?
-  uint64_t bike_network_ : 1;   // Edge that is part of a bicycle network
-  uint64_t use_sidepath_ : 1;   // Is there a cycling path to the side that should be preferred?
-  uint64_t dismount_ : 1;       // Do you need to dismount when biking on this edge?
-  uint64_t sidewalk_left_ : 1;  // Sidewalk to the left of the edge
-  uint64_t sidewalk_right_ : 1; // Sidewalk to the right of the edge
-  uint64_t shoulder_ : 1;       // Does the edge have a shoulder?
-  uint64_t lane_conn_ : 1;      // 1 if has lane connectivity, 0 otherwise
-  uint64_t turnlanes_ : 1;      // Does this edge have turn lanes (end of edge)
-  uint64_t sign_ : 1;           // Exit signs exist for this edge
-  uint64_t internal_ : 1;       // Edge that is internal to an intersection
-  uint64_t tunnel_ : 1;         // Is this edge part of a tunnel
-  uint64_t bridge_ : 1;         // Is this edge part of a bridge?
-  uint64_t traffic_signal_ : 1; // Traffic signal at end of the directed edge
-  uint64_t seasonal_ : 1;       // Seasonal access (ex. no access in winter)
-  uint64_t deadend_ : 1;        // Leads to a dead-end (no other drivable roads) TODO
-  uint64_t bss_connection_ : 1; // Does this lead to(come out from) a bike share station?
-  uint64_t stop_sign_ : 1;      // Stop sign at end of the directed edge
-  uint64_t yield_sign_ : 1;     // Yield/give way sign at end of the directed edge
-  uint64_t hov_type_ : 1;       // if (is_hov_only()==true), this means (HOV2=0, HOV3=1)
-  uint64_t indoor_ : 1;         // Is this edge indoor
-  uint64_t lit_ : 1;            // Is the edge lit?
-  uint64_t dest_only_hgv_ : 1;  // destonly for HGV specifically
+  uint64_t forwardaccess_ : 12;  // Access (bit mask) in forward direction (see graphconstants.h)
+  uint64_t reverseaccess_ : 12;  // Access (bit mask) in reverse direction (see graphconstants.h)
+  uint64_t max_up_slope_ : 5;    // Maximum upward slope
+  uint64_t max_down_slope_ : 5;  // Maximum downward slope
+  uint64_t sac_scale_ : 3;       // Is this edge for hiking and if so how difficult is the hike?
+  uint64_t cycle_lane_ : 2;      // Does this edge have bicycle lanes?
+  uint64_t bike_network_ : 1;    // Edge that is part of a bicycle network
+  uint64_t use_sidepath_ : 1;    // Is there a cycling path to the side that should be preferred?
+  uint64_t dismount_ : 1;        // Do you need to dismount when biking on this edge?
+  uint64_t sidewalk_left_ : 1;   // Sidewalk to the left of the edge
+  uint64_t sidewalk_right_ : 1;  // Sidewalk to the right of the edge
+  uint64_t shoulder_ : 1;        // Does the edge have a shoulder?
+  uint64_t lane_conn_ : 1;       // 1 if has lane connectivity, 0 otherwise
+  uint64_t turnlanes_ : 1;       // Does this edge have turn lanes (end of edge)
+  uint64_t sign_ : 1;            // Exit signs exist for this edge
+  uint64_t internal_ : 1;        // Edge that is internal to an intersection
+  uint64_t tunnel_ : 1;          // Is this edge part of a tunnel
+  uint64_t bridge_ : 1;          // Is this edge part of a bridge?
+  uint64_t traffic_signal_ : 1;  // Traffic signal at end of the directed edge
+  uint64_t UNUSED_seasonal_ : 1; // Used to be "seasonal", was never used, can be reclaimed
+  uint64_t deadend_ : 1;         // Leads to a dead-end (no other drivable roads) TODO
+  uint64_t bss_connection_ : 1;  // Does this lead to(come out from) a bike share station?
+  uint64_t stop_sign_ : 1;       // Stop sign at end of the directed edge
+  uint64_t yield_sign_ : 1;      // Yield/give way sign at end of the directed edge
+  uint64_t hov_type_ : 1;        // if (is_hov_only()==true), this means (HOV2=0, HOV3=1)
+  uint64_t indoor_ : 1;          // Is this edge indoor
+  uint64_t lit_ : 1;             // Is the edge lit?
+  uint64_t dest_only_hgv_ : 1;   // destonly for HGV specifically
   uint64_t spare4_ : 3;
 
   // 5th 8-byte word

--- a/valhalla/baldr/directededge.h
+++ b/valhalla/baldr/directededge.h
@@ -1237,7 +1237,7 @@ protected:
   uint64_t tunnel_ : 1;          // Is this edge part of a tunnel
   uint64_t bridge_ : 1;          // Is this edge part of a bridge?
   uint64_t traffic_signal_ : 1;  // Traffic signal at end of the directed edge
-  uint64_t spare1_ : 1; // Used to be "seasonal", was never used, can be reclaimed
+  uint64_t spare1_ : 1;          // Used to be "seasonal", was never used, can be reclaimed
   uint64_t deadend_ : 1;         // Leads to a dead-end (no other drivable roads) TODO
   uint64_t bss_connection_ : 1;  // Does this lead to(come out from) a bike share station?
   uint64_t stop_sign_ : 1;       // Stop sign at end of the directed edge

--- a/valhalla/baldr/directededge.h
+++ b/valhalla/baldr/directededge.h
@@ -1218,34 +1218,34 @@ protected:
   uint64_t has_predicted_speed_ : 1;    // Does this edge have a predicted speed records?
 
   // 4th 8-byte word
-  uint64_t forwardaccess_ : 12;  // Access (bit mask) in forward direction (see graphconstants.h)
-  uint64_t reverseaccess_ : 12;  // Access (bit mask) in reverse direction (see graphconstants.h)
-  uint64_t max_up_slope_ : 5;    // Maximum upward slope
-  uint64_t max_down_slope_ : 5;  // Maximum downward slope
-  uint64_t sac_scale_ : 3;       // Is this edge for hiking and if so how difficult is the hike?
-  uint64_t cycle_lane_ : 2;      // Does this edge have bicycle lanes?
-  uint64_t bike_network_ : 1;    // Edge that is part of a bicycle network
-  uint64_t use_sidepath_ : 1;    // Is there a cycling path to the side that should be preferred?
-  uint64_t dismount_ : 1;        // Do you need to dismount when biking on this edge?
-  uint64_t sidewalk_left_ : 1;   // Sidewalk to the left of the edge
-  uint64_t sidewalk_right_ : 1;  // Sidewalk to the right of the edge
-  uint64_t shoulder_ : 1;        // Does the edge have a shoulder?
-  uint64_t lane_conn_ : 1;       // 1 if has lane connectivity, 0 otherwise
-  uint64_t turnlanes_ : 1;       // Does this edge have turn lanes (end of edge)
-  uint64_t sign_ : 1;            // Exit signs exist for this edge
-  uint64_t internal_ : 1;        // Edge that is internal to an intersection
-  uint64_t tunnel_ : 1;          // Is this edge part of a tunnel
-  uint64_t bridge_ : 1;          // Is this edge part of a bridge?
-  uint64_t traffic_signal_ : 1;  // Traffic signal at end of the directed edge
-  uint64_t spare1_ : 1;          // Used to be "seasonal", was never used, can be reclaimed
-  uint64_t deadend_ : 1;         // Leads to a dead-end (no other drivable roads) TODO
-  uint64_t bss_connection_ : 1;  // Does this lead to(come out from) a bike share station?
-  uint64_t stop_sign_ : 1;       // Stop sign at end of the directed edge
-  uint64_t yield_sign_ : 1;      // Yield/give way sign at end of the directed edge
-  uint64_t hov_type_ : 1;        // if (is_hov_only()==true), this means (HOV2=0, HOV3=1)
-  uint64_t indoor_ : 1;          // Is this edge indoor
-  uint64_t lit_ : 1;             // Is the edge lit?
-  uint64_t dest_only_hgv_ : 1;   // destonly for HGV specifically
+  uint64_t forwardaccess_ : 12; // Access (bit mask) in forward direction (see graphconstants.h)
+  uint64_t reverseaccess_ : 12; // Access (bit mask) in reverse direction (see graphconstants.h)
+  uint64_t max_up_slope_ : 5;   // Maximum upward slope
+  uint64_t max_down_slope_ : 5; // Maximum downward slope
+  uint64_t sac_scale_ : 3;      // Is this edge for hiking and if so how difficult is the hike?
+  uint64_t cycle_lane_ : 2;     // Does this edge have bicycle lanes?
+  uint64_t bike_network_ : 1;   // Edge that is part of a bicycle network
+  uint64_t use_sidepath_ : 1;   // Is there a cycling path to the side that should be preferred?
+  uint64_t dismount_ : 1;       // Do you need to dismount when biking on this edge?
+  uint64_t sidewalk_left_ : 1;  // Sidewalk to the left of the edge
+  uint64_t sidewalk_right_ : 1; // Sidewalk to the right of the edge
+  uint64_t shoulder_ : 1;       // Does the edge have a shoulder?
+  uint64_t lane_conn_ : 1;      // 1 if has lane connectivity, 0 otherwise
+  uint64_t turnlanes_ : 1;      // Does this edge have turn lanes (end of edge)
+  uint64_t sign_ : 1;           // Exit signs exist for this edge
+  uint64_t internal_ : 1;       // Edge that is internal to an intersection
+  uint64_t tunnel_ : 1;         // Is this edge part of a tunnel
+  uint64_t bridge_ : 1;         // Is this edge part of a bridge?
+  uint64_t traffic_signal_ : 1; // Traffic signal at end of the directed edge
+  uint64_t spare1_ : 1;         // Used to be "seasonal", was never used, can be reclaimed
+  uint64_t deadend_ : 1;        // Leads to a dead-end (no other drivable roads) TODO
+  uint64_t bss_connection_ : 1; // Does this lead to(come out from) a bike share station?
+  uint64_t stop_sign_ : 1;      // Stop sign at end of the directed edge
+  uint64_t yield_sign_ : 1;     // Yield/give way sign at end of the directed edge
+  uint64_t hov_type_ : 1;       // if (is_hov_only()==true), this means (HOV2=0, HOV3=1)
+  uint64_t indoor_ : 1;         // Is this edge indoor
+  uint64_t lit_ : 1;            // Is the edge lit?
+  uint64_t dest_only_hgv_ : 1;  // destonly for HGV specifically
   uint64_t spare4_ : 3;
 
   // 5th 8-byte word

--- a/valhalla/baldr/directededge.h
+++ b/valhalla/baldr/directededge.h
@@ -1237,7 +1237,7 @@ protected:
   uint64_t tunnel_ : 1;          // Is this edge part of a tunnel
   uint64_t bridge_ : 1;          // Is this edge part of a bridge?
   uint64_t traffic_signal_ : 1;  // Traffic signal at end of the directed edge
-  uint64_t UNUSED_seasonal_ : 1; // Used to be "seasonal", was never used, can be reclaimed
+  uint64_t spare1_ : 1; // Used to be "seasonal", was never used, can be reclaimed
   uint64_t deadend_ : 1;         // Leads to a dead-end (no other drivable roads) TODO
   uint64_t bss_connection_ : 1;  // Does this lead to(come out from) a bike share station?
   uint64_t stop_sign_ : 1;       // Stop sign at end of the directed edge

--- a/valhalla/mjolnir/osmway.h
+++ b/valhalla/mjolnir/osmway.h
@@ -2629,7 +2629,7 @@ struct OSMWay {
   uint32_t tunnel_ : 1;
   uint32_t toll_ : 1;
   uint32_t bridge_ : 1;
-  uint32_t UNUSED_seasonal_ : 1; // can be reclaimed
+  uint32_t spare1_ : 1;
   uint32_t drive_on_right_ : 1;
   uint32_t bike_network_ : 4;
   uint32_t exit_ : 1;

--- a/valhalla/mjolnir/osmway.h
+++ b/valhalla/mjolnir/osmway.h
@@ -2087,22 +2087,6 @@ struct OSMWay {
   }
 
   /**
-   * Set seasonal flag.
-   * @param  seasonal   Is this seasonal?
-   */
-  void set_seasonal(const bool seasonal) {
-    seasonal_ = seasonal;
-  }
-
-  /**
-   * Get the seasonal flag.
-   * @return  Returns seasonal flag.
-   */
-  bool seasonal() const {
-    return seasonal_;
-  }
-
-  /**
    * Set wheelchair flag.
    * @param  wheelchair   Is this wheelchair?
    */
@@ -2645,7 +2629,7 @@ struct OSMWay {
   uint32_t tunnel_ : 1;
   uint32_t toll_ : 1;
   uint32_t bridge_ : 1;
-  uint32_t seasonal_ : 1;
+  uint32_t UNUSED_seasonal_ : 1; // can be reclaimed
   uint32_t drive_on_right_ : 1;
   uint32_t bike_network_ : 4;
   uint32_t exit_ : 1;


### PR DESCRIPTION
AFAICT we never used this `seasonal` attribute, yet it's in both OSMWay and DirectedEdge. The latter has only 3 bits left, so re-claiming 1 bit would be quite nice.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.
