### PR TITLE
chore: Bump gtest to v1.16.0 to fix link errors on MacOS with clang17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
    * FIXED: remove start maneuver if route starts on stairs/escalators [#5127](https://github.com/valhalla/valhalla/pull/5127)
    * FIXED: compilation with clang 20 [#5208](https://github.com/valhalla/valhalla/pull/5208)
    * FIXED: compatibility with GEOS <3.12 [#5224](https://github.com/valhalla/valhalla/pull/5224)
+   * FIXED: gtest linkage errors with clang 17+ on MacOS [#5227](https://github.com/valhalla/valhalla/pull/5227)
 * **Enhancement**
    * ADDED: Consider smoothness in all profiles that use surface [#4949](https://github.com/valhalla/valhalla/pull/4949)
    * ADDED: costing parameters to exclude certain edges `exclude_tolls`, `exclude_bridges`, `exclude_tunnels`, `exclude_highways`, `exclude_ferries`. They need to be enabled in the config with `service_limits.allow_hard_exclusions`. Also added location search filters `exclude_ferry` and `exclude_toll` to complement these changes. [#4524](https://github.com/valhalla/valhalla/pull/4524)


### PR DESCRIPTION
# Issue

This PR updates gtest library to v1.16.0 to fix strange linker errors with all tests that I've encountered once updated MacOS to Sequoia that ships with clang17.

```
[ 24%] Linking CXX executable directededge
Undefined symbols for architecture arm64:
  "testing::internal::MakeAndRegisterTestInfo(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, char const*, char const*, char const*, testing::internal::CodeLocation, void const*, void (*)(), void (*)(), testing::internal::TestFactoryBase*)", referenced from:
      __GLOBAL__sub_I_admin.cc in admin.cc.o
      __GLOBAL__sub_I_admin.cc in admin.cc.o
      __GLOBAL__sub_I_admin.cc in admin.cc.o
      __GLOBAL__sub_I_admin.cc in admin.cc.o
ld: symbol(s) not found for architecture arm64
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
Undefined symbols for architecture arm64:
  "testing::internal::MakeAndRegisterTestInfo(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, char const*, char const*, char const*, testing::internal::CodeLocation, void const*, void (*)(), void (*)(), testing::internal::TestFactoryBase*)", referenced from:
      __GLOBAL__sub_I_access_restriction.cc in access_restriction.cc.o
ld: symbol(s) not found for architecture arm64
make[3]: *** [test/admin] Error 1
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [test/CMakeFiles/admin.dir/all] Error 2
make[2]: *** Waiting for unfinished jobs....
make[3]: *** [test/access_restriction] Error 1
make[2]: *** [test/CMakeFiles/access_restriction.dir/all] Error 2
[ 24%] Linking CXX executable aabb2
Undefined symbols for architecture arm64:
  "testing::internal::MakeAndRegisterTestInfo(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, char const*, char const*, char const*, testing::internal::CodeLocation, void const*, void (*)(), void (*)(), testing::internal::TestFactoryBase*)", referenced from:
      __GLOBAL__sub_I_distanceapproximator.cc in distanceapproximator.cc.o
      __GLOBAL__sub_I_distanceapproximator.cc in distanceapproximator.cc.o
      __GLOBAL__sub_I_distanceapproximator.cc in distanceapproximator.cc.o
ld: symbol(s) not found for architecture arm64
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
make[3]: *** [test/distanceapproximator] Error 1
make[2]: *** [test/CMakeFiles/distanceapproximator.dir/all] Error 2
Undefined symbols for architecture arm64:
  "testing::internal::MakeAndRegisterTestInfo(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, char const*, char const*, char const*, testing::internal::CodeLocation, void const*, void (*)(), void (*)(), testing::internal::TestFactoryBase*)", referenced from:
      __GLOBAL__sub_I_directededge.cc in directededge.cc.o
      __GLOBAL__sub_I_directededge.cc in directededge.cc.o
      __GLOBAL__sub_I_directededge.cc in directededge.cc.o
ld: symbol(s) not found for architecture arm64
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
make[3]: *** [test/directededge] Error 1
make[2]: *** [test/CMakeFiles/directededge.dir/all] Error 2
```

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
