### PR TITLE
feat: publish `valhalla_service` with linux python bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@
    * CHANGED: Link libvalhalla to libgeos. Build command to use `nmake` on Windows instead of `make`. Skipping check for `CMAKE_BUILD_TYPE` when using a multi-config generator like Visual Studio or XCode. [#5294](https://github.com/valhalla/valhalla/pull/5294)
    * ADDED: workflow to publish Python bindings for all major platforms to PyPI [#5280](https://github.com/valhalla/valhalla/pull/5280)
    * ADDED: git sha version suffix for executables [#5307](https://github.com/valhalla/valhalla/pull/5307)
+   * ADDED: `valhalla_service` to Linux Python package [#5315](https://github.com/valhalla/valhalla/pull/5315)
 
 ## Release Date: 2024-10-10 Valhalla 3.5.1
 * **Removed**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,9 +88,9 @@
    * CHANGED: Link libvalhalla to libgeos. Build command to use `nmake` on Windows instead of `make`. Skipping check for `CMAKE_BUILD_TYPE` when using a multi-config generator like Visual Studio or XCode. [#5294](https://github.com/valhalla/valhalla/pull/5294)
    * ADDED: workflow to publish Python bindings for all major platforms to PyPI [#5280](https://github.com/valhalla/valhalla/pull/5280)
    * ADDED: git sha version suffix for executables [#5307](https://github.com/valhalla/valhalla/pull/5307)
-   * ADDED: `valhalla_service` to Linux Python package [#5315](https://github.com/valhalla/valhalla/pull/5315)
    * ADDED: version modifier in public servers [#5316](https://github.com/valhalla/valhalla/pull/5316)
    * CHANGED: pyvalhalla-git PyPI repository to pyvalhalla-weekly [#5310](https://github.com/valhalla/valhalla/pull/5310)
+   * ADDED: `valhalla_service` to Linux Python package [#5315](https://github.com/valhalla/valhalla/pull/5315)
 
 ## Release Date: 2024-10-10 Valhalla 3.5.1
 * **Removed**

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ DEFAULT_VALHALLA_BUILD_DIR = "./build_manylinux"
 
 THIS_DIR = Path(__file__).parent.resolve()
 BINARIES = [
-    # "valhalla_service", # sadly auditwheel(/patchelf?) corrupts valhalla_service somehow
+    "valhalla_service", # this needed a custom-built "patchelf" for auditwheel to properly fix
     "valhalla_build_tiles",
     "valhalla_build_admins",
     "valhalla_add_predicted_traffic",


### PR DESCRIPTION
Currently we're not able to publish  `valhalla_service` with the Linux Python bindings, bcs it seemed `auditwheel` corrupts the binary somehow. @xnox suggested to try a newer `patchelf` than is available in AlmaLinux 8 and that seemed to have worked (https://github.com/valhalla/manylinux/commit/55402ca1f6d3a78aea010ab006d86dae02f0dc9e).

Again, thanks a ton @xnox, your suggestions saved me a world of pain :)