### PR TITLE
chore: revert schedule gha

### DIFF
--- a/.github/workflows/osx_win_python_builds.yml
+++ b/.github/workflows/osx_win_python_builds.yml
@@ -10,7 +10,7 @@ on:
   # We run this once a week so we regularly publish pyvalhalla-weekly
   # but not on _every_ master commit
   schedule:
-    - cron: "*/5 * * * *"
+    - cron: "0 0 * * 0"
   push:
     paths-ignore:
       - "*.md"

--- a/src/bindings/python/scripts/build_manylinux.sh
+++ b/src/bindings/python/scripts/build_manylinux.sh
@@ -12,7 +12,7 @@ echo "[INFO] ccache dir is $(ccache -k cache_dir) with CCACHE_DIR=${CCACHE_DIR:-
 # have no own dependencies which might be installed on the system and thus outdated
 export LD_LIBRARY_PATH="/usr/local/lib64:/usr/local/lib"
 
-cmake -B ${BUILD_DIR} \
+cmake -B ${BUILD_DIR} -G Ninja \
   -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
   -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF `# turns off lto, which triggers a gcc/ld bug` \
   -DENABLE_PYTHON_BINDINGS=OFF `# setuptools will build the bindings` \
@@ -23,8 +23,8 @@ cmake -B ${BUILD_DIR} \
   -DVALHALLA_VERSION_MODIFIER=${VALHALLA_VERSION_MODIFIER:-}
 
 echo "[INFO] Building & installing libvalhalla..."
-LDFLAGS=-fno-lto cmake --build ${BUILD_DIR} -- -j$(nproc) > /dev/null
-${MAKE} -C ${BUILD_DIR} install
+LDFLAGS=-fno-lto cmake --build ${BUILD_DIR} -j$(nproc) > /dev/null
+cmake --install ${BUILD_DIR}
 
 ccache -s
 

--- a/src/bindings/python/scripts/build_manylinux.sh
+++ b/src/bindings/python/scripts/build_manylinux.sh
@@ -24,7 +24,7 @@ cmake -B ${BUILD_DIR} \
 
 echo "[INFO] Building & installing libvalhalla..."
 LDFLAGS=-fno-lto cmake --build ${BUILD_DIR} -- -j$(nproc) > /dev/null
-make -C ${BUILD_DIR} install
+${MAKE} -C ${BUILD_DIR} install
 
 ccache -s
 


### PR DESCRIPTION
GHA didn't trigger the 5 min schedule for a while and then spuriously (every 8 - 12 mins or so). In fact, they don't guarantee the schedule to run exactly when it's specified.

This is reverting the GHA schedule change for debugging purposes. I also changed the linux build system to `ninja` so it's run in parallel (`make` had some problems with parallelization).