### PR TITLE
normalize paths on valhalla_build_extract 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
    * FIXED: Fix time info calculation across time zone boundaries [#5163](https://github.com/valhalla/valhalla/pull/5163)
    * FIXED: pass thor config to matrix algorithms in `valhalla_run_matrix` [#5053](https://github.com/valhalla/valhalla/pull/5053)
    * FIXED: clang warning: bool literal returned from `main` `[-Wmain]` [#5173](https://github.com/valhalla/valhalla/pull/5173)
+   * FIXED: normalize paths on valhalla_build_extract for windows  [#5176](https://github.com/valhalla/valhalla/pull/5176)
 * **Enhancement**
    * ADDED: Consider smoothness in all profiles that use surface [#4949](https://github.com/valhalla/valhalla/pull/4949)
    * ADDED: `admin_crossings` request parameter for `/route` [#4941](https://github.com/valhalla/valhalla/pull/4941)

--- a/scripts/valhalla_build_extract
+++ b/scripts/valhalla_build_extract
@@ -91,7 +91,7 @@ class TileResolver:
         for t in list(dict.fromkeys(self.matched_paths)):
             LOGGER.debug(f"Adding tile {t} to the tar file")
             # Normalize path to use forward slashes, fixes issues when running on Windows
-            normalized_path = str(t).replace("\\", "/")  
+            normalized_path = str(t).replace("\\", "/")
             if self._is_tar:
                 tar_member = self._tar_obj.getmember(normalized_path)
                 tar.addfile(tar_member, self._tar_obj.extractfile(tar_member.name))

--- a/scripts/valhalla_build_extract
+++ b/scripts/valhalla_build_extract
@@ -90,12 +90,14 @@ class TileResolver:
         # since 3.7 python dicts are insertion-ordered, so order is preserved
         for t in list(dict.fromkeys(self.matched_paths)):
             LOGGER.debug(f"Adding tile {t} to the tar file")
+            # Normalize path to use forward slashes, fixes issues when running on Windows
+            normalized_path = str(t).replace("\\", "/")  
             if self._is_tar:
-                tar_member = self._tar_obj.getmember(str(t))
+                tar_member = self._tar_obj.getmember(normalized_path)
                 tar.addfile(tar_member, self._tar_obj.extractfile(tar_member.name))
             else:
-                tar.add(str(self.path.joinpath(t)), arcname=t)
-                tar_member = tar.getmember(str(t))
+                tar.add(str(self.path.joinpath(normalized_path)), arcname=normalized_path)
+                tar_member = tar.getmember(normalized_path)
 
 
 description = "Builds a tar extract from the tiles in mjolnir.tile_dir to the path specified in mjolnir.tile_extract."


### PR DESCRIPTION
Updated valhalla_build_extract to normalize paths for using on windows.

# Issue

connected to issue #5175 should fix it

This PR addresses an issue where the `valhalla_build_extract` script fails on Windows due to `pathlib.Path.joinpath` generating Windows-style paths with backslashes (`\`). 
These paths are incompatible with the tar archive format, which expects forward slashes (/). 
The error manifests as a `KeyError` when calling `tar.getmember()`.

Tested on Windows Server 2019, with a local valhalla built with vcpkg

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
