### PR TITLE
chore: switch to clang tidy from PyPI and remove mason support

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,6 @@
 ---
 Checks:          'bugprone-throw-keyword-missing,clang-*,performance*,-performance-move-const-arg,misc-unused-parameters'
 WarningsAsErrors: ''
-AnalyzeTemporaryDtors: false
 CheckOptions:
   - key:             google-readability-braces-around-statements.ShortStatementLines
     value:           '1'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
    * ADDED: Sqlite3 RAII wrapper around sqlite3* and spatielite connection [#5206](https://github.com/valhalla/valhalla/pull/5206)
    * CHANGED: Improved SQL statements when building admins [#5219](https://github.com/valhalla/valhalla/pull/5219)
    * CHANGED: Replace `boost::geometry` by GEOS for operations with admin/tz polygons and clip them by tile bbox [#5204](https://github.com/valhalla/valhalla/pull/5204)
+   * CHANGED: Switch to PyPI version of `clang-format` [#5237](https://github.com/valhalla/valhalla/pull/5237)
 
 ## Release Date: 2024-10-10 Valhalla 3.5.1
 * **Removed**

--- a/scripts/bash_utils.sh
+++ b/scripts/bash_utils.sh
@@ -2,22 +2,14 @@
 
 set -o errexit -o pipefail -o nounset
 
-function setup_mason {
-
-  if [ ! -f mason/mason ] ; then
-      echo "Installing mason"
-      mkdir -p ./mason
-      curl -sSfL https://github.com/mapbox/mason/archive/6e12456fd85e842eda63e87e5b706a7e961e522d.tar.gz \
-        | tar \
-          --gunzip \
-            --extract \
-            --strip-components=1 \
-            --exclude="*md" \
-            --exclude="test*" \
-            --directory=./mason
-  fi
-
-}
+# see https://pypi.org/project/black/#history
+readonly BLACK_VERSION=24.10.0
+# see https://pypi.org/project/flake8/#history
+readonly FLAKE8_VERSION=7.1.1
+# see https://pypi.org/project/clang-format/#history
+readonly CLANG_FORMAT_VERSION=11.0.1
+# see https://pypi.org/project/clang-tidy/#history
+readonly CLANG_TIDY_VERSION=20.1.0
 
 function setup_python {
   local python_bin=""
@@ -30,4 +22,17 @@ function setup_python {
     return
   fi
   echo ${python_bin}
+}
+
+function install_py_packages {
+  local deps="black==$BLACK_VERSION flake8==$FLAKE8_VERSION clang-format==$CLANG_FORMAT_VERSION clang-tidy==$CLANG_TIDY_VERSION"
+
+  local py=$1
+  if [[ $(${py} -m pip list | grep -c "black\|flake8\|clang-format\|clang-tidy") -ne 4 ]]; then
+    if [[ $(${py} -c 'import sys; print(int(sys.base_prefix != sys.prefix or hasattr(sys, "real_prefix")))') -eq 1 ]]; then
+      ${py} -m pip install ${deps}
+    else
+      sudo PIP_BREAK_SYSTEM_PACKAGES=1 ${py} -m pip install ${deps}
+    fi
+  fi
 }

--- a/scripts/bash_utils.sh
+++ b/scripts/bash_utils.sh
@@ -2,15 +2,6 @@
 
 set -o errexit -o pipefail -o nounset
 
-readonly OS=$(uname)
-if [[ $OS = "Linux" ]] ; then
-    readonly NPROC=$(nproc)
-elif [[ ${OS} = "Darwin" ]] ; then
-    readonly NPROC=$(sysctl -n hw.physicalcpu)
-else
-    readonly NPROC=1
-fi
-
 function setup_mason {
 
   if [ ! -f mason/mason ] ; then

--- a/scripts/bash_utils.sh
+++ b/scripts/bash_utils.sh
@@ -2,16 +2,16 @@
 
 set -o errexit -o pipefail -o nounset
 
-function setup_mason {
+readonly OS=$(uname)
+if [[ $OS = "Linux" ]] ; then
+    readonly NPROC=$(nproc)
+elif [[ ${OS} = "Darwin" ]] ; then
+    readonly NPROC=$(sysctl -n hw.physicalcpu)
+else
+    readonly NPROC=1
+fi
 
-  readonly OS=$(uname)
-  if [[ $OS = "Linux" ]] ; then
-      readonly NPROC=$(nproc)
-  elif [[ ${OS} = "Darwin" ]] ; then
-      readonly NPROC=$(sysctl -n hw.physicalcpu)
-  else
-      readonly NPROC=1
-  fi
+function setup_mason {
 
   if [ ! -f mason/mason ] ; then
       echo "Installing mason"

--- a/scripts/clang-tidy-only-diff.sh
+++ b/scripts/clang-tidy-only-diff.sh
@@ -4,16 +4,9 @@
 set -o errexit -o pipefail -o nounset
 
 readonly base=$(git merge-base refs/remotes/origin/master HEAD)
-readonly build_dir=build
-
-readonly CLANG_TIDY_VERSION=7.0.0
+readonly build_dir=build/Release
 
 source scripts/bash_utils.sh
-setup_mason
-
-./mason/mason install clang-tidy $CLANG_TIDY_VERSION
-./mason/mason link clang-tidy $CLANG_TIDY_VERSION
-readonly CLANG_TIDY=$(pwd)/mason_packages/.link/bin/clang-tidy
 
 # Backup compile_commands and filter out protobuf generated .pb.cc files
 readonly tidy_dir=.tidytmp
@@ -42,6 +35,9 @@ if [ ${#modified_filepaths[@]} = 0 ]; then
 fi
 
 readonly FIX_ERRORS="-fix -fix-errors"
+py=$(setup_python)
+install_py_packages $py
+CLANG_TIDY_CMD="${py} -c \"from clang_tidy import clang_tidy; clang_tidy()\""
 
 readonly num_jobs="${1:-$(nproc)}"
 # -m specifies that `parallel` should distribute the arguments evenly across the executing jobs.
@@ -52,7 +48,7 @@ parallel \
   -m \
   -j $num_jobs \
   --halt-on-error now,fail=1 \
-  ${CLANG_TIDY} \
+  "${CLANG_TIDY_CMD}" \
   -p $tidy_dir \
   -header-filter "^$(pwd)/valhalla/[^/]+$" \
   ${FIX_ERRORS} \

--- a/scripts/clang_format_wrapper.py
+++ b/scripts/clang_format_wrapper.py
@@ -1,0 +1,6 @@
+# /usr/bin/env python3
+
+# This is a wrapper to be able to use xargs on PyPI's clang-format package
+from clang_format import clang_format
+
+clang_format()

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -8,29 +8,19 @@ set -o errexit -o pipefail -o nounset
 #  - 0 everything looks fine
 
 
-readonly CLANG_FORMAT_VERSION=11.0.0
+readonly CLANG_FORMAT_VERSION=11.0.1
 
 if [[ $(uname -i) == 'aarch64' ]]; then
   echo 'Formatting is disabled on arm for the time being'
   exit
 fi
 source scripts/bash_utils.sh
-setup_mason
-
-./mason/mason install clang-format $CLANG_FORMAT_VERSION
-./mason/mason link clang-format $CLANG_FORMAT_VERSION
-readonly CLANG_FORMAT=$(pwd)/mason_packages/.link/bin/clang-format
-
-echo "Using clang-format $CLANG_FORMAT_VERSION from ${CLANG_FORMAT}"
-
-find src valhalla test -type f -name '*.h' -o -name '*.cc' \
-  | xargs -I{} -P ${NPROC} ${CLANG_FORMAT} -i -style=file {}
 
 # Python setup
 py=$(setup_python)
 if [[ $(python3 -m pip list | grep -c "black\|flake8") -ne 2 ]]; then
   if [[ $(python3 -c 'import sys; print(int(sys.base_prefix != sys.prefix or hasattr(sys, "real_prefix")))') -eq 1 ]]; then
-    ${py} -m pip install black==24.10.0 flake8==7.1.1
+    ${py} -m pip install black==24.10.0 flake8==7.1.1 clang-format=="$CLANG_FORMAT_VERSION"
   else
     sudo PIP_BREAK_SYSTEM_PACKAGES=1 ${py} -m pip install black==24.10.0 flake8==7.1.1
   fi
@@ -42,3 +32,11 @@ ${py} -m black --line-length=105 --skip-string-normalization ${python_sources}
 
 # Python linter
 ${py} -m flake8 --max-line-length=105 --extend-ignore=E501,E731,E203 --extend-exclude=src/bindings/python/__init__.py ${python_sources}
+
+# clang-format
+readonly CLANG_FORMAT="$(${py} -c 'import sys; print(sys.prefix)')"/bin/clang-format
+
+echo "Using clang-format $CLANG_FORMAT_VERSION from ${CLANG_FORMAT}"
+
+find src valhalla test -type f -name '*.h' -o -name '*.cc' \
+  | xargs -I{} -P ${NPROC} ${CLANG_FORMAT} -i -style=file {}

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -49,7 +49,5 @@ elif [[ ${OS} = "Darwin" ]] ; then
 else
     readonly NPROC=1
 fi
-
-# TODO: either put this in a script
 find src valhalla test -type f -name '*.h' -o -name '*.cc' \
   | xargs -I{} -P ${NPROC} ${py} scripts/clang_format_wrapper.py -style=file -i {}

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -38,7 +38,7 @@ ${py} -m black --line-length=105 --skip-string-normalization ${python_sources}
 ${py} -m flake8 --max-line-length=105 --extend-ignore=E501,E731,E203 --extend-exclude=src/bindings/python/__init__.py ${python_sources}
 
 # clang-format
-echo "Using $(${py} scripts/clang_format_wrapper.py) --version)"
+echo "Using $(${py} scripts/clang_format_wrapper.py --version)"
 
 # determine how many threads to use
 readonly OS=$(uname)
@@ -49,5 +49,6 @@ elif [[ ${OS} = "Darwin" ]] ; then
 else
     readonly NPROC=1
 fi
+
 find src valhalla test -type f -name '*.h' -o -name '*.cc' \
   | xargs -I{} -P ${NPROC} ${py} scripts/clang_format_wrapper.py -style=file -i {}

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -7,6 +7,10 @@ set -o errexit -o pipefail -o nounset
 #  - 1 there are files to be formatted
 #  - 0 everything looks fine
 
+# see https://pypi.org/project/black/#history
+readonly BLACK_VERSION=24.10.0
+# see https://pypi.org/project/flake8/#history
+readonly FLAKE8_VERSION=7.1.1
 # see https://pypi.org/project/clang-format/#history
 readonly CLANG_FORMAT_VERSION=11.0.1
 
@@ -18,12 +22,11 @@ source scripts/bash_utils.sh
 
 # Python setup
 py=$(setup_python)
-CLANG_FORMAT_CMD="${py} -c \"from clang_format import clang_format; clang_format()\""
 if [[ $(${py} -m pip list | grep -c "black\|flake8\|clang-format") -ne 2 ]]; then
   if [[ $(${py} -c 'import sys; print(int(sys.base_prefix != sys.prefix or hasattr(sys, "real_prefix")))') -eq 1 ]]; then
-    ${py} -m pip install black==24.10.0 flake8==7.1.1 clang-format=="$CLANG_FORMAT_VERSION"
+    ${py} -m pip install black==$BLACK_VERSION flake8==$FLAKE8_VERSION clang-format==$CLANG_FORMAT_VERSION
   else
-    PIP_BREAK_SYSTEM_PACKAGES=1 ${py} -m pip install black==24.10.0 flake8==7.1.1 clang-format=="$CLANG_FORMAT_VERSION"
+    sudo PIP_BREAK_SYSTEM_PACKAGES=1 ${py} -m pip install black==$BLACK_VERSION flake8==$FLAKE8_VERSION clang-format==$CLANG_FORMAT_VERSION
   fi
 fi
 python_sources=$(LANG=C find scripts src/bindings/python -type f -exec file {} \; | grep -F "Python script" | sed 's/:.*//')
@@ -35,7 +38,7 @@ ${py} -m black --line-length=105 --skip-string-normalization ${python_sources}
 ${py} -m flake8 --max-line-length=105 --extend-ignore=E501,E731,E203 --extend-exclude=src/bindings/python/__init__.py ${python_sources}
 
 # clang-format
-echo "Using $(eval "${CLANG_FORMAT_CMD}" --version)"
+echo "Using $(${py} scripts/clang_format_wrapper.py) --version)"
 
 # determine how many threads to use
 readonly OS=$(uname)
@@ -47,5 +50,6 @@ else
     readonly NPROC=1
 fi
 
+# TODO: either put this in a script
 find src valhalla test -type f -name '*.h' -o -name '*.cc' \
-  | xargs -I{} -P ${NPROC} ${py} -c "from clang_format import clang_format; clang_format()" -style=file -i {}
+  | xargs -I{} -P ${NPROC} ${py} scripts/clang_format_wrapper.py -style=file -i {}

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -7,13 +7,6 @@ set -o errexit -o pipefail -o nounset
 #  - 1 there are files to be formatted
 #  - 0 everything looks fine
 
-# see https://pypi.org/project/black/#history
-readonly BLACK_VERSION=24.10.0
-# see https://pypi.org/project/flake8/#history
-readonly FLAKE8_VERSION=7.1.1
-# see https://pypi.org/project/clang-format/#history
-readonly CLANG_FORMAT_VERSION=11.0.1
-
 if [[ $(uname -i) == 'aarch64' ]]; then
   echo 'Formatting is disabled on arm for the time being'
   exit
@@ -22,13 +15,7 @@ source scripts/bash_utils.sh
 
 # Python setup
 py=$(setup_python)
-if [[ $(${py} -m pip list | grep -c "black\|flake8\|clang-format") -ne 2 ]]; then
-  if [[ $(${py} -c 'import sys; print(int(sys.base_prefix != sys.prefix or hasattr(sys, "real_prefix")))') -eq 1 ]]; then
-    ${py} -m pip install black==$BLACK_VERSION flake8==$FLAKE8_VERSION clang-format==$CLANG_FORMAT_VERSION
-  else
-    sudo PIP_BREAK_SYSTEM_PACKAGES=1 ${py} -m pip install black==$BLACK_VERSION flake8==$FLAKE8_VERSION clang-format==$CLANG_FORMAT_VERSION
-  fi
-fi
+install_py_packages $py
 python_sources=$(LANG=C find scripts src/bindings/python -type f -exec file {} \; | grep -F "Python script" | sed 's/:.*//')
 
 # Python formatter


### PR DESCRIPTION
Following up on #5237 (also based on that)

This PR switches the repository to install clang-tidy from mason to PyPI. We currently use v7.x, but PyPI only started distributing at v13.x. Since it's already a major jump, we might as well go all the way to the newest one, v20.1.0.

I'll have another PR, based on and pointed to this one, where I run clang-tidy with the newer version. Should be easier to review the changes. We could also close #5237 and just merge this one, I don't really care.