### PR TITLE
fix: protobuf < 3.15 private has_ members

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
 
   build-arm-release:
     docker:
-      - image: arm64v8/ubuntu:22.04
+      - image: arm64v8/ubuntu:24.04
     resource_class: arm.xlarge
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
 
   build-release:
     docker:
-      - image: ubuntu:24.04
+      - image: ubuntu:22.04
     resource_class: xlarge
     steps:
       - checkout
@@ -94,7 +94,7 @@ jobs:
 
   build-arm-release:
     docker:
-      - image: arm64v8/ubuntu:24.04
+      - image: arm64v8/ubuntu:22.04
     resource_class: arm.xlarge
     steps:
       - checkout

--- a/proto/trip.proto
+++ b/proto/trip.proto
@@ -236,8 +236,12 @@ message TripLeg {
     }
     repeated Level levels = 61;
     uint32 level_precision = 62;
-    Speeds speeds_faded = 63;
-    Speeds speeds_non_faded = 64;
+    oneof has_speeds_faded {
+      Speeds speeds_faded = 63;
+    }
+    oneof has_speeds_non_faded {
+      Speeds speeds_non_faded = 64;
+    }
     SpeedType speed_type = 65;
   }
 

--- a/proto/trip.proto
+++ b/proto/trip.proto
@@ -121,18 +121,10 @@ message TripLeg {
   }
 
   message Speeds {
-    oneof has_predicted_flow {
-      float predicted_flow = 1;
-    }
-    oneof has_constrained_flow {
-      float constrained_flow = 2;
-    }
-    oneof has_free_flow {
-      float free_flow = 3;
-    }
-    oneof has_current_flow {
-      float current_flow = 4;
-    }
+    float predicted_flow = 1;
+    float constrained_flow = 2;
+    float free_flow = 3;
+    float current_flow = 4;
     float no_flow = 5;
   }
 

--- a/scripts/warnings_overview.py
+++ b/scripts/warnings_overview.py
@@ -60,7 +60,7 @@ def main():
     )
     if list_parameters:
         for files_amount, warning_id in list_parameters:
-            print(f"  {warning_id}: max {"all" if files_amount != -1 else files_amount} source paths")
+            print(f"  {warning_id}: max {'all' if files_amount != -1 else files_amount} source paths")
 
     warnings_counter = Counter()
     warnings_files_requested = defaultdict(int)

--- a/src/bindings/python/valhalla/_scripts.py
+++ b/src/bindings/python/valhalla/_scripts.py
@@ -47,7 +47,7 @@ def run(from_main=False) -> None:
         # https://github.com/adang1345/delvewheel/issues/62#issuecomment-2977988121
         # the DLLs are installed to site-packages/ directly for some reason, see
         # https://github.com/adang1345/delvewheel/issues/64
-        env=dict(PATH=f"{sysconfig.get_paths()["purelib"]}" if IS_WIN else None),
+        env=dict(PATH=f"{sysconfig.get_paths()['purelib']}" if IS_WIN else None),
     )
 
     # raises CalledProcessError if not successful

--- a/src/tyr/trace_serializer.cc
+++ b/src/tyr/trace_serializer.cc
@@ -47,16 +47,16 @@ void serialize_speeds(const valhalla::TripLeg_Edge& edge,
                       rapidjson::writer_wrapper_t& writer) {
   auto speeds = is_faded ? edge.speeds_faded() : edge.speeds_non_faded();
   writer.start_object(is_faded ? "speeds_faded" : "speeds_non_faded");
-  if (speeds.has_current_flow_case()) {
+  if (speeds.current_flow()) {
     writer("current_flow", speed_serializer(speeds.current_flow()));
   }
-  if (speeds.has_predicted_flow_case()) {
+  if (speeds.predicted_flow()) {
     writer("predicted_flow", speed_serializer(speeds.predicted_flow()));
   }
-  if (speeds.has_constrained_flow_case()) {
+  if (speeds.constrained_flow()) {
     writer("constrained_flow", speed_serializer(speeds.constrained_flow()));
   }
-  if (speeds.has_free_flow_case()) {
+  if (speeds.free_flow()) {
     writer("free_flow", speed_serializer(speeds.free_flow()));
   }
   writer("no_flow", speed_serializer(speeds.no_flow()));

--- a/src/tyr/trace_serializer.cc
+++ b/src/tyr/trace_serializer.cc
@@ -47,16 +47,16 @@ void serialize_speeds(const valhalla::TripLeg_Edge& edge,
                       rapidjson::writer_wrapper_t& writer) {
   auto speeds = is_faded ? edge.speeds_faded() : edge.speeds_non_faded();
   writer.start_object(is_faded ? "speeds_faded" : "speeds_non_faded");
-  if (speeds.has_current_flow()) {
+  if (speeds.has_current_flow_case()) {
     writer("current_flow", speed_serializer(speeds.current_flow()));
   }
-  if (speeds.has_predicted_flow()) {
+  if (speeds.has_predicted_flow_case()) {
     writer("predicted_flow", speed_serializer(speeds.predicted_flow()));
   }
-  if (speeds.has_constrained_flow()) {
+  if (speeds.has_constrained_flow_case()) {
     writer("constrained_flow", speed_serializer(speeds.constrained_flow()));
   }
-  if (speeds.has_free_flow()) {
+  if (speeds.has_free_flow_case()) {
     writer("free_flow", speed_serializer(speeds.free_flow()));
   }
   writer("no_flow", speed_serializer(speeds.no_flow()));
@@ -220,7 +220,7 @@ void serialize_edges(const AttributesController& controller,
       }
       if (controller(kEdgeSpeedsFaded) &&
           options.date_time_type() == Options::DateTimeType::Options_DateTimeType_current &&
-          edge.has_speeds_faded()) {
+          edge.has_speeds_faded_case()) {
         serialize_speeds(edge, true, serialize_speed, writer);
       }
       if (controller(kEdgeSpeedsNonFaded)) {


### PR DESCRIPTION
In #5324 we missed that it introduced `has_xxx()` usages for optional fields which they ripped out in 3.0 and reintroduced in protobuf < 3.15 (such a messed up library!). cc @johannes-no 

Only realized it bcs the public server couldn't build Valhalla, it runs on 22.04 with protobuf 3.12. One more reason for us to run CI on the oldest available OS version (or the oldest we want to support). 