### PR TITLE
Fix multi-edge steps maneuver, improved stairs maneuvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -377,6 +377,7 @@
    * FIXED: Osmway struct update: added up to 33 and not 32 [#3808](https://github.com/valhalla/valhalla/pull/3808)
    * FIXED: Fix out-of-range linestrings in expansion [#4603](https://github.com/valhalla/valhalla/pull/4603)
    * FIXED: Osmway struct update: used 1 bit for multiple levels from spare bits [#5112](https://github.com/valhalla/valhalla/issues/5112)
+   * FIXES: multi-edge steps maneuvers [#5191](https://github.com/valhalla/valhalla/pull/5191)
 
 * **Enhancement**
    * CHANGED: Pronunciation for names and destinations [#3132](https://github.com/valhalla/valhalla/pull/3132)

--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -885,9 +885,14 @@ ManeuversBuilder::CombineManeuvers(std::list<Maneuver>& maneuvers,
     curr_man->set_elevator(true);
   }
 
-  // If needed, set steps
+  // If needed, set indoor steps
   if (next_man->indoor_steps()) {
     curr_man->set_indoor_steps(true);
+  }
+
+  // If needed, set steps
+  if (next_man->is_steps()) {
+    curr_man->set_steps(true);
   }
 
   // If needed, set escalator
@@ -2212,6 +2217,18 @@ bool ManeuversBuilder::CanManeuverIncludePrevEdge(Maneuver& maneuver, int node_i
     return false;
   }
   if (maneuver.indoor_steps() && prev_edge->IsStepsUse() && prev_edge->indoor()) {
+    return true;
+  }
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Process steps
+  if (maneuver.is_steps() && !(prev_edge->IsStepsUse())) {
+    return false;
+  }
+  if (prev_edge->IsStepsUse() && !maneuver.is_steps()) {
+    return false;
+  }
+  if (maneuver.is_steps() && prev_edge->IsStepsUse()) {
     return true;
   }
 

--- a/src/odin/narrativebuilder.cc
+++ b/src/odin/narrativebuilder.cc
@@ -482,7 +482,16 @@ void NarrativeBuilder::Build(std::list<Maneuver>& maneuvers) {
       }
       case DirectionsLeg_Maneuver_Type_kStepsEnter: {
         // Set instruction
-        maneuver.set_instruction(FormStepsInstruction(maneuver));
+        auto instr = FormStepsInstruction(maneuver);
+        maneuver.set_instruction(instr);
+        maneuver.set_verbal_transition_alert_instruction(instr);
+
+        // Set verbal pre transition instruction
+        maneuver.set_verbal_pre_transition_instruction(instr);
+
+        // Set verbal post transition instruction
+        maneuver.set_verbal_post_transition_instruction(
+            FormVerbalPostTransitionInstruction(maneuver));
         break;
       }
       case DirectionsLeg_Maneuver_Type_kEscalatorEnter: {

--- a/test/gurka/test_indoor.cc
+++ b/test/gurka/test_indoor.cc
@@ -221,8 +221,10 @@ TEST_F(Indoor, IndoorStepsManeuver) {
   // Verify steps instructions
   int maneuver_index = 1;
   gurka::assert::raw::expect_instructions_at_maneuver_index(result, maneuver_index,
-                                                            "Take the stairs to Parking.", "", "", "",
-                                                            "");
+                                                            "Take the stairs to Parking.", "",
+                                                            "Take the stairs to Parking.",
+                                                            "Take the stairs to Parking.",
+                                                            "Continue for 200 meters.");
 }
 
 TEST_F(Indoor, OutdoorStepsManeuver) {
@@ -238,7 +240,9 @@ TEST_F(Indoor, OutdoorStepsManeuver) {
   // Verify steps instructions
   int maneuver_index = 1;
   gurka::assert::raw::expect_instructions_at_maneuver_index(result, maneuver_index,
-                                                            "Take the stairs.", "", "", "", "");
+                                                            "Take the stairs.", "",
+                                                            "Take the stairs.", "Take the stairs.",
+                                                            "Continue for 200 meters.");
 }
 
 TEST_F(Indoor, EscalatorManeuver) {
@@ -304,8 +308,10 @@ TEST_F(Indoor, CombineStepsManeuvers) {
   // Verify steps instructions
   int maneuver_index = 1;
   gurka::assert::raw::expect_instructions_at_maneuver_index(result, maneuver_index,
-                                                            "Take the stairs to Level 3.", "", "", "",
-                                                            "");
+                                                            "Take the stairs to Level 3.", "",
+                                                            "Take the stairs to Level 3.",
+                                                            "Take the stairs to Level 3.",
+                                                            "Continue for 2 kilometers.");
 }
 
 // Dont combine maneuvers if there is a level change
@@ -322,8 +328,10 @@ TEST_F(Indoor, OutdoorStepsLevelChange) {
   // Verify steps instructions
   int maneuver_index = 1;
   gurka::assert::raw::expect_instructions_at_maneuver_index(result, maneuver_index,
-                                                            "Take the stairs to Level 4.", "", "", "",
-                                                            "");
+                                                            "Take the stairs to Level 4.", "",
+                                                            "Take the stairs to Level 4.",
+                                                            "Take the stairs to Level 4.",
+                                                            "Continue for 300 meters.");
 }
 TEST_F(Indoor, StepsLevelChanges) {
   // get a route via steps and check the level changelog
@@ -431,6 +439,54 @@ TEST(Standalone, ElevatorMultiCueInstructions) {
       expect_instructions_at_maneuver_index(result, maneuver_index, "Take the elevator to Level 3.",
                                             "", "Take the elevator to Level 3.",
                                             "Take the elevator to Level 3. Then Turn right onto CF.",
+                                            "Continue for less than 10 meters.");
+}
+
+TEST(Standalone, MultiEdgeSteps) {
+  constexpr double gridsize_metres = 1;
+
+  const std::string ascii_map = R"(
+              E 
+              |
+      z---A---B--C---D---x
+                 |
+                 F
+    )";
+
+  const gurka::ways ways = {
+      {"zA", {{"highway", "footway"}, {"level", "0"}}},
+      {"ABCD", {{"highway", "steps"}, {"level", "1;2;3;4"}}},
+      {"BE", {{"highway", "corridor"}, {"indoor", "yes"}, {"level", "2"}}},
+      {"CF", {{"highway", "corridor"}, {"indoor", "yes"}, {"level", "3"}}},
+      {"Dx", {{"highway", "footway"}, {"level", "4"}}},
+  };
+
+  const auto layout =
+      gurka::detail::map_to_coordinates(ascii_map, gridsize_metres, {5.1079374, 52.0887174});
+  auto map =
+      gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_multi_edge_steps", build_config);
+
+  auto result = gurka::do_action(valhalla::Options::route, map, {"z", "x"}, "pedestrian",
+                                 {
+                                     {"/locations/0/node_snap_tolerance", "0"},
+                                     {"/locations/1/node_snap_tolerance", "0"},
+                                     {"/locations/0/radius", "1"},
+                                     {"/locations/1/radius", "1"},
+                                 });
+  gurka::assert::raw::expect_path(result, {"zA", "ABCD", "ABCD", "ABCD", "Dx"});
+
+  // Verify maneuver types
+  gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
+                                                DirectionsLeg_Maneuver_Type_kStepsEnter,
+                                                DirectionsLeg_Maneuver_Type_kContinue,
+                                                DirectionsLeg_Maneuver_Type_kDestination});
+
+  // Verify steps instructions
+  int maneuver_index = 1;
+  gurka::assert::raw::
+      expect_instructions_at_maneuver_index(result, maneuver_index, "Take the stairs to Level 4.", "",
+                                            "Take the stairs to Level 4.",
+                                            "Take the stairs to Level 4. Then Continue on Dx.",
                                             "Continue for less than 10 meters.");
 }
 /****************************************************************************************/


### PR DESCRIPTION
# Issue

Routes following multiple subsequent edges with `use=kSteps` and `indoor=false` were generating one maneuver for each edge. This PR fixes this and adds some more detailed instructions for stairs. 

## Tasklist

 - [x] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
