### PR TITLE
fix: fix adding leap seconds twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
    * FIXED: Fix type mismatch in `src/tyr/serializers.cc` [#5145](https://github.com/valhalla/valhalla/pull/5145)
    * FIXED: Multimodal ferry reclassification [#5139](https://github.com/valhalla/valhalla/pull/5139)
    * FIXED: Fix time info calculation across time zone boundaries [#5163](https://github.com/valhalla/valhalla/pull/5163)
+   * FIXED: Fix leap seconds when checking conditional access restrictions and historical traffic [#5163](https://github.com/valhalla/valhalla/pull/5163)
 
 * **Enhancement**
    * ADDED: Consider smoothness in all profiles that use surface [#4949](https://github.com/valhalla/valhalla/pull/4949)

--- a/src/sif/recost.cc
+++ b/src/sif/recost.cc
@@ -93,12 +93,12 @@ void recost_forward(baldr::GraphReader& reader,
     // queued edges as normal
     uint8_t time_restrictions_TODO = baldr::kInvalidRestriction;
     // if its not time dependent set to 0 for Allowed method below
-    const uint64_t localtime = offset_time.valid ? offset_time.local_time : 0;
+    const uint64_t sys_epoch = offset_time.valid ? offset_time.sys_epoch : 0;
     // we should call 'Allowed' method even if 'ignore_access' flag is true in order to
     // evaluate time restrictions
     const auto next_id = edge_cb();
     if (predecessor != baldr::kInvalidLabel &&
-        (!costing.Allowed(edge, !next_id.Is_Valid(), label, tile, edge_id, localtime,
+        (!costing.Allowed(edge, !next_id.Is_Valid(), label, tile, edge_id, sys_epoch,
                           offset_time.timezone_index, time_restrictions_TODO) &&
          !ignore_access)) {
       throw std::runtime_error("This path requires different edge access than this costing allows");

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -237,7 +237,7 @@ inline bool BidirectionalAStar::ExpandInner(baldr::GraphReader& graphreader,
   // Skip this edge if no access is allowed (based on costing method)
   // or if a complex restriction prevents transition onto this edge.
   // if its not time dependent set to 0 for Allowed and Restricted methods below
-  const uint64_t localtime = time_info.valid ? time_info.local_time : 0;
+  const uint64_t sys_epoch = time_info.valid ? time_info.sys_epoch : 0;
   uint8_t restriction_idx = kInvalidRestriction;
   if (FORWARD) {
     // Why is is_dest false?
@@ -248,17 +248,17 @@ inline bool BidirectionalAStar::ExpandInner(baldr::GraphReader& graphreader,
     // We can set is_dest incorrectly in the second case, but it is the rare case.
     // The result path will be correct, because there are cosing.Allowed calls inside recost_forward
     // function in second time.
-    if (!costing_->Allowed(meta.edge, false, pred, tile, meta.edge_id, localtime,
+    if (!costing_->Allowed(meta.edge, false, pred, tile, meta.edge_id, sys_epoch,
                            time_info.timezone_index, restriction_idx) ||
         costing_->Restricted(meta.edge, pred, edgelabels_forward_, tile, meta.edge_id, true,
-                             &edgestatus_forward_, localtime, time_info.timezone_index)) {
+                             &edgestatus_forward_, sys_epoch, time_info.timezone_index)) {
       return false;
     }
   } else {
-    if (!costing_->AllowedReverse(meta.edge, pred, opp_edge, t2, opp_edge_id, localtime,
+    if (!costing_->AllowedReverse(meta.edge, pred, opp_edge, t2, opp_edge_id, sys_epoch,
                                   time_info.timezone_index, restriction_idx) ||
         costing_->Restricted(meta.edge, pred, edgelabels_reverse_, tile, meta.edge_id, false,
-                             &edgestatus_reverse_, localtime, time_info.timezone_index)) {
+                             &edgestatus_reverse_, sys_epoch, time_info.timezone_index)) {
       return false;
     }
   }

--- a/src/thor/costmatrix.cc
+++ b/src/thor/costmatrix.cc
@@ -470,18 +470,18 @@ bool CostMatrix::ExpandInner(baldr::GraphReader& graphreader,
   // or if a complex restriction prevents transition onto this edge.
   uint8_t restriction_idx = kInvalidRestriction;
   if (FORWARD) {
-    if (!costing_->Allowed(meta.edge, false, pred, tile, meta.edge_id, time_info.local_time,
+    if (!costing_->Allowed(meta.edge, false, pred, tile, meta.edge_id, time_info.sys_epoch,
                            time_info.timezone_index, restriction_idx) ||
         costing_->Restricted(meta.edge, pred, edgelabels, tile, meta.edge_id, true,
-                             &edgestatus_[FORWARD][index], time_info.local_time,
+                             &edgestatus_[FORWARD][index], time_info.sys_epoch,
                              time_info.timezone_index)) {
       return false;
     }
   } else {
-    if (!costing_->AllowedReverse(meta.edge, pred, opp_edge, t2, opp_edge_id, time_info.local_time,
+    if (!costing_->AllowedReverse(meta.edge, pred, opp_edge, t2, opp_edge_id, time_info.sys_epoch,
                                   time_info.timezone_index, restriction_idx) ||
         costing_->Restricted(meta.edge, pred, edgelabels, tile, meta.edge_id, false,
-                             &edgestatus_[FORWARD][index], time_info.local_time,
+                             &edgestatus_[FORWARD][index], time_info.sys_epoch,
                              time_info.timezone_index)) {
       return false;
     }

--- a/src/thor/dijkstras.cc
+++ b/src/thor/dijkstras.cc
@@ -185,12 +185,12 @@ void Dijkstras::ExpandInner(baldr::GraphReader& graphreader,
       // With date time we check time dependent restrictions and access
       const bool allowed =
           FORWARD ? costing_->Allowed(directededge, is_dest, pred, tile, edgeid,
-                                      offset_time.local_time, nodeinfo->timezone(), restriction_idx)
+                                      offset_time.sys_epoch, nodeinfo->timezone(), restriction_idx)
                   : costing_->AllowedReverse(directededge, pred, opp_edge, t2, oppedgeid,
-                                             offset_time.local_time, nodeinfo->timezone(),
+                                             offset_time.sys_epoch, nodeinfo->timezone(),
                                              restriction_idx);
       if (!allowed || costing_->Restricted(directededge, pred, bdedgelabels_, tile, edgeid, true,
-                                           todo, offset_time.local_time, nodeinfo->timezone())) {
+                                           todo, offset_time.sys_epoch, nodeinfo->timezone())) {
         continue;
       }
     } else {

--- a/src/thor/timedistancematrix.cc
+++ b/src/thor/timedistancematrix.cc
@@ -108,17 +108,17 @@ void TimeDistanceMatrix::Expand(GraphReader& graphreader,
     uint8_t restriction_idx = kInvalidRestriction;
     const bool is_dest = dest_edges_.find(edgeid) != dest_edges_.cend();
     if (FORWARD) {
-      if (!costing_->Allowed(directededge, is_dest, pred, tile, edgeid, offset_time.local_time,
+      if (!costing_->Allowed(directededge, is_dest, pred, tile, edgeid, offset_time.sys_epoch,
                              nodeinfo->timezone(), restriction_idx) ||
           costing_->Restricted(directededge, pred, edgelabels_, tile, edgeid, true, nullptr,
-                               offset_time.local_time, nodeinfo->timezone())) {
+                               offset_time.sys_epoch, nodeinfo->timezone())) {
         continue;
       }
     } else {
       if (!costing_->AllowedReverse(directededge, pred, opp_edge, t2, opp_edge_id,
-                                    offset_time.local_time, nodeinfo->timezone(), restriction_idx) ||
+                                    offset_time.sys_epoch, nodeinfo->timezone(), restriction_idx) ||
           (costing_->Restricted(directededge, pred, edgelabels_, tile, edgeid, false, nullptr,
-                                offset_time.local_time, nodeinfo->timezone()))) {
+                                offset_time.sys_epoch, nodeinfo->timezone()))) {
         continue;
       }
     }

--- a/src/thor/unidirectional_astar.cc
+++ b/src/thor/unidirectional_astar.cc
@@ -231,17 +231,17 @@ inline bool UnidirectionalAStar<expansion_direction, FORWARD>::ExpandInner(
     // (based on costing method)
     uint8_t restriction_idx = kInvalidRestriction;
     if (FORWARD) {
-      if (!costing_->Allowed(meta.edge, dest_path_edge, pred, tile, meta.edge_id,
-                             time_info.local_time, nodeinfo->timezone(), restriction_idx) ||
+      if (!costing_->Allowed(meta.edge, dest_path_edge, pred, tile, meta.edge_id, time_info.sys_epoch,
+                             nodeinfo->timezone(), restriction_idx) ||
           costing_->Restricted(meta.edge, pred, edgelabels_, tile, meta.edge_id, true, &edgestatus_,
-                               time_info.local_time, nodeinfo->timezone())) {
+                               time_info.sys_epoch, nodeinfo->timezone())) {
         return false;
       }
     } else {
       if (!costing_->AllowedReverse(meta.edge, pred, opp_edge, endtile, opp_edge_id,
-                                    time_info.local_time, nodeinfo->timezone(), restriction_idx) ||
+                                    time_info.sys_epoch, nodeinfo->timezone(), restriction_idx) ||
           costing_->Restricted(meta.edge, pred, edgelabels_, tile, meta.edge_id, false, &edgestatus_,
-                               time_info.local_time, nodeinfo->timezone())) {
+                               time_info.sys_epoch, nodeinfo->timezone())) {
         return false;
       }
     }
@@ -324,17 +324,17 @@ inline bool UnidirectionalAStar<expansion_direction, FORWARD>::ExpandInner(
     auto update_label = [&]() {
       uint8_t restriction_idx = kInvalidRestriction;
       if (FORWARD) {
-        if (!costing_->Allowed(meta.edge, false, pred, tile, meta.edge_id, time_info.local_time,
+        if (!costing_->Allowed(meta.edge, false, pred, tile, meta.edge_id, time_info.sys_epoch,
                                nodeinfo->timezone(), restriction_idx) ||
             costing_->Restricted(meta.edge, pred, edgelabels_, tile, meta.edge_id, true, &edgestatus_,
-                                 time_info.local_time, nodeinfo->timezone())) {
+                                 time_info.sys_epoch, nodeinfo->timezone())) {
           return false;
         }
       } else {
         if (!costing_->AllowedReverse(meta.edge, pred, opp_edge, endtile, opp_edge_id,
-                                      time_info.local_time, nodeinfo->timezone(), restriction_idx) ||
+                                      time_info.sys_epoch, nodeinfo->timezone(), restriction_idx) ||
             costing_->Restricted(meta.edge, pred, edgelabels_, tile, meta.edge_id, false,
-                                 &edgestatus_, time_info.local_time, nodeinfo->timezone())) {
+                                 &edgestatus_, time_info.sys_epoch, nodeinfo->timezone())) {
           return false;
         }
       }

--- a/test/gurka/test_time_tracking.cc
+++ b/test/gurka/test_time_tracking.cc
@@ -48,7 +48,7 @@ TEST(TimeTracking, make) {
     location.set_date_time("2020-04-01T12:34");
     ti = baldr::TimeInfo::make(location, reader, cache, 7777);
     // zero out the part we dont care to test
-    ti.local_time = 0;
+    ti.sys_epoch = 0;
     ti.second_of_week = 0;
     ti.seconds_from_now = 0;
     ti.negative_seconds_from_now = 0;


### PR DESCRIPTION
It seems we were adding leap seconds twice before checking conditional restrictions and historical traffic. that's just 30 seconds off or so, but well, also only 10 mins work.. I actually hope some test will fail!

The bulk of the PR is simply refactoring to rename `TimeInfo::local_time` to `TimeInfo::sys_epoch` which is what that thing really is.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.
