### PR TITLE
perf: Replace `boost::geometry` by GEOS for operations with admin/tz polygons and clip them by tile bbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
    * CHANGED: Make static factor vectors/arrays in sif constexpr [#5200](https://github.com/valhalla/valhalla/pull/5200)
    * ADDED: Sqlite3 RAII wrapper around sqlite3* and spatielite connection [#5206](https://github.com/valhalla/valhalla/pull/5206)
    * CHANGED: Improved SQL statements when building admins [#5219](https://github.com/valhalla/valhalla/pull/5219)
+   * CHANGED: Replace `boost::geometry` by GEOS for operations with admin/tz polygons and clip them by tile bbox [#5204](https://github.com/valhalla/valhalla/pull/5204)
 
 ## Release Date: 2024-10-10 Valhalla 3.5.1
 * **Removed**

--- a/src/mjolnir/admin.cc
+++ b/src/mjolnir/admin.cc
@@ -378,7 +378,7 @@ GetAdminInfo(AdminDB& db,
 }
 
 // Get all the country access records from the db and save them to a map.
-std::unordered_map<std::string, std::vector<int>> GetCountryAccess(Sqlite3& db) {
+std::unordered_map<std::string, std::vector<int>> GetCountryAccess(AdminDB& db) {
   std::unordered_map<std::string, std::vector<int>> country_access;
   sqlite3_stmt* stmt = 0;
   uint32_t ret;

--- a/src/mjolnir/admin.cc
+++ b/src/mjolnir/admin.cc
@@ -203,7 +203,7 @@ void GetData(AdminDB& db,
              std::multimap<uint32_t, Geometry>& polys,
              std::unordered_map<uint32_t, bool>& drive_on_right,
              std::unordered_map<uint32_t, bool>& allow_intersection_names,
-             language_poly_index& language_ploys,
+             language_poly_index& language_polys,
              bool languages_only = false) {
   uint32_t result = 0;
   bool dor = true;
@@ -274,11 +274,11 @@ void GetData(AdminDB& db,
 
       if (!default_language.empty()) {
         auto langs = ParseLanguageTokens(default_language);
-        language_ploys.push_back(std::make_tuple(geom.clone(), langs, true));
+        language_polys.push_back(std::make_tuple(geom.clone(), std::move(langs), true));
       }
       if (!supported_languages.empty()) {
         auto langs = ParseLanguageTokens(supported_languages);
-        language_ploys.push_back(std::make_tuple(geom.clone(), langs, false));
+        language_polys.push_back(std::make_tuple(geom.clone(), std::move(langs), false));
       }
 
       polys.emplace(index, std::move(geom));
@@ -308,11 +308,11 @@ void GetData(AdminDB& db,
 
       if (!default_language.empty()) {
         auto langs = ParseLanguageTokens(default_language);
-        language_ploys.push_back(std::make_tuple(geom.clone(), langs, true));
+        language_polys.push_back(std::make_tuple(geom.clone(), std::move(langs), true));
       }
       if (!supported_languages.empty()) {
         auto langs = ParseLanguageTokens(supported_languages);
-        language_ploys.push_back(std::make_tuple(std::move(geom), langs, false));
+        language_polys.push_back(std::make_tuple(std::move(geom), std::move(langs), false));
       }
     }
 

--- a/src/mjolnir/admin.cc
+++ b/src/mjolnir/admin.cc
@@ -1,9 +1,10 @@
 #include "mjolnir/admin.h"
 #include "baldr/datetime.h"
-#include "mjolnir/sqlite3.h"
 #include "mjolnir/util.h"
 
 #include <geos_c.h>
+#include <sqlite3.h>
+
 #include <unordered_map>
 
 namespace valhalla {
@@ -37,7 +38,7 @@ AdminDB::~AdminDB() {
 }
 
 std::optional<AdminDB> AdminDB::open(const std::string& path) {
-  auto db = Sqlite3::open(path);
+  auto db = Sqlite3::open(path, SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX);
   if (db) {
     return AdminDB(std::move(*db));
   }

--- a/src/mjolnir/adminbuilder.cc
+++ b/src/mjolnir/adminbuilder.cc
@@ -1,9 +1,5 @@
-#include <cstdint>
-#include <string>
-#include <vector>
-
-#include "filesystem.h"
 #include "mjolnir/adminbuilder.h"
+#include "filesystem.h"
 #include "mjolnir/adminconstants.h"
 #include "mjolnir/pbfadminparser.h"
 #include "mjolnir/sqlite3.h"
@@ -14,6 +10,11 @@
 #include <boost/property_tree/ptree.hpp>
 
 #include <geos_c.h>
+#include <sqlite3.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
 
 BOOST_GEOMETRY_REGISTER_POINT_2D(valhalla::midgard::PointLL,
                                  double,

--- a/src/mjolnir/convert_transit.cc
+++ b/src/mjolnir/convert_transit.cc
@@ -1168,11 +1168,10 @@ void build_tiles(const boost::property_tree::ptree& pt,
 
     // Add routes to the tile. Get vector of route types.
     std::vector<uint32_t> route_types = AddRoutes(tile_pbf, tilebuilder_transit);
-    auto tile_bounds = tiles.TileBounds(tile_id.tileid());
     bool tile_within_one_tz = false;
     std::multimap<uint32_t, Geometry> tz_polys;
     if (tz_db) {
-      tz_polys = GetTimeZones(*tz_db, tile_bounds);
+      tz_polys = GetTimeZones(*tz_db, tiles.TileBounds(tile_id.tileid()));
       if (tz_polys.size() < 2) {
         tile_within_one_tz = true;
       }

--- a/src/mjolnir/convert_transit.cc
+++ b/src/mjolnir/convert_transit.cc
@@ -529,7 +529,6 @@ void AddToGraph(GraphTileBuilder& tilebuilder_transit,
                 const std::unordered_map<uint32_t, Shape>& shape_data,
                 const std::vector<float>& distances,
                 const std::vector<uint32_t>& route_types,
-                bool tile_within_one_tz,
                 const std::multimap<uint32_t, Geometry>& tz_polys,
                 uint32_t& no_dir_edge_count) {
   auto t1 = std::chrono::high_resolution_clock::now();
@@ -604,7 +603,7 @@ void AddToGraph(GraphTileBuilder& tilebuilder_transit,
       if (timezone == 0) {
         // fallback to tz database.
         timezone =
-            (tile_within_one_tz) ? tz_polys.begin()->first : GetMultiPolyId(tz_polys, station_ll);
+            (tz_polys.size() == 1) ? tz_polys.begin()->first : GetMultiPolyId(tz_polys, station_ll);
 
         if (timezone == 0) {
           LOG_WARN("Timezone not found for station " + station.name());
@@ -649,7 +648,7 @@ void AddToGraph(GraphTileBuilder& tilebuilder_transit,
         if (timezone == 0) {
           // fallback to tz database.
           timezone =
-              (tile_within_one_tz) ? tz_polys.begin()->first : GetMultiPolyId(tz_polys, egress_ll);
+              (tz_polys.size() == 1) ? tz_polys.begin()->first : GetMultiPolyId(tz_polys, egress_ll);
           if (timezone == 0) {
             LOG_WARN("Timezone not found for egress " + egress.name());
           }
@@ -826,7 +825,7 @@ void AddToGraph(GraphTileBuilder& tilebuilder_transit,
     if (timezone == 0) {
       // fallback to tz database.
       timezone =
-          (tile_within_one_tz) ? tz_polys.begin()->first : GetMultiPolyId(tz_polys, platform_ll);
+          (tz_polys.size() == 1) ? tz_polys.begin()->first : GetMultiPolyId(tz_polys, platform_ll);
       if (timezone == 0) {
         LOG_WARN("Timezone not found for platform " + platform.name());
       }
@@ -1168,19 +1167,14 @@ void build_tiles(const boost::property_tree::ptree& pt,
 
     // Add routes to the tile. Get vector of route types.
     std::vector<uint32_t> route_types = AddRoutes(tile_pbf, tilebuilder_transit);
-    bool tile_within_one_tz = false;
     std::multimap<uint32_t, Geometry> tz_polys;
     if (tz_db) {
       tz_polys = GetTimeZones(*tz_db, tiles.TileBounds(tile_id.tileid()));
-      if (tz_polys.size() < 2) {
-        tile_within_one_tz = true;
-      }
     }
 
     // Add nodes, directededges, and edgeinfo
     AddToGraph(tilebuilder_transit, tile_id, tile_pbf, transit_dir, lock, stop_edge_map,
-               stop_no_access, shapes, distances, route_types, tile_within_one_tz, tz_polys,
-               stats.no_dir_edge_count);
+               stop_no_access, shapes, distances, route_types, tz_polys, stats.no_dir_edge_count);
 
     LOG_INFO("Tile " + std::to_string(tile_id.tileid()) + ": added " +
              std::to_string(tile_pbf.nodes_size()) + " stops, " +

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -502,7 +502,6 @@ void BuildTileSet(const std::string& ways_file,
 
       // Get the admin polygons. If only one exists for the tile check if the
       // tile is entirely inside the polygon
-      bool tile_within_one_admin = false;
       std::multimap<uint32_t, Geometry> admin_polys;
       std::unordered_map<uint32_t, bool> drive_on_right;
       std::unordered_map<uint32_t, bool> allow_intersection_names;
@@ -511,19 +510,11 @@ void BuildTileSet(const std::string& ways_file,
       if (admin_db) {
         admin_polys = GetAdminInfo(*admin_db, drive_on_right, allow_intersection_names,
                                    language_polys, tiling.TileBounds(id), graphtile);
-        if (admin_polys.size() == 1) {
-          // TODO - check if tile bounding box is entirely inside the polygon...
-          tile_within_one_admin = true;
-        }
       }
 
       std::multimap<uint32_t, Geometry> tz_polys;
-      bool tile_within_one_tz = false;
       if (tz_db) {
         tz_polys = GetTimeZones(*tz_db, tiling.TileBounds(id));
-        if (tz_polys.size() == 1) {
-          tile_within_one_tz = true;
-        }
       }
 
       // Iterate through the nodes
@@ -558,8 +549,8 @@ void BuildTileSet(const std::string& ways_file,
         std::vector<std::pair<std::string, bool>> default_languages;
 
         if (use_admin_db) {
-          admin_index = (tile_within_one_admin) ? admin_polys.begin()->first
-                                                : GetMultiPolyId(admin_polys, node_ll, graphtile);
+          admin_index = (admin_polys.size() == 1) ? admin_polys.begin()->first
+                                                  : GetMultiPolyId(admin_polys, node_ll, graphtile);
           dor = drive_on_right[admin_index];
           default_languages = GetMultiPolyIndexes(language_polys, node_ll);
 
@@ -1281,7 +1272,7 @@ void BuildTileSet(const std::string& ways_file,
 
         // Set the time zone index
         uint32_t tz_index =
-            (tile_within_one_tz) ? tz_polys.begin()->first : GetMultiPolyId(tz_polys, node_ll);
+            (tz_polys.size() == 1) ? tz_polys.begin()->first : GetMultiPolyId(tz_polys, node_ll);
 
         graphtile.nodes().back().set_timezone(tz_index);
 

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -1498,9 +1498,6 @@ void GraphBuilder::Build(const boost::property_tree::ptree& pt,
                pt.get<unsigned int>("mjolnir.concurrency", std::thread::hardware_concurrency()));
 
   auto tile_dir = pt.get<std::string>("mjolnir.tile_dir");
-  // Disable sqlite3 internal memory tracking (results in a high-contention mutex, and we don't care
-  // about marginal sqlite memory usage).
-  sqlite3_config(SQLITE_CONFIG_MEMSTATUS, false);
 
   BuildLocalTiles(threads, osmdata, ways_file, way_nodes_file, nodes_file, edges_file,
                   complex_from_restriction_file, complex_to_restriction_file, linguistic_node_file,

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -508,18 +508,9 @@ void BuildTileSet(const std::string& ways_file,
       std::unordered_map<uint32_t, bool> allow_intersection_names;
       language_poly_index language_polys;
 
-      // Tile might contain nodes slightly beyond the bbox.
-      const AABB2<PointLL> tile_bbox = [id, &tiling]() {
-        const double eps = 1e-3;
-        AABB2<PointLL> tile_bounds = tiling.TileBounds(id);
-        AABB2<PointLL> bbox(tile_bounds.minx() - eps, tile_bounds.miny() - eps,
-                            tile_bounds.maxx() + eps, tile_bounds.maxy() + eps);
-        return bbox;
-      }();
-
       if (admin_db) {
         admin_polys = GetAdminInfo(*admin_db, drive_on_right, allow_intersection_names,
-                                   language_polys, tile_bbox, graphtile);
+                                   language_polys, tiling.TileBounds(id), graphtile);
         if (admin_polys.size() == 1) {
           // TODO - check if tile bounding box is entirely inside the polygon...
           tile_within_one_admin = true;
@@ -529,7 +520,7 @@ void BuildTileSet(const std::string& ways_file,
       std::multimap<uint32_t, Geometry> tz_polys;
       bool tile_within_one_tz = false;
       if (tz_db) {
-        tz_polys = GetTimeZones(*tz_db, tile_bbox);
+        tz_polys = GetTimeZones(*tz_db, tiling.TileBounds(id));
         if (tz_polys.size() == 1) {
           tile_within_one_tz = true;
         }

--- a/src/mjolnir/graphenhancer.cc
+++ b/src/mjolnir/graphenhancer.cc
@@ -1290,7 +1290,7 @@ void enhance(const boost::property_tree::ptree& pt,
   bool use_urban_tag = pt.get<bool>("data_processing.use_urban_tag", false);
   bool use_admin_db = pt.get<bool>("data_processing.use_admin_db", true);
   // Initialize the admin DB (if it exists)
-  auto admin_db = (database && use_admin_db) ? Sqlite3::open(*database) : std::optional<Sqlite3>{};
+  auto admin_db = (database && use_admin_db) ? AdminDB::open(*database) : std::optional<AdminDB>{};
   if (!database && use_admin_db) {
     LOG_WARN("Admin db not found. Not saving admin information.");
   } else if (!admin_db && use_admin_db) {

--- a/src/mjolnir/ingest_transit.cc
+++ b/src/mjolnir/ingest_transit.cc
@@ -5,6 +5,7 @@
 #include <memory>
 #include <mutex>
 #include <queue>
+#include <set>
 #include <sstream>
 #include <string>
 #include <thread>

--- a/src/mjolnir/landmarks.cc
+++ b/src/mjolnir/landmarks.cc
@@ -14,6 +14,7 @@
 #include "sif/nocost.h"
 
 #include <osmium/io/pbf_input.hpp>
+#include <sqlite3.h>
 
 #include <future>
 #include <string_view>

--- a/src/mjolnir/statistics_database.cc
+++ b/src/mjolnir/statistics_database.cc
@@ -5,6 +5,8 @@
 #include "midgard/logging.h"
 #include "mjolnir/sqlite3.h"
 
+#include <sqlite3.h>
+
 using namespace valhalla::midgard;
 using namespace valhalla::baldr;
 using namespace valhalla::mjolnir;

--- a/src/mjolnir/valhalla_benchmark_admins.cc
+++ b/src/mjolnir/valhalla_benchmark_admins.cc
@@ -10,6 +10,7 @@
 #include <boost/geometry/io/wkt/wkt.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <cxxopts.hpp>
+#include <sqlite3.h>
 
 #include "baldr/admininfo.h"
 #include "baldr/graphconstants.h"

--- a/test/graphbuilder.cc
+++ b/test/graphbuilder.cc
@@ -1,17 +1,14 @@
 #include "mjolnir/graphbuilder.h"
 #include "baldr/graphreader.h"
-#include "midgard/sequence.h"
 #include "mjolnir/admin.h"
 #include "mjolnir/directededgebuilder.h"
 #include "mjolnir/osmdata.h"
 #include "mjolnir/pbfgraphparser.h"
-#include "mjolnir/util.h"
-
-#include <string>
 
 #include <boost/property_tree/ptree.hpp>
+#include <gtest/gtest.h>
 
-#include "test.h"
+#include <string>
 
 using boost::property_tree::ptree;
 using namespace valhalla;
@@ -19,8 +16,6 @@ using namespace valhalla::midgard;
 using namespace valhalla::mjolnir;
 using valhalla::baldr::GraphId;
 using valhalla::baldr::GraphReader;
-using valhalla::mjolnir::build_tile_set;
-using valhalla::mjolnir::TileManifest;
 
 #if !defined(VALHALLA_SOURCE_DIR)
 #define VALHALLA_SOURCE_DIR
@@ -131,22 +126,85 @@ TEST(Graphbuilder, NewTimezones) {
   TestNodeInfo test_node;
   auto sql_db = Sqlite3::open(VALHALLA_BUILD_DIR "test/data/tz.sqlite");
   ASSERT_TRUE(sql_db);
+  auto geos_context = NewGEOSContext();
 
   const auto& tzdb = DateTime::get_tz_db();
 
   // America/Ciudad_Juarez
-  auto ciudad_juarez_polys = GetTimeZones(*sql_db, {-106.450948, 31.669746, -106.386046, 31.724371});
+  auto ciudad_juarez_polys =
+      GetTimeZones(*sql_db, geos_context, {-106.450948, 31.669746, -106.386046, 31.724371});
   EXPECT_EQ(ciudad_juarez_polys.begin()->first, tzdb.to_index("America/Ciudad_Juarez"));
   test_node.set_timezone(ciudad_juarez_polys.begin()->first);
   EXPECT_EQ(test_node.get_raw_timezone_field(), tzdb.to_index("America/Ojinaga"));
   EXPECT_EQ(test_node.get_raw_timezone_ext1_field(), 1);
 
   // Asia/Qostanay
-  auto qostanay_polys = GetTimeZones(*sql_db, {62.41766759, 51.37601571, 64.83104595, 52.71089583});
+  auto qostanay_polys =
+      GetTimeZones(*sql_db, geos_context, {62.41766759, 51.37601571, 64.83104595, 52.71089583});
   EXPECT_EQ(qostanay_polys.begin()->first, tzdb.to_index("Asia/Qostanay"));
   test_node.set_timezone(qostanay_polys.begin()->first);
   EXPECT_EQ(test_node.get_raw_timezone_field(), tzdb.to_index("Asia/Qyzylorda"));
   EXPECT_EQ(test_node.get_raw_timezone_ext1_field(), 1);
+}
+
+TEST(Graphbuilder, AdminBbox) {
+  auto admin_db = Sqlite3::open(VALHALLA_BUILD_DIR "test/data/language_admin.sqlite");
+  auto geos_context = NewGEOSContext();
+
+  const auto& tiling = TileHierarchy::levels().back().tiles;
+
+  // Problematic tile in Belgium where boost::geometry::intersection(box, polygon) fails to produce
+  // multiple polygons.
+  const GraphId id(811462);
+  GraphTileBuilder graphtile(tile_dir, id, false);
+  std::unordered_map<uint32_t, bool> drive_on_right;
+  std::unordered_map<uint32_t, bool> allow_intersection_names;
+  language_poly_index language_polys;
+
+  const AABB2<PointLL> tile_bounds = tiling.TileBounds(id);
+  const double eps = 1e-3;
+  const AABB2<PointLL> tile_bbox(tile_bounds.minx() - eps, tile_bounds.miny() - eps,
+                                 tile_bounds.maxx() + eps, tile_bounds.maxy() + eps);
+
+  auto admin_polys = GetAdminInfo(*admin_db, geos_context, drive_on_right, allow_intersection_names,
+                                  language_polys, tile_bbox, graphtile);
+
+  const auto admin_name = [&](const Admin& admin) {
+    return admin.country_iso() + "/" + admin.state_iso();
+  };
+
+  ASSERT_EQ(admin_polys.size(), 3);
+  EXPECT_EQ(admin_name(graphtile.admins_builder(0)), "/"); // default empty strings
+  EXPECT_EQ(admin_name(graphtile.admins_builder(1)), "BE/VLG");
+  EXPECT_EQ(admin_name(graphtile.admins_builder(2)), "BE/WAL");
+  EXPECT_EQ(admin_name(graphtile.admins_builder(3)), "BE/");
+
+  // fr, nl, nl, fr
+  ASSERT_EQ(language_polys.size(), 4);
+
+  EXPECT_EQ(admin_name(graphtile.admins_builder(
+                GetMultiPolyId(admin_polys, geos_context,
+                               PointLL(tile_bbox.minx() + eps, tile_bbox.miny() + eps), graphtile))),
+            "BE/VLG");
+  EXPECT_EQ(admin_name(graphtile.admins_builder(
+                GetMultiPolyId(admin_polys, geos_context,
+                               PointLL(tile_bbox.maxx() - eps, tile_bbox.miny() + eps), graphtile))),
+            "BE/VLG");
+  EXPECT_EQ(admin_name(graphtile.admins_builder(
+                GetMultiPolyId(admin_polys, geos_context,
+                               PointLL(tile_bbox.minx() + eps, tile_bbox.maxy() - eps), graphtile))),
+            "BE/VLG");
+  EXPECT_EQ(admin_name(graphtile.admins_builder(
+                GetMultiPolyId(admin_polys, geos_context,
+                               PointLL(tile_bbox.maxx() - eps, tile_bbox.maxy() - eps), graphtile))),
+            "BE/VLG");
+
+  EXPECT_EQ(admin_name(graphtile.admins_builder(
+                GetMultiPolyId(admin_polys, geos_context,
+                               PointLL((tile_bbox.minx() + tile_bbox.maxx()) / 2,
+                                       tile_bbox.miny() + eps),
+                               graphtile))),
+            "BE/WAL");
 }
 
 class HarrisburgTestSuiteEnv : public ::testing::Environment {

--- a/test/graphbuilder.cc
+++ b/test/graphbuilder.cc
@@ -158,13 +158,9 @@ TEST(Graphbuilder, AdminBbox) {
   std::unordered_map<uint32_t, bool> allow_intersection_names;
   language_poly_index language_polys;
 
-  const AABB2<PointLL> tile_bounds = tiling.TileBounds(id);
-  const double eps = 1e-3;
-  const AABB2<PointLL> tile_bbox(tile_bounds.minx() - eps, tile_bounds.miny() - eps,
-                                 tile_bounds.maxx() + eps, tile_bounds.maxy() + eps);
-
+  const AABB2<PointLL> bbox = tiling.TileBounds(id);
   auto admin_polys = GetAdminInfo(*admin_db, drive_on_right, allow_intersection_names, language_polys,
-                                  tile_bbox, graphtile);
+                                  bbox, graphtile);
 
   const auto admin_name = [&](const Admin& admin) {
     return admin.country_iso() + "/" + admin.state_iso();
@@ -179,27 +175,22 @@ TEST(Graphbuilder, AdminBbox) {
   // fr, nl, nl, fr
   ASSERT_EQ(language_polys.size(), 4);
 
+  // Ensure that tile corners are handled correctly
   EXPECT_EQ(admin_name(graphtile.admins_builder(
-                GetMultiPolyId(admin_polys, PointLL(tile_bounds.minx(), tile_bounds.miny()),
-                               graphtile))),
+                GetMultiPolyId(admin_polys, PointLL(bbox.minx(), bbox.miny()), graphtile))),
             "BE/VLG");
   EXPECT_EQ(admin_name(graphtile.admins_builder(
-                GetMultiPolyId(admin_polys, PointLL(tile_bounds.maxx(), tile_bounds.miny()),
-                               graphtile))),
+                GetMultiPolyId(admin_polys, PointLL(bbox.maxx(), bbox.miny()), graphtile))),
             "BE/VLG");
   EXPECT_EQ(admin_name(graphtile.admins_builder(
-                GetMultiPolyId(admin_polys, PointLL(tile_bounds.minx(), tile_bounds.maxy()),
-                               graphtile))),
+                GetMultiPolyId(admin_polys, PointLL(bbox.minx(), bbox.maxy()), graphtile))),
             "BE/VLG");
   EXPECT_EQ(admin_name(graphtile.admins_builder(
-                GetMultiPolyId(admin_polys, PointLL(tile_bounds.maxx(), tile_bounds.maxy()),
-                               graphtile))),
+                GetMultiPolyId(admin_polys, PointLL(bbox.maxx(), bbox.maxy()), graphtile))),
             "BE/VLG");
 
   EXPECT_EQ(admin_name(graphtile.admins_builder(
-                GetMultiPolyId(admin_polys,
-                               PointLL((tile_bounds.minx() + tile_bounds.maxx()) / 2,
-                                       tile_bounds.miny()),
+                GetMultiPolyId(admin_polys, PointLL((bbox.minx() + bbox.maxx()) / 2, bbox.miny()),
                                graphtile))),
             "BE/WAL");
 }

--- a/test/gurka/test_admin_sidewalk_crossing_override.cc
+++ b/test/gurka/test_admin_sidewalk_crossing_override.cc
@@ -1,6 +1,7 @@
 #include <filesystem>
 
 #include <gtest/gtest.h>
+#include <sqlite3.h>
 
 #include "baldr/admin.h"
 #include "gurka.h"

--- a/test/gurka/test_admin_uk_override.cc
+++ b/test/gurka/test_admin_uk_override.cc
@@ -1,5 +1,6 @@
 #include <filesystem>
 #include <gtest/gtest.h>
+#include <sqlite3.h>
 
 #include "baldr/admin.h"
 #include "gurka.h"

--- a/test/gurka/test_build_admin.cc
+++ b/test/gurka/test_build_admin.cc
@@ -1,6 +1,7 @@
 #include <filesystem>
 
 #include <gtest/gtest.h>
+#include <sqlite3.h>
 
 #include "baldr/admin.h"
 #include "gurka.h"

--- a/valhalla/mjolnir/admin.h
+++ b/valhalla/mjolnir/admin.h
@@ -157,7 +157,7 @@ GetAdminInfo(AdminDB& db,
  * Get all the country access records from the db and save them to a map.
  * @param  db    sqlite3 db handle
  */
-std::unordered_map<std::string, std::vector<int>> GetCountryAccess(Sqlite3& db);
+std::unordered_map<std::string, std::vector<int>> GetCountryAccess(AdminDB& db);
 
 } // namespace mjolnir
 } // namespace valhalla

--- a/valhalla/mjolnir/admin.h
+++ b/valhalla/mjolnir/admin.h
@@ -7,10 +7,13 @@
 #include <valhalla/mjolnir/graphtilebuilder.h>
 #include <valhalla/mjolnir/sqlite3.h>
 
-#include <geos_c.h>
-
 #include <cstdint>
 #include <unordered_map>
+
+struct GEOSContextHandle_HS;
+struct GEOSGeom_t;
+struct GEOSPrepGeom_t;
+struct GEOSWKBReader_t;
 
 using namespace valhalla::baldr;
 using namespace valhalla::midgard;
@@ -25,10 +28,10 @@ typedef std::shared_ptr<GEOSContextHandle_HS> geos_context_type;
 // RAII wrapper for GEOSGeometry
 struct Geometry {
   geos_context_type context;
-  GEOSGeometry* geometry;
-  const GEOSPreparedGeometry* prepared;
+  GEOSGeom_t* geometry;
+  const GEOSPrepGeom_t* prepared;
 
-  Geometry(geos_context_type ctx, GEOSGeometry* geom);
+  Geometry(geos_context_type ctx, GEOSGeom_t* geom);
   ~Geometry();
 
   // This class cannot be copied, but can be moved
@@ -58,7 +61,7 @@ typedef std::vector<std::tuple<Geometry, std::vector<std::string>, bool>> langua
 class AdminDB {
   Sqlite3 db;
   geos_context_type geos_context;
-  GEOSWKBReader* wkb_reader;
+  GEOSWKBReader_t* wkb_reader;
 
   // Constructor is private, use `AdminDB::open()` instead.
   AdminDB(Sqlite3&& db);

--- a/valhalla/mjolnir/sqlite3.h
+++ b/valhalla/mjolnir/sqlite3.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <sqlite3.h>
-
 #include <optional>
 #include <string>
+
+struct sqlite3;
 
 namespace valhalla {
 namespace mjolnir {
@@ -18,8 +18,7 @@ class Sqlite3 final {
   }
 
 public:
-  static std::optional<Sqlite3> open(const std::string& path,
-                                     int flags = SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX);
+  static std::optional<Sqlite3> open(const std::string& path, int flags);
   ~Sqlite3();
 
   // This class cannot be copied, but can be moved

--- a/valhalla/mjolnir/util.h
+++ b/valhalla/mjolnir/util.h
@@ -8,10 +8,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include <sqlite3.h>
-// needs to be after sqlite include
-#include <spatialite.h>
-
 #include <valhalla/baldr/directededge.h>
 #include <valhalla/baldr/graphid.h>
 #include <valhalla/baldr/graphtileptr.h>


### PR DESCRIPTION
# Issue

Use GEOS instead of `boost::geometry` for operations with admin and tz polygons, inspired by https://github.com/valhalla/valhalla/pull/5193#discussion_r2048315797

With this PR, the `BuildLocalTiles` timing on my M3 Max with europe-latest.osm.pbf (30GB) reduced from 1998s to 554s.

Major performance improvement (on systems that are not limited by filesystem read speed) comes from 
- clipping admin/tz polygons by tile bbox
- direct reading WKB from sqlite without intermediate transformation to WKT that was required for `boost::geometry`

Because of GEOS's [thread safe API](https://libgeos.org/usage/c_api/#reentrantthreadsafe-api), that require passing a context everywhere, noticeable amount of refactoring is required around interaction with admin/tz dbs - see new `AdminDB` class for more details.

## Tasklist

 - [x] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?

- first attempt to clip admin polygons with `boost::geometry` was taken in https://github.com/valhalla/valhalla/pull/5193 and during https://github.com/valhalla/valhalla/pull/5193#discussion_r2048315797 discussion I jumped into complete migration to GEOS
- some from the current PR were moved into https://github.com/valhalla/valhalla/pull/5206 that sets up concept of object to partially incapsulate handles, needed to work with admin db. Current PR extends that object to have GEOS context and WKB reader in a single place.
