### PR TITLE
chore(python): move python extension to valhalla module namespace

### DIFF
--- a/.github/workflows/osx_win_python_builds.yml
+++ b/.github/workflows/osx_win_python_builds.yml
@@ -361,7 +361,7 @@ jobs:
           ls -l build/vcpkg_installed/custom-x64-windows/bin
       
       - name: Determine package to publish
-        if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' }}
+        # if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' }}
         shell: bash
         run: |
           VALHALLA_RELEASE_PKG="pyvalhalla"
@@ -371,7 +371,7 @@ jobs:
           echo "VALHALLA_RELEASE_PKG=${VALHALLA_RELEASE_PKG}" >> $GITHUB_ENV
       
       - uses: pypa/cibuildwheel@v2.23.3
-        if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' }}
+        # if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' }}
         env:
           # used in setup.py
           CIBW_ENVIRONMENT: >
@@ -381,7 +381,7 @@ jobs:
             VALHALLA_BUILD_BIN_DIR=build/Release
 
       - name: Upload wheels
-        if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' }}
+        # if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: wheels-win-amd64
@@ -441,7 +441,7 @@ jobs:
     name: Verify wheels with executables in a fresh environment
     needs: [publish_pypi, build_win]
     runs-on: windows-2022
-    if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' }}
+    # if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ ext_modules = [
         # TODO: currently this installs the extension module directly to site-packages
         # we want to move it to the site-packages/valhalla folder with "valhalla._valhalla"
         # NOTE: this has impact on Windows where we need to add the DLL path manually
-        "_valhalla",
+        "valhalla._valhalla",
         [os.path.join("src", "bindings", "python", "valhalla", "_valhalla.cc")],
         cxx_std=17,
         include_pybind11=False,  # use submodule'd pybind11

--- a/src/bindings/python/valhalla/_scripts.py
+++ b/src/bindings/python/valhalla/_scripts.py
@@ -3,7 +3,6 @@ import platform
 from shutil import which
 import subprocess
 import sys
-import sysconfig
 
 from . import PYVALHALLA_DIR
 
@@ -43,11 +42,6 @@ def run(from_main=False) -> None:
         [str(prog_path)] + prog_args,
         stderr=sys.stderr,
         stdout=subprocess.DEVNULL if is_quiet else sys.stdout,
-        # on Win we need to add the path to vendored DLLs manually, see
-        # https://github.com/adang1345/delvewheel/issues/62#issuecomment-2977988121
-        # the DLLs are installed to site-packages/ directly for some reason, see
-        # https://github.com/adang1345/delvewheel/issues/64
-        env=dict(PATH=f"{sysconfig.get_paths()['purelib']}" if IS_WIN else None),
     )
 
     # raises CalledProcessError if not successful


### PR DESCRIPTION
closes #5349 

Mainly so Windows doesn't install vendored libs to `site-packages/` directly but to `site-packages/valhalla.libs/` which `delvewheel` automatically adds to the path where runtime DLLs are searched in.
