### PR TITLE
perf: Clip admin/languages/timezones polygons by tile bbox for faster calculus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
    * UPDATED: bump tz from 2025a to 2025b [#5164](https://github.com/valhalla/valhalla/pull/5164)
    * ADDED: Mutithreaded `PBFGraphParser::ParseWays()` [#5143](https://github.com/valhalla/valhalla/pull/5143)
    * CHANGED: "Multilevel Way" message logging level changed from WARN to DEBUG [#5188](https://github.com/valhalla/valhalla/pull/5188)
+   * CHANGED: Clip admin/languages/timezones polygons by tile bbox for faster calculus [#5193](https://github.com/valhalla/valhalla/pull/5193)
 
 ## Release Date: 2024-10-10 Valhalla 3.5.1
 * **Removed**

--- a/src/mjolnir/admin.cc
+++ b/src/mjolnir/admin.cc
@@ -13,10 +13,12 @@ namespace mjolnir {
 
 namespace {
 
-// Replace polygon by bbox if it is entirely inside the polygon for faster calculus.
+// Replace polygon by bbox if the bbox is entirely inside the polygon for faster calculus.
 // Sadly, `bg::intersection(bg::multi_polygon, bg::multi_polygon)` produces too many points,
-// while `bg::intersection(bg::box, bg::multi_polygon)` doesn't work in all cases (sometimes
-// produces bad multi_polygon) if bbox is not fully covered by polygon.
+// while `bg::intersection(bg::box, bg::multi_polygon)` fails in some cases (sometimes
+// produces incomplete `multi_polygon`) if bbox is not fully covered by polygon - clipping a polygon
+// might produce multiple polygons, and boost appears to process each polygon in the multi_polygon
+// sequentially, potentially losing some parts.
 void ClipPolygon(multi_polygon_type& poly, const AABB2<PointLL>& bbox) {
   multi_polygon_type bbox_poly;
   bg::convert(bg::model::box<point_type>{{bbox.minx(), bbox.miny()}, {bbox.maxx(), bbox.maxy()}},

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -509,9 +509,18 @@ void BuildTileSet(const std::string& ways_file,
       std::unordered_map<uint32_t, bool> allow_intersection_names;
       language_poly_index language_polys;
 
+      // Tile might contain nodes slightly beyond the bbox.
+      const AABB2<PointLL> tile_bbox = [id, &tiling]() {
+        const double eps = 1e-3;
+        AABB2<PointLL> tile_bounds = tiling.TileBounds(id);
+        AABB2<PointLL> bbox(tile_bounds.minx() - eps, tile_bounds.miny() - eps,
+                            tile_bounds.maxx() + eps, tile_bounds.maxy() + eps);
+        return bbox;
+      }();
+
       if (admin_db_handle) {
         admin_polys = GetAdminInfo(admin_db_handle, drive_on_right, allow_intersection_names,
-                                   language_polys, tiling.TileBounds(id), graphtile);
+                                   language_polys, tile_bbox, graphtile);
         if (admin_polys.size() == 1) {
           // TODO - check if tile bounding box is entirely inside the polygon...
           tile_within_one_admin = true;
@@ -519,7 +528,7 @@ void BuildTileSet(const std::string& ways_file,
       }
 
       bool tile_within_one_tz = false;
-      auto tz_polys = GetTimeZones(tz_db_handle, tiling.TileBounds(id));
+      auto tz_polys = GetTimeZones(tz_db_handle, tile_bbox);
       if (tz_polys.size() == 1) {
         tile_within_one_tz = true;
       }


### PR DESCRIPTION
# Issue

Reduces CPU usage during "build" stage by clipping admin polygons that fully cover the tile.

Sadly, I was unable to measure any difference with planet build on AWS EC2 as "build" stage hits EBS read throughput. Still, I see the difference on a small extracts on my M3 Max (`BuildLocalTiles` timings for europe-latest.osm.pbf reduced from 1998s to 1030s).

CPU graph from m7a.4xlarge with the whole planet build:
<img width="1554" alt="image" src="https://github.com/user-attachments/assets/2b20b36e-e3c1-4f92-9d8c-a2b273293d67" />

- Blue line - master
- Orange line - from the PR
- Purple text - my annotations what is happening 

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
