### PR TITLE
chore: fix python release workflow

### DIFF
--- a/.github/workflows/osx_win_python_builds.yml
+++ b/.github/workflows/osx_win_python_builds.yml
@@ -55,7 +55,7 @@ jobs:
   build_python_wheels_linux:
     name: Build Linux Python wheels
     runs-on: ubuntu-latest
-    if: ${{ github.env.PUBLISH_PYPI }}
+    if: ${{ env.PUBLISH_PYPI }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -122,7 +122,7 @@ jobs:
 
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
-        if: ${{ github.env.SETUP_TMATE }}
+        if: ${{ env.SETUP_TMATE }}
         with:
           detached: true
   
@@ -193,7 +193,7 @@ jobs:
       # only package python bindings if it's not a PR
 
       - name: Determine package to publish
-        if: ${{ github.env.PUBLISH_PYPI }}
+        if: ${{ env.PUBLISH_PYPI }}
         run: |
           VALHALLA_RELEASE_PKG="pyvalhalla"
           if [[ ${{ startsWith(github.ref, 'refs/tags') }} == "false" ]]; then
@@ -202,14 +202,14 @@ jobs:
           echo "VALHALLA_RELEASE_PKG=${VALHALLA_RELEASE_PKG}" >> $GITHUB_ENV
       
       - uses: pypa/cibuildwheel@v2.23.3
-        if: ${{ github.env.PUBLISH_PYPI }}
+        if: ${{ env.PUBLISH_PYPI }}
         env:
           CIBW_ENVIRONMENT: >
             VALHALLA_RELEASE_PKG=${{ env.VALHALLA_RELEASE_PKG }}
           MACOSX_DEPLOYMENT_TARGET: 14
 
       - name: Upload wheels
-        if: ${{ github.env.PUBLISH_PYPI }}
+        if: ${{ env.PUBLISH_PYPI }}
         uses: actions/upload-artifact@v4
         with:
           name: wheels-osx-arm64
@@ -218,7 +218,7 @@ jobs:
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
         # only run this if manually invoked and debug_enabled == true or a previous step failed
-        if: ${{ github.env.SETUP_TMATE }}
+        if: ${{ env.SETUP_TMATE }}
         with:
           detached: true
   
@@ -336,7 +336,7 @@ jobs:
           ./build/$BUILD_TYPE/valhalla_service.exe ./test/win/valhalla.json isochrone "{\"locations\": [{\"lat\": 52.10205, \"lon\": 5.114651}], \"costing\": \"auto\", \"contours\":[{\"time\":15,\"color\":\"ff0000\"}]}"
       
       - name: Determine package to publish
-        if: ${{ github.env.PUBLISH_PYPI }}
+        if: ${{ env.PUBLISH_PYPI }}
         shell: bash
         run: |
           VALHALLA_RELEASE_PKG="pyvalhalla"
@@ -352,7 +352,7 @@ jobs:
           ls -l build/vcpkg_installed/custom-x64-windows/bin
       
       - uses: pypa/cibuildwheel@v2.23.3
-        if: ${{ github.env.PUBLISH_PYPI }}
+        if: ${{ env.PUBLISH_PYPI }}
         env:
           # used in setup.py
           CIBW_ENVIRONMENT: >
@@ -363,7 +363,7 @@ jobs:
             delvewheel repair --add-path build/vcpkg_installed/custom-x64-windows/bin {wheel} -w {dest_dir}
 
       - name: Upload wheels
-        if: ${{ github.env.PUBLISH_PYPI }}
+        if: ${{ env.PUBLISH_PYPI }}
         uses: actions/upload-artifact@v4
         with:
           name: wheels-win-amd64
@@ -372,7 +372,7 @@ jobs:
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
         # only run this if manually invoked and debug_enabled == true or a previous step failed
-        if: ${{ github.env.SETUP_TMATE }}
+        if: ${{ env.SETUP_TMATE }}
         with:
           detached: true
 
@@ -381,7 +381,7 @@ jobs:
     needs: [build_python_wheels_linux]
     runs-on: ubuntu-latest
     container: python:3.13-slim-bookworm
-    if: ${{ github.env.PUBLISH_PYPI }}
+    if: ${{ env.PUBLISH_PYPI }}
     steps:
       - uses: actions/checkout@v4
 
@@ -402,7 +402,7 @@ jobs:
     needs: [verify_wheels, build_osx, build_win]
     runs-on: ubuntu-latest
     # if: ${{ always() }}
-    if: ${{ github.env.PUBLISH_PYPI }}
+    if: ${{ env.PUBLISH_PYPI }}
 
     permissions:
       id-token: write # This is required for requesting the JWT from Github for PyPI

--- a/.github/workflows/osx_win_python_builds.yml
+++ b/.github/workflows/osx_win_python_builds.yml
@@ -10,7 +10,7 @@ on:
   # We run this once a week so we regularly publish pyvalhalla-weekly
   # but not on _every_ master commit
   schedule:
-    - cron: "0 0 * * 0"
+    - cron: "*/5 * * * *"
   push:
     paths-ignore:
       - "*.md"

--- a/.github/workflows/osx_win_python_builds.yml
+++ b/.github/workflows/osx_win_python_builds.yml
@@ -48,14 +48,25 @@ concurrency:
 env:
   # only run tmate if manually invoked and debug_enabled == true or a previous step failed
   SETUP_TMATE: ${{ (((github.event_name == 'workflow_dispatch') && (github.event.inputs.debug_enabled == 'true')) || (github.job.status != 'success')) && (github.repository_owner == 'valhalla') }}
-  # only publish to PyPI on tags, schedule or workflow_dispatch (only on master!)
   PUBLISH_PYPI: ${{ (startsWith(github.ref, 'refs/tags') || (github.event_name == 'schedule') || ((github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/master'))) && (github.repository_owner == 'valhalla') }}
 
 jobs:
+  # only publish to PyPI on tags, schedule or workflow_dispatch (only on master!)
+  # very annoying: env vars can't be referenced in job's "if" statements, so we have to do this
+  # https://stackoverflow.com/questions/73797254/environment-variables-in-github-actions
+  publish_pypi:
+    name: Whether to publish PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Are we publishing to PyPI? ${{ env.PUBLISH_PYPI }}"
+    outputs:
+      PUBLISH_PYPI: ${{ env.PUBLISH_PYPI }}
+
   build_python_wheels_linux:
     name: Build Linux Python wheels
     runs-on: ubuntu-latest
-    if: ${{ env.PUBLISH_PYPI }}
+    needs: [publish_pypi]
+    if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -71,7 +82,8 @@ jobs:
           python-version: '3.12'
 
       - name: Get branch name
-        run: echo "VALHALLA_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_ENV
+        run: |
+          echo "VALHALLA_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_ENV
 
       - name: Get version modifier
         if: github.ref == 'refs/heads/master'
@@ -129,6 +141,7 @@ jobs:
   build_osx:
     runs-on: macos-14
     name: Build OSX & Python wheels
+    needs: [publish_pypi]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -193,7 +206,7 @@ jobs:
       # only package python bindings if it's not a PR
 
       - name: Determine package to publish
-        if: ${{ env.PUBLISH_PYPI }}
+        if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' }}
         run: |
           VALHALLA_RELEASE_PKG="pyvalhalla"
           if [[ ${{ startsWith(github.ref, 'refs/tags') }} == "false" ]]; then
@@ -202,14 +215,14 @@ jobs:
           echo "VALHALLA_RELEASE_PKG=${VALHALLA_RELEASE_PKG}" >> $GITHUB_ENV
       
       - uses: pypa/cibuildwheel@v2.23.3
-        if: ${{ env.PUBLISH_PYPI }}
+        if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' }}
         env:
           CIBW_ENVIRONMENT: >
             VALHALLA_RELEASE_PKG=${{ env.VALHALLA_RELEASE_PKG }}
           MACOSX_DEPLOYMENT_TARGET: 14
 
       - name: Upload wheels
-        if: ${{ env.PUBLISH_PYPI }}
+        if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: wheels-osx-arm64
@@ -225,6 +238,7 @@ jobs:
   build_win:
     name: Build Win & Python wheels
     runs-on: windows-2022
+    needs: [publish_pypi]
     env:
       BUILD_TYPE: Release
       MSVC_VERSION: "2022"
@@ -334,16 +348,6 @@ jobs:
           ./build/$BUILD_TYPE/valhalla_build_tiles.exe -c ./test/win/valhalla.json ./test/data/utrecht_netherlands.osm.pbf
           ./build/$BUILD_TYPE/valhalla_run_isochrone.exe --config ./test/win/valhalla.json -j "{\"locations\": [{\"lat\": 52.10205, \"lon\": 5.114651}], \"costing\": \"auto\", \"contours\":[{\"time\":15,\"color\":\"ff0000\"}]}"
           ./build/$BUILD_TYPE/valhalla_service.exe ./test/win/valhalla.json isochrone "{\"locations\": [{\"lat\": 52.10205, \"lon\": 5.114651}], \"costing\": \"auto\", \"contours\":[{\"time\":15,\"color\":\"ff0000\"}]}"
-      
-      - name: Determine package to publish
-        if: ${{ env.PUBLISH_PYPI }}
-        shell: bash
-        run: |
-          VALHALLA_RELEASE_PKG="pyvalhalla"
-          if [[ ${{ startsWith(github.ref, 'refs/tags') }} == "false" ]]; then
-            VALHALLA_RELEASE_PKG="${VALHALLA_RELEASE_PKG}-weekly"
-          fi
-          echo "VALHALLA_RELEASE_PKG=${VALHALLA_RELEASE_PKG}" >> $GITHUB_ENV
         
       - name: Print libs
         shell: bash
@@ -351,8 +355,18 @@ jobs:
           ls -l build/vcpkg_installed/custom-x64-windows/lib
           ls -l build/vcpkg_installed/custom-x64-windows/bin
       
+      - name: Determine package to publish
+        if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' }}
+        shell: bash
+        run: |
+          VALHALLA_RELEASE_PKG="pyvalhalla"
+          if [[ ${{ startsWith(github.ref, 'refs/tags') }} == "false" ]]; then
+            VALHALLA_RELEASE_PKG="${VALHALLA_RELEASE_PKG}-weekly"
+          fi
+          echo "VALHALLA_RELEASE_PKG=${VALHALLA_RELEASE_PKG}" >> $GITHUB_ENV
+      
       - uses: pypa/cibuildwheel@v2.23.3
-        if: ${{ env.PUBLISH_PYPI }}
+        if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' }}
         env:
           # used in setup.py
           CIBW_ENVIRONMENT: >
@@ -363,7 +377,7 @@ jobs:
             delvewheel repair --add-path build/vcpkg_installed/custom-x64-windows/bin {wheel} -w {dest_dir}
 
       - name: Upload wheels
-        if: ${{ env.PUBLISH_PYPI }}
+        if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: wheels-win-amd64
@@ -378,10 +392,10 @@ jobs:
 
   verify_wheels:
     name: Verify wheels with executables in a fresh environment
-    needs: [build_python_wheels_linux]
+    needs: [publish_pypi, build_python_wheels_linux]
     runs-on: ubuntu-latest
     container: python:3.13-slim-bookworm
-    if: ${{ env.PUBLISH_PYPI }}
+    if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -399,10 +413,10 @@ jobs:
   
   upload_all:
     name: Upload if release
-    needs: [verify_wheels, build_osx, build_win]
+    needs: [publish_pypi, verify_wheels, build_osx, build_win]
     runs-on: ubuntu-latest
     # if: ${{ always() }}
-    if: ${{ env.PUBLISH_PYPI }}
+    if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' }}
 
     permissions:
       id-token: write # This is required for requesting the JWT from Github for PyPI


### PR DESCRIPTION
closes https://github.com/valhalla/valhalla/issues/5322

So far we couldn't actually release `pyvalhalla` or `pyvalhalla-weekly` bcs the GHA yml had a silly mistake where I referenced `${{ github.env.PUBLISH_PYPI }}` where `github.env` is the _path_ to the env file for each step.. Just `env.PUBLISH_PYPI` works.