### PR TITLE
fix: remove `GraphId` and `OSMWay` incompatible forward declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
    * FIXED: invert expansion_direction for expansion properties in costmatrix [#5266](https://github.com/valhalla/valhalla/pull/5266)
    * FIXED: set initial precision in matrix serializer [#5267](https://github.com/valhalla/valhalla/pull/5267)
    * FIXED: pass correct edge id to expansion callback in bidirectional a* [#5265](https://github.com/valhalla/valhalla/pull/5265)
+   * FIXED: remove `GraphId` and `OSMWay` incompatible forward declarations [#5270](https://github.com/valhalla/valhalla/pull/5270)
 * **Enhancement**
    * ADDED: Consider smoothness in all profiles that use surface [#4949](https://github.com/valhalla/valhalla/pull/4949)
    * ADDED: costing parameters to exclude certain edges `exclude_tolls`, `exclude_bridges`, `exclude_tunnels`, `exclude_highways`, `exclude_ferries`. They need to be enabled in the config with `service_limits.allow_hard_exclusions`. Also added location search filters `exclude_ferry` and `exclude_toll` to complement these changes. [#4524](https://github.com/valhalla/valhalla/pull/4524)

--- a/valhalla/mjolnir/directededgebuilder.h
+++ b/valhalla/mjolnir/directededgebuilder.h
@@ -11,12 +11,11 @@ using namespace valhalla::baldr;
 
 namespace valhalla {
 namespace baldr {
-class GraphId;
+struct GraphId;
 }
 
 namespace mjolnir {
-
-class OSMWay;
+struct OSMWay;
 
 /**
  * Derived class to build a directed edge given OSM way and other properties.

--- a/valhalla/mjolnir/directededgebuilder.h
+++ b/valhalla/mjolnir/directededgebuilder.h
@@ -10,12 +10,7 @@
 using namespace valhalla::baldr;
 
 namespace valhalla {
-namespace baldr {
-struct GraphId;
-}
-
 namespace mjolnir {
-struct OSMWay;
 
 /**
  * Derived class to build a directed edge given OSM way and other properties.


### PR DESCRIPTION
# Issue

@nilsnolde The `GraphId` and `OSMWay` forward declarations introduced in https://github.com/valhalla/valhalla/pull/5269 are not compatible with their definitions.

Btw. they are not needed at all because `node_expander.h` anyway includes these files.

```
$ cmake .. -DCMAKE_BUILD_TYPE=Release && cmake --build . -j 12
-- The CXX compiler identification is AppleClang 17.0.0.17000013
-- The C compiler identification is AppleClang 17.0.0.17000013
...
In file included from ./valhalla/src/mjolnir/admin.cc:1:
In file included from ./valhalla/valhalla/mjolnir/admin.h:7:
In file included from ./valhalla/valhalla/mjolnir/graphtilebuilder.h:17:
./valhalla/valhalla/mjolnir/directededgebuilder.h:14:1: error: class 'GraphId' was previously declared as a struct; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Werror,-Wmismatched-tags]
   14 | class GraphId;
      | ^
./valhalla/valhalla/baldr/graphid.h:32:8: note: previous use is here
   32 | struct GraphId {
      |        ^
./valhalla/valhalla/mjolnir/directededgebuilder.h:14:1: note: did you mean struct here?
   14 | class GraphId;
      | ^~~~~
      | struct
./valhalla/valhalla/mjolnir/directededgebuilder.h:19:1: error: class 'OSMWay' was previously declared as a struct; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Werror,-Wmismatched-tags]
   19 | class OSMWay;
      | ^
./valhalla/valhalla/mjolnir/osmway.h:18:8: note: previous use is here
   18 | struct OSMWay {
      |        ^
./valhalla/valhalla/mjolnir/directededgebuilder.h:19:1: note: did you mean struct here?
   19 | class OSMWay;
      | ^~~~~
      | struct
2 errors generated.
make[2]: *** [src/mjolnir/CMakeFiles/valhalla-mjolnir.dir/admin.cc.o] Error 1
[ 46%] Building CXX object src/odin/CMakeFiles/valhalla-odin.dir/util.cc.o
In file included from ./valhalla/src/mjolnir/bssbuilder.cc:11:
In file included from ./valhalla/valhalla/mjolnir/graphtilebuilder.h:17:
./valhalla/valhalla/mjolnir/directededgebuilder.h:14:1: error: class 'GraphId' was previously declared as a struct; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Werror,-Wmismatched-tags]
   14 | class GraphId;
      | ^
./valhalla/valhalla/baldr/graphid.h:32:8: note: previous use is here
   32 | struct GraphId {
      |        ^
./valhalla/valhalla/mjolnir/directededgebuilder.h:14:1: note: did you mean struct here?
   14 | class GraphId;
      | ^~~~~
      | struct
./valhalla/valhalla/mjolnir/directededgebuilder.h:19:1: error: class 'OSMWay' was previously declared as a struct; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Werror,-Wmismatched-tags]
   19 | class OSMWay;
      | ^
./valhalla/valhalla/mjolnir/osmway.h:18:8: note: previous use is here
   18 | struct OSMWay {
      |        ^
./valhalla/valhalla/mjolnir/directededgebuilder.h:19:1: note: did you mean struct here?
   19 | class OSMWay;
      | ^~~~~
      | struct
2 errors generated.
make[2]: *** [src/mjolnir/CMakeFiles/valhalla-mjolnir.dir/bssbuilder.cc.o] Error 1
In file included from ./valhalla/src/mjolnir/convert_transit.cc:14:
In file included from ./valhalla/valhalla/mjolnir/admin.h:7:
In file included from ./valhalla/valhalla/mjolnir/graphtilebuilder.h:17:
./valhalla/valhalla/mjolnir/directededgebuilder.h:14:1: error: class 'GraphId' was previously declared as a struct; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Werror,-Wmismatched-tags]
   14 | class GraphId;
      | ^
./valhalla/valhalla/baldr/graphid.h:32:8: note: previous use is here
   32 | struct GraphId {
      |        ^
./valhalla/valhalla/mjolnir/directededgebuilder.h:14:1: note: did you mean struct here?
   14 | class GraphId;
      | ^~~~~
      | struct
./valhalla/valhalla/mjolnir/directededgebuilder.h:19:1: error: class 'OSMWay' was previously declared as a struct; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Werror,-Wmismatched-tags]
   19 | class OSMWay;
      | ^
./valhalla/valhalla/mjolnir/osmway.h:18:8: note: previous use is here
   18 | struct OSMWay {
      |        ^
./valhalla/valhalla/mjolnir/directededgebuilder.h:19:1: note: did you mean struct here?
   19 | class OSMWay;
      | ^~~~~
      | struct
2 errors generated.
```

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
