### PR TITLE
compatibility with geos <3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
    * FIXED: multi-edge steps maneuvers [#5191](https://github.com/valhalla/valhalla/pull/5191)
    * FIXED: remove start maneuver if route starts on stairs/escalators [#5127](https://github.com/valhalla/valhalla/pull/5127)
    * FIXED: compilation with clang 20 [#5208](https://github.com/valhalla/valhalla/pull/5208)
+   * FIXED: compability with GEOS <3.12 [#5224](https://github.com/valhalla/valhalla/pull/5224)
 * **Enhancement**
    * ADDED: Consider smoothness in all profiles that use surface [#4949](https://github.com/valhalla/valhalla/pull/4949)
    * ADDED: costing parameters to exclude certain edges `exclude_tolls`, `exclude_bridges`, `exclude_tunnels`, `exclude_highways`, `exclude_ferries`. They need to be enabled in the config with `service_limits.allow_hard_exclusions`. Also added location search filters `exclude_ferry` and `exclude_toll` to complement these changes. [#4524](https://github.com/valhalla/valhalla/pull/4524)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
    * FIXED: multi-edge steps maneuvers [#5191](https://github.com/valhalla/valhalla/pull/5191)
    * FIXED: remove start maneuver if route starts on stairs/escalators [#5127](https://github.com/valhalla/valhalla/pull/5127)
    * FIXED: compilation with clang 20 [#5208](https://github.com/valhalla/valhalla/pull/5208)
-   * FIXED: compability with GEOS <3.12 [#5224](https://github.com/valhalla/valhalla/pull/5224)
+   * FIXED: compatibility with GEOS <3.12 [#5224](https://github.com/valhalla/valhalla/pull/5224)
 * **Enhancement**
    * ADDED: Consider smoothness in all profiles that use surface [#4949](https://github.com/valhalla/valhalla/pull/4949)
    * ADDED: costing parameters to exclude certain edges `exclude_tolls`, `exclude_bridges`, `exclude_tunnels`, `exclude_highways`, `exclude_ferries`. They need to be enabled in the config with `service_limits.allow_hard_exclusions`. Also added location search filters `exclude_ferry` and `exclude_toll` to complement these changes. [#4524](https://github.com/valhalla/valhalla/pull/4524)

--- a/src/mjolnir/admin.cc
+++ b/src/mjolnir/admin.cc
@@ -29,11 +29,14 @@ Geometry::~Geometry() {
 }
 
 bool Geometry::intersects(const PointLL& ll) const {
-  // TODO: use GEOSPreparedIntersectsXY_r in the future
+#if GEOS_VERSION_MINOR < 12
   auto* p = GEOSGeom_createPointFromXY_r(context.get(), ll.lng(), ll.lat());
   bool intersects = GEOSPreparedIntersects_r(context.get(), prepared, p);
   GEOSGeom_destroy_r(context.get(), p);
   return intersects;
+#else
+  return GEOSPreparedIntersectsXY_r(context.get(), prepared, ll.lng(), ll.lat());
+#endif
 }
 
 Geometry Geometry::clone() const {

--- a/src/mjolnir/admin.cc
+++ b/src/mjolnir/admin.cc
@@ -29,7 +29,10 @@ Geometry::~Geometry() {
 }
 
 bool Geometry::intersects(const PointLL& ll) const {
-  return GEOSPreparedIntersectsXY_r(context.get(), prepared, ll.lng(), ll.lat());
+  auto* p = GEOSGeom_createPointFromXY_r(context.get(), ll.lat(), ll.lng());
+  bool intersects = GEOSPreparedIntersects_r(context.get(), prepared, p);
+  GEOSGeom_destroy_r(context.get(), p);
+  return intersects;
 }
 
 Geometry Geometry::clone() const {

--- a/src/mjolnir/admin.cc
+++ b/src/mjolnir/admin.cc
@@ -29,7 +29,8 @@ Geometry::~Geometry() {
 }
 
 bool Geometry::intersects(const PointLL& ll) const {
-  auto* p = GEOSGeom_createPointFromXY_r(context.get(), ll.lat(), ll.lng());
+  // TODO: use GEOSPreparedIntersectsXY_r in the future
+  auto* p = GEOSGeom_createPointFromXY_r(context.get(), ll.lng(), ll.lat());
   bool intersects = GEOSPreparedIntersects_r(context.get(), prepared, p);
   GEOSGeom_destroy_r(context.get(), p);
   return intersects;


### PR DESCRIPTION
# Issue

I noticed that the latest build on our public server failed because `GEOSPreparedIntersectsXY_r` was only added in GEOS 3.12 (released less than a year ago). I can't the public server that easily updated to that version of GEOS without an OS upgrade (we're still on Ubuntu 22.04 LTS), and I suspect other Valhalla users might have similar issues. I'd say we just make it compatible to older versions which means temporarily creating a geometry and destroying right after the intersects check. 
 
## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
