### PR TITLE
fixed ci status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Valhalla is an open source routing engine and accompanying libraries for use wit
 
 ## Build Status
 
-| Linux | macOS | Windows | Code Coverage |
-| ----- | ----- | ------- | ------------- |
+| Linux | macOS & Windows | Code Coverage |
+| ----- | --------------- | ------------- |
 | [![Circle CI](https://circleci.com/gh/valhalla/valhalla/tree/master.svg?style=svg)](https://circleci.com/gh/valhalla/valhalla/tree/master) | [![Windows & macOS CI](https://github.com/valhalla/valhalla/actions/workflows/osx_win_python_builds.yml/badge.svg)](https://github.com/valhalla/valhalla/actions/workflows/osx_win_python_builds.yml) | [![codecov](https://codecov.io/gh/valhalla/valhalla/branch/master/graph/badge.svg)](https://codecov.io/gh/valhalla/valhalla) |
 
 


### PR DESCRIPTION
Windows and OSX CI converged, so we need to update the CI badge. Sadly these badges are per-workflow