### PR TITLE
Documentation fixes

### DIFF
--- a/docs/docs/mjolnir/tag_parsing.md
+++ b/docs/docs/mjolnir/tag_parsing.md
@@ -5,7 +5,7 @@
 1. [OSM Data Model Overview](#osm-data-model-overview)
 2. [OSM Processing Overview](#osm-processing-overview)
 3. [Lua Tag Processing](#lua-tag-processing)
-4. [C++ Tag Processing](#c++-tag-processing)
+4. [C++ Tag Processing](#c-tag-processing)
 5. [Common Pitfalls and Debugging](#common-pitfalls-and-debugging)
 
 ## OSM Data Model Overview
@@ -24,7 +24,7 @@ The basic flow valhalla follows when creating routing tiles is as follows:
 * Parse all the relations and their tags
 * Parse all the nodes and their tags
 
-Each of the step uses a combination of `lua` and `c++` to transform the tags into a structured set of values. From `c++` we call into `lua` passing it a single element. What comes out is a `map` of `keys` to `values` where both have been massaged to fit into a small (compared to the original data) set of permutations. Then the `c++` side of things will turn an element's key value pair strings into well defined structures for storage. The result of this is a vector of fixed-size (static number of bytes) structures (think of a `c++` `struct`) for each element type. Because we turn the tags into fixed-size structures we can store these in a file and use memory mapping to complete this process on very large datasets (the planet) with very modest hardware. Note that we don't store relations in a file simply because they require very little space. 
+Each of the step uses a combination of `lua` and `c++` to transform the tags into a structured set of values. From `c++` we call into `lua` passing it a single element. What comes out is a `map` of `keys` to `values` where both have been massaged to fit into a small (compared to the original data) set of permutations. Then the `c++` side of things will turn an element's key value pair strings into well defined structures for storage. The result of this is a vector of fixed-size (static number of bytes) structures (think of a `c++` `struct`) for each element type. Because we turn the tags into fixed-size structures we can store these in a file and use memory mapping to complete this process on very large datasets (the planet) with very modest hardware. Note that we don't store relations in a file simply because they require very little space.
 
 Once we've gotten all of the basic structures parsed out of the OSM data model into a well-defined set of structures we simply iterate over those structures to create the graph. We take care to sort the structures so that we can iterate over ways and then, within a given way, over the nodes that comprise it (in the right order).
 

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -1,27 +1,28 @@
 # Unit tests
 
-Valhalla currently uses googletest for unit testing.
+Valhalla currently uses GoogleTest for unit testing.
 
-- The basics are covered in [googletest primer](https://github.com/google/googletest/blob/master/docs/primer.md)
+- The basics are covered in [GoogleTest primer](https://github.com/google/googletest/blob/master/docs/primer.md)
 - More advanced topics  are covered [here](https://github.com/google/googletest/blob/master/docs/advanced.md)
 
 Important things to note:
-* EXPECT_XXX macros mark the test as failed but continue execution
+
+* `EXPECT_XXX` macros mark the test as failed but continue execution
     * Allows to test more at once
-    * A preferred way over ASSERT_XXX
-    * ASSERT_XXX family should be used when it's pointless to continue the test
-        * e.g. the method we test returns nullptr instead of  a valid pointer
+    * A preferred way over `ASSERT_XXX`
+    * `ASSERT_XXX` family should be used when it's pointless to continue the test
+        * e.g. the method we test returns `nullptr` instead of a valid pointer
 * Tests execution order is unspecified
     * If the order is needed fixtures or test suite environments may help
     * Sometimes it may hint the test design needs rethinking
 * Be careful with _ in test names - gtest joins a suite name with test name using _
-    * TEST(Foo, Basic_test) and TEST(Foo_Basic, test) will produce a conflict
+    * `TEST(Foo, Basic_test)` and `TEST(Foo_Basic, test)` will produce a conflict
     * In practice it never happens - no need to worry much about it
-* Be aware of curly braces{} inside macros
+* Be aware of curly braces `{}` inside macros
     * A typical case -> container with initializer list creation inside assert macro
     * Preprocessor is dumb and thinks commas separate the arguments
-    * ASSERT_EQ(foo, vector{1,2,3});
-    * Fixing this can be done by adding () - ASSERT_EQ(foo, (vector{1,2,3}));
-* Disabling a test is easy - just prefix its name with DISABLED_
-    * TEST(PredictiveTraffic, DISABLED_test_predictive_traffic)
+    * `ASSERT_EQ(foo, vector{1,2,3});`
+    * Fixing this can be done by adding `()` - `ASSERT_EQ(foo, (vector{1,2,3}));`
+* Disabling a test is easy - just prefix its name with `DISABLED_`
+    * `TEST(PredictiveTraffic, DISABLED_test_predictive_traffic)`
     * They are still compiled and there is always a warning each time the suite runs


### PR DESCRIPTION
I was reading through the documentation and found that the [`Internal notes` > `Unit tests`](https://valhalla.github.io/valhalla/testing/) doesn't render the list correctly:

![image](https://github.com/user-attachments/assets/f75fe272-84c6-4d78-84ee-8b6cf12fed38)

That turned out to be a missing empty line between the preceding title and the list. I corrected that and added some inline code formatting to improve readability;

![image](https://github.com/user-attachments/assets/9b73ab9b-ee6d-4c50-b5c9-5fd6644aba6d)

I also changed "googletest" to "GoogleTest" to match how the name is presented on their own site.

---

While building the docs I also observed a warning:

![image](https://github.com/user-attachments/assets/633b282e-525d-46f9-aea6-3e373aa75521)

The source said:

```
#c++-tag-processing
```

But the actual anchor is:

```
#c-tag-processing
```

And while the docs appear to work, as the anchor seems to be auto-fixed along with the warning I included a commit here to avoid the warning.