### PR TITLE
Windows build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,25 +60,30 @@ endif()
 # Explicitly set the build type to Release if no other type is specified
 # on the command line.  Without this, cmake defaults to an unoptimized,
 # non-debug build, which almost nobody wants.
-if(NOT MSVC_IDE) # TODO: May need to be extended for Xcode, CLion, etc.
+get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+
+if(isMultiConfig)
+    message(STATUS "Multi-config generator detected (${CMAKE_GENERATOR}) — skipping CMAKE_BUILD_TYPE checks.")
+else()
+  # CMAKE_BUILD_TYPE is only relevant for single-configuration generators.
   if(NOT CMAKE_BUILD_TYPE)
     message(STATUS "No build type specified, defaulting to Release")
     set(CMAKE_BUILD_TYPE Release)
   endif()
-endif()
 
-if(CMAKE_BUILD_TYPE STREQUAL Debug)
-  message(STATUS "Configuring in debug mode")
-elseif(CMAKE_BUILD_TYPE STREQUAL Release)
-  message(STATUS "Configuring in release mode")
-elseif(CMAKE_BUILD_TYPE STREQUAL RelWithDebInfo)
-  message(STATUS "Configuring in release mode with debug symbols")
-elseif(CMAKE_BUILD_TYPE STREQUAL MinRelSize)
-  message(STATUS "Configuring in release mode with minimized size")
-elseif(CMAKE_BUILD_TYPE STREQUAL None)
-  message(STATUS "Configuring without a mode, no optimization flags will be set")
-else()
-  message(FATAL_ERROR "Unrecognized build type. Use one of Debug, Release, RelWithDebInfo, MinRelSize, None")
+  if(CMAKE_BUILD_TYPE STREQUAL Debug)
+    message(STATUS "Configuring in debug mode")
+  elseif(CMAKE_BUILD_TYPE STREQUAL Release)
+    message(STATUS "Configuring in release mode")
+  elseif(CMAKE_BUILD_TYPE STREQUAL RelWithDebInfo)
+    message(STATUS "Configuring in release mode with debug symbols")
+  elseif(CMAKE_BUILD_TYPE STREQUAL MinRelSize)
+    message(STATUS "Configuring in release mode with minimized size")
+  elseif(CMAKE_BUILD_TYPE STREQUAL None)
+    message(STATUS "Configuring without a mode, no optimization flags will be set")
+  else()
+    message(FATAL_ERROR "Unrecognized build type. Use one of Debug, Release, RelWithDebInfo, MinRelSize, None")
+  endif()
 endif()
 
 if(ENABLE_CCACHE AND (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU"))
@@ -320,7 +325,7 @@ endif()
 foreach(script valhalla_build_config valhalla_build_elevation
   valhalla_build_extract valhalla_build_timezones)
   configure_file(${VALHALLA_SOURCE_DIR}/scripts/${script} ${CMAKE_BINARY_DIR}/${script} COPYONLY)
-  
+
   install(
     FILES
       scripts/${script}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,6 +235,7 @@ if(ENABLE_DATA_TOOLS)
   find_package(SQLite3 REQUIRED)
   pkg_check_modules(SpatiaLite REQUIRED IMPORTED_TARGET spatialite)
   pkg_check_modules(LuaJIT REQUIRED IMPORTED_TARGET luajit)
+  pkg_check_modules(GEOS REQUIRED IMPORTED_TARGET geos)
 endif()
 
 if (ENABLE_THREAD_SAFE_TILE_REF_COUNT)
@@ -303,8 +304,6 @@ if(ENABLE_DATA_TOOLS)
   endforeach()
 
   # Target-specific dependencies
-  pkg_check_modules(GEOS REQUIRED IMPORTED_TARGET geos)
-  target_link_libraries(valhalla_build_admins PkgConfig::GEOS)
   target_sources(valhalla_build_statistics
     PUBLIC
       ${VALHALLA_SOURCE_DIR}/src/mjolnir/statistics.cc

--- a/docs/docs/building.md
+++ b/docs/docs/building.md
@@ -37,26 +37,73 @@ Instead of installing the dependencies system-wide, you can also opt to use [`vc
 
 The following commands should work on all platforms:
 
+### Clone sources
+
 ```bash
 git clone --recurse-submodules https://github.com/valhalla/valhalla
 cd valhalla
-
+# Clone vcpkg for dependencies:
 git clone https://github.com/microsoft/vcpkg && git -C vcpkg checkout <some-tag>
-./vcpkg/bootstrap-vcpkg.sh
-# windows: cmd.exe /c bootstrap-vcpkg.bat
-
-# only build Release versions of dependencies, not Debug
-echo "set(VCPKG_BUILD_TYPE Release)" >> vcpkg/triplets/x64-linux.cmake
-# windows: echo.set(VCPKG_BUILD_TYPE release)>> .\vcpkg\triplets\x64-windows.cmake
-# osx: echo "set(VCPKG_BUILD_TYPE release)" >> vcpkg/triplets/arm64-osx.cmake
-
-# vcpkg will install everything during cmake configuration
-# if you want to ENABLE_SERVICES=ON, install https://github.com/kevinkreiser/prime_server#build-and-install (no Windows)
-cmake -B build -DCMAKE_TOOLCHAIN_FILE=$PWD/vcpkg/scripts/buildsystems/vcpkg.cmake -DENABLE_SERVICE=OFF
-cmake --build build -- -j$(nproc)
-# windows: cmake --build build --config Release -- /clp:ErrorsOnly /p:BuildInParallel=true /m:4
-# osx: cmake --build build -- -j$(sysctl -n hw.physicalcpu)
 ```
+### Bootstrap `vcpkg`
+
+```bash
+# linux / macOS
+./vcpkg/bootstrap-vcpkg.sh
+```
+```bash
+# windows
+cmd.exe /c .\vcpkg\bootstrap-vcpkg.bat
+```
+
+#### Set build type (Optional)
+
+To build only release build without any debug symbols:
+
+
+```bash
+# linux
+echo "set(VCPKG_BUILD_TYPE Release)" >> vcpkg/triplets/x64-linux.cmake
+```
+```bash
+# osx
+echo "set(VCPKG_BUILD_TYPE release)" >> vcpkg/triplets/arm64-osx.cmake
+```
+```bash
+# windows
+echo set(VCPKG_BUILD_TYPE release)>> .\vcpkg\triplets\x64-windows.cmake
+```
+
+### Configure CMake
+
+`vcpkg` will install everything during cmake configuration.
+
+If you want to `ENABLE_SERVICES=ON`, install https://github.com/kevinkreiser/prime_server#build-and-install (Not available for Windows).
+
+```bash
+# linux / maxOS
+cmake -B build -DCMAKE_TOOLCHAIN_FILE=$PWD/vcpkg/scripts/buildsystems/vcpkg.cmake -DENABLE_SERVICES=OFF
+```
+```bash
+# windows
+cmake -B build -DCMAKE_TOOLCHAIN_FILE=%CD%\vcpkg\scripts\buildsystems\vcpkg.cmake -DENABLE_SERVICES=OFF
+```
+
+### Build
+
+```bash
+# linux
+cmake --build build -- -j$(nproc)
+```
+```bash
+# osx:
+cmake --build build -- -j$(sysctl -n hw.physicalcpu)
+```
+```bash
+# windows: (/m:4 = Use up to 4 processes)
+cmake --build build --config Release -- /clp:ErrorsOnly /p:BuildInParallel=true /m:4
+```
+
 
 ## Platform-specific builds
 

--- a/src/baldr/CMakeLists.txt
+++ b/src/baldr/CMakeLists.txt
@@ -2,9 +2,16 @@
 set(tz_db_files africa antarctica asia australasia backward etcetera europe
   northamerica southamerica leapseconds)
 
+## Select make command based on platform
+if(WIN32)
+  set(MAKE_CMD nmake)
+else()
+  set(MAKE_CMD make)
+endif()
+
 # Process the leap seconds file (it's in .gitignore of the tz repo)
 add_custom_command(OUTPUT ${VALHALLA_SOURCE_DIR}/third_party/tz/leapseconds
-COMMAND make leapseconds
+COMMAND ${MAKE_CMD} leapseconds
 WORKING_DIRECTORY ${VALHALLA_SOURCE_DIR}/third_party/tz
 COMMENT "Compiling third_party/tz/leapseconds with awk"
 DEPENDS ${VALHALLA_SOURCE_DIR}/third_party/tz/leapseconds.awk)
@@ -38,7 +45,7 @@ set(includes
      ${CMAKE_CURRENT_BINARY_DIR}/src/baldr
      )
 
-set(system_includes 
+set(system_includes
   ${date_include_dir}
   $<$<BOOL:${WIN32}>:${dirent_include_dir}>
   ${rapidjson_include_dir})

--- a/src/mjolnir/CMakeLists.txt
+++ b/src/mjolnir/CMakeLists.txt
@@ -95,6 +95,7 @@ valhalla_module(NAME mjolnir
   DEPENDS
     valhalla::proto
     valhalla::baldr
+    PkgConfig::GEOS
     PkgConfig::SpatiaLite
     SQLite3::SQLite3
     Boost::boost


### PR DESCRIPTION
Some changes to allow valhalla to build on Windows via CMake. (MSVC generator)

I split it into four commits that each fix a small issue by itself, but I needed all the fixes to make the build work.

* Some fixes to typos in the documentation.
* Then I tweaked the command examples a bit, separating platform specific example commands: 
![bilde](https://github.com/user-attachments/assets/dd6ca954-a97e-4222-b4ef-a23bf1f0f9a2)
* Made Windows builds use `nmake` instead of `make` - since `make` isn't part of a normal Visual Studio dev environment.
* Moved the GEOS linking to mjolnir where it's used.
