### PR TITLE
Log OSM IDs of nodes outside of tile

### DIFF
--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -1398,8 +1398,8 @@ uint32_t GetGridId(const midgard::PointLL& pointll,
   if (tile_id >= 0) {
     auto base_ll = tiling.Base(tile_id);
     float grid_size = tiling.TileSize() / static_cast<float>(grid_divisions);
-    uint32_t row = static_cast<uint32_t>((pointll.lat() - base_ll.lat()) / grid_size);
-    uint32_t col = static_cast<uint32_t>((pointll.lng() - base_ll.lng()) / grid_size);
+    uint32_t row = static_cast<uint32_t>(std::max(pointll.lat() - base_ll.lat(), 0.) / grid_size);
+    uint32_t col = static_cast<uint32_t>(std::max(pointll.lng() - base_ll.lng(), 0.) / grid_size);
     if (row > grid_divisions || col > grid_divisions) {
       LOG_ERROR("grid row = " + std::to_string(row) + " col = " + std::to_string(col));
       return 0;


### PR DESCRIPTION
# Issue

Sometimes pops ups in build logs: 

```
2025/04/30 16:42:48.786018 [ERROR] grid row = 4294967289 col = 11519 
```

Looks like a wrap-around error to me, and if I'm doing the math correctly, some of these are up to several kilometers outside of their tile :smile:  Wondering what's going on there. 

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
