### PR TITLE
Fix matrix heading 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
    * FIXED: compilation with clang 20 [#5208](https://github.com/valhalla/valhalla/pull/5208)
    * FIXED: compatibility with GEOS <3.12 [#5224](https://github.com/valhalla/valhalla/pull/5224)
    * FIXED: gtest linkage errors with clang 17+ on MacOS [#5227](https://github.com/valhalla/valhalla/pull/5227)
+   * FIXED: matrix headings [#5244](https://github.com/valhalla/valhalla/pull/5244)
 * **Enhancement**
    * ADDED: Consider smoothness in all profiles that use surface [#4949](https://github.com/valhalla/valhalla/pull/4949)
    * ADDED: costing parameters to exclude certain edges `exclude_tolls`, `exclude_bridges`, `exclude_tunnels`, `exclude_highways`, `exclude_ferries`. They need to be enabled in the config with `service_limits.allow_hard_exclusions`. Also added location search filters `exclude_ferry` and `exclude_toll` to complement these changes. [#4524](https://github.com/valhalla/valhalla/pull/4524)

--- a/src/thor/costmatrix.cc
+++ b/src/thor/costmatrix.cc
@@ -55,9 +55,9 @@ CostMatrix::CostMatrix(const boost::property_tree::ptree& config)
       max_reserved_locations_count_(
           config.get<uint32_t>("costmatrix.max_reserved_locations", kMaxLocationReservation)),
       check_reverse_connections_(config.get<bool>("costmatrix.check_reverse_connection", false)),
-      access_mode_(kAutoAccess), mode_(travel_mode_t::kDrive), locs_count_{0, 0},
-      locs_remaining_{0, 0}, current_pathdist_threshold_(0), targets_{new ReachedMap},
-      sources_{new ReachedMap} {
+      access_mode_(kAutoAccess),
+      mode_(travel_mode_t::kDrive), locs_count_{0, 0}, locs_remaining_{0, 0},
+      current_pathdist_threshold_(0), targets_{new ReachedMap}, sources_{new ReachedMap} {
 }
 
 CostMatrix::~CostMatrix() {

--- a/src/thor/costmatrix.cc
+++ b/src/thor/costmatrix.cc
@@ -55,9 +55,9 @@ CostMatrix::CostMatrix(const boost::property_tree::ptree& config)
       max_reserved_locations_count_(
           config.get<uint32_t>("costmatrix.max_reserved_locations", kMaxLocationReservation)),
       check_reverse_connections_(config.get<bool>("costmatrix.check_reverse_connection", false)),
-      access_mode_(kAutoAccess),
-      mode_(travel_mode_t::kDrive), locs_count_{0, 0}, locs_remaining_{0, 0},
-      current_pathdist_threshold_(0), targets_{new ReachedMap}, sources_{new ReachedMap} {
+      access_mode_(kAutoAccess), mode_(travel_mode_t::kDrive), locs_count_{0, 0},
+      locs_remaining_{0, 0}, current_pathdist_threshold_(0), targets_{new ReachedMap},
+      sources_{new ReachedMap} {
 }
 
 CostMatrix::~CostMatrix() {
@@ -1296,17 +1296,13 @@ std::string CostMatrix::RecostFormPath(GraphReader& graphreader,
     std::vector<PointLL> shp = tile->edgeinfo(start_edge).shape();
     if (!start_edge->forward())
       std::reverse(shp.begin(), shp.end());
-    request.mutable_matrix()
-        ->mutable_begin_heading()
-        ->Set(connection_idx, PointLL::HeadingAlongPolyline(shp, start_edge->length() * source_pct));
+    request.mutable_matrix()->mutable_begin_heading()->Set(connection_idx, source_edge.heading());
     const DirectedEdge* end_edge =
         graphreader.directededge(static_cast<GraphId>(target_edge.graph_id()), tile);
     shp = tile->edgeinfo(end_edge).shape();
     if (!end_edge->forward())
       std::reverse(shp.begin(), shp.end());
-    request.mutable_matrix()
-        ->mutable_end_heading()
-        ->Set(connection_idx, PointLL::HeadingAlongPolyline(shp, end_edge->length() * target_pct));
+    request.mutable_matrix()->mutable_end_heading()->Set(connection_idx, target_edge.heading());
   }
 
   // bail if no shape was requested

--- a/test/gurka/test_matrix.cc
+++ b/test/gurka/test_matrix.cc
@@ -869,12 +869,17 @@ TEST(StandAlone, VerboseResponse) {
   const std::string ascii_map = R"(
     A-1-------B----C----D----E--2-------F
                    |    |
-                   J----K
-                   |    |             
-                   |    |             
-                   3    4             
-                   |    |
-                   L----M
+                   J----K--5------N
+                   |    |         \
+                   |    |          \
+                   3    4           6           
+                   |    |            \
+                   L----M             \
+                                       O
+                                       |
+                                       7
+                                       |
+                                       P
            )";
 
   const gurka::ways ways = {
@@ -882,15 +887,15 @@ TEST(StandAlone, VerboseResponse) {
       {"CD", {{"highway", "residential"}}}, {"DE", {{"highway", "residential"}}},
       {"FE", {{"highway", "residential"}}}, {"CJ", {{"highway", "residential"}}},
       {"JK", {{"highway", "residential"}}}, {"JLMK", {{"highway", "residential"}}},
-      {"KD", {{"highway", "residential"}}},
+      {"KD", {{"highway", "residential"}}}, {"KNOP", {{"highway", "residential"}}},
   };
 
   const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100);
   gurka::map map = gurka::buildtiles(layout, ways, {}, {}, "test/data/matrix_verbose_response",
                                      {{"service_limits.max_timedep_distance_matrix", "50000"}});
-  rapidjson::Document res_doc;
-  std::string res;
   {
+    rapidjson::Document res_doc;
+    std::string res;
     auto api = gurka::do_action(valhalla::Options::sources_to_targets, map, {"1", "2", "3", "4"},
                                 {"1", "2", "3", "4"}, "auto", {{"/prioritize_bidirectional", "1"}},
                                 nullptr, &res);
@@ -961,6 +966,94 @@ TEST(StandAlone, VerboseResponse) {
                   .GetObject()["end_heading"]
                   .GetDouble(),
               180);
+  }
+
+  // check heading at long and winding edges
+  {
+    rapidjson::Document res_doc;
+    std::string res;
+    auto api = gurka::do_action(valhalla::Options::sources_to_targets, map, {"1", "5", "6", "7"},
+                                {"1", "5", "6", "7"}, "auto",
+                                {{"/prioritize_bidirectional", "1"}, {"/shape_format", "polyline6"}},
+                                nullptr, &res);
+
+    res_doc.Parse(res.c_str());
+
+    // sanity check
+    EXPECT_EQ(api.matrix().algorithm(), Matrix::CostMatrix);
+
+    for (size_t i = 0; i < 4; ++i) {
+      for (size_t j = 0; j < 4; ++j) {
+        bool key_should_exist = true;
+        if (i == j)
+          key_should_exist = false;
+        EXPECT_EQ(res_doc["sources_to_targets"].GetArray()[i].GetArray()[j].GetObject().HasMember(
+                      "begin_heading"),
+                  key_should_exist);
+        EXPECT_EQ(res_doc["sources_to_targets"].GetArray()[i].GetArray()[j].GetObject().HasMember(
+                      "end_heading"),
+                  key_should_exist);
+        EXPECT_EQ(res_doc["sources_to_targets"].GetArray()[i].GetArray()[j].GetObject().HasMember(
+                      "begin_lat"),
+                  key_should_exist);
+        EXPECT_EQ(res_doc["sources_to_targets"].GetArray()[i].GetArray()[j].GetObject().HasMember(
+                      "begin_lon"),
+                  key_should_exist);
+        EXPECT_EQ(res_doc["sources_to_targets"].GetArray()[i].GetArray()[j].GetObject().HasMember(
+                      "end_lat"),
+                  key_should_exist);
+        EXPECT_EQ(res_doc["sources_to_targets"].GetArray()[i].GetArray()[j].GetObject().HasMember(
+                      "end_lon"),
+                  key_should_exist);
+      }
+    }
+    size_t a, b;
+    auto get_shape = [&res_doc](size_t i, size_t j) {
+      return res_doc["sources_to_targets"]
+          .GetArray()[i]
+          .GetArray()[j]
+          .GetObject()["shape"]
+          .GetString();
+    };
+    auto get_heading = [&res_doc](size_t i, size_t j, const char* which) {
+      return res_doc["sources_to_targets"].GetArray()[i].GetArray()[j].GetObject()[which].GetDouble();
+    };
+
+    // 1 -> 5
+    a = 0;
+    b = 1;
+    EXPECT_EQ(get_heading(a, b, "begin_heading"), 90) << get_shape(a, b);
+    EXPECT_EQ(get_heading(a, b, "end_heading"), 90) << get_shape(a, b);
+
+    // 5 -> 1
+    a = 1;
+    b = 0;
+    EXPECT_EQ(get_heading(a, b, "begin_heading"), 270) << get_shape(a, b);
+    EXPECT_EQ(get_heading(a, b, "end_heading"), 270) << get_shape(a, b);
+
+    // 1 -> 6
+    a = 0;
+    b = 2;
+    EXPECT_EQ(get_heading(a, b, "begin_heading"), 90) << get_shape(a, b);
+    EXPECT_EQ(get_heading(a, b, "end_heading"), 140.1) << get_shape(a, b);
+
+    // 6 -> 1
+    a = 2;
+    b = 0;
+    EXPECT_EQ(get_heading(a, b, "begin_heading"), 320.1) << get_shape(a, b);
+    EXPECT_EQ(get_heading(a, b, "end_heading"), 270) << get_shape(a, b);
+
+    // 1 -> 7
+    a = 0;
+    b = 3;
+    EXPECT_EQ(get_heading(a, b, "begin_heading"), 90) << get_shape(a, b);
+    EXPECT_EQ(get_heading(a, b, "end_heading"), 180) << get_shape(a, b);
+
+    // 7 -> 1
+    a = 3;
+    b = 0;
+    EXPECT_EQ(get_heading(a, b, "begin_heading"), 0) << get_shape(a, b);
+    EXPECT_EQ(get_heading(a, b, "end_heading"), 270) << get_shape(a, b);
   }
 }
 


### PR DESCRIPTION
# Issue

Accidentally used the heading relative to the shape's start point instead of the absolute heading of the segment along which the start/end point is projected.
 
## Tasklist

 - [x] Add tests


## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
