### PR TITLE
Bump clang-tidy version to `11.0.0`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
           key: ccache-debug-linux-x86_64-v3-{{ .Branch }}-{{ epoch }}
           paths:
             - ~/.cache/ccache
-      - run: scripts/clang-tidy-only-diff.sh 4
+      - run: scripts/clang-tidy-only-diff.sh
       - run: sudo make -C build install
       - run: make -C build package
       - run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,6 +227,7 @@
    * ADDED: Add option `edge.country_crossing` to trace attributes [#4825](https://github.com/valhalla/valhalla/pull/4825)
    * CHANGED: Unification of turn costs for ramps and roundabouts [#4827](https://github.com/valhalla/valhalla/pull/4827)
    * CHANGED: updated dockerfile to use ubuntu 24.04 [#4805](https://github.com/valhalla/valhalla/pull/4805)
+   * CHANGED: Bump clang-tidy version to 11.0.0 [#5231](https://github.com/valhalla/valhalla/pull/5231)
 
 ## Release Date: 2023-05-11 Valhalla 3.4.0
 * **Removed**

--- a/scripts/clang-tidy-only-diff.sh
+++ b/scripts/clang-tidy-only-diff.sh
@@ -6,7 +6,7 @@ set -o errexit -o pipefail -o nounset
 readonly base=$(git merge-base refs/remotes/origin/master HEAD)
 readonly build_dir=build
 
-readonly CLANG_TIDY_VERSION=7.0.0
+readonly CLANG_TIDY_VERSION=11.0.0
 
 source scripts/bash_utils.sh
 setup_mason

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -1610,7 +1610,7 @@ void GraphBuilder::AddPronunciationsWithLang(std::vector<std::string>& pronuncia
 
   auto get_pronunciations = [](const std::vector<std::string>& pronunciation_tokens,
                                const std::vector<baldr::Language>& pronunciation_langs,
-                               const std::map<size_t, size_t> indexMap, const size_t key,
+                               const std::map<size_t, size_t>& indexMap, const size_t key,
                                const baldr::PronunciationAlphabet verbal_type) {
     linguistic_text_header_t header{static_cast<uint8_t>(baldr::Language::kNone),
                                     0,

--- a/src/mjolnir/landmarks.cc
+++ b/src/mjolnir/landmarks.cc
@@ -194,7 +194,7 @@ std::vector<Landmark> LandmarkDatabase::get_landmarks_by_ids(const std::vector<i
   sql += ")";
 
   // callback for the sql query
-  auto populate_landmarks = [](void* data, int argc, char** argv, char** col_names) {
+  auto populate_landmarks = [](void* data, int /*argc*/, char** argv, char** /*col_names*/) {
     std::vector<Landmark>* landmarks = static_cast<std::vector<Landmark>*>(data);
 
     int64_t landmark_id = static_cast<int64_t>(std::stoi(argv[0]));

--- a/src/mjolnir/osmway.cc
+++ b/src/mjolnir/osmway.cc
@@ -160,7 +160,7 @@ void OSMWay::AddPronunciationsWithLang(std::vector<std::string>& pronunciations,
 
   auto get_pronunciations = [](const std::vector<std::string>& pronunciation_tokens,
                                const std::vector<baldr::Language>& pronunciation_langs,
-                               const std::map<size_t, size_t> indexMap, const size_t key,
+                               const std::map<size_t, size_t>& indexMap, const size_t key,
                                const baldr::PronunciationAlphabet verbal_type) {
     linguistic_text_header_t header{static_cast<uint8_t>(baldr::Language::kNone),
                                     0,

--- a/src/mjolnir/shortcutbuilder.cc
+++ b/src/mjolnir/shortcutbuilder.cc
@@ -380,7 +380,8 @@ std::pair<uint32_t, uint32_t> AddShortcutEdges(GraphReader& reader,
   }
 
   // Check if this is the last edge in a shortcut (if the endnode cannot be contracted).
-  auto last_edge = [&reader](graph_tile_ptr tile, const GraphId& endnode, EdgePairs& edgepairs) {
+  auto last_edge = [&reader](const graph_tile_ptr& tile, const GraphId& endnode,
+                             EdgePairs& edgepairs) {
     return !CanContract(reader, tile, endnode, edgepairs);
   };
 

--- a/src/odin/signs.cc
+++ b/src/odin/signs.cc
@@ -23,8 +23,9 @@ Signs::Signs() {
 
 void Signs::Sort(std::vector<Sign>* signs) {
   // Sort signs by descending consecutive count order
-  std::sort(signs->begin(), signs->end(),
-            [](Sign a, Sign b) { return b.consecutive_count() < a.consecutive_count(); });
+  std::sort(signs->begin(), signs->end(), [](const Sign& a, const Sign& b) {
+    return b.consecutive_count() < a.consecutive_count();
+  });
 }
 
 void Signs::CountAndSort(std::vector<Sign>* prev_signs, std::vector<Sign>* curr_signs) {

--- a/src/skadi/sample.cc
+++ b/src/skadi/sample.cc
@@ -203,7 +203,7 @@ public:
   ~tile_data();
   tile_data& operator=(const tile_data& other);
 
-  tile_data& operator=(tile_data&& other) {
+  tile_data& operator=(tile_data&& other) noexcept {
     std::swap(c, other.c);
     std::swap(data, other.data);
     std::swap(index, other.index);

--- a/src/thor/triplegbuilder.cc
+++ b/src/thor/triplegbuilder.cc
@@ -686,7 +686,7 @@ void SetElevation(TripLeg_Edge* trip_edge,
 
   // Lambda to get elevation at specified distance
   double interval = 0.0;
-  const auto find_elevation = [&interval](const std::vector<float> elevation, const double d) {
+  const auto find_elevation = [&interval](const std::vector<float>& elevation, const double d) {
     // Find index based on the stored interval and the desired distance
     uint32_t index = static_cast<uint32_t>(d / interval);
     if (index >= elevation.size() - 1) {

--- a/src/tyr/route_summary_cache.h
+++ b/src/tyr/route_summary_cache.h
@@ -21,7 +21,8 @@ struct NamedSegment {
   NamedSegment(const NamedSegment& ns) : name(ns.name), index(ns.index), distance(ns.distance) {
   }
 
-  NamedSegment(NamedSegment&& ns) : name(std::move(ns.name)), index(ns.index), distance(ns.distance) {
+  NamedSegment(NamedSegment&& ns) noexcept
+      : name(std::move(ns.name)), index(ns.index), distance(ns.distance) {
   }
 
   NamedSegment& operator=(const NamedSegment& ns);

--- a/src/tyr/serializers.cc
+++ b/src/tyr/serializers.cc
@@ -257,7 +257,7 @@ std::string serializePbf(Api& request) {
 }
 
 // Generate leg shape in geojson format.
-baldr::json::MapPtr geojson_shape(const std::vector<midgard::PointLL> shape) {
+baldr::json::MapPtr geojson_shape(const std::vector<midgard::PointLL>& shape) {
   auto geojson = baldr::json::map({});
   auto coords = baldr::json::array({});
   coords->reserve(shape.size());
@@ -270,7 +270,7 @@ baldr::json::MapPtr geojson_shape(const std::vector<midgard::PointLL> shape) {
   return geojson;
 }
 
-void geojson_shape(const std::vector<midgard::PointLL> shape, rapidjson::writer_wrapper_t& writer) {
+void geojson_shape(const std::vector<midgard::PointLL>& shape, rapidjson::writer_wrapper_t& writer) {
   writer("type", "LineString");
   writer.start_array("coordinates");
   writer.set_precision(tyr::kCoordinatePrecision);

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -215,7 +215,7 @@ bool add_date_to_locations(Options& options,
     }
   }
 
-  return std::find_if(locations.begin(), locations.end(), [](valhalla::Location loc) {
+  return std::find_if(locations.begin(), locations.end(), [](const valhalla::Location& loc) {
            return !loc.date_time().empty();
          }) != locations.end();
 }

--- a/test/gurka/test_expansion.cc
+++ b/test/gurka/test_expansion.cc
@@ -33,7 +33,7 @@ protected:
   valhalla::Api do_expansion_action(std::string* res,
                                     bool skip_opps,
                                     bool dedupe,
-                                    std::string action,
+                                    const std::string& action,
                                     const std::vector<std::string>& props,
                                     const std::vector<std::string>& waypoints,
                                     const bool pbf) {

--- a/test/gurka/test_gtfs.cc
+++ b/test/gurka/test_gtfs.cc
@@ -966,7 +966,7 @@ TEST(GtfsExample, route_trip4) {
 
 TEST(GtfsExample, isochrones) {
 
-  auto WaypointToBoostPoint = [&](std::string waypoint) {
+  auto WaypointToBoostPoint = [&](const std::string& waypoint) {
     auto point = map.nodes[waypoint];
     return point_type(point.x(), point.y());
   };

--- a/test/gurka/test_locate.cc
+++ b/test/gurka/test_locate.cc
@@ -43,7 +43,7 @@ TEST(locate, basic_properties) {
   test::build_live_traffic_data(map.config);
 
   // turn on some traffic for fun
-  auto traffic_cb = [](baldr::GraphReader& reader, baldr::TrafficTile& tile, int index,
+  auto traffic_cb = [](baldr::GraphReader& /*reader*/, baldr::TrafficTile& /*tile*/, int /*index*/,
                        valhalla::baldr::TrafficSpeed* current) -> void {
     current->overall_encoded_speed = 124 >> 1;
     current->encoded_speed1 = 126 >> 1;

--- a/test/gurka/test_recost.cc
+++ b/test/gurka/test_recost.cc
@@ -433,7 +433,9 @@ TEST(recosting, throwing) {
 
   // setup a callback for the recosting to tell us about the new label each made
   bool called = false;
-  sif::LabelCallback label_cb = [&called](const sif::PathEdgeLabel& label) -> void { called = true; };
+  sif::LabelCallback label_cb = [&called](const sif::PathEdgeLabel& /*label*/) -> void {
+    called = true;
+  };
 
   // build up the costing object
   auto costing = sif::CostFactory().Create(Costing::auto_);

--- a/test/hierarchylimits.cc
+++ b/test/hierarchylimits.cc
@@ -38,10 +38,10 @@ struct HierarchyLimitsTestParams {
   HierarchyLimitsTestParams(std::string&& req,
                             std::vector<HierarchyLimits>& hl,
                             bool use_pbf,
-                            std::unordered_map<std::string, std::string> overrides = {})
+                            const std::unordered_map<std::string, std::string>& overrides = {})
       : request(req), cfg(make_test_config(std::move(overrides))), hierarchy_limits_config_path(""),
         expected_hierarchy_limits(hl), pbf(use_pbf){};
-  HierarchyLimitsTestParams(std::unordered_map<std::string, std::string> overrides,
+  HierarchyLimitsTestParams(const std::unordered_map<std::string, std::string>& overrides,
                             std::string& config_path)
       : cfg(make_test_config(std::move(overrides))), hierarchy_limits_config_path(config_path){};
 

--- a/test/incident_loading.cc
+++ b/test/incident_loading.cc
@@ -26,10 +26,10 @@ struct testable_singleton : public incident_singleton_t {
   testable_singleton(const boost::property_tree::ptree& config, bool initialize)
       : incident_singleton_t(config,
                              {},
-                             [initialize](boost::property_tree::ptree,
-                                          std::unordered_set<valhalla::baldr::GraphId>,
-                                          std::shared_ptr<state_t> state,
-                                          std::function<bool(size_t)>) {
+                             [initialize](const boost::property_tree::ptree&,
+                                          const std::unordered_set<valhalla::baldr::GraphId>&,
+                                          const std::shared_ptr<state_t>& state,
+                                          const std::function<bool(size_t)>&) {
                                state->initialized.store(initialize);
                                state->signal.notify_one();
                              }) {

--- a/test/isochrone.cc
+++ b/test/isochrone.cc
@@ -246,7 +246,7 @@ TEST(Isochrones, OriginEdge) {
                                  {{"/contours/0/time", "10"}}, {}, &geojson);
   std::vector<PointLL> iso_polygon = polygon_from_geojson(geojson);
 
-  auto WaypointToBoostPoint = [&](std::string waypoint) {
+  auto WaypointToBoostPoint = [&](const std::string& waypoint) {
     auto point = map.nodes[waypoint];
     return point_type(point.x(), point.y());
   };
@@ -281,7 +281,7 @@ TEST(Isochrones, LongEdge) {
                                  {{"/contours/0/time", "15"}}, {}, &geojson);
   std::vector<PointLL> iso_polygon = polygon_from_geojson(geojson);
 
-  auto WaypointToBoostPoint = [&](std::string waypoint) {
+  auto WaypointToBoostPoint = [&](const std::string& waypoint) {
     auto point = map.nodes[waypoint];
     return point_type(point.x(), point.y());
   };

--- a/test/lua.cc
+++ b/test/lua.cc
@@ -41,7 +41,7 @@ TEST(Lua, ZeroMantissa) {
   ASSERT_FLOAT_EQ(2.0f, std::stof(results["maxheight"]));
 }
 
-void assert_height_parses(std::string maxheight, float expected) {
+void assert_height_parses(const std::string& maxheight, float expected) {
   mjolnir::LuaTagTransform lua(std::string(lua_graph_lua, lua_graph_lua + lua_graph_lua_len));
 
   TagsBuilder tags;

--- a/test/viterbi_search.cc
+++ b/test/viterbi_search.cc
@@ -188,7 +188,7 @@ std::vector<size_t> generate_column_counts(size_t column_length,
 
 std::vector<Column> generate_columns(std::uniform_int_distribution<int> transition_cost_distribution,
                                      std::uniform_int_distribution<int> emission_cost_distribution,
-                                     std::vector<size_t> column_counts) {
+                                     const std::vector<size_t>& column_counts) {
   std::vector<Column> columns;
 
   for (const auto count : column_counts) {

--- a/valhalla/baldr/double_bucket_queue.h
+++ b/valhalla/baldr/double_bucket_queue.h
@@ -48,8 +48,8 @@ public:
     reuse(mincost, range, bucketsize, labelcontainer);
   }
 
-  DoubleBucketQueue(DoubleBucketQueue&&) = default;
-  DoubleBucketQueue& operator=(DoubleBucketQueue&&) = default;
+  DoubleBucketQueue(DoubleBucketQueue&&) noexcept = default;
+  DoubleBucketQueue& operator=(DoubleBucketQueue&&) noexcept = default;
   DoubleBucketQueue(const DoubleBucketQueue&) = delete;
   DoubleBucketQueue& operator=(const DoubleBucketQueue&) = delete;
 

--- a/valhalla/baldr/landmark.h
+++ b/valhalla/baldr/landmark.h
@@ -103,7 +103,7 @@ struct Landmark {
   double lat;
 
   Landmark(const int64_t id,
-           const std::string name,
+           const std::string& name,
            const LandmarkType type,
            const double lng,
            const double lat)

--- a/valhalla/meili/match_result.h
+++ b/valhalla/meili/match_result.h
@@ -120,7 +120,7 @@ struct MatchResults {
 
   MatchResults(const MatchResults&) = delete;
   MatchResults& operator=(const MatchResults&) = delete;
-  MatchResults(MatchResults&& o) {
+  MatchResults(MatchResults&& o) noexcept {
     results = std::move(o.results);
     segments = std::move(o.segments);
     edges = std::move(o.edges);
@@ -128,7 +128,7 @@ struct MatchResults {
     e1 = segments.empty() || segments.front().source < 1.0f ? edges.cbegin() : edges.cbegin() + 1;
     e2 = segments.empty() || segments.back().target > 0.0f ? edges.cend() : edges.cend() - 1;
   }
-  MatchResults& operator=(MatchResults&& o) {
+  MatchResults& operator=(MatchResults&& o) noexcept {
     results = std::move(o.results);
     segments = std::move(o.segments);
     edges = std::move(o.edges);

--- a/valhalla/meili/state.h
+++ b/valhalla/meili/state.h
@@ -35,7 +35,7 @@ public:
 
   void SetRoute(const std::vector<StateId>& stateids,
                 const std::unordered_map<uint16_t, uint32_t>& results,
-                labelset_ptr_t labelset) const {
+                const labelset_ptr_t& labelset) const {
     if (!labelset) {
       throw std::runtime_error("expect valid labelset but got nullptr");
     }

--- a/valhalla/meili/topk_search.h
+++ b/valhalla/meili/topk_search.h
@@ -4,6 +4,7 @@
 #include <functional>
 #include <memory>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include <valhalla/meili/stateid.h>
@@ -48,7 +49,7 @@ public:
                         std::function<StateId(const StateId::Time&)> claim_stateid,
                         std::unordered_map<StateId, StateId>& initial_origins,
                         std::unordered_set<StateId>& removed_origins)
-      : vs_(vs), claim_stateid_(claim_stateid),
+      : vs_(vs), claim_stateid_(std::move(claim_stateid)),
         original_emission_cost_model_(vs.emission_cost_model()),
         original_transition_cost_model_(vs.transition_cost_model()), origin_(), clone_(),
         initial_origins_(initial_origins), removed_origins_(removed_origins),

--- a/valhalla/midgard/elevation_encoding.h
+++ b/valhalla/midgard/elevation_encoding.h
@@ -1,6 +1,7 @@
 #ifndef VALHALLA_MIDGARD_ELEVATION_ENCODING_H_
 #define VALHALLA_MIDGARD_ELEVATION_ENCODING_H_
 
+#include <algorithm>
 #include <cmath>
 #include <type_traits>
 #include <vector>

--- a/valhalla/midgard/sequence.h
+++ b/valhalla/midgard/sequence.h
@@ -126,8 +126,8 @@ namespace midgard {
 template <class T> class mem_map {
 public:
   // non-copyable
-  mem_map(mem_map&&) = default;
-  mem_map& operator=(mem_map&&) = default;
+  mem_map(mem_map&&) noexcept = default;
+  mem_map& operator=(mem_map&&) noexcept = default;
   mem_map(const mem_map&) = delete;
   mem_map& operator=(const mem_map&) = delete;
 

--- a/valhalla/midgard/util.h
+++ b/valhalla/midgard/util.h
@@ -683,7 +683,7 @@ template <typename T> struct Finally {
   T t;
   explicit Finally(T t) : t(t){};
   Finally() = delete;
-  Finally(Finally&& f) = default;
+  Finally(Finally&& f) noexcept = default;
   Finally(const Finally&) = delete;
   Finally& operator=(const Finally&) = delete;
   Finally& operator=(Finally&&) = delete;

--- a/valhalla/mjolnir/linkclassification.h
+++ b/valhalla/mjolnir/linkclassification.h
@@ -6,6 +6,8 @@
 namespace valhalla {
 namespace mjolnir {
 
+struct OSMData;
+
 // Reclassify links (ramps and turn channels). OSM usually classifies links as
 // the best classification, while to more effectively create shortcuts it is
 // better to "downgrade" link edges to the lower classification.

--- a/valhalla/mjolnir/osmlinguistic.h
+++ b/valhalla/mjolnir/osmlinguistic.h
@@ -2,6 +2,7 @@
 #define VALHALLA_MJOLNIR_OSMLINGUISTIC_H
 
 #include <cstdint>
+#include <cstring>
 
 #include <valhalla/baldr/graphconstants.h>
 

--- a/valhalla/sif/costfactory.h
+++ b/valhalla/sif/costfactory.h
@@ -91,7 +91,7 @@ public:
   cost_ptr_t Create(const Costing& costing) const {
     auto itr = factory_funcs_.find(costing.type());
     if (itr == factory_funcs_.end()) {
-      auto costing_str = Costing_Enum_Name(costing.type());
+      const auto& costing_str = Costing_Enum_Name(costing.type());
       throw std::runtime_error("No costing method found for '" + costing_str + "'");
     }
     // create the cost using the function pointer

--- a/valhalla/thor/isochrone.h
+++ b/valhalla/thor/isochrone.h
@@ -63,7 +63,7 @@ public:
    * @param callback the functor to call back when the Dijkstra makes progress
    *                             on a given edge
    */
-  void SetInnerExpansionCallback(const expansion_callback_t callback) {
+  void SetInnerExpansionCallback(const expansion_callback_t& callback) {
     inner_expansion_callback_ = callback;
   }
 

--- a/valhalla/tyr/serializers.h
+++ b/valhalla/tyr/serializers.h
@@ -133,8 +133,8 @@ baldr::json::ArrayPtr serializeWarnings(const valhalla::Api& api);
  * @param shape  The points making up the line.
  * @returns The GeoJSON geometry of the LineString
  */
-baldr::json::MapPtr geojson_shape(const std::vector<midgard::PointLL> shape);
-void geojson_shape(const std::vector<midgard::PointLL> shape, rapidjson::writer_wrapper_t& writer);
+baldr::json::MapPtr geojson_shape(const std::vector<midgard::PointLL>& shape);
+void geojson_shape(const std::vector<midgard::PointLL>& shape, rapidjson::writer_wrapper_t& writer);
 
 // Elevation serialization support
 
@@ -194,7 +194,7 @@ get_elevation(const TripLeg& path_leg, const float interval, const float start_d
   std::vector<std::pair<uint32_t, uint32_t>> bridges;
   for (const auto& node : path_leg.node()) {
     // Get the edge on the path, the starting elevation and sampling interval
-    auto path_edge = node.edge();
+    const auto& path_edge = node.edge();
     float edge_interval = path_edge.elevation_sampling_interval();
 
     // Identify consecutive bridge/tunnel edges and store elevation indexes at start and end.


### PR DESCRIPTION
# Issue

This PR updates clang-tidy to 11.0.0 as it is the latest version available in mason.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
