### PR TITLE
chore: switch to pypi version of clang-format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
    * ADDED: Sqlite3 RAII wrapper around sqlite3* and spatielite connection [#5206](https://github.com/valhalla/valhalla/pull/5206)
    * CHANGED: Improved SQL statements when building admins [#5219](https://github.com/valhalla/valhalla/pull/5219)
    * CHANGED: Replace `boost::geometry` by GEOS for operations with admin/tz polygons and clip them by tile bbox [#5204](https://github.com/valhalla/valhalla/pull/5204)
+   * CHANGED: Switch to PyPI version of `clang-format` [#5237](https://github.com/valhalla/valhalla/pull/5237)
 
 ## Release Date: 2024-10-10 Valhalla 3.5.1
 * **Removed**

--- a/scripts/bash_utils.sh
+++ b/scripts/bash_utils.sh
@@ -2,15 +2,6 @@
 
 set -o errexit -o pipefail -o nounset
 
-readonly OS=$(uname)
-if [[ $OS = "Linux" ]] ; then
-    readonly NPROC=$(nproc)
-elif [[ ${OS} = "Darwin" ]] ; then
-    readonly NPROC=$(sysctl -n hw.physicalcpu)
-else
-    readonly NPROC=1
-fi
-
 function setup_mason {
 
   if [ ! -f mason/mason ] ; then

--- a/scripts/bash_utils.sh
+++ b/scripts/bash_utils.sh
@@ -2,16 +2,16 @@
 
 set -o errexit -o pipefail -o nounset
 
-function setup_mason {
+readonly OS=$(uname)
+if [[ $OS = "Linux" ]] ; then
+    readonly NPROC=$(nproc)
+elif [[ ${OS} = "Darwin" ]] ; then
+    readonly NPROC=$(sysctl -n hw.physicalcpu)
+else
+    readonly NPROC=1
+fi
 
-  readonly OS=$(uname)
-  if [[ $OS = "Linux" ]] ; then
-      readonly NPROC=$(nproc)
-  elif [[ ${OS} = "Darwin" ]] ; then
-      readonly NPROC=$(sysctl -n hw.physicalcpu)
-  else
-      readonly NPROC=1
-  fi
+function setup_mason {
 
   if [ ! -f mason/mason ] ; then
       echo "Installing mason"

--- a/scripts/clang_format_wrapper.py
+++ b/scripts/clang_format_wrapper.py
@@ -1,0 +1,6 @@
+# /usr/bin/env python3
+
+# This is a wrapper to be able to use xargs on PyPI's clang-format package
+from clang_format import clang_format
+
+clang_format()

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -8,29 +8,19 @@ set -o errexit -o pipefail -o nounset
 #  - 0 everything looks fine
 
 
-readonly CLANG_FORMAT_VERSION=11.0.0
+readonly CLANG_FORMAT_VERSION=11.0.1
 
 if [[ $(uname -i) == 'aarch64' ]]; then
   echo 'Formatting is disabled on arm for the time being'
   exit
 fi
 source scripts/bash_utils.sh
-setup_mason
-
-./mason/mason install clang-format $CLANG_FORMAT_VERSION
-./mason/mason link clang-format $CLANG_FORMAT_VERSION
-readonly CLANG_FORMAT=$(pwd)/mason_packages/.link/bin/clang-format
-
-echo "Using clang-format $CLANG_FORMAT_VERSION from ${CLANG_FORMAT}"
-
-find src valhalla test -type f -name '*.h' -o -name '*.cc' \
-  | xargs -I{} -P ${NPROC} ${CLANG_FORMAT} -i -style=file {}
 
 # Python setup
 py=$(setup_python)
 if [[ $(python3 -m pip list | grep -c "black\|flake8") -ne 2 ]]; then
   if [[ $(python3 -c 'import sys; print(int(sys.base_prefix != sys.prefix or hasattr(sys, "real_prefix")))') -eq 1 ]]; then
-    ${py} -m pip install black==24.10.0 flake8==7.1.1
+    ${py} -m pip install black==24.10.0 flake8==7.1.1 clang-format=="$CLANG_FORMAT_VERSION"
   else
     sudo PIP_BREAK_SYSTEM_PACKAGES=1 ${py} -m pip install black==24.10.0 flake8==7.1.1
   fi
@@ -42,3 +32,11 @@ ${py} -m black --line-length=105 --skip-string-normalization ${python_sources}
 
 # Python linter
 ${py} -m flake8 --max-line-length=105 --extend-ignore=E501,E731,E203 --extend-exclude=src/bindings/python/__init__.py ${python_sources}
+
+# clang-format
+readonly CLANG_FORMAT="$(${py} -c 'import sys; print(sys.prefix)')"/bin/clang-format
+
+echo "Using clang-format $CLANG_FORMAT_VERSION from ${CLANG_FORMAT}"
+
+find src valhalla test -type f -name '*.h' -o -name '*.cc' \
+  | xargs -I{} -P ${NPROC} ${CLANG_FORMAT} -i -style=file {}

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -22,7 +22,7 @@ source scripts/bash_utils.sh
 
 # Python setup
 py=$(setup_python)
-if [[ $(${py} -m pip list | grep -c "black\|flake8\|clang-format") -ne 2 ]]; then
+if [[ $(${py} -m pip list | grep -c "black\|flake8\|clang-format") -ne 3 ]]; then
   if [[ $(${py} -c 'import sys; print(int(sys.base_prefix != sys.prefix or hasattr(sys, "real_prefix")))') -eq 1 ]]; then
     ${py} -m pip install black==$BLACK_VERSION flake8==$FLAKE8_VERSION clang-format==$CLANG_FORMAT_VERSION
   else

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -49,7 +49,5 @@ elif [[ ${OS} = "Darwin" ]] ; then
 else
     readonly NPROC=1
 fi
-
-# TODO: either put this in a script
 find src valhalla test -type f -name '*.h' -o -name '*.cc' \
   | xargs -I{} -P ${NPROC} ${py} scripts/clang_format_wrapper.py -style=file -i {}

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -38,7 +38,7 @@ ${py} -m black --line-length=105 --skip-string-normalization ${python_sources}
 ${py} -m flake8 --max-line-length=105 --extend-ignore=E501,E731,E203 --extend-exclude=src/bindings/python/__init__.py ${python_sources}
 
 # clang-format
-echo "Using $(${py} scripts/clang_format_wrapper.py) --version)"
+echo "Using $(${py} scripts/clang_format_wrapper.py --version)"
 
 # determine how many threads to use
 readonly OS=$(uname)
@@ -49,5 +49,6 @@ elif [[ ${OS} = "Darwin" ]] ; then
 else
     readonly NPROC=1
 fi
+
 find src valhalla test -type f -name '*.h' -o -name '*.cc' \
   | xargs -I{} -P ${NPROC} ${py} scripts/clang_format_wrapper.py -style=file -i {}

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -7,6 +7,10 @@ set -o errexit -o pipefail -o nounset
 #  - 1 there are files to be formatted
 #  - 0 everything looks fine
 
+# see https://pypi.org/project/black/#history
+readonly BLACK_VERSION=24.10.0
+# see https://pypi.org/project/flake8/#history
+readonly FLAKE8_VERSION=7.1.1
 # see https://pypi.org/project/clang-format/#history
 readonly CLANG_FORMAT_VERSION=11.0.1
 
@@ -18,12 +22,11 @@ source scripts/bash_utils.sh
 
 # Python setup
 py=$(setup_python)
-CLANG_FORMAT_CMD="${py} -c \"from clang_format import clang_format; clang_format()\""
 if [[ $(${py} -m pip list | grep -c "black\|flake8\|clang-format") -ne 2 ]]; then
   if [[ $(${py} -c 'import sys; print(int(sys.base_prefix != sys.prefix or hasattr(sys, "real_prefix")))') -eq 1 ]]; then
-    ${py} -m pip install black==24.10.0 flake8==7.1.1 clang-format=="$CLANG_FORMAT_VERSION"
+    ${py} -m pip install black==$BLACK_VERSION flake8==$FLAKE8_VERSION clang-format==$CLANG_FORMAT_VERSION
   else
-    PIP_BREAK_SYSTEM_PACKAGES=1 ${py} -m pip install black==24.10.0 flake8==7.1.1 clang-format=="$CLANG_FORMAT_VERSION"
+    sudo PIP_BREAK_SYSTEM_PACKAGES=1 ${py} -m pip install black==$BLACK_VERSION flake8==$FLAKE8_VERSION clang-format==$CLANG_FORMAT_VERSION
   fi
 fi
 python_sources=$(LANG=C find scripts src/bindings/python -type f -exec file {} \; | grep -F "Python script" | sed 's/:.*//')
@@ -35,7 +38,7 @@ ${py} -m black --line-length=105 --skip-string-normalization ${python_sources}
 ${py} -m flake8 --max-line-length=105 --extend-ignore=E501,E731,E203 --extend-exclude=src/bindings/python/__init__.py ${python_sources}
 
 # clang-format
-echo "Using $(eval "${CLANG_FORMAT_CMD}" --version)"
+echo "Using $(${py} scripts/clang_format_wrapper.py) --version)"
 
 # determine how many threads to use
 readonly OS=$(uname)
@@ -47,5 +50,6 @@ else
     readonly NPROC=1
 fi
 
+# TODO: either put this in a script
 find src valhalla test -type f -name '*.h' -o -name '*.cc' \
-  | xargs -I{} -P ${NPROC} ${py} -c "from clang_format import clang_format; clang_format()" -style=file -i {}
+  | xargs -I{} -P ${NPROC} ${py} scripts/clang_format_wrapper.py -style=file -i {}


### PR DESCRIPTION
ref https://github.com/valhalla/valhalla/pull/5231#issuecomment-2853942941.

This PR switches the repository to install `clang-format` from mason to PyPI.  The version slightly changes from 11.0.0 to 11.0.1, which didn't seem to introduce any changes.
