### PR TITLE
Fix un-evaluated access restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
    * FIXED: version modifier in `/status` response [#5357](https://github.com/valhalla/valhalla/pull/5357)
    * FIXED: unknowns should be 500 and not 400 [#5359](https://github.com/valhalla/valhalla/pull/5359)
    * FIXED: Cover **all** nodes in the current tile by density index [#5338](https://github.com/valhalla/valhalla/pull/5338)
+   * FIXED: early return when evaluating access restrictions [#5363](https://github.com/valhalla/valhalla/pull/5363)
 * **Enhancement**
    * ADDED: Consider smoothness in all profiles that use surface [#4949](https://github.com/valhalla/valhalla/pull/4949)
    * ADDED: costing parameters to exclude certain edges `exclude_tolls`, `exclude_bridges`, `exclude_tunnels`, `exclude_highways`, `exclude_ferries`. They need to be enabled in the config with `service_limits.allow_hard_exclusions`. Also added location search filters `exclude_ferry` and `exclude_toll` to complement these changes. [#4524](https://github.com/valhalla/valhalla/pull/4524)

--- a/src/baldr/accessrestriction.cc
+++ b/src/baldr/accessrestriction.cc
@@ -104,7 +104,11 @@ bool AccessRestriction::operator<(const AccessRestriction& other) const {
       if (type() == other.type()) {
         return value() < other.value();
       }
-      return type() < other.type();
+      // the way in which access restrictions are evaluated
+      // makes it necessary to keep all the timed restrictions
+      // at the end
+      return type() == AccessType::kMaxAxles ? other.type() > AccessType::kMaxAxleLoad
+                                             : type() < other.type();
     }
     return modes() < other.modes();
   }

--- a/src/baldr/accessrestriction.cc
+++ b/src/baldr/accessrestriction.cc
@@ -104,11 +104,7 @@ bool AccessRestriction::operator<(const AccessRestriction& other) const {
       if (type() == other.type()) {
         return value() < other.value();
       }
-      // the way in which access restrictions are evaluated
-      // makes it necessary to keep all the timed restrictions
-      // at the end
-      return type() == AccessType::kMaxAxles ? other.type() > AccessType::kMaxAxleLoad
-                                             : type() < other.type();
+      return type() < other.type();
     }
     return modes() < other.modes();
   }

--- a/test/gurka/test_truck.cc
+++ b/test/gurka/test_truck.cc
@@ -322,7 +322,7 @@ TEST(StandAlone, TestTruck) {
       {"AE",
        {
            {"highway", "secondary"},
-           {"maxaxles", "1"},
+           {"maxheight", "1"},
            {"hgv:conditional", "yes @ (09:00-18:00)"},
        }},
       {"EF", {{"highway", "secondary"}}},
@@ -347,7 +347,7 @@ TEST(StandAlone, TestTruck) {
   try {
     valhalla::Api route =
         gurka::do_action(valhalla::Options::route, map, {"D", "F"}, "truck",
-                         {{"/date_time/type", "1"}, {"/date_time/value", "2020-10-10T16:00"}});
+                         {{"/costing_options/truck/height", "3"}, {"/date_time/type", "1"}, {"/date_time/value", "2020-10-10T16:00"}});
     FAIL() << "Expected route to fail.";
   } catch (const valhalla_exception_t& err) { EXPECT_EQ(err.code, 442); } catch (...) {
     FAIL() << "Expected different error code.";

--- a/test/gurka/test_truck.cc
+++ b/test/gurka/test_truck.cc
@@ -345,9 +345,10 @@ TEST(StandAlone, TestTruck) {
 
   // this one should fail not because of time constraint but because of maxaxles
   try {
-    valhalla::Api route =
-        gurka::do_action(valhalla::Options::route, map, {"D", "F"}, "truck",
-                         {{"/costing_options/truck/height", "3"}, {"/date_time/type", "1"}, {"/date_time/value", "2020-10-10T16:00"}});
+    valhalla::Api route = gurka::do_action(valhalla::Options::route, map, {"D", "F"}, "truck",
+                                           {{"/costing_options/truck/height", "3"},
+                                            {"/date_time/type", "1"},
+                                            {"/date_time/value", "2020-10-10T16:00"}});
     FAIL() << "Expected route to fail.";
   } catch (const valhalla_exception_t& err) { EXPECT_EQ(err.code, 442); } catch (...) {
     FAIL() << "Expected different error code.";

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -685,12 +685,13 @@ public:
         tile->GetAccessRestrictions(edgeid.id(), access_mode);
 
     bool time_allowed = false;
+    bool timed_in_range = false;
 
     for (size_t i = 0; i < restrictions.size(); ++i) {
       const auto& restriction = restrictions[i];
       // Compare the time to the time-based restrictions
       baldr::AccessType access_type = restriction.type();
-      if (!ignore_non_vehicular_restrictions_ &&
+      if ((!timed_in_range) && !ignore_non_vehicular_restrictions_ &&
           (access_type == baldr::AccessType::kTimedAllowed ||
            access_type == baldr::AccessType::kTimedDenied ||
            access_type == baldr::AccessType::kDestinationAllowed)) {
@@ -712,9 +713,9 @@ public:
 
             // We are in range at the time we are allowed at this edge
             if (access_type == baldr::AccessType::kTimedAllowed)
-              return true;
+              timed_in_range = true;
             else if (access_type == baldr::AccessType::kDestinationAllowed)
-              return allow_conditional_destination_ || is_dest;
+              timed_in_range = allow_conditional_destination_ || is_dest;
             else
               return false;
           }
@@ -730,7 +731,7 @@ public:
     // if we have time allowed restrictions then these restrictions are
     // the only time we can route here.  Meaning all other time is restricted.
     // We looped over all the time allowed restrictions and we were never in range.
-    return !time_allowed || (current_time == 0);
+    return timed_in_range || !time_allowed || (current_time == 0);
   }
 
   /**


### PR DESCRIPTION
# Issue

The early return statements in `DynamicCost::EvaluateRestrictions(...)` when the time is within a `kTimedAllowed` or `kDestinationAllowed`  range can lead to other access restrictions not being checked. This is due to the way in which access restrictions are sorted within the tile: first by edge ID, then by access mask, then by type and finally by value. This leads  to two problems: some access restrictions might have a "higher" access mask than the timed ones (see example in the added gurka test), and the `maxaxles` restriction type added in #3648 has a "higher" type.

I think the best solution is to get rid of those early returns to make sure all restrictions are checked. I introduced a `timed_in_range` flag which can be used to skip any timed restrictions once we've found one in range, so the overhead should be minimal. 

