### PR TITLE
feat: Change `Multilevel Way` warning to debug message to reduce spam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
    * CHANGED: Move `bss_info_` from `OSMNode` to the new `OSMBSSNode` to reduce `way_nodes.bin` size [#5147](https://github.com/valhalla/valhalla/pull/5147)
    * UPDATED: bump tz from 2025a to 2025b [#5164](https://github.com/valhalla/valhalla/pull/5164)
    * ADDED: Mutithreaded `PBFGraphParser::ParseWays()` [#5143](https://github.com/valhalla/valhalla/pull/5143)
+   * CHANGED: "Multilevel Way" message logging level changed from WARN to DEBUG [#5188](https://github.com/valhalla/valhalla/pull/5188)
 
 ## Release Date: 2024-10-10 Valhalla 3.5.1
 * **Removed**

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -267,8 +267,8 @@ void ConstructEdges(const std::string& ways_file,
           node.start_of = edges.size() + 1; // + 1 because the edge has not been added yet
           element = node;
           if (way.multiple_levels()) {
-            LOG_WARN("Multilevel Way [ID:" + std::to_string(way.way_id()) +
-                     "] - Additional edge created");
+            LOG_DEBUG("Multilevel Way [ID:" + std::to_string(way.way_id()) +
+                      "] - Additional edge created");
           }
         }
       } // If this edge has a signal not at a intersection


### PR DESCRIPTION
# Issue

Fixes spam (10k warnings for the whole planet build) introduced in https://github.com/valhalla/valhalla/pull/5138 by switching logging level from warning to debug.
All users who want to investigate such messages would be able to see them with `LOGGING_LEVEL` set to `DEBUG`.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
