### PR TITLE
fix: Clang 20 compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
    * FIXED: level changes for multi-level start/end edges [#5126](https://github.com/valhalla/valhalla/pull/5126)
    * FIXED: multi-edge steps maneuvers [#5191](https://github.com/valhalla/valhalla/pull/5191)
    * FIXED: remove start maneuver if route starts on stairs/escalators [#5127](https://github.com/valhalla/valhalla/pull/5127)
+   * FIXED: compilation with clang 20 [#5208](https://github.com/valhalla/valhalla/pull/5208)
 * **Enhancement**
    * ADDED: Consider smoothness in all profiles that use surface [#4949](https://github.com/valhalla/valhalla/pull/4949)
    * ADDED: costing parameters to exclude certain edges `exclude_tolls`, `exclude_bridges`, `exclude_tunnels`, `exclude_highways`, `exclude_ferries`. They need to be enabled in the config with `service_limits.allow_hard_exclusions`. Also added location search filters `exclude_ferry` and `exclude_toll` to complement these changes. [#4524](https://github.com/valhalla/valhalla/pull/4524)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -188,12 +188,15 @@ target_include_directories(valhalla
     ${VALHALLA_SOURCE_DIR}/valhalla # TODO: this path must be removed and changed to #include <valhalla/...> in headers
     ${VALHALLA_BINARY_DIR}
     ${VALHALLA_BINARY_DIR}/valhalla  # TODO: this path must be removed and changed to #include <valhalla/...> in headers
+  PRIVATE
+    ${libvalhalla_include_directories}
+)
+target_include_directories(valhalla SYSTEM PUBLIC
     ${rapidjson_include_dir}
     ${date_include_dir}
     ${VALHALLA_SOURCE_DIR}/third_party/cpp-statsd-client/include
     $<$<BOOL:${WIN32}>:${dirent_include_dir}>
-  PRIVATE
-    ${libvalhalla_include_directories})
+)
 
 target_link_libraries(valhalla
   PUBLIC
@@ -210,7 +213,7 @@ set_target_properties(valhalla PROPERTIES
 # pkg-config installation
 if(PKG_CONFIG_FOUND)
   include(ValhallaPkgConfig)
-  
+
   configure_valhalla_pc()
 
   install(FILES

--- a/src/mjolnir/osmaccessrestriction.cc
+++ b/src/mjolnir/osmaccessrestriction.cc
@@ -7,13 +7,6 @@ using namespace valhalla::baldr;
 namespace valhalla {
 namespace mjolnir {
 
-OSMAccessRestriction::OSMAccessRestriction() {
-  memset(this, 0, sizeof(OSMAccessRestriction));
-}
-
-OSMAccessRestriction::~OSMAccessRestriction() {
-}
-
 // Set the restriction type
 void OSMAccessRestriction::set_type(AccessType type) {
   attributes_.type_ = static_cast<uint16_t>(type);

--- a/valhalla/mjolnir/osmaccessrestriction.h
+++ b/valhalla/mjolnir/osmaccessrestriction.h
@@ -20,12 +20,12 @@ public:
   /**
    * Constructor
    */
-  OSMAccessRestriction();
+  OSMAccessRestriction() = default;
 
   /**
    * Destructor.
    */
-  ~OSMAccessRestriction();
+  ~OSMAccessRestriction() = default;
 
   /**
    * Set the restriction type
@@ -69,16 +69,16 @@ public:
   void set_direction(AccessRestrictionDirection direction);
 
 protected:
-  uint64_t value_;
+  uint64_t value_ = 0;
 
   struct Attributes {
     uint16_t type_ : 4;
     uint16_t modes_ : 12;
   };
-  Attributes attributes_;
-  AccessRestrictionDirection direction_;
-  uint16_t spare_[2];
-  uint8_t spare2_;
+  Attributes attributes_ = {0, 0};
+  AccessRestrictionDirection direction_ = AccessRestrictionDirection::kBoth;
+  uint16_t spare_[2] = {0, 0};
+  uint8_t spare2_ = 0;
 };
 
 } // namespace mjolnir


### PR DESCRIPTION
# Issue

Fixes a few warnings that were introduced in recent clang and that fail compilation with `-Werror`

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
