### PR TITLE
feat: use rapidjson for height serializer

### DIFF
--- a/src/tyr/height_serializer.cc
+++ b/src/tyr/height_serializer.cc
@@ -1,8 +1,7 @@
 #include "baldr/json.h"
 #include "skadi/sample.h"
 #include "tyr/serializers.h"
-
-#include <sstream>
+#include "valhalla/baldr/rapidjson_utils.h"
 
 using namespace valhalla;
 using namespace valhalla::midgard;

--- a/src/tyr/height_serializer.cc
+++ b/src/tyr/height_serializer.cc
@@ -10,51 +10,57 @@ using namespace valhalla::baldr;
 
 namespace {
 
-json::ArrayPtr serialize_range_height(const std::vector<double>& ranges,
-                                      const std::vector<double>& heights,
-                                      const uint32_t precision,
-                                      const double no_data_value) {
-  auto array = json::array({});
+void serialize_range_height(rapidjson::writer_wrapper_t& writer,
+                            const std::vector<double>& ranges,
+                            const std::vector<double>& heights,
+                            const uint32_t precision,
+                            const double no_data_value) {
+  writer.start_array("range_height");
+  writer.set_precision(precision);
   // for each posting
   auto range = ranges.cbegin();
 
   for (const auto height : heights) {
-    auto element = json::array({json::fixed_t{*range, 0}});
+    writer.start_array();
     if (height == no_data_value) {
-      element->push_back(nullptr);
+      writer(nullptr);
     } else {
-      element->push_back({json::fixed_t{height, precision}});
+      writer(height);
     }
-    array->push_back(element);
+    writer.end_array();
     ++range;
   }
-  return array;
+  writer.end_array();
 }
 
-json::ArrayPtr serialize_height(const std::vector<double>& heights,
-                                const uint32_t precision,
-                                const double no_data_value) {
-  auto array = json::array({});
-
+void serialize_height(rapidjson::writer_wrapper_t& writer,
+                      const std::vector<double>& heights,
+                      const uint32_t precision,
+                      const double no_data_value) {
+  writer.start_array("height");
+  writer.set_precision(precision);
   for (const auto height : heights) {
     // add all heights's to an array
     if (height == no_data_value) {
-      array->push_back(nullptr);
+      writer(nullptr);
     } else {
-      array->push_back({json::fixed_t{height, precision}});
+      writer(height);
     }
   }
-
-  return array;
+  writer.end_array();
 }
 
-json::ArrayPtr serialize_shape(const google::protobuf::RepeatedPtrField<valhalla::Location>& shape) {
-  auto array = json::array({});
+void serialize_shape(rapidjson::writer_wrapper_t& writer,
+                     const google::protobuf::RepeatedPtrField<valhalla::Location>& shape) {
+  writer.start_array("shape");
+  writer.set_precision(6);
   for (const auto& p : shape) {
-    array->emplace_back(json::map(
-        {{"lon", json::fixed_t{p.ll().lng(), 6}}, {"lat", json::fixed_t{p.ll().lat(), 6}}}));
+    writer.start_object();
+    writer("lon", p.ll().lng());
+    writer("lat", p.ll().lat());
+    writer.end_object();
   }
-  return array;
+  writer.end_array();
 }
 
 } // namespace
@@ -71,37 +77,35 @@ namespace tyr {
 std::string serializeHeight(const Api& request,
                             const std::vector<double>& heights,
                             const std::vector<double>& ranges) {
-  auto json = json::map({});
+  rapidjson::writer_wrapper_t writer(4096);
+  writer.start_object();
 
   // get the precision to use for returned heights
   uint32_t precision = request.options().height_precision();
 
   // get the distances between the postings
   if (ranges.size()) {
-    json = json::map({{"range_height", serialize_range_height(ranges, heights, precision,
-                                                              skadi::get_no_data_value())}});
+    serialize_range_height(writer, ranges, heights, precision, skadi::get_no_data_value());
   } // just the postings
   else {
-    json = json::map({{"height", serialize_height(heights, precision, skadi::get_no_data_value())}});
+    serialize_height(writer, heights, precision, skadi::get_no_data_value());
   }
   // send back the shape as well
   if (request.options().has_encoded_polyline_case()) {
-    json->emplace("encoded_polyline", request.options().encoded_polyline());
+    writer("encoded_polyline", request.options().encoded_polyline());
   } else {
-    json->emplace("shape", serialize_shape(request.options().shape()));
+    serialize_shape(writer, request.options().shape());
   }
   if (request.options().has_id_case()) {
-    json->emplace("id", request.options().id());
+    writer("id", request.options().id());
   }
 
   // add warnings to json response
   if (request.info().warnings_size() >= 1) {
-    json->emplace("warnings", serializeWarnings(request));
+    serializeWarnings(request, writer);
   }
-
-  std::stringstream ss;
-  ss << *json;
-  return ss.str();
+  writer.end_object();
+  return writer.get_buffer();
 }
 } // namespace tyr
 } // namespace valhalla

--- a/src/tyr/serializers.cc
+++ b/src/tyr/serializers.cc
@@ -178,6 +178,7 @@ void serializeWarnings(const valhalla::Api& api, rapidjson::writer_wrapper_t& wr
   writer.end_array();
 }
 
+// sroute_serializer_osrm and isochrone_serializer are still depending on this
 json::ArrayPtr serializeWarnings(const valhalla::Api& api) {
   auto warnings = json::array({});
   for (const auto& warning : api.info().warnings()) {


### PR DESCRIPTION
# Issue

This PR addresses issue https://github.com/valhalla/valhalla/issues/5190 by migrating the `height` API serializer from the legacy `json::` implementation to `rapidjson` for improved performance and consistency.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
