### PR TITLE
chore: link geos to all mjolnir programs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
    * FIXED: set initial precision in matrix serializer [#5267](https://github.com/valhalla/valhalla/pull/5267)
    * FIXED: pass correct edge id to expansion callback in bidirectional a* [#5265](https://github.com/valhalla/valhalla/pull/5265)
    * FIXED: remove `GraphId` and `OSMWay` incompatible forward declarations [#5270](https://github.com/valhalla/valhalla/pull/5270)
+   * FIXED: link `geos` to all mjolnir programs [#5275](https://github.com/valhalla/valhalla/pull/5275)
 * **Enhancement**
    * ADDED: Consider smoothness in all profiles that use surface [#4949](https://github.com/valhalla/valhalla/pull/4949)
    * ADDED: costing parameters to exclude certain edges `exclude_tolls`, `exclude_bridges`, `exclude_tunnels`, `exclude_highways`, `exclude_ferries`. They need to be enabled in the config with `service_limits.allow_hard_exclusions`. Also added location search filters `exclude_ferry` and `exclude_toll` to complement these changes. [#4524](https://github.com/valhalla/valhalla/pull/4524)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,13 +283,14 @@ if(ENABLE_TOOLS)
 endif()
 
 if(ENABLE_DATA_TOOLS)
+  pkg_check_modules(GEOS REQUIRED IMPORTED_TARGET geos)
   foreach(program ${valhalla_data_tools})
     get_source_path(path ${program})
     add_executable(${program} ${path})
     create_source_groups("Source Files" ${path})
     set_target_properties(${program} PROPERTIES FOLDER "Data Tools")
     target_include_directories(${program} PRIVATE ${cxxopts_include_dir})
-    target_link_libraries(${program} valhalla)
+    target_link_libraries(${program} valhalla PkgConfig::GEOS)
     if (LuaJIT_FOUND AND APPLE AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
       # Using LuaJIT on macOS on Intel processors requires a couple of extra linker flags
       target_link_options(${program} PUBLIC -pagezero_size 10000 -image_base 100000000)
@@ -298,8 +299,6 @@ if(ENABLE_DATA_TOOLS)
   endforeach()
 
   # Target-specific dependencies
-  pkg_check_modules(GEOS REQUIRED IMPORTED_TARGET geos)
-  target_link_libraries(valhalla_build_admins PkgConfig::GEOS)
   target_sources(valhalla_build_statistics
     PUBLIC
       ${VALHALLA_SOURCE_DIR}/src/mjolnir/statistics.cc


### PR DESCRIPTION
I just built the valhalla library on AlmaLinux 8 for https://github.com/valhalla/valhalla/issues/4624 and among, completely unrelated, other very annoying things, I realized that a few `mjolnir` executables didn't link to `geos` even though they should because they need it via `mjolnir/admin.cc`.

The gcc15 command to build `valhalla_build_tiles` on my local arch linux is linking to `libgeos_c.so` (and apparently on all other local and CI machines). But the same thing on AlmaLinux 8 with gcc14 results in `undefined reference`s while linking for `valhalla_build_tiles` (and other `mjolnir programs).

This PR fixes that by just linking every `mjolnir` program to `geos`. Could make it more specific, it's just 5-6 programs in total. Though I have no idea how this works for any other build currently, we're so far only linking `valhalla_build_admins` to `geos`.

