### PR TITLE
fix wrong edge id in bidir a* expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
    * FIXED: matrix headings [#5244](https://github.com/valhalla/valhalla/pull/5244)
    * FIXED: fix semi-trivial paths in costmatrix [#5249](https://github.com/valhalla/valhalla/pull/5249)
    * FIXED: rename `check_reverse_connections` [#5255](https://github.com/valhalla/valhalla/pull/5255)
+   * FIXED: pass correct edge id to expansion callback in bidirectional a* [#5265](https://github.com/valhalla/valhalla/pull/5265)
 * **Enhancement**
    * ADDED: Consider smoothness in all profiles that use surface [#4949](https://github.com/valhalla/valhalla/pull/4949)
    * ADDED: costing parameters to exclude certain edges `exclude_tolls`, `exclude_bridges`, `exclude_tunnels`, `exclude_highways`, `exclude_ferries`. They need to be enabled in the config with `service_limits.allow_hard_exclusions`. Also added location search filters `exclude_ferry` and `exclude_toll` to complement these changes. [#4524](https://github.com/valhalla/valhalla/pull/4524)

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -759,7 +759,7 @@ BidirectionalAStar::GetBestPath(valhalla::Location& origin,
         const auto prev_pred = rev_pred.predecessor() == kInvalidLabel
                                    ? GraphId{}
                                    : edgelabels_reverse_[rev_pred.predecessor()].edgeid();
-        expansion_callback_(graphreader, rev_pred.opp_edgeid(), prev_pred, "bidirectional_astar",
+        expansion_callback_(graphreader, rev_pred.edgeid(), prev_pred, "bidirectional_astar",
                             Expansion_EdgeStatus_settled, rev_pred.cost().secs,
                             rev_pred.path_distance(), rev_pred.cost().cost,
                             Expansion_ExpansionType_reverse);

--- a/test/gurka/test_expansion.cc
+++ b/test/gurka/test_expansion.cc
@@ -171,7 +171,7 @@ TEST_P(ExpansionTest, Routing) {
 
 TEST_P(ExpansionTest, RoutingNoOpposites) {
   // test AStar expansion and no opposite edges
-  check_results("route", {"E", "H"}, true, 16, GetParam());
+  check_results("route", {"E", "H"}, true, 15, GetParam());
 }
 
 TEST_P(ExpansionTest, Matrix) {
@@ -194,7 +194,7 @@ TEST_P(ExpansionTest, IsochroneNoOppositesDedupe) {
 
 TEST_P(ExpansionTest, RoutingDedupe) {
   // test AStar expansion
-  check_results("route", {"E", "H"}, false, 7, GetParam(), true);
+  check_results("route", {"E", "H"}, false, 9, GetParam(), true);
 }
 
 TEST_P(ExpansionTest, RoutingNoOppositesDedupe) {


### PR DESCRIPTION
# Issue

While debugging, I noticed that it was impossible to trace the reverse search expansion, and saw that instead of passing the reverse predecessor, its opposing edge ID was passed (i.e. the one used for traversal only).  
