### PR TITLE
POC: exclude_polygons with GEOS

### DIFF
--- a/src/loki/polygon_search.cc
+++ b/src/loki/polygon_search.cc
@@ -1,6 +1,9 @@
+#include <cstdarg>
+
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/register/point.hpp>
 #include <boost/geometry/geometries/register/ring.hpp>
+#include <geos_c.h>
 
 #include <valhalla/baldr/json.h>
 #include <valhalla/loki/polygon_search.h>
@@ -94,6 +97,170 @@ std::string to_geojson(const std::unordered_set<vb::GraphId>& edge_ids, vb::Grap
 namespace valhalla {
 namespace loki {
 
+geos_t::geos_t() : ctx(GEOS_init_r()) {
+  LOG_WARN("GEOS Init");
+}
+geos_t::~geos_t() {
+  finishGEOS_r(ctx);
+}
+GEOSGeometry* geos_t::linestring_from_shape(const std::vector<PointLL>& shape) const {
+  GEOSCoordSequence* geos_coords = GEOSCoordSeq_create_r(ctx, shape.size(), 2);
+  size_t i = 0;
+  for (const auto& coord : shape) {
+    GEOSCoordSeq_setX_r(ctx, geos_coords, i, coord.lng());
+    GEOSCoordSeq_setY_r(ctx, geos_coords, i, coord.lat());
+    ++i;
+  }
+
+  return GEOSGeom_createLineString_r(ctx, geos_coords);
+}
+GEOSGeometry* geos_t::polygon_from_pbf(const valhalla::Ring& ring) const {
+  // possibly need to close this ring
+  auto& first = ring.coords().at(0);
+  auto& last = ring.coords().at(ring.coords_size() - 1);
+  bool closed = first.lat() == last.lat() && first.lng() == last.lng();
+  GEOSCoordSequence* geos_coords =
+      GEOSCoordSeq_create_r(ctx, closed ? ring.coords_size() : ring.coords_size() + 1, 2);
+  size_t i = 0;
+  for (const auto& coord : ring.coords()) {
+    GEOSCoordSeq_setX_r(ctx, geos_coords, i, coord.lng());
+    GEOSCoordSeq_setY_r(ctx, geos_coords, i, coord.lat());
+    ++i;
+  }
+
+  if (!closed) {
+    GEOSCoordSeq_setX_r(ctx, geos_coords, i, ring.coords().at(0).lng());
+    GEOSCoordSeq_setY_r(ctx, geos_coords, i, ring.coords().at(0).lat());
+  }
+
+  return GEOSGeom_createPolygon_r(ctx, GEOSGeom_createLinearRing_r(ctx, geos_coords), nullptr, 0);
+}
+
+std::unordered_set<vb::GraphId>
+edges_in_polygons(const google::protobuf::RepeatedPtrField<valhalla::Ring>& rings_pbf,
+                  baldr::GraphReader& reader,
+                  const std::shared_ptr<sif::DynamicCost>& costing,
+                  float max_length,
+                  const loki::geos_t& geos_helper) {
+  // protect for bogus input
+  if (rings_pbf.empty() || rings_pbf.Get(0).coords().empty() ||
+      !rings_pbf.Get(0).coords()[0].has_lat_case() || !rings_pbf.Get(0).coords()[0].has_lng_case()) {
+    return {};
+  }
+
+  // convert to bg object and check length restriction
+  const GEOSPreparedGeometry* multipolygon = nullptr;
+  double rings_length = 0;
+  {
+    std::vector<GEOSGeometry*> polygons;
+    polygons.reserve(rings_pbf.size());
+    size_t perimeter = 0;
+    for (const auto& ring_pbf : rings_pbf) {
+      for (size_t i = 1; i < ring_pbf.coords_size(); ++i) {
+        auto approx = DistanceApproximator(
+            PointLL{ring_pbf.coords().at(i - 1).lng(), ring_pbf.coords().at(i - 1).lat()});
+        auto this_ll = PointLL{ring_pbf.coords().at(i).lng(), ring_pbf.coords().at(i).lat()};
+        perimeter += approx.DistanceSquared(this_ll);
+        if (perimeter > max_length) {
+          throw valhalla_exception_t(167,
+                                     std::to_string(static_cast<size_t>(max_length)) + " meters");
+        }
+      }
+      polygons.push_back(geos_helper.polygon_from_pbf(ring_pbf));
+    }
+    auto* collection = GEOSGeom_createCollection_r(geos_helper.ctx, GEOS_MULTIPOLYGON,
+                                                   polygons.data(), polygons.size());
+    if (collection == NULL)
+      throw std::runtime_error("Bad polygon");
+    multipolygon = GEOSPrepare_r(geos_helper.ctx, collection);
+
+    if (multipolygon == NULL)
+      throw std::runtime_error("Bad polygon");
+  }
+
+  // keep track which tile's bins intersect which rings
+  bins_collector bins_intersected;
+  std::unordered_set<vb::GraphId> avoid_edge_ids;
+  // Get the lowest level and tiles
+  const auto& tiles = vb::TileHierarchy::levels().back().tiles;
+  const auto bin_level = vb::TileHierarchy::levels().back().level;
+
+  {
+    std::vector<ring_bg_t> rings_bg;
+    for (const auto& ring_pbf : rings_pbf) {
+      rings_bg.push_back(PBFToRing(ring_pbf));
+      const ring_bg_t ring_bg = rings_bg.back();
+    }
+
+    // first pull out all *unique* bins which intersect the rings
+    for (size_t ring_idx = 0; ring_idx < rings_bg.size(); ring_idx++) {
+      auto ring = rings_bg[ring_idx];
+      auto line_intersected = tiles.Intersect(ring);
+      for (const auto& tb : line_intersected) {
+        for (const auto& b : tb.second) {
+          bins_intersected[static_cast<uint32_t>(tb.first)][b].push_back(ring_idx);
+        }
+      }
+    }
+  }
+  size_t nbins = 0;
+  for (const auto& intersection : bins_intersected) {
+    auto tile = reader.GetGraphTile({intersection.first, bin_level, 0});
+    if (!tile) {
+      continue;
+    }
+    for (const auto& bin : intersection.second) {
+      nbins++;
+      // tile will be mutated most likely in the loop
+      reader.GetGraphTile({intersection.first, bin_level, 0}, tile);
+      for (const auto& edge_id : tile->GetBin(bin.first)) {
+        if (avoid_edge_ids.count(edge_id) != 0) {
+          continue;
+        }
+        // TODO: optimize the tile switching by enqueuing edges
+        // from other levels & tiles and process them after this big loop
+        if (edge_id.Tile_Base() != tile->header()->graphid().Tile_Base() &&
+            !reader.GetGraphTile(edge_id, tile)) {
+          continue;
+        }
+        const auto edge = tile->directededge(edge_id);
+        auto opp_tile = tile;
+        const baldr::DirectedEdge* opp_edge = nullptr;
+        baldr::GraphId opp_id;
+
+        // bail if we wouldnt be allowed on this edge anyway (or its opposing)
+        if (!costing->Allowed(edge, tile) &&
+            (!(opp_id = reader.GetOpposingEdgeId(edge_id, opp_edge, opp_tile)).Is_Valid() ||
+             !costing->Allowed(opp_edge, opp_tile))) {
+          continue;
+        }
+
+        // TODO: some logic to set percent_along for origin/destination edges
+        // careful: polygon can intersect a single edge multiple times
+        auto edge_info = tile->edgeinfo(edge);
+        auto& shape = edge_info.shape();
+        GEOSGeometry* line = geos_helper.linestring_from_shape(shape);
+        if (line == NULL)
+          throw std::runtime_error("Bad line");
+
+        bool intersects = GEOSPreparedIntersects_r(geos_helper.ctx, multipolygon, line);
+
+        GEOSGeom_destroy_r(geos_helper.ctx, line);
+
+        if (intersects) {
+          avoid_edge_ids.emplace(edge_id);
+          avoid_edge_ids.emplace(
+              opp_id.Is_Valid() ? opp_id : reader.GetOpposingEdgeId(edge_id, opp_edge, opp_tile));
+        }
+      }
+    }
+  }
+
+  GEOSPreparedGeom_destroy_r(geos_helper.ctx, multipolygon);
+  LOG_INFO("Bins: " + std::to_string(nbins));
+
+  return avoid_edge_ids;
+}
 std::unordered_set<vb::GraphId>
 edges_in_rings(const google::protobuf::RepeatedPtrField<valhalla::Ring>& rings_pbf,
                baldr::GraphReader& reader,

--- a/src/loki/worker.cc
+++ b/src/loki/worker.cc
@@ -124,8 +124,8 @@ void loki_worker_t::parse_costing(Api& api, bool allow_none) {
   } catch (const std::runtime_error&) { throw valhalla_exception_t{125, "'" + costing_str + "'"}; }
 
   if (options.exclude_polygons_size()) {
-    const auto edges =
-        edges_in_rings(options.exclude_polygons(), *reader, costing, max_exclude_polygons_length);
+    const auto edges = edges_in_polygons(options.exclude_polygons(), *reader, costing,
+                                         max_exclude_polygons_length, geos_helper);
     auto& co = *options.mutable_costings()->find(options.costing_type())->second.mutable_options();
     for (const auto& edge_id : edges) {
       auto* avoid = co.add_exclude_edges();

--- a/valhalla/loki/polygon_search.h
+++ b/valhalla/loki/polygon_search.h
@@ -1,12 +1,22 @@
 #ifndef VALHALLA_LOKI_POLYGON_SEARCH_H_
 #define VALHALLA_LOKI_POLYGON_SEARCH_H_
 
+#include <geos_c.h>
 #include <valhalla/baldr/graphreader.h>
 #include <valhalla/proto/options.pb.h>
 #include <valhalla/sif/dynamiccost.h>
 
 namespace valhalla {
 namespace loki {
+
+struct geos_t {
+  geos_t();
+  ~geos_t();
+  GEOSGeometry* linestring_from_shape(const std::vector<PointLL>& shape) const;
+  GEOSGeometry* polygon_from_pbf(const valhalla::Ring& ring) const;
+
+  GEOSContextHandle_t ctx;
+};
 
 /**
  * Finds all edge IDs which are intersected by the ring
@@ -21,6 +31,19 @@ edges_in_rings(const google::protobuf::RepeatedPtrField<valhalla::Ring>& rings,
                const std::shared_ptr<sif::DynamicCost>& costing,
                float max_length);
 
+/**
+ * Finds all edge IDs which are intersected by the ring
+ *
+ * @param rings The (optionally closed) rings to intersect edges with
+ * @param reader GraphReader instance
+ *
+ */
+std::unordered_set<valhalla::baldr::GraphId>
+edges_in_polygons(const google::protobuf::RepeatedPtrField<valhalla::Ring>& rings,
+                  baldr::GraphReader& reader,
+                  const std::shared_ptr<sif::DynamicCost>& costing,
+                  float max_length,
+                  const geos_t& geos_helper);
 } // namespace loki
 } // namespace valhalla
 

--- a/valhalla/loki/worker.h
+++ b/valhalla/loki/worker.h
@@ -10,6 +10,7 @@
 #include <valhalla/baldr/location.h>
 #include <valhalla/baldr/pathlocation.h>
 #include <valhalla/baldr/rapidjson_utils.h>
+#include <valhalla/loki/polygon_search.h>
 #include <valhalla/midgard/pointll.h>
 #include <valhalla/proto/options.pb.h>
 #include <valhalla/sif/costfactory.h>
@@ -68,6 +69,7 @@ protected:
   sif::CostFactory factory;
   sif::cost_ptr_t costing;
   std::shared_ptr<baldr::GraphReader> reader;
+  geos_t geos_helper;
   std::shared_ptr<baldr::connectivity_map_t> connectivity_map;
   std::unordered_set<Options::Action> actions;
   std::string action_str;

--- a/valhalla/midgard/tiles.h
+++ b/valhalla/midgard/tiles.h
@@ -6,6 +6,8 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include <geos_c.h>
+
 #include <valhalla/midgard/aabb2.h>
 #include <valhalla/midgard/constants.h>
 #include <valhalla/midgard/ellipse.h>
@@ -369,6 +371,9 @@ public:
   template <class container_t>
   std::unordered_map<int32_t, std::unordered_set<unsigned short>>
   Intersect(const container_t& line_string) const;
+
+  std::unordered_map<int32_t, std::unordered_set<unsigned short>>
+  Intersect(const GEOSGeometry* line_string) const;
 
   /**
    * Intersect the bounding box with the tiles to see which tiles and sub-cells


### PR DESCRIPTION
# Issue

This is a *very* rough draft of replacing boost geometry with GEOS for the exclude polygon functionality. This is still far from ideal, but already significantly improves the performance of the intersection checks for large polygons. 

@nilsnolde had some interesting ideas in #4387, and this only scratches the surface. If we changed the interface slightly, we could easily support holes with GEOS. A big caveat right now is that the tile/bin intersection logic does not work with GEOS geometries, so there is a lot of overhead copying that we should get rid of :smile: 

### Some TODOs:

  - [ ] better interfacing between midgard and geos 
  - [ ] accept rings 
 
