### PR TITLE
make matrix serializers use rapidjson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@
    * UPDATED: bump tz from 2025a to 2025b [#5164](https://github.com/valhalla/valhalla/pull/5164)
    * ADDED: Mutithreaded `PBFGraphParser::ParseWays()` [#5143](https://github.com/valhalla/valhalla/pull/5143)
    * CHANGED: "Multilevel Way" message logging level changed from WARN to DEBUG [#5188](https://github.com/valhalla/valhalla/pull/5188)
-   * Use rapidjson for valhalla matrix serializer [#5189](https://github.com/valhalla/valhalla/pull/5189)
+   * Use rapidjson for matrix serializers [#5189](https://github.com/valhalla/valhalla/pull/5189)
 
 ## Release Date: 2024-10-10 Valhalla 3.5.1
 * **Removed**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
    * UPDATED: bump tz from 2025a to 2025b [#5164](https://github.com/valhalla/valhalla/pull/5164)
    * ADDED: Mutithreaded `PBFGraphParser::ParseWays()` [#5143](https://github.com/valhalla/valhalla/pull/5143)
    * CHANGED: "Multilevel Way" message logging level changed from WARN to DEBUG [#5188](https://github.com/valhalla/valhalla/pull/5188)
+   * Use rapidjson for valhalla matrix serializer [#5189](https://github.com/valhalla/valhalla/pull/5189)
 
 ## Release Date: 2024-10-10 Valhalla 3.5.1
 * **Removed**

--- a/src/tyr/expansion_serializer.cc
+++ b/src/tyr/expansion_serializer.cc
@@ -16,7 +16,7 @@ std::string serializeExpansion(Api& request, const std::string& algo) {
   writer.start_object();
   writer("type", "FeatureCollection");
   writer.start_array("features");
-  writer.set_precision(6);
+  writer.set_precision(kCoordinatePrecision);
 
   std::unordered_set<Options::ExpansionProperties> exp_props;
   for (const auto& prop : request.options().expansion_properties()) {
@@ -54,20 +54,20 @@ std::string serializeExpansion(Api& request, const std::string& algo) {
 
     // make the properties
     if (exp_props.count(Options_ExpansionProperties_duration)) {
-      writer("duration", static_cast<uint64_t>(expansion.durations(i)));
+      writer("duration", expansion.durations(i));
     }
     if (exp_props.count(Options_ExpansionProperties_distance)) {
-      writer("distance", static_cast<uint64_t>(expansion.distances(i)));
+      writer("distance", expansion.distances(i));
     }
     if (exp_props.count(Options_ExpansionProperties_cost)) {
-      writer("cost", static_cast<uint64_t>(expansion.costs(i)));
+      writer("cost", expansion.costs(i));
     }
     if (exp_props.count(Options_ExpansionProperties_edge_status))
       writer("edge_status", Expansion_EdgeStatus_Enum_Name(expansion.edge_status(i)));
     if (exp_props.count(Options_ExpansionProperties_edge_id))
-      writer("edge_id", static_cast<uint64_t>(expansion.edge_id(i)));
+      writer("edge_id", expansion.edge_id(i));
     if (exp_props.count(Options_ExpansionProperties_pred_edge_id))
-      writer("pred_edge_id", static_cast<uint64_t>(expansion.pred_edge_id(i)));
+      writer("pred_edge_id", expansion.pred_edge_id(i));
     if (exp_props.count(Options_ExpansionProperties_expansion_type))
       writer("expansion_type", static_cast<uint64_t>(expansion.expansion_type(i)));
 

--- a/src/tyr/matrix_serializer.cc
+++ b/src/tyr/matrix_serializer.cc
@@ -43,11 +43,12 @@ void serialize_duration(const valhalla::Matrix& matrix,
 void serialize_distance(const valhalla::Matrix& matrix,
                         rapidjson::writer_wrapper_t& writer,
                         size_t start_td,
-                        const size_t td_count) {
+                        const size_t td_count,
+                        double distance_scale) {
   for (size_t i = start_td; i < start_td + td_count; ++i) {
     // check to make sure a route was found; if not, return null for distance in matrix result
     if (matrix.distances()[i] != kMaxCost) {
-      writer(static_cast<uint64_t>(matrix.distances()[i]));
+      writer(static_cast<uint64_t>(matrix.distances()[i]) * distance_scale);
     } else {
       writer(static_cast<std::nullptr_t>(nullptr));
     }
@@ -302,7 +303,7 @@ std::string serialize(const Api& request, double distance_scale) {
     for (int source_index = 0; source_index < options.sources_size(); ++source_index) {
       const auto first_td = source_index * options.targets_size();
       writer.start_array();
-      serialize_distance(request.matrix(), writer, first_td, options.targets_size());
+      serialize_distance(request.matrix(), writer, first_td, options.targets_size(), distance_scale);
       writer.end_array();
     }
     writer.end_array();

--- a/src/tyr/route_serializer_valhalla.cc
+++ b/src/tyr/route_serializer_valhalla.cc
@@ -136,16 +136,16 @@ void summary(const valhalla::Api& api, int route_index, rapidjson::writer_wrappe
   writer("has_toll", has_toll);
   writer("has_highway", has_highway);
   writer("has_ferry", has_ferry);
-  writer.set_precision(6);
+  writer.set_precision(tyr::kCoordinatePrecision);
   writer("min_lat", bbox.miny());
   writer("min_lon", bbox.minx());
   writer("max_lat", bbox.maxy());
   writer("max_lon", bbox.maxx());
-  writer.set_precision(3);
+  writer.set_precision(tyr::kDefaultPrecision);
   writer("time", route_time);
   writer.set_precision(api.options().units() == Options::miles ? 4 : 3);
   writer("length", route_length);
-  writer.set_precision(3);
+  writer.set_precision(tyr::kDefaultPrecision);
   writer("cost", route_cost);
   auto recost_itr = api.options().recostings().begin();
   for (auto recost : recost_times) {
@@ -158,7 +158,7 @@ void summary(const valhalla::Api& api, int route_index, rapidjson::writer_wrappe
   writer.end_object();
 
   writer("status_message", "Found route between points");
-  writer("status", static_cast<uint64_t>(0)); // 0 success
+  writer("status", 0); // 0 success
   writer("units", valhalla::Options_Units_Enum_Name(api.options().units()));
   writer("language", api.options().language());
 
@@ -168,7 +168,7 @@ void summary(const valhalla::Api& api, int route_index, rapidjson::writer_wrappe
 void locations(const valhalla::Api& api, int route_index, rapidjson::writer_wrapper_t& writer) {
 
   int index = 0;
-  writer.set_precision(6);
+  writer.set_precision(tyr::kCoordinatePrecision);
   writer.start_array("locations");
   for (const auto& leg : api.directions().routes(route_index).legs()) {
     for (auto location = leg.location().begin() + index; location != leg.location().end();
@@ -211,7 +211,7 @@ void locations(const valhalla::Api& api, int route_index, rapidjson::writer_wrap
         writer("side_of_street", Location_SideOfStreet_Enum_Name(location->side_of_street()));
       }
 
-      writer("original_index", static_cast<uint64_t>(location->correlation().original_index()));
+      writer("original_index", location->correlation().original_index());
 
       writer.end_object();
     }
@@ -239,12 +239,12 @@ void turn_lanes(const TripLeg& leg,
       writer.start_object();
 
       // Directions as a bit mask
-      writer("directions", static_cast<uint64_t>(turn_lane.directions_mask()));
+      writer("directions", turn_lane.directions_mask());
 
       if (turn_lane.state() == TurnLane::kActive) {
-        writer("active", static_cast<uint64_t>(turn_lane.active_direction()));
+        writer("active", turn_lane.active_direction());
       } else if (turn_lane.state() == TurnLane::kValid) {
-        writer("valid", static_cast<uint64_t>(turn_lane.active_direction()));
+        writer("valid", turn_lane.active_direction());
       }
 
       writer.end_object();
@@ -318,11 +318,11 @@ void legs(valhalla::Api& api, int route_index, rapidjson::writer_wrapper_t& writ
       if (!depart_maneuver) {
         uint32_t node_index = maneuver.begin_path_index();
         uint32_t in_brg = etp.GetPrevEdge(node_index)->end_heading();
-        writer("bearing_before", static_cast<uint64_t>(in_brg));
+        writer("bearing_before", in_brg);
       }
       if (!arrive_maneuver) {
         uint32_t out_brg = maneuver.begin_heading();
-        writer("bearing_after", static_cast<uint64_t>(out_brg));
+        writer("bearing_after", out_brg);
       }
 
       // Time, length, cost, and shape indexes
@@ -330,14 +330,14 @@ void legs(valhalla::Api& api, int route_index, rapidjson::writer_wrapper_t& writ
       const auto& begin_node = trip_leg_itr->node(maneuver.begin_path_index());
       auto cost = end_node.cost().elapsed_cost().cost() - begin_node.cost().elapsed_cost().cost();
 
-      writer.set_precision(3);
+      writer.set_precision(tyr::kDefaultPrecision);
       writer("time", maneuver.time());
       writer.set_precision(length_prec);
       writer("length", maneuver.length());
-      writer.set_precision(3);
+      writer.set_precision(tyr::kDefaultPrecision);
       writer("cost", cost);
-      writer("begin_shape_index", static_cast<uint64_t>(maneuver.begin_shape_index()));
-      writer("end_shape_index", static_cast<uint64_t>(maneuver.end_shape_index()));
+      writer("begin_shape_index", maneuver.begin_shape_index());
+      writer("end_shape_index", maneuver.end_shape_index());
       auto recost_itr = api.options().recostings().begin();
       auto begin_recost_itr = begin_node.recosts().begin();
       for (const auto& end_recost : end_node.recosts()) {
@@ -383,8 +383,7 @@ void legs(valhalla::Api& api, int route_index, rapidjson::writer_wrapper_t& writ
             writer("text", maneuver.sign().exit_numbers(i).text());
             // Add the exit number consecutive count only if greater than zero
             if (maneuver.sign().exit_numbers(i).consecutive_count() > 0) {
-              writer("consecutive_count",
-                     static_cast<uint64_t>(maneuver.sign().exit_numbers(i).consecutive_count()));
+              writer("consecutive_count", maneuver.sign().exit_numbers(i).consecutive_count());
             }
             writer.end_object();
           }
@@ -400,8 +399,7 @@ void legs(valhalla::Api& api, int route_index, rapidjson::writer_wrapper_t& writ
             writer("text", maneuver.sign().exit_onto_streets(i).text());
             // Add the exit branch consecutive count only if greater than zero
             if (maneuver.sign().exit_onto_streets(i).consecutive_count() > 0) {
-              writer("consecutive_count",
-                     static_cast<uint64_t>(maneuver.sign().exit_onto_streets(i).consecutive_count()));
+              writer("consecutive_count", maneuver.sign().exit_onto_streets(i).consecutive_count());
             }
             writer.end_object();
           }
@@ -418,8 +416,7 @@ void legs(valhalla::Api& api, int route_index, rapidjson::writer_wrapper_t& writ
             // Add the exit toward consecutive count only if greater than zero
             if (maneuver.sign().exit_toward_locations(i).consecutive_count() > 0) {
               writer("consecutive_count",
-                     static_cast<uint64_t>(
-                         maneuver.sign().exit_toward_locations(i).consecutive_count()));
+                     maneuver.sign().exit_toward_locations(i).consecutive_count());
             }
             writer.end_object();
           }
@@ -435,8 +432,7 @@ void legs(valhalla::Api& api, int route_index, rapidjson::writer_wrapper_t& writ
             writer("text", maneuver.sign().exit_names(i).text());
             // Add the exit name consecutive count only if greater than zero
             if (maneuver.sign().exit_names(i).consecutive_count() > 0) {
-              writer("consecutive_count",
-                     static_cast<uint64_t>(maneuver.sign().exit_names(i).consecutive_count()));
+              writer("consecutive_count", maneuver.sign().exit_names(i).consecutive_count());
             }
             writer.end_object();
           }
@@ -448,7 +444,7 @@ void legs(valhalla::Api& api, int route_index, rapidjson::writer_wrapper_t& writ
 
       // Roundabout count
       if (maneuver.roundabout_exit_count() > 0) {
-        writer("roundabout_exit_count", static_cast<uint64_t>(maneuver.roundabout_exit_count()));
+        writer("roundabout_exit_count", maneuver.roundabout_exit_count());
       }
 
       // Depart and arrive instructions
@@ -482,8 +478,8 @@ void legs(valhalla::Api& api, int route_index, rapidjson::writer_wrapper_t& writ
         if (!transit_info.headsign().empty()) {
           writer("headsign", transit_info.headsign());
         }
-        writer("color", static_cast<uint64_t>(transit_info.color()));
-        writer("text_color", static_cast<uint64_t>(transit_info.text_color()));
+        writer("color", transit_info.color());
+        writer("text_color", transit_info.text_color());
         if (!transit_info.description().empty()) {
           writer("description", transit_info.description());
         }
@@ -535,7 +531,7 @@ void legs(valhalla::Api& api, int route_index, rapidjson::writer_wrapper_t& writ
 
             // latitude and longitude
             if (transit_stop.has_ll()) {
-              writer.set_precision(6);
+              writer.set_precision(tyr::kCoordinatePrecision);
               writer("lat", transit_stop.ll().lat());
               writer("lon", transit_stop.ll().lng());
             }
@@ -618,10 +614,10 @@ void legs(valhalla::Api& api, int route_index, rapidjson::writer_wrapper_t& writ
         while (next_node_itr != trip_leg_itr->node().end()) {
           if (next_node_itr->admin_index() != node_itr->admin_index()) {
             writer.start_object();
-            writer("from_admin_index", static_cast<uint64_t>(node_itr->admin_index()));
-            writer("to_admin_index", static_cast<uint64_t>(next_node_itr->admin_index()));
-            writer("begin_shape_index", static_cast<uint64_t>(node_itr->edge().begin_shape_index()));
-            writer("end_shape_index", static_cast<uint64_t>(node_itr->edge().end_shape_index()));
+            writer("from_admin_index", node_itr->admin_index());
+            writer("to_admin_index", next_node_itr->admin_index());
+            writer("begin_shape_index", node_itr->edge().begin_shape_index());
+            writer("end_shape_index", node_itr->edge().end_shape_index());
             writer.end_object();
           }
           ++node_itr;
@@ -636,10 +632,10 @@ void legs(valhalla::Api& api, int route_index, rapidjson::writer_wrapper_t& writ
       writer.start_array("level_changes");
       for (auto& level_change : directions_leg.level_changes()) {
         writer.start_array();
-        writer(static_cast<int64_t>(level_change.shape_index()));
+        writer(level_change.shape_index());
         writer.set_precision(std::max(level_change.precision(), static_cast<uint32_t>(1)));
         writer(level_change.level());
-        writer.set_precision(3);
+        writer.set_precision(tyr::kDefaultPrecision);
         writer.end_array();
       }
       writer.end_array();
@@ -649,16 +645,16 @@ void legs(valhalla::Api& api, int route_index, rapidjson::writer_wrapper_t& writ
     writer("has_toll", has_toll);
     writer("has_highway", has_highway);
     writer("has_ferry", has_ferry);
-    writer.set_precision(6);
+    writer.set_precision(tyr::kCoordinatePrecision);
     writer("min_lat", directions_leg.summary().bbox().min_ll().lat());
     writer("min_lon", directions_leg.summary().bbox().min_ll().lng());
     writer("max_lat", directions_leg.summary().bbox().max_ll().lat());
     writer("max_lon", directions_leg.summary().bbox().max_ll().lng());
-    writer.set_precision(3);
+    writer.set_precision(tyr::kDefaultPrecision);
     writer("time", directions_leg.summary().time());
     writer.set_precision(length_prec);
     writer("length", directions_leg.summary().length());
-    writer.set_precision(3);
+    writer.set_precision(tyr::kDefaultPrecision);
     writer("cost", trip_leg_itr->node().rbegin()->cost().elapsed_cost().cost());
     auto recost_itr = api.options().recostings().begin();
     for (const auto& recost : trip_leg_itr->node().rbegin()->recosts()) {

--- a/src/tyr/serializers.cc
+++ b/src/tyr/serializers.cc
@@ -269,6 +269,20 @@ baldr::json::MapPtr geojson_shape(const std::vector<midgard::PointLL> shape) {
   geojson->emplace("coordinates", coords);
   return geojson;
 }
+
+void geojson_shape(const std::vector<midgard::PointLL> shape, rapidjson::writer_wrapper_t& writer) {
+  writer("type", "LineString");
+  writer.start_array("coordinates");
+  writer.set_precision(6);
+  for (const auto& p : shape) {
+    writer.start_array();
+    writer(p.lng());
+    writer(p.lat());
+    writer.end_array();
+  }
+  writer.set_precision(3);
+  writer.end_array();
+}
 } // namespace tyr
 } // namespace valhalla
 

--- a/src/tyr/serializers.cc
+++ b/src/tyr/serializers.cc
@@ -273,14 +273,14 @@ baldr::json::MapPtr geojson_shape(const std::vector<midgard::PointLL> shape) {
 void geojson_shape(const std::vector<midgard::PointLL> shape, rapidjson::writer_wrapper_t& writer) {
   writer("type", "LineString");
   writer.start_array("coordinates");
-  writer.set_precision(6);
+  writer.set_precision(tyr::kCoordinatePrecision);
   for (const auto& p : shape) {
     writer.start_array();
     writer(p.lng());
     writer(p.lat());
     writer.end_array();
   }
-  writer.set_precision(3);
+  writer.set_precision(kDefaultPrecision);
   writer.end_array();
 }
 } // namespace tyr
@@ -344,6 +344,55 @@ waypoint(const valhalla::Location& location, bool is_tracepoint, bool is_optimiz
 
   return waypoint;
 }
+void waypoint(const valhalla::Location& location,
+              rapidjson::writer_wrapper_t& writer,
+              bool is_tracepoint,
+              bool is_optimized) {
+  // Output location as a lon,lat array. Note this is the projected
+  // lon,lat on the nearest road.
+  writer.start_object();
+  writer.start_array("location");
+  writer.set_precision(kCoordinatePrecision);
+  writer(location.correlation().edges(0).ll().lng());
+  writer(location.correlation().edges(0).ll().lat());
+  writer.end_array();
+  writer.set_precision(kDefaultPrecision);
+
+  // Add street name.
+  std::string name =
+      location.correlation().edges_size() && location.correlation().edges(0).names_size()
+          ? location.correlation().edges(0).names(0)
+          : "";
+  writer("name", name);
+
+  // Add distance in meters from the input location to the nearest
+  // point on the road used in the route
+  // TODO: since distance was normalized in thor - need to recalculate here
+  //       in the future we shall have store separately from score
+  writer("distance", to_ll(location.ll()).Distance(to_ll(location.correlation().edges(0).ll())));
+
+  // If the location was used for a tracepoint we trigger extra serialization
+  if (is_tracepoint) {
+    writer("alternatives_count", location.correlation().edges_size() - 1);
+    if (location.correlation().waypoint_index() == numeric_limits<uint32_t>::max()) {
+      // when tracepoint is neither a break nor leg's starting/ending
+      // point (shape_index is uint32_t max), we assign null to its waypoint_index
+      writer("waypoint_index", nullptr);
+    } else {
+      writer("waypoint_index", location.correlation().waypoint_index());
+    }
+    writer("matchings_index", location.correlation().route_index());
+  }
+
+  // If the location was used for optimized route we add trips_index and waypoint
+  // index (index of the waypoint in the trip)
+  if (is_optimized) {
+    int trips_index = 0; // TODO
+    writer("trips_index", trips_index);
+    writer("waypoint_index", location.correlation().waypoint_index());
+  }
+  writer.end_object();
+}
 
 // Serialize locations (called waypoints in OSRM). Waypoints are described here:
 //     http://project-osrm.org/docs/v5.5.1/api/#waypoint-object
@@ -358,6 +407,18 @@ json::ArrayPtr waypoints(const google::protobuf::RepeatedPtrField<valhalla::Loca
     }
   }
   return waypoints;
+}
+
+void waypoints(const google::protobuf::RepeatedPtrField<valhalla::Location>& locations,
+               rapidjson::writer_wrapper_t& writer,
+               bool is_tracepoint) {
+  for (const auto& location : locations) {
+    if (location.correlation().edges().size() == 0) {
+      writer(nullptr);
+    } else {
+      waypoint(location, writer, is_tracepoint, false);
+    }
+  }
 }
 
 json::ArrayPtr waypoints(const valhalla::Trip& trip) {

--- a/src/tyr/trace_serializer.cc
+++ b/src/tyr/trace_serializer.cc
@@ -59,7 +59,7 @@ void serialize_edges(const AttributesController& controller,
 
       writer.start_object();
       if (controller(kEdgeTruckRoute)) {
-        writer("truck_route", static_cast<bool>(edge.truck_route()));
+        writer("truck_route", edge.truck_route());
       }
       if (controller(kEdgeTruckSpeed) && (edge.truck_speed() > 0)) {
         writer("truck_speed", static_cast<uint64_t>(std::round(edge.truck_speed() * scale)));
@@ -72,13 +72,13 @@ void serialize_edges(const AttributesController& controller,
         }
       }
       if (controller(kEdgeDensity)) {
-        writer("density", static_cast<uint64_t>(edge.density()));
+        writer("density", edge.density());
       }
       if (controller(kEdgeSacScale)) {
         writer("sac_scale", static_cast<uint64_t>(edge.sac_scale()));
       }
       if (controller(kEdgeShoulder)) {
-        writer("shoulder", static_cast<bool>(edge.shoulder()));
+        writer("shoulder", edge.shoulder());
       }
       if (controller(kEdgeSidewalk)) {
         writer("sidewalk", to_string(edge.sidewalk()));
@@ -90,7 +90,7 @@ void serialize_edges(const AttributesController& controller,
         writer("cycle_lane", to_string(static_cast<CycleLane>(edge.cycle_lane())));
       }
       if (controller(kEdgeLaneCount)) {
-        writer("lane_count", static_cast<uint64_t>(edge.lane_count()));
+        writer("lane_count", edge.lane_count());
       }
       if (edge.lane_connectivity_size()) {
         writer.start_array("lane_connectivity");
@@ -104,13 +104,13 @@ void serialize_edges(const AttributesController& controller,
         writer.end_array();
       }
       if (controller(kEdgeMaxDownwardGrade)) {
-        writer("max_downward_grade", static_cast<int64_t>(edge.max_downward_grade()));
+        writer("max_downward_grade", edge.max_downward_grade());
       }
       if (controller(kEdgeMaxUpwardGrade)) {
-        writer("max_upward_grade", static_cast<int64_t>(edge.max_upward_grade()));
+        writer("max_upward_grade", edge.max_upward_grade());
       }
       if (controller(kEdgeWeightedGrade)) {
-        writer.set_precision(3);
+        writer.set_precision(tyr::kDefaultPrecision);
         writer("weighted_grade", edge.weighted_grade());
       }
       if (controller(kEdgeMeanElevation)) {
@@ -124,10 +124,10 @@ void serialize_edges(const AttributesController& controller,
         }
       }
       if (controller(kEdgeWayId)) {
-        writer("way_id", static_cast<uint64_t>(edge.way_id()));
+        writer("way_id", edge.way_id());
       }
       if (controller(kEdgeId)) {
-        writer("id", static_cast<uint64_t>(edge.id()));
+        writer("id", edge.id());
       }
       if (controller(kEdgeTravelMode)) {
         writer("travel_mode", to_string(edge.travel_mode()));
@@ -148,22 +148,22 @@ void serialize_edges(const AttributesController& controller,
         writer("drive_on_right", static_cast<bool>(!edge.drive_on_left()));
       }
       if (controller(kEdgeInternalIntersection)) {
-        writer("internal_intersection", static_cast<bool>(edge.internal_intersection()));
+        writer("internal_intersection", edge.internal_intersection());
       }
       if (controller(kEdgeRoundabout)) {
-        writer("roundabout", static_cast<bool>(edge.roundabout()));
+        writer("roundabout", edge.roundabout());
       }
       if (controller(kEdgeBridge)) {
-        writer("bridge", static_cast<bool>(edge.bridge()));
+        writer("bridge", edge.bridge());
       }
       if (controller(kEdgeTunnel)) {
-        writer("tunnel", static_cast<bool>(edge.tunnel()));
+        writer("tunnel", edge.tunnel());
       }
       if (controller(kEdgeUnpaved)) {
-        writer("unpaved", static_cast<bool>(edge.unpaved()));
+        writer("unpaved", edge.unpaved());
       }
       if (controller(kEdgeToll)) {
-        writer("toll", static_cast<bool>(edge.toll()));
+        writer("toll", edge.toll());
       }
       if (controller(kEdgeUse)) {
         writer("use", to_string(static_cast<baldr::Use>(edge.use())));
@@ -172,16 +172,16 @@ void serialize_edges(const AttributesController& controller,
         writer("traversability", to_string(edge.traversability()));
       }
       if (controller(kEdgeEndShapeIndex)) {
-        writer("end_shape_index", static_cast<uint64_t>(edge.end_shape_index()));
+        writer("end_shape_index", edge.end_shape_index());
       }
       if (controller(kEdgeBeginShapeIndex)) {
-        writer("begin_shape_index", static_cast<uint64_t>(edge.begin_shape_index()));
+        writer("begin_shape_index", edge.begin_shape_index());
       }
       if (controller(kEdgeEndHeading)) {
-        writer("end_heading", static_cast<uint64_t>(edge.end_heading()));
+        writer("end_heading", edge.end_heading());
       }
       if (controller(kEdgeBeginHeading)) {
-        writer("begin_heading", static_cast<uint64_t>(edge.begin_heading()));
+        writer("begin_heading", edge.begin_heading());
       }
       if (controller(kEdgeRoadClass)) {
         writer("road_class", to_string(static_cast<baldr::RoadClass>(edge.road_class())));
@@ -190,10 +190,10 @@ void serialize_edges(const AttributesController& controller,
         writer("speed", static_cast<uint64_t>(std::round(edge.speed() * scale)));
       }
       if (controller(kEdgeCountryCrossing)) {
-        writer("country_crossing", static_cast<bool>(edge.country_crossing()));
+        writer("country_crossing", edge.country_crossing());
       }
       if (controller(kEdgeForward)) {
-        writer("forward", static_cast<bool>(edge.forward()));
+        writer("forward", edge.forward());
       }
       if (controller(kEdgeLevels)) {
         if (edge.levels_size()) {
@@ -201,16 +201,16 @@ void serialize_edges(const AttributesController& controller,
           writer.set_precision(edge.level_precision());
           for (const auto& level : edge.levels()) {
             writer.start_array();
-            writer(static_cast<float>(level.start()));
-            writer(static_cast<float>(level.end()));
+            writer(level.start());
+            writer(level.end());
             writer.end_array();
           }
           writer.end_array();
-          writer.set_precision(3);
+          writer.set_precision(tyr::kDefaultPrecision);
         }
       }
       if (controller(kEdgeLength)) {
-        writer.set_precision(3);
+        writer.set_precision(tyr::kDefaultPrecision);
         writer("length", edge.length_km() * scale);
         if (edge.source_along_edge() != 0.f) {
           writer("source_percent_along", edge.source_along_edge());
@@ -231,7 +231,7 @@ void serialize_edges(const AttributesController& controller,
         writer.start_array("traffic_segments");
         for (const auto& segment : edge.traffic_segment()) {
           writer.start_object();
-          writer.set_precision(3);
+          writer.set_precision(tyr::kDefaultPrecision);
           writer("segment_id", segment.segment_id());
           writer("begin_percent", segment.begin_percent());
           writer("end_percent", segment.end_percent());
@@ -306,13 +306,13 @@ void serialize_edges(const AttributesController& controller,
               writer("driveability", to_string(xedge.driveability()));
             }
             if (controller(kNodeIntersectingEdgeFromEdgeNameConsistency)) {
-              writer("from_edge_name_consistency", static_cast<bool>(xedge.prev_name_consistency()));
+              writer("from_edge_name_consistency", xedge.prev_name_consistency());
             }
             if (controller(kNodeIntersectingEdgeToEdgeNameConsistency)) {
-              writer("to_edge_name_consistency", static_cast<bool>(xedge.curr_name_consistency()));
+              writer("to_edge_name_consistency", xedge.curr_name_consistency());
             }
             if (controller(kNodeIntersectingEdgeBeginHeading)) {
-              writer("begin_heading", static_cast<uint64_t>(xedge.begin_heading()));
+              writer("begin_heading", xedge.begin_heading());
             }
             if (controller(kNodeIntersectingEdgeUse)) {
               writer("use", to_string(static_cast<baldr::Use>(xedge.use())));
@@ -326,27 +326,27 @@ void serialize_edges(const AttributesController& controller,
         }
 
         if (controller(kNodeElapsedTime)) {
-          writer.set_precision(3);
+          writer.set_precision(tyr::kDefaultPrecision);
           writer("elapsed_time", node.cost().elapsed_cost().seconds());
           writer("elapsed_cost", node.cost().elapsed_cost().cost());
         }
         if (controller(kNodeAdminIndex)) {
-          writer("admin_index", static_cast<uint64_t>(node.admin_index()));
+          writer("admin_index", node.admin_index());
         }
         if (controller(kNodeType)) {
           writer("type", to_string(static_cast<baldr::NodeType>(node.type())));
         }
         if (controller(kNodeTrafficSignal)) {
-          writer("traffic_signal", static_cast<bool>(node.traffic_signal()));
+          writer("traffic_signal", node.traffic_signal());
         }
         if (controller(kNodeFork)) {
-          writer("fork", static_cast<bool>(node.fork()));
+          writer("fork", node.fork());
         }
         if (controller(kNodeTimeZone) && !node.time_zone().empty()) {
           writer("time_zone", node.time_zone());
         }
         if (controller(kNodeTransitionTime)) {
-          writer.set_precision(3);
+          writer.set_precision(tyr::kDefaultPrecision);
           writer("transition_time", node.cost().transition_cost().seconds());
         }
 
@@ -392,7 +392,7 @@ void serialize_matched_points(const AttributesController& controller,
 
     // Process matched point
     if (controller(kMatchedPoint)) {
-      writer.set_precision(6);
+      writer.set_precision(tyr::kCoordinatePrecision);
       writer("lon", match_result.lnglat.first);
       writer("lat", match_result.lnglat.second);
     }
@@ -421,25 +421,25 @@ void serialize_matched_points(const AttributesController& controller,
 
     // Process matched point begin route discontinuity
     if (controller(kMatchedBeginRouteDiscontinuity) && match_result.begins_discontinuity) {
-      writer("begin_route_discontinuity", static_cast<bool>(match_result.begins_discontinuity));
+      writer("begin_route_discontinuity", match_result.begins_discontinuity);
     }
 
     // Process matched point end route discontinuity
     if (controller(kMatchedEndRouteDiscontinuity) && match_result.ends_discontinuity) {
-      writer("end_route_discontinuity", static_cast<bool>(match_result.ends_discontinuity));
+      writer("end_route_discontinuity", match_result.ends_discontinuity);
     }
 
     // Process matched point distance along edge
     if (controller(kMatchedDistanceAlongEdge) &&
         (match_result.GetType() != meili::MatchResult::Type::kUnmatched)) {
-      writer.set_precision(6);
+      writer.set_precision(tyr::kCoordinatePrecision);
       writer("distance_along_edge", match_result.distance_along);
     }
 
     // Process matched point distance from trace point
     if (controller(kMatchedDistanceFromTracePoint) &&
         (match_result.GetType() != meili::MatchResult::Type::kUnmatched)) {
-      writer.set_precision(6);
+      writer.set_precision(tyr::kCoordinatePrecision);
       writer("distance_from_trace_point", match_result.distance_from);
     }
     writer.end_object();
@@ -451,7 +451,7 @@ void serialize_shape_attributes(const AttributesController& controller,
                                 const TripLeg& trip_path,
                                 rapidjson::writer_wrapper_t& writer) {
   writer.start_object("shape_attributes");
-  writer.set_precision(3);
+  writer.set_precision(tyr::kDefaultPrecision);
   if (controller(kShapeAttributesTime)) {
     writer.start_array("time");
     for (const auto& time : trip_path.shape_attributes().time()) {
@@ -500,13 +500,13 @@ void append_trace_info(
 
   // Add confidence_score
   if (controller(kConfidenceScore)) {
-    writer.set_precision(3);
+    writer.set_precision(tyr::kDefaultPrecision);
     writer("confidence_score", std::get<kConfidenceScoreIndex>(map_match_result));
   }
 
   // Add raw_score
   if (controller(kRawScore)) {
-    writer.set_precision(3);
+    writer.set_precision(tyr::kDefaultPrecision);
     writer("raw_score", std::get<kRawScoreIndex>(map_match_result));
   }
 

--- a/test/matrix.cc
+++ b/test/matrix.cc
@@ -507,8 +507,8 @@ TEST(Matrix, default_matrix) {
             json["sources_to_targets"].GetArray()[0][1].MemberCapacity());
 
   // first values in the object
-  EXPECT_DOUBLE_EQ(json["sources_to_targets"].GetArray()[0][0].GetObject()["distance"].GetDouble(),
-                   5.88);
+  EXPECT_NEAR(json["sources_to_targets"].GetArray()[0][0].GetObject()["distance"].GetDouble(), 5.88,
+              0.0001);
   EXPECT_EQ(json["sources_to_targets"].GetArray()[0][0].GetObject()["time"].GetInt64(), 473);
   EXPECT_EQ(json["sources_to_targets"].GetArray()[0][0].GetObject()["to_index"].GetInt64(), 0);
   EXPECT_EQ(json["sources_to_targets"].GetArray()[0][0].GetObject()["from_index"].GetInt64(), 0);
@@ -558,7 +558,7 @@ TEST(Matrix, slim_matrix) {
             json["sources_to_targets"].GetObject()["distances"][0].Size());
 
   // first value of "distances" array
-  EXPECT_DOUBLE_EQ(json["sources_to_targets"].GetObject()["distances"][0][0].GetDouble(), 5.88);
+  EXPECT_NEAR(json["sources_to_targets"].GetObject()["distances"][0][0].GetDouble(), 5.88, 0.0001);
 
   // first value of "durations" array
   EXPECT_EQ(json["sources_to_targets"].GetObject()["durations"][0][0].GetInt64(), 473);

--- a/valhalla/baldr/rapidjson_utils.h
+++ b/valhalla/baldr/rapidjson_utils.h
@@ -340,13 +340,14 @@ public:
       static_assert(always_false<K>, "Unsupported key type");
     }
 
-    if constexpr (std::is_same_v<V, int> || std::is_same_v<V, int32_t>) {
+    if constexpr (std::is_same_v<V, int> || std::is_same_v<V, int32_t> || std::is_same_v<V, long>) {
       writer.Int64(static_cast<int64_t>(value));
-    } else if constexpr (std::is_same_v<V, unsigned int> || std::is_same_v<V, uint32_t>) {
+    } else if constexpr (std::is_same_v<V, unsigned int> || std::is_same_v<V, uint32_t> ||
+                         std::is_same_v<V, unsigned long>) {
       writer.Uint64(static_cast<uint64_t>(value));
-    } else if constexpr (std::is_same_v<V, uint64_t>) {
+    } else if constexpr (std::is_same_v<V, uint64_t> || std::is_same_v<V, unsigned long long>) {
       writer.Uint64(value);
-    } else if constexpr (std::is_same_v<V, int64_t>) {
+    } else if constexpr (std::is_same_v<V, int64_t> || std::is_same_v<V, long long>) {
       writer.Int64(value);
     } else if constexpr (std::is_same_v<V, double> || std::is_same_v<V, float>) {
       writer.Double(value);

--- a/valhalla/baldr/rapidjson_utils.h
+++ b/valhalla/baldr/rapidjson_utils.h
@@ -348,14 +348,14 @@ public:
       writer.Uint64(value);
     } else if constexpr (std::is_same_v<V, int64_t>) {
       writer.Int64(value);
-    } else if constexpr (is_string_like_v<V>) {
-      writer.String(value);
     } else if constexpr (std::is_same_v<V, double> || std::is_same_v<V, float>) {
       writer.Double(value);
     } else if constexpr (std::is_same_v<V, bool>) {
       writer.Bool(value);
     } else if constexpr (std::is_same_v<V, std::nullptr_t>) {
       writer.Null();
+    } else if constexpr (is_string_like_v<V>) {
+      writer.String(value);
     } else {
       static_assert(always_false<V>, "Unsupported value type");
     }
@@ -370,14 +370,14 @@ public:
       writer.Uint64(value);
     } else if constexpr (std::is_same_v<V, int64_t>) {
       writer.Int64(value);
-    } else if constexpr (is_string_like_v<V>) {
-      writer.String(value);
     } else if constexpr (std::is_same_v<V, double> || std::is_same_v<V, float>) {
       writer.Double(value);
     } else if constexpr (std::is_same_v<V, bool>) {
       writer.Bool(value);
     } else if constexpr (std::is_same_v<V, std::nullptr_t>) {
       writer.Null();
+    } else if constexpr (is_string_like_v<V>) {
+      writer.String(value);
     } else {
       static_assert(always_false<V>, "Unsupported value type");
     }

--- a/valhalla/tyr/serializers.h
+++ b/valhalla/tyr/serializers.h
@@ -21,6 +21,9 @@
 namespace valhalla {
 namespace tyr {
 
+constexpr unsigned int kDefaultPrecision = 3;
+constexpr unsigned int kCoordinatePrecision = 6;
+
 /**
  * Turn path and directions into a route that one can follow
  */
@@ -256,6 +259,10 @@ namespace osrm {
  */
 valhalla::baldr::json::MapPtr
 waypoint(const valhalla::Location& location, bool is_tracepoint = false, bool is_optimized = false);
+void waypoint(const valhalla::Location& location,
+              rapidjson::writer_wrapper_t& writer,
+              bool is_tracepoint = false,
+              bool is_optimized = false);
 
 /*
  * Serialize locations into osrm waypoints
@@ -263,6 +270,9 @@ waypoint(const valhalla::Location& location, bool is_tracepoint = false, bool is
 valhalla::baldr::json::ArrayPtr
 waypoints(const google::protobuf::RepeatedPtrField<valhalla::Location>& locations,
           bool tracepoints = false);
+void waypoints(const google::protobuf::RepeatedPtrField<valhalla::Location>& locations,
+               rapidjson::writer_wrapper_t& writer,
+               bool tracepoints = false);
 valhalla::baldr::json::ArrayPtr waypoints(const valhalla::Trip& locations);
 valhalla::baldr::json::ArrayPtr intermediate_waypoints(const valhalla::TripLeg& leg);
 

--- a/valhalla/tyr/serializers.h
+++ b/valhalla/tyr/serializers.h
@@ -131,6 +131,7 @@ baldr::json::ArrayPtr serializeWarnings(const valhalla::Api& api);
  * @returns The GeoJSON geometry of the LineString
  */
 baldr::json::MapPtr geojson_shape(const std::vector<midgard::PointLL> shape);
+void geojson_shape(const std::vector<midgard::PointLL> shape, rapidjson::writer_wrapper_t& writer);
 
 // Elevation serialization support
 


### PR DESCRIPTION
# Issue

Switches the valhalla and osrm matrix_serializers from valhalla's internal json serializer to rapidjson (see #5190).

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
