### PR TITLE
ci: Do not run "Update public FOSSGIS servers" workflow in forks

### DIFF
--- a/.github/workflows/update_public_servers.yml
+++ b/.github/workflows/update_public_servers.yml
@@ -1,4 +1,4 @@
-name: Update public FOSSGIS servers 
+name: Update public FOSSGIS servers
 
 on:
   push:
@@ -21,6 +21,7 @@ jobs:
   update_servers:
     name: Update servers
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'valhalla'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
# Issue

Fixes annoying emails that attempt to update FOSGIS from my fork have failed...

<img width="603" height="458" alt="image" src="https://github.com/user-attachments/assets/04ab4854-49f5-4090-8be2-131d3808fc14" />

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
