### PR TITLE
Destination only for access restrictions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@
    * CHANGED: refactor to make valhalla/filesystem functionally redundant [#5319](https://github.com/valhalla/valhalla/pull/5319)
    * ADDED: Distribute C++ executables for Windows Python bindings [#5348](https://github.com/valhalla/valhalla/pull/5348)
    * ADDED: Distribute C++ executables for OSX Python bindings [#5301](https://github.com/valhalla/valhalla/pull/5301)
+   * ADDED: support for destination exceptions for access restrictions [#5354](https://github.com/valhalla/valhalla/pull/5354)
 
 ## Release Date: 2024-10-10 Valhalla 3.5.1
 * **Removed**

--- a/lua/graph.lua
+++ b/lua/graph.lua
@@ -422,6 +422,14 @@ lit = {
   ["sunset-sunrise"] = "true"
 }
 
+-- used the most common combinations according to taginfo
+conditional_access_restriction = {
+  ["none @ destination"]  = 1,
+  ["none @ delivery"]  = 1,
+  ["no @ destination"]  = 1,
+  ["none @ (destination)"]  = 1,
+}
+
 --node proc needs the same info as above but in the form of a mask so duplicate..
 motor_vehicle_node = {
 ["yes"] = 1,
@@ -1838,6 +1846,42 @@ function filter_tags_generic(kv)
   kv["maxspeed:hgv"] = normalize_speed(kv["maxspeed:hgv"])
   kv["maxspeed:hgv:forward"] = normalize_speed(kv["maxspeed:hgv:forward"])
   kv["maxspeed:hgv:backward"] = normalize_speed(kv["maxspeed:hgv:backward"])
+
+  local access_restriction_tags = {
+    "maxweight", "maxheight", "maxlength", "maxwidth", "hazmat", "maxaxles", "maxaxleload"
+  }
+
+  for _, restr_tag in pairs(access_restriction_tags) do 
+    -- find out if there are exemptions
+    local conditional_tag = string.format("%s:conditional", restr_tag)
+    local except_destination = conditional_access_restriction[kv[conditional_tag]] or 0
+    if except_destination == 1 then 
+      kv[restr_tag] = tostring(kv[restr_tag]) .. "~" -- parse this later in the graphparser
+    end
+  end
+
+  local directed_access_restriction_tags = {
+    "maxweight", "maxheight", "maxlength", "maxwidth", "hazmat"
+  }
+
+  local directions = {
+    "forward", "backward"
+  }
+
+  -- also look for local exemptions in uni-directional restrictions
+  for _, restr_key in pairs(directed_access_restriction_tags) do 
+    for _, direction in pairs(directions) do 
+      local key = restr_key .. "_" .. direction
+      local tag = restr_key .. ":" .. direction
+      local conditional_tag = string.format("%s:conditional", tag)
+      local except_destination = conditional_access_restriction[kv[conditional_tag]] or 0
+      if except_destination == 1 then 
+        kv[key] = tostring(kv[key]) .. "~" -- parse this later in the graphparser
+      end
+    end
+  end
+
+
 
   if (kv["hgv:national_network"] or kv["hgv:state_network"] or kv["hgv"] == "local" or kv["hgv"] == "designated") then
     kv["truck_route"] = "true"

--- a/src/baldr/accessrestriction.cc
+++ b/src/baldr/accessrestriction.cc
@@ -26,9 +26,10 @@ namespace baldr {
 AccessRestriction::AccessRestriction(const uint32_t edgeindex,
                                      const AccessType type,
                                      const uint32_t modes,
-                                     const uint64_t value)
-    : edgeindex_(edgeindex), type_(static_cast<uint32_t>(type)), modes_(modes), spare_(0),
-      value_(value) {
+                                     const uint64_t value,
+                                     const bool except_destination)
+    : edgeindex_(edgeindex), type_(static_cast<uint32_t>(type)), modes_(modes),
+      except_destination_(except_destination), spare_(0), value_(value) {
 }
 
 // Get the internal edge Id.
@@ -49,6 +50,14 @@ AccessType AccessRestriction::type() const {
 // Get the modes impacted by access restriction.
 uint32_t AccessRestriction::modes() const {
   return modes_;
+}
+
+bool AccessRestriction::except_destination() const {
+  return static_cast<bool>(except_destination_);
+}
+
+void AccessRestriction::set_except_destination(const bool except_destination) {
+  except_destination_ = static_cast<uint64_t>(except_destination);
 }
 
 // Get the value

--- a/src/meili/routing.cc
+++ b/src/meili/routing.cc
@@ -162,12 +162,13 @@ inline bool IsEdgeAllowed(const baldr::DirectedEdge* edge,
                           const sif::cost_ptr_t& costing,
                           const Label& pred_edgelabel,
                           const graph_tile_ptr& tile,
-                          uint8_t& restriction_idx) {
+                          uint8_t& restriction_idx,
+                          uint8_t& destonly_access_restr_mask) {
   bool valid_pred =
       (!pred_edgelabel.edgeid().Is_Valid() && costing->Allowed(edge, tile, sif::kDisallowShortcut)) ||
       edgeid == pred_edgelabel.edgeid();
-  bool restricted =
-      !costing->Allowed(edge, false, pred_edgelabel, tile, edgeid, 0, 0, restriction_idx);
+  bool restricted = !costing->Allowed(edge, false, pred_edgelabel, tile, edgeid, 0, 0,
+                                      restriction_idx, destonly_access_restr_mask);
   return valid_pred || !restricted;
 }
 
@@ -406,7 +407,9 @@ find_shortest_path(baldr::GraphReader& reader,
 
       // Skip it if its not allowed
       uint8_t restriction_idx = -1;
-      if (!IsEdgeAllowed(directededge, edgeid, costing, label, tile, restriction_idx)) {
+      uint8_t destonly_restriction_mask = 0;
+      if (!IsEdgeAllowed(directededge, edgeid, costing, label, tile, restriction_idx,
+                         destonly_restriction_mask)) {
         continue;
       }
 
@@ -549,8 +552,10 @@ find_shortest_path(baldr::GraphReader& reader,
 
         // Skip if edge is not allowed
         uint8_t restriction_idx = -1;
-        if (!directed_edge || !IsEdgeAllowed(directed_edge, origin_edge.id, costing, label,
-                                             start_tile, restriction_idx)) {
+        uint8_t destonly_restriction_mask = 0;
+        if (!directed_edge ||
+            !IsEdgeAllowed(directed_edge, origin_edge.id, costing, label, start_tile, restriction_idx,
+                           destonly_restriction_mask)) {
           continue;
         }
 

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -395,7 +395,7 @@ uint32_t AddAccessRestrictions(const uint32_t edgeid,
         (forward && direction == AccessRestrictionDirection::kForward) ||
         (!forward && direction == AccessRestrictionDirection::kBackward)) {
       AccessRestriction access_restriction(edgeid, r->second.type(), r->second.modes(),
-                                           r->second.value());
+                                           r->second.value(), r->second.except_destination());
       graphtile.AddAccessRestriction(access_restriction);
       modes |= r->second.modes();
     }

--- a/src/mjolnir/graphfilter.cc
+++ b/src/mjolnir/graphfilter.cc
@@ -316,7 +316,8 @@ void FilterTiles(GraphReader& reader,
           auto restrictions = tile->GetAccessRestrictions(edgeid.id(), kAllAccess);
           for (const auto& res : restrictions) {
             tilebuilder.AddAccessRestriction(AccessRestriction(tilebuilder.directededges().size(),
-                                                               res.type(), res.modes(), res.value()));
+                                                               res.type(), res.modes(), res.value(),
+                                                               res.except_destination()));
           }
         }
 
@@ -681,7 +682,8 @@ void AggregateTiles(GraphReader& reader, std::unordered_map<GraphId, GraphId>& o
           auto restrictions = tile->GetAccessRestrictions(edgeid.id(), kAllAccess);
           for (const auto& res : restrictions) {
             tilebuilder.AddAccessRestriction(AccessRestriction(tilebuilder.directededges().size(),
-                                                               res.type(), res.modes(), res.value()));
+                                                               res.type(), res.modes(), res.value(),
+                                                               res.except_destination()));
           }
         }
 

--- a/src/mjolnir/hierarchybuilder.cc
+++ b/src/mjolnir/hierarchybuilder.cc
@@ -274,7 +274,8 @@ void FormTilesInNewLevel(GraphReader& reader,
         auto restrictions = tile->GetAccessRestrictions(base_edge_id.id(), kAllAccess);
         for (const auto& res : restrictions) {
           tilebuilder->AddAccessRestriction(AccessRestriction(tilebuilder->directededges().size(),
-                                                              res.type(), res.modes(), res.value()));
+                                                              res.type(), res.modes(), res.value(),
+                                                              res.except_destination()));
         }
       }
 

--- a/src/mjolnir/osmaccessrestriction.cc
+++ b/src/mjolnir/osmaccessrestriction.cc
@@ -45,5 +45,13 @@ void OSMAccessRestriction::set_direction(AccessRestrictionDirection direction) {
   direction_ = direction;
 };
 
+bool OSMAccessRestriction::except_destination() const {
+  return static_cast<bool>(except_destination_);
+};
+
+void OSMAccessRestriction::set_except_destination(const bool except_destination) {
+  except_destination_ = except_destination;
+}
+
 } // namespace mjolnir
 } // namespace valhalla

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -988,15 +988,27 @@ struct graph_parser {
     tag_handlers_["hazmat"] = [this]() {
       OSMAccessRestriction restriction;
       restriction.set_type(AccessType::kHazmat);
-      restriction.set_value(tag_.second == "true" ? true : false);
       restriction.set_modes(kTruckAccess);
+      auto pos = tag_.second.find("~");
+      if (pos != std::string::npos) {
+        restriction.set_value(tag_.second.substr(0, pos) == "true" ? true : false);  
+        restriction.set_except_destination(true);
+      } else {
+        restriction.set_value(tag_.second == "true" ? true : false);  
+      }
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
     };
     tag_handlers_["hazmat_forward"] = [this]() {
       OSMAccessRestriction restriction;
       restriction.set_type(AccessType::kHazmat);
-      restriction.set_value(tag_.second == "true" ? true : false);
+      auto pos = tag_.second.find("~");
+      if (pos != std::string::npos) {
+        restriction.set_value(tag_.second.substr(0, pos) == "true" ? true : false);  
+        restriction.set_except_destination(true);
+      } else {
+        restriction.set_value(tag_.second == "true" ? true : false);  
+      }
       restriction.set_modes(kTruckAccess);
       restriction.set_direction(AccessRestrictionDirection::kForward);
       osmdata_.access_restrictions.insert(
@@ -1005,128 +1017,218 @@ struct graph_parser {
     tag_handlers_["hazmat_backward"] = [this]() {
       OSMAccessRestriction restriction;
       restriction.set_type(AccessType::kHazmat);
-      restriction.set_value(tag_.second == "true" ? true : false);
       restriction.set_modes(kTruckAccess);
       restriction.set_direction(AccessRestrictionDirection::kBackward);
+      auto pos = tag_.second.find("~");
+      if (pos != std::string::npos) {
+        restriction.set_value(tag_.second.substr(0, pos) == "true" ? true : false);  
+        restriction.set_except_destination(true);
+      } else {
+        restriction.set_value(tag_.second == "true" ? true : false);  
+      }
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
     };
     tag_handlers_["maxheight"] = [this]() {
       OSMAccessRestriction restriction;
       restriction.set_type(AccessType::kMaxHeight);
-      restriction.set_value(std::stof(tag_.second) * 100);
       restriction.set_modes(kTruckAccess | kAutoAccess | kHOVAccess | kTaxiAccess | kBusAccess);
+      auto pos = tag_.second.find("~");
+      if (pos != std::string::npos) {
+        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);  
+        restriction.set_except_destination(true);
+      } else {
+        restriction.set_value(std::stof(tag_.second) * 100);  
+      }
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
     };
     tag_handlers_["maxheight_forward"] = [this]() {
       OSMAccessRestriction restriction;
       restriction.set_type(AccessType::kMaxHeight);
-      restriction.set_value(std::stof(tag_.second) * 100);
       restriction.set_modes(kTruckAccess | kAutoAccess | kHOVAccess | kTaxiAccess | kBusAccess);
       restriction.set_direction(AccessRestrictionDirection::kForward);
+      auto pos = tag_.second.find("~");
+      if (pos != std::string::npos) {
+        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);  
+        restriction.set_except_destination(true);
+      } else {
+        restriction.set_value(std::stof(tag_.second) * 100);  
+      }
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
     };
     tag_handlers_["maxheight_backward"] = [this]() {
       OSMAccessRestriction restriction;
       restriction.set_type(AccessType::kMaxHeight);
-      restriction.set_value(std::stof(tag_.second) * 100);
       restriction.set_modes(kTruckAccess | kAutoAccess | kHOVAccess | kTaxiAccess | kBusAccess);
       restriction.set_direction(AccessRestrictionDirection::kBackward);
+      auto pos = tag_.second.find("~");
+      if (pos != std::string::npos) {
+        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);  
+        restriction.set_except_destination(true);
+      } else {
+        restriction.set_value(std::stof(tag_.second) * 100);  
+      }
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
     };
     tag_handlers_["maxwidth"] = [this]() {
       OSMAccessRestriction restriction;
       restriction.set_type(AccessType::kMaxWidth);
-      restriction.set_value(std::stof(tag_.second) * 100);
       restriction.set_modes(kTruckAccess | kAutoAccess | kHOVAccess | kTaxiAccess | kBusAccess);
+      auto pos = tag_.second.find("~");
+      if (pos != std::string::npos) {
+        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);  
+        restriction.set_except_destination(true);
+      } else {
+        restriction.set_value(std::stof(tag_.second) * 100);  
+      }
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
     };
     tag_handlers_["maxwidth_forward"] = [this]() {
       OSMAccessRestriction restriction;
       restriction.set_type(AccessType::kMaxWidth);
-      restriction.set_value(std::stof(tag_.second) * 100);
       restriction.set_modes(kTruckAccess | kAutoAccess | kHOVAccess | kTaxiAccess | kBusAccess);
       restriction.set_direction(AccessRestrictionDirection::kForward);
+      auto pos = tag_.second.find("~");
+      if (pos != std::string::npos) {
+        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);  
+        restriction.set_except_destination(true);
+      } else {
+        restriction.set_value(std::stof(tag_.second) * 100);  
+      }
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
     };
     tag_handlers_["maxwidth_backward"] = [this]() {
       OSMAccessRestriction restriction;
       restriction.set_type(AccessType::kMaxWidth);
-      restriction.set_value(std::stof(tag_.second) * 100);
       restriction.set_modes(kTruckAccess | kAutoAccess | kHOVAccess | kTaxiAccess | kBusAccess);
       restriction.set_direction(AccessRestrictionDirection::kBackward);
+      auto pos = tag_.second.find("~");
+      if (pos != std::string::npos) {
+        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);  
+        restriction.set_except_destination(true);
+      } else {
+        restriction.set_value(std::stof(tag_.second) * 100);  
+      }
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
     };
     tag_handlers_["maxlength"] = [this]() {
       OSMAccessRestriction restriction;
       restriction.set_type(AccessType::kMaxLength);
-      restriction.set_value(std::stof(tag_.second) * 100);
       restriction.set_modes(kTruckAccess);
+      auto pos = tag_.second.find("~");
+      if (pos != std::string::npos) {
+        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);  
+        restriction.set_except_destination(true);
+      } else {
+        restriction.set_value(std::stof(tag_.second) * 100);  
+      }
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
     };
     tag_handlers_["maxlength_forward"] = [this]() {
       OSMAccessRestriction restriction;
       restriction.set_type(AccessType::kMaxLength);
-      restriction.set_value(std::stof(tag_.second) * 100);
       restriction.set_modes(kTruckAccess);
       restriction.set_direction(AccessRestrictionDirection::kForward);
+      auto pos = tag_.second.find("~");
+      if (pos != std::string::npos) {
+        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);  
+        restriction.set_except_destination(true);
+      } else {
+        restriction.set_value(std::stof(tag_.second) * 100);  
+      }
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
     };
     tag_handlers_["maxlength_backward"] = [this]() {
       OSMAccessRestriction restriction;
       restriction.set_type(AccessType::kMaxLength);
-      restriction.set_value(std::stof(tag_.second) * 100);
       restriction.set_modes(kTruckAccess);
       restriction.set_direction(AccessRestrictionDirection::kBackward);
+      auto pos = tag_.second.find("~");
+      if (pos != std::string::npos) {
+        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);  
+        restriction.set_except_destination(true);
+      } else {
+        restriction.set_value(std::stof(tag_.second) * 100);  
+      }
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
     };
     tag_handlers_["maxweight"] = [this]() {
       OSMAccessRestriction restriction;
       restriction.set_type(AccessType::kMaxWeight);
-      restriction.set_value(std::stof(tag_.second) * 100);
       restriction.set_modes(kTruckAccess);
+      auto pos = tag_.second.find("~");
+      if (pos != std::string::npos) {
+        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);  
+        restriction.set_except_destination(true);
+      } else {
+        restriction.set_value(std::stof(tag_.second) * 100);  
+      }
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
     };
     tag_handlers_["maxweight_forward"] = [this]() {
       OSMAccessRestriction restriction;
       restriction.set_type(AccessType::kMaxWeight);
-      restriction.set_value(std::stof(tag_.second) * 100);
       restriction.set_modes(kTruckAccess);
       restriction.set_direction(AccessRestrictionDirection::kForward);
+      auto pos = tag_.second.find("~");
+      if (pos != std::string::npos) {
+        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);  
+        restriction.set_except_destination(true);
+      } else {
+        restriction.set_value(std::stof(tag_.second) * 100);  
+      }
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
     };
     tag_handlers_["maxweight_backward"] = [this]() {
       OSMAccessRestriction restriction;
       restriction.set_type(AccessType::kMaxWeight);
-      restriction.set_value(std::stof(tag_.second) * 100);
       restriction.set_modes(kTruckAccess);
       restriction.set_direction(AccessRestrictionDirection::kBackward);
+      auto pos = tag_.second.find("~");
+      if (pos != std::string::npos) {
+        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);  
+        restriction.set_except_destination(true);
+      } else {
+        restriction.set_value(std::stof(tag_.second) * 100);  
+      }
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
     };
     tag_handlers_["maxaxleload"] = [this]() {
       OSMAccessRestriction restriction;
       restriction.set_type(AccessType::kMaxAxleLoad);
-      restriction.set_value(std::stof(tag_.second) * 100);
       restriction.set_modes(kTruckAccess);
+      auto pos = tag_.second.find("~");
+      if (pos != std::string::npos) {
+        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);  
+        restriction.set_except_destination(true);
+      } else {
+        restriction.set_value(std::stof(tag_.second) * 100);  
+      }
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
     };
     tag_handlers_["maxaxles"] = [this]() {
       OSMAccessRestriction restriction;
       restriction.set_type(AccessType::kMaxAxles);
-      restriction.set_value(std::stoul(tag_.second));
+      auto pos = tag_.second.find("~");
+      if (pos != std::string::npos) {
+        restriction.set_value(std::stof(tag_.second.substr(0, pos)));  
+        restriction.set_except_destination(true);
+      } else {
+        restriction.set_value(std::stof(tag_.second));  
+      }
       restriction.set_modes(kTruckAccess);
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
@@ -2770,7 +2872,8 @@ struct graph_parser {
           ProcessPronunciationTag(OSMLinguistic::Type::kJunctionName, alphabet);
         }
       }
-    }
+    } // end tags loop
+
 
     if (!use_direction_on_ways_) {
 
@@ -3770,6 +3873,9 @@ struct graph_parser {
         }
       }
     }
+
+    // destonly access restrictions here
+    
 
     // Add the way to the list
     ways_->push_back(way_);

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -2872,7 +2872,7 @@ struct graph_parser {
           ProcessPronunciationTag(OSMLinguistic::Type::kJunctionName, alphabet);
         }
       }
-    } // end tags loop
+    }
 
     if (!use_direction_on_ways_) {
 
@@ -3872,8 +3872,6 @@ struct graph_parser {
         }
       }
     }
-
-    // destonly access restrictions here
 
     // Add the way to the list
     ways_->push_back(way_);

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -991,10 +991,10 @@ struct graph_parser {
       restriction.set_modes(kTruckAccess);
       auto pos = tag_.second.find("~");
       if (pos != std::string::npos) {
-        restriction.set_value(tag_.second.substr(0, pos) == "true" ? true : false);  
+        restriction.set_value(tag_.second.substr(0, pos) == "true" ? true : false);
         restriction.set_except_destination(true);
       } else {
-        restriction.set_value(tag_.second == "true" ? true : false);  
+        restriction.set_value(tag_.second == "true" ? true : false);
       }
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
@@ -1004,10 +1004,10 @@ struct graph_parser {
       restriction.set_type(AccessType::kHazmat);
       auto pos = tag_.second.find("~");
       if (pos != std::string::npos) {
-        restriction.set_value(tag_.second.substr(0, pos) == "true" ? true : false);  
+        restriction.set_value(tag_.second.substr(0, pos) == "true" ? true : false);
         restriction.set_except_destination(true);
       } else {
-        restriction.set_value(tag_.second == "true" ? true : false);  
+        restriction.set_value(tag_.second == "true" ? true : false);
       }
       restriction.set_modes(kTruckAccess);
       restriction.set_direction(AccessRestrictionDirection::kForward);
@@ -1021,10 +1021,10 @@ struct graph_parser {
       restriction.set_direction(AccessRestrictionDirection::kBackward);
       auto pos = tag_.second.find("~");
       if (pos != std::string::npos) {
-        restriction.set_value(tag_.second.substr(0, pos) == "true" ? true : false);  
+        restriction.set_value(tag_.second.substr(0, pos) == "true" ? true : false);
         restriction.set_except_destination(true);
       } else {
-        restriction.set_value(tag_.second == "true" ? true : false);  
+        restriction.set_value(tag_.second == "true" ? true : false);
       }
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
@@ -1035,10 +1035,10 @@ struct graph_parser {
       restriction.set_modes(kTruckAccess | kAutoAccess | kHOVAccess | kTaxiAccess | kBusAccess);
       auto pos = tag_.second.find("~");
       if (pos != std::string::npos) {
-        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);  
+        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);
         restriction.set_except_destination(true);
       } else {
-        restriction.set_value(std::stof(tag_.second) * 100);  
+        restriction.set_value(std::stof(tag_.second) * 100);
       }
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
@@ -1050,10 +1050,10 @@ struct graph_parser {
       restriction.set_direction(AccessRestrictionDirection::kForward);
       auto pos = tag_.second.find("~");
       if (pos != std::string::npos) {
-        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);  
+        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);
         restriction.set_except_destination(true);
       } else {
-        restriction.set_value(std::stof(tag_.second) * 100);  
+        restriction.set_value(std::stof(tag_.second) * 100);
       }
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
@@ -1065,10 +1065,10 @@ struct graph_parser {
       restriction.set_direction(AccessRestrictionDirection::kBackward);
       auto pos = tag_.second.find("~");
       if (pos != std::string::npos) {
-        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);  
+        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);
         restriction.set_except_destination(true);
       } else {
-        restriction.set_value(std::stof(tag_.second) * 100);  
+        restriction.set_value(std::stof(tag_.second) * 100);
       }
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
@@ -1079,10 +1079,10 @@ struct graph_parser {
       restriction.set_modes(kTruckAccess | kAutoAccess | kHOVAccess | kTaxiAccess | kBusAccess);
       auto pos = tag_.second.find("~");
       if (pos != std::string::npos) {
-        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);  
+        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);
         restriction.set_except_destination(true);
       } else {
-        restriction.set_value(std::stof(tag_.second) * 100);  
+        restriction.set_value(std::stof(tag_.second) * 100);
       }
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
@@ -1094,10 +1094,10 @@ struct graph_parser {
       restriction.set_direction(AccessRestrictionDirection::kForward);
       auto pos = tag_.second.find("~");
       if (pos != std::string::npos) {
-        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);  
+        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);
         restriction.set_except_destination(true);
       } else {
-        restriction.set_value(std::stof(tag_.second) * 100);  
+        restriction.set_value(std::stof(tag_.second) * 100);
       }
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
@@ -1109,10 +1109,10 @@ struct graph_parser {
       restriction.set_direction(AccessRestrictionDirection::kBackward);
       auto pos = tag_.second.find("~");
       if (pos != std::string::npos) {
-        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);  
+        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);
         restriction.set_except_destination(true);
       } else {
-        restriction.set_value(std::stof(tag_.second) * 100);  
+        restriction.set_value(std::stof(tag_.second) * 100);
       }
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
@@ -1123,10 +1123,10 @@ struct graph_parser {
       restriction.set_modes(kTruckAccess);
       auto pos = tag_.second.find("~");
       if (pos != std::string::npos) {
-        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);  
+        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);
         restriction.set_except_destination(true);
       } else {
-        restriction.set_value(std::stof(tag_.second) * 100);  
+        restriction.set_value(std::stof(tag_.second) * 100);
       }
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
@@ -1138,10 +1138,10 @@ struct graph_parser {
       restriction.set_direction(AccessRestrictionDirection::kForward);
       auto pos = tag_.second.find("~");
       if (pos != std::string::npos) {
-        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);  
+        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);
         restriction.set_except_destination(true);
       } else {
-        restriction.set_value(std::stof(tag_.second) * 100);  
+        restriction.set_value(std::stof(tag_.second) * 100);
       }
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
@@ -1153,10 +1153,10 @@ struct graph_parser {
       restriction.set_direction(AccessRestrictionDirection::kBackward);
       auto pos = tag_.second.find("~");
       if (pos != std::string::npos) {
-        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);  
+        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);
         restriction.set_except_destination(true);
       } else {
-        restriction.set_value(std::stof(tag_.second) * 100);  
+        restriction.set_value(std::stof(tag_.second) * 100);
       }
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
@@ -1167,10 +1167,10 @@ struct graph_parser {
       restriction.set_modes(kTruckAccess);
       auto pos = tag_.second.find("~");
       if (pos != std::string::npos) {
-        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);  
+        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);
         restriction.set_except_destination(true);
       } else {
-        restriction.set_value(std::stof(tag_.second) * 100);  
+        restriction.set_value(std::stof(tag_.second) * 100);
       }
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
@@ -1182,10 +1182,10 @@ struct graph_parser {
       restriction.set_direction(AccessRestrictionDirection::kForward);
       auto pos = tag_.second.find("~");
       if (pos != std::string::npos) {
-        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);  
+        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);
         restriction.set_except_destination(true);
       } else {
-        restriction.set_value(std::stof(tag_.second) * 100);  
+        restriction.set_value(std::stof(tag_.second) * 100);
       }
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
@@ -1197,10 +1197,10 @@ struct graph_parser {
       restriction.set_direction(AccessRestrictionDirection::kBackward);
       auto pos = tag_.second.find("~");
       if (pos != std::string::npos) {
-        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);  
+        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);
         restriction.set_except_destination(true);
       } else {
-        restriction.set_value(std::stof(tag_.second) * 100);  
+        restriction.set_value(std::stof(tag_.second) * 100);
       }
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
@@ -1211,10 +1211,10 @@ struct graph_parser {
       restriction.set_modes(kTruckAccess);
       auto pos = tag_.second.find("~");
       if (pos != std::string::npos) {
-        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);  
+        restriction.set_value(std::stof(tag_.second.substr(0, pos)) * 100);
         restriction.set_except_destination(true);
       } else {
-        restriction.set_value(std::stof(tag_.second) * 100);  
+        restriction.set_value(std::stof(tag_.second) * 100);
       }
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
@@ -1224,10 +1224,10 @@ struct graph_parser {
       restriction.set_type(AccessType::kMaxAxles);
       auto pos = tag_.second.find("~");
       if (pos != std::string::npos) {
-        restriction.set_value(std::stof(tag_.second.substr(0, pos)));  
+        restriction.set_value(std::stof(tag_.second.substr(0, pos)));
         restriction.set_except_destination(true);
       } else {
-        restriction.set_value(std::stof(tag_.second));  
+        restriction.set_value(std::stof(tag_.second));
       }
       restriction.set_modes(kTruckAccess);
       osmdata_.access_restrictions.insert(
@@ -2874,7 +2874,6 @@ struct graph_parser {
       }
     } // end tags loop
 
-
     if (!use_direction_on_ways_) {
 
       uint8_t alpha = static_cast<uint8_t>(PronunciationAlphabet::kIpa);
@@ -3875,7 +3874,6 @@ struct graph_parser {
     }
 
     // destonly access restrictions here
-    
 
     // Add the way to the list
     ways_->push_back(way_);

--- a/src/mjolnir/shortcutbuilder.cc
+++ b/src/mjolnir/shortcutbuilder.cc
@@ -510,7 +510,8 @@ std::pair<uint32_t, uint32_t> AddShortcutEdges(GraphReader& reader,
         for (const auto& res : access_restrictions.all_restrictions) {
           tilebuilder.AddAccessRestriction(AccessRestriction(tilebuilder.directededges().size(),
                                                              res.second.type(), res.second.modes(),
-                                                             res.second.value()));
+                                                             res.second.value(),
+                                                             res.second.except_destination()));
         }
       }
 
@@ -671,7 +672,8 @@ std::pair<uint32_t, uint32_t> FormShortcuts(GraphReader& reader, const TileLevel
           auto restrictions = tile->GetAccessRestrictions(edgeid.id(), kAllAccess);
           for (const auto& res : restrictions) {
             tilebuilder.AddAccessRestriction(AccessRestriction(tilebuilder.directededges().size(),
-                                                               res.type(), res.modes(), res.value()));
+                                                               res.type(), res.modes(), res.value(),
+                                                               res.except_destination()));
           }
         }
 

--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -177,7 +177,8 @@ public:
                        const baldr::GraphId& edgeid,
                        const uint64_t current_time,
                        const uint32_t tz_index,
-                       uint8_t& restriction_idx) const override;
+                       uint8_t& restriction_idx,
+                       uint8_t& destonly_access_restr_mask) const override;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
@@ -204,7 +205,8 @@ public:
                               const baldr::GraphId& opp_edgeid,
                               const uint64_t current_time,
                               const uint32_t tz_index,
-                              uint8_t& restriction_idx) const override;
+                              uint8_t& restriction_idx,
+                              uint8_t& destonly_access_restr_mask) const override;
 
   /**
    * Callback for Allowed doing mode  specific restriction checks
@@ -413,7 +415,8 @@ bool AutoCost::Allowed(const baldr::DirectedEdge* edge,
                        const baldr::GraphId& edgeid,
                        const uint64_t current_time,
                        const uint32_t tz_index,
-                       uint8_t& restriction_idx) const {
+                       uint8_t& restriction_idx,
+                       uint8_t& destonly_access_restr_mask) const {
 
   // Check access, U-turn, and simple turn restriction.
   // Allow U-turns at dead-end nodes in case the origin is inside
@@ -430,7 +433,7 @@ bool AutoCost::Allowed(const baldr::DirectedEdge* edge,
   }
 
   return DynamicCost::EvaluateRestrictions(access_mask_, edge, is_dest, tile, edgeid, current_time,
-                                           tz_index, restriction_idx);
+                                           tz_index, restriction_idx, destonly_access_restr_mask);
 }
 
 // Checks if access is allowed for an edge on the reverse path (from
@@ -442,7 +445,8 @@ bool AutoCost::AllowedReverse(const baldr::DirectedEdge* edge,
                               const baldr::GraphId& opp_edgeid,
                               const uint64_t current_time,
                               const uint32_t tz_index,
-                              uint8_t& restriction_idx) const {
+                              uint8_t& restriction_idx,
+                              uint8_t& destonly_access_restr_mask) const {
   // Check access, U-turn, and simple turn restriction.
   // Allow U-turns at dead-end nodes.
   if (!IsAccessible(opp_edge) || (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
@@ -456,13 +460,11 @@ bool AutoCost::AllowedReverse(const baldr::DirectedEdge* edge,
   }
 
   return DynamicCost::EvaluateRestrictions(access_mask_, opp_edge, false, tile, opp_edgeid,
-                                           current_time, tz_index, restriction_idx);
+                                           current_time, tz_index, restriction_idx,
+                                           destonly_access_restr_mask);
 }
 
 bool AutoCost::ModeSpecificAllowed(const baldr::AccessRestriction& restriction) const {
-  if (restriction.except_destination() && allow_destination_only_)
-    return true;
-
   switch (restriction.type()) {
     case AccessType::kMaxHeight:
       return height_ <= static_cast<float>(restriction.value() * 0.01);
@@ -751,7 +753,8 @@ public:
                        const baldr::GraphId& edgeid,
                        const uint64_t current_time,
                        const uint32_t tz_index,
-                       uint8_t& restriction_idx) const override;
+                       uint8_t& restriction_idx,
+                       uint8_t& destonly_access_restr_mask) const override;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
@@ -778,7 +781,8 @@ public:
                               const baldr::GraphId& opp_edgeid,
                               const uint64_t current_time,
                               const uint32_t tz_index,
-                              uint8_t& restriction_idx) const override;
+                              uint8_t& restriction_idx,
+                              uint8_t& destonly_access_restr_mask) const override;
 };
 
 // Check if access is allowed on the specified edge.
@@ -789,7 +793,8 @@ bool BusCost::Allowed(const baldr::DirectedEdge* edge,
                       const baldr::GraphId& edgeid,
                       const uint64_t current_time,
                       const uint32_t tz_index,
-                      uint8_t& restriction_idx) const {
+                      uint8_t& restriction_idx,
+                      uint8_t& destonly_access_restr_mask) const {
   // Check access, U-turn, and simple turn restriction.
   // Allow U-turns at dead-end nodes.
   if (!IsAccessible(edge) || (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
@@ -803,7 +808,7 @@ bool BusCost::Allowed(const baldr::DirectedEdge* edge,
   }
 
   return DynamicCost::EvaluateRestrictions(access_mask_, edge, is_dest, tile, edgeid, current_time,
-                                           tz_index, restriction_idx);
+                                           tz_index, restriction_idx, destonly_access_restr_mask);
 }
 
 // Checks if access is allowed for an edge on the reverse path (from
@@ -815,7 +820,8 @@ bool BusCost::AllowedReverse(const baldr::DirectedEdge* edge,
                              const baldr::GraphId& opp_edgeid,
                              const uint64_t current_time,
                              const uint32_t tz_index,
-                             uint8_t& restriction_idx) const {
+                             uint8_t& restriction_idx,
+                             uint8_t& destonly_access_restr_mask) const {
   // Check access, U-turn, and simple turn restriction.
   // Allow U-turns at dead-end nodes.
   if (!IsAccessible(opp_edge) || (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
@@ -829,7 +835,8 @@ bool BusCost::AllowedReverse(const baldr::DirectedEdge* edge,
   }
 
   return DynamicCost::EvaluateRestrictions(access_mask_, opp_edge, false, tile, opp_edgeid,
-                                           current_time, tz_index, restriction_idx);
+                                           current_time, tz_index, restriction_idx,
+                                           destonly_access_restr_mask);
 }
 
 void ParseBusCostOptions(const rapidjson::Document& doc,
@@ -884,7 +891,8 @@ public:
                        const baldr::GraphId& edgeid,
                        const uint64_t current_time,
                        const uint32_t tz_index,
-                       uint8_t& restriction_idx) const override;
+                       uint8_t& restriction_idx,
+                       uint8_t& destonly_access_restr_mask) const override;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
@@ -910,7 +918,8 @@ public:
                               const baldr::GraphId& opp_edgeid,
                               const uint64_t current_time,
                               const uint32_t tz_index,
-                              uint8_t& restriction_idx) const override;
+                              uint8_t& restriction_idx,
+                              uint8_t& destonly_access_restr_mask) const override;
 
   /**
    * Returns the cost to traverse the edge and an estimate of the actual time
@@ -968,7 +977,8 @@ bool TaxiCost::Allowed(const baldr::DirectedEdge* edge,
                        const baldr::GraphId& edgeid,
                        const uint64_t current_time,
                        const uint32_t tz_index,
-                       uint8_t& restriction_idx) const {
+                       uint8_t& restriction_idx,
+                       uint8_t& destonly_access_restr_mask) const {
   // Check access, U-turn, and simple turn restriction.
   // Allow U-turns at dead-end nodes in case the origin is inside
   // a not thru region and a heading selected an edge entering the
@@ -984,7 +994,7 @@ bool TaxiCost::Allowed(const baldr::DirectedEdge* edge,
   }
 
   return DynamicCost::EvaluateRestrictions(access_mask_, edge, is_dest, tile, edgeid, current_time,
-                                           tz_index, restriction_idx);
+                                           tz_index, restriction_idx, destonly_access_restr_mask);
 }
 
 // Checks if access is allowed for an edge on the reverse path (from
@@ -996,7 +1006,8 @@ bool TaxiCost::AllowedReverse(const baldr::DirectedEdge* edge,
                               const baldr::GraphId& opp_edgeid,
                               const uint64_t current_time,
                               const uint32_t tz_index,
-                              uint8_t& restriction_idx) const {
+                              uint8_t& restriction_idx,
+                              uint8_t& destonly_access_restr_mask) const {
   // Check access, U-turn, and simple turn restriction.
   // Allow U-turns at dead-end nodes.
   if (!IsAccessible(opp_edge) || (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
@@ -1009,7 +1020,8 @@ bool TaxiCost::AllowedReverse(const baldr::DirectedEdge* edge,
     return false;
   }
   return DynamicCost::EvaluateRestrictions(access_mask_, opp_edge, false, tile, opp_edgeid,
-                                           current_time, tz_index, restriction_idx);
+                                           current_time, tz_index, restriction_idx,
+                                           destonly_access_restr_mask);
 }
 
 void ParseTaxiCostOptions(const rapidjson::Document& doc,
@@ -1038,7 +1050,7 @@ namespace {
 
 class TestAutoCost : public AutoCost {
 public:
-  TestAutoCost(const Costing& costing_options) : AutoCost(costing_options){};
+  TestAutoCost(const Costing& costing_options) : AutoCost(costing_options) {};
 
   using AutoCost::alley_penalty_;
   using AutoCost::country_crossing_cost_;

--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -460,6 +460,9 @@ bool AutoCost::AllowedReverse(const baldr::DirectedEdge* edge,
 }
 
 bool AutoCost::ModeSpecificAllowed(const baldr::AccessRestriction& restriction) const {
+  if (restriction.except_destination() && allow_destination_only_)
+    return true;
+
   switch (restriction.type()) {
     case AccessType::kMaxHeight:
       return height_ <= static_cast<float>(restriction.value() * 0.01);

--- a/src/sif/bicyclecost.cc
+++ b/src/sif/bicyclecost.cc
@@ -259,7 +259,8 @@ public:
                        const baldr::GraphId& edgeid,
                        const uint64_t current_time,
                        const uint32_t tz_index,
-                       uint8_t& restriction_idx) const override;
+                       uint8_t& restriction_idx,
+                       uint8_t& destonly_access_restr_mask) const override;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
@@ -286,7 +287,8 @@ public:
                               const baldr::GraphId& opp_edgeid,
                               const uint64_t current_time,
                               const uint32_t tz_index,
-                              uint8_t& restriction_idx) const override;
+                              uint8_t& restriction_idx,
+                              uint8_t& destonly_access_restr_mask) const override;
 
   /**
    * Only transit costings are valid for this method call, hence we throw
@@ -548,7 +550,8 @@ bool BicycleCost::Allowed(const baldr::DirectedEdge* edge,
                           const baldr::GraphId& edgeid,
                           const uint64_t current_time,
                           const uint32_t tz_index,
-                          uint8_t& restriction_idx) const {
+                          uint8_t& restriction_idx,
+                          uint8_t& destonly_access_restr_mask) const {
   // Check bicycle access and turn restrictions. Bicycles should obey
   // vehicular turn restrictions. Allow Uturns at dead ends only.
   // Skip impassable edges and shortcut edges.
@@ -572,7 +575,7 @@ bool BicycleCost::Allowed(const baldr::DirectedEdge* edge,
     return false;
   }
   return DynamicCost::EvaluateRestrictions(access_mask_, edge, is_dest, tile, edgeid, current_time,
-                                           tz_index, restriction_idx);
+                                           tz_index, restriction_idx, destonly_access_restr_mask);
 }
 
 // Checks if access is allowed for an edge on the reverse path (from
@@ -584,7 +587,8 @@ bool BicycleCost::AllowedReverse(const baldr::DirectedEdge* edge,
                                  const baldr::GraphId& opp_edgeid,
                                  const uint64_t current_time,
                                  const uint32_t tz_index,
-                                 uint8_t& restriction_idx) const {
+                                 uint8_t& restriction_idx,
+                                 uint8_t& destonly_access_restr_mask) const {
   // Check access, U-turn (allow at dead-ends), and simple turn restriction.
   // Do not allow transit connection edges.
   if (!IsAccessible(opp_edge) || opp_edge->is_shortcut() ||
@@ -602,7 +606,8 @@ bool BicycleCost::AllowedReverse(const baldr::DirectedEdge* edge,
     return false;
   }
   return DynamicCost::EvaluateRestrictions(access_mask_, opp_edge, false, tile, opp_edgeid,
-                                           current_time, tz_index, restriction_idx);
+                                           current_time, tz_index, restriction_idx,
+                                           destonly_access_restr_mask);
 }
 
 // Returns the cost to traverse the edge and an estimate of the actual time
@@ -914,7 +919,7 @@ namespace {
 
 class TestBicycleCost : public BicycleCost {
 public:
-  TestBicycleCost(const Costing& costing_options) : BicycleCost(costing_options){};
+  TestBicycleCost(const Costing& costing_options) : BicycleCost(costing_options) {};
 
   using BicycleCost::alley_penalty_;
   using BicycleCost::country_crossing_cost_;

--- a/src/sif/motorcyclecost.cc
+++ b/src/sif/motorcyclecost.cc
@@ -142,7 +142,8 @@ public:
                        const baldr::GraphId& edgeid,
                        const uint64_t current_time,
                        const uint32_t tz_index,
-                       uint8_t& restriction_idx) const override;
+                       uint8_t& restriction_idx,
+                       uint8_t& destonly_access_restr_mask) const override;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
@@ -169,7 +170,8 @@ public:
                               const baldr::GraphId& opp_edgeid,
                               const uint64_t current_time,
                               const uint32_t tz_index,
-                              uint8_t& restriction_idx) const override;
+                              uint8_t& restriction_idx,
+                              uint8_t& destonly_access_restr_mask) const override;
 
   /**
    * Only transit costings are valid for this method call, hence we throw
@@ -348,7 +350,8 @@ bool MotorcycleCost::Allowed(const baldr::DirectedEdge* edge,
                              const baldr::GraphId& edgeid,
                              const uint64_t current_time,
                              const uint32_t tz_index,
-                             uint8_t& restriction_idx) const {
+                             uint8_t& restriction_idx,
+                             uint8_t& destonly_access_restr_mask) const {
   // Check access, U-turn, and simple turn restriction.
   // Allow U-turns at dead-end nodes.
   if (!IsAccessible(edge) || (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
@@ -360,7 +363,7 @@ bool MotorcycleCost::Allowed(const baldr::DirectedEdge* edge,
   }
 
   return DynamicCost::EvaluateRestrictions(access_mask_, edge, is_dest, tile, edgeid, current_time,
-                                           tz_index, restriction_idx);
+                                           tz_index, restriction_idx, destonly_access_restr_mask);
 }
 
 // Checks if access is allowed for an edge on the reverse path (from
@@ -372,7 +375,8 @@ bool MotorcycleCost::AllowedReverse(const baldr::DirectedEdge* edge,
                                     const baldr::GraphId& opp_edgeid,
                                     const uint64_t current_time,
                                     const uint32_t tz_index,
-                                    uint8_t& restriction_idx) const {
+                                    uint8_t& restriction_idx,
+                                    uint8_t& destonly_access_restr_mask) const {
   // Check access, U-turn, and simple turn restriction.
   // Allow U-turns at dead-end nodes.
   if (!IsAccessible(opp_edge) || (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
@@ -384,7 +388,8 @@ bool MotorcycleCost::AllowedReverse(const baldr::DirectedEdge* edge,
   }
 
   return DynamicCost::EvaluateRestrictions(access_mask_, opp_edge, false, tile, opp_edgeid,
-                                           current_time, tz_index, restriction_idx);
+                                           current_time, tz_index, restriction_idx,
+                                           destonly_access_restr_mask);
 }
 
 Cost MotorcycleCost::EdgeCost(const baldr::DirectedEdge* edge,
@@ -603,7 +608,7 @@ namespace {
 
 class TestMotorcycleCost : public MotorcycleCost {
 public:
-  TestMotorcycleCost(const Costing& costing_options) : MotorcycleCost(costing_options){};
+  TestMotorcycleCost(const Costing& costing_options) : MotorcycleCost(costing_options) {};
 
   using MotorcycleCost::alley_penalty_;
   using MotorcycleCost::country_crossing_cost_;

--- a/src/sif/motorscootercost.cc
+++ b/src/sif/motorscootercost.cc
@@ -193,7 +193,8 @@ public:
                        const baldr::GraphId& edgeid,
                        const uint64_t current_time,
                        const uint32_t tz_index,
-                       uint8_t& restriction_idx) const override;
+                       uint8_t& restriction_idx,
+                       uint8_t& destonly_access_restr_mask) const override;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
@@ -220,7 +221,8 @@ public:
                               const baldr::GraphId& opp_edgeid,
                               const uint64_t current_time,
                               const uint32_t tz_index,
-                              uint8_t& restriction_idx) const override;
+                              uint8_t& restriction_idx,
+                              uint8_t& destonly_access_restr_mask) const override;
 
   /**
    * Only transit costings are valid for this method call, hence we throw
@@ -367,7 +369,8 @@ bool MotorScooterCost::Allowed(const baldr::DirectedEdge* edge,
                                const baldr::GraphId& edgeid,
                                const uint64_t current_time,
                                const uint32_t tz_index,
-                               uint8_t& restriction_idx) const {
+                               uint8_t& restriction_idx,
+                               uint8_t& destonly_access_restr_mask) const {
   // Check access, U-turn, and simple turn restriction.
   // Allow U-turns at dead-end nodes.
   if (!IsAccessible(edge) || (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
@@ -379,7 +382,7 @@ bool MotorScooterCost::Allowed(const baldr::DirectedEdge* edge,
   }
 
   return DynamicCost::EvaluateRestrictions(access_mask_, edge, is_dest, tile, edgeid, current_time,
-                                           tz_index, restriction_idx);
+                                           tz_index, restriction_idx, destonly_access_restr_mask);
 }
 
 // Checks if access is allowed for an edge on the reverse path (from
@@ -391,7 +394,8 @@ bool MotorScooterCost::AllowedReverse(const baldr::DirectedEdge* edge,
                                       const baldr::GraphId& opp_edgeid,
                                       const uint64_t current_time,
                                       const uint32_t tz_index,
-                                      uint8_t& restriction_idx) const {
+                                      uint8_t& restriction_idx,
+                                      uint8_t& destonly_access_restr_mask) const {
   // Check access, U-turn, and simple turn restriction.
   // Allow U-turns at dead-end nodes.
   if (!IsAccessible(opp_edge) || (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
@@ -403,7 +407,8 @@ bool MotorScooterCost::AllowedReverse(const baldr::DirectedEdge* edge,
   }
 
   return DynamicCost::EvaluateRestrictions(access_mask_, opp_edge, false, tile, opp_edgeid,
-                                           current_time, tz_index, restriction_idx);
+                                           current_time, tz_index, restriction_idx,
+                                           destonly_access_restr_mask);
 }
 
 Cost MotorScooterCost::EdgeCost(const baldr::DirectedEdge* edge,
@@ -627,7 +632,7 @@ namespace {
 
 class TestMotorScooterCost : public MotorScooterCost {
 public:
-  TestMotorScooterCost(const Costing& costing_options) : MotorScooterCost(costing_options){};
+  TestMotorScooterCost(const Costing& costing_options) : MotorScooterCost(costing_options) {};
 
   using MotorScooterCost::alley_penalty_;
   using MotorScooterCost::country_crossing_cost_;

--- a/src/sif/nocost.cc
+++ b/src/sif/nocost.cc
@@ -58,6 +58,7 @@ public:
                        const baldr::GraphId&,
                        const uint64_t,
                        const uint32_t,
+                       uint8_t&,
                        uint8_t&) const override {
     return !edge->is_shortcut();
   }
@@ -87,6 +88,7 @@ public:
                               const baldr::GraphId&,
                               const uint64_t,
                               const uint32_t,
+                              uint8_t&,
                               uint8_t&) const override {
     return !opp_edge->is_shortcut();
   }

--- a/src/sif/pedestriancost.cc
+++ b/src/sif/pedestriancost.cc
@@ -308,7 +308,8 @@ public:
                        const baldr::GraphId& edgeid,
                        const uint64_t current_time,
                        const uint32_t tz_index,
-                       uint8_t& restriction_idx) const override;
+                       uint8_t& restriction_idx,
+                       uint8_t& destonly_access_restr_mask) const override;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
@@ -335,7 +336,8 @@ public:
                               const baldr::GraphId& opp_edgeid,
                               const uint64_t current_time,
                               const uint32_t tz_index,
-                              uint8_t& restriction_idx) const override;
+                              uint8_t& restriction_idx,
+                              uint8_t& destonly_access_restr_mask) const override;
 
   /**
    * Only transit costings are valid for this method call, hence we throw
@@ -656,7 +658,8 @@ bool PedestrianCost::Allowed(const baldr::DirectedEdge* edge,
                              const baldr::GraphId& edgeid,
                              const uint64_t current_time,
                              const uint32_t tz_index,
-                             uint8_t& restriction_idx) const {
+                             uint8_t& restriction_idx,
+                             uint8_t& destonly_access_restr_mask) const {
   if (!IsAccessible(edge) || (edge->surface() > minimal_allowed_surface_) || edge->is_shortcut() ||
       IsUserAvoidEdge(edgeid) || edge->sac_scale() > max_hiking_difficulty_ ||
       (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx() &&
@@ -676,7 +679,7 @@ bool PedestrianCost::Allowed(const baldr::DirectedEdge* edge,
   }
 
   return DynamicCost::EvaluateRestrictions(access_mask_, edge, is_dest, tile, edgeid, current_time,
-                                           tz_index, restriction_idx);
+                                           tz_index, restriction_idx, destonly_access_restr_mask);
 }
 
 // Checks if access is allowed for an edge on the reverse path (from
@@ -688,7 +691,8 @@ bool PedestrianCost::AllowedReverse(const baldr::DirectedEdge* edge,
                                     const baldr::GraphId& opp_edgeid,
                                     const uint64_t current_time,
                                     const uint32_t tz_index,
-                                    uint8_t& restriction_idx) const {
+                                    uint8_t& restriction_idx,
+                                    uint8_t& destonly_access_restr_mask) const {
   // Do not check max walking distance and assume we are not allowing
   // transit connections. Assume this method is never used in
   // multimodal routes).
@@ -704,7 +708,8 @@ bool PedestrianCost::AllowedReverse(const baldr::DirectedEdge* edge,
   }
 
   return DynamicCost::EvaluateRestrictions(access_mask_, opp_edge, false, tile, opp_edgeid,
-                                           current_time, tz_index, restriction_idx);
+                                           current_time, tz_index, restriction_idx,
+                                           destonly_access_restr_mask);
 }
 
 // Returns the cost to traverse the edge and an estimate of the actual time
@@ -926,7 +931,7 @@ namespace {
 
 class TestPedestrianCost : public PedestrianCost {
 public:
-  TestPedestrianCost(const Costing& costing_options) : PedestrianCost(costing_options){};
+  TestPedestrianCost(const Costing& costing_options) : PedestrianCost(costing_options) {};
 
   using PedestrianCost::alley_penalty_;
   using PedestrianCost::country_crossing_cost_;

--- a/src/sif/recost.cc
+++ b/src/sif/recost.cc
@@ -92,6 +92,7 @@ void recost_forward(baldr::GraphReader& reader,
     // so that we can find if we reach the end of the restriction. then we need to replay the
     // queued edges as normal
     uint8_t time_restrictions_TODO = baldr::kInvalidRestriction;
+    uint8_t destonly_restriction_mask = 0;
     // if its not time dependent set to 0 for Allowed method below
     const uint64_t localtime = offset_time.valid ? offset_time.local_time : 0;
     // we should call 'Allowed' method even if 'ignore_access' flag is true in order to
@@ -99,7 +100,8 @@ void recost_forward(baldr::GraphReader& reader,
     const auto next_id = edge_cb();
     if (predecessor != baldr::kInvalidLabel &&
         (!costing.Allowed(edge, !next_id.Is_Valid(), label, tile, edge_id, localtime,
-                          offset_time.timezone_index, time_restrictions_TODO) &&
+                          offset_time.timezone_index, time_restrictions_TODO,
+                          destonly_restriction_mask) &&
          !ignore_access)) {
       throw std::runtime_error("This path requires different edge access than this costing allows");
     }

--- a/src/sif/transitcost.cc
+++ b/src/sif/transitcost.cc
@@ -112,7 +112,8 @@ public:
                        const baldr::GraphId& edgeid,
                        const uint64_t current_time,
                        const uint32_t tz_index,
-                       uint8_t& restriction_idx) const override;
+                       uint8_t& restriction_idx,
+                       uint8_t& destonly_access_restr_mask) const override;
 
   /**
    * Checks if access is allowed for an edge on the reverse path
@@ -138,7 +139,8 @@ public:
                               const baldr::GraphId& opp_edgeid,
                               const uint64_t current_time,
                               const uint32_t tz_index,
-                              uint8_t& restriction_idx) const override;
+                              uint8_t& restriction_idx,
+                              uint8_t& destonly_access_restr_mask) const override;
 
   /**
    * Checks if access is allowed for the provided node. Node access can
@@ -524,6 +526,7 @@ bool TransitCost::Allowed(const baldr::DirectedEdge* edge,
                           const baldr::GraphId&,
                           const uint64_t,
                           const uint32_t,
+                          uint8_t&,
                           uint8_t&) const {
   // TODO - obtain and check the access restrictions.
 
@@ -555,6 +558,7 @@ bool TransitCost::AllowedReverse(const baldr::DirectedEdge*,
                                  const baldr::GraphId&,
                                  const uint64_t,
                                  const uint32_t,
+                                 uint8_t&,
                                  uint8_t&) const {
   // This method should not be called since time based routes do not use
   // bidirectional A*

--- a/src/sif/truckcost.cc
+++ b/src/sif/truckcost.cc
@@ -402,6 +402,10 @@ bool TruckCost::AllowMultiPass() const {
 }
 
 bool TruckCost::ModeSpecificAllowed(const baldr::AccessRestriction& restriction) const {
+
+  if (restriction.except_destination() && allow_destination_only_)
+    return true;
+
   switch (restriction.type()) {
     case AccessType::kHazmat:
       if (hazmat_ && !restriction.value()) {
@@ -768,7 +772,7 @@ namespace {
 
 class TestTruckCost : public TruckCost {
 public:
-  TestTruckCost(const Costing& costing_options) : TruckCost(costing_options){};
+  TestTruckCost(const Costing& costing_options) : TruckCost(costing_options) {};
 
   using TruckCost::alley_penalty_;
   using TruckCost::country_crossing_cost_;

--- a/src/sif/truckcost.cc
+++ b/src/sif/truckcost.cc
@@ -772,7 +772,7 @@ namespace {
 
 class TestTruckCost : public TruckCost {
 public:
-  TestTruckCost(const Costing& costing_options) : TruckCost(costing_options) {};
+  TestTruckCost(const Costing& costing_options) : TruckCost(costing_options){};
 
   using TruckCost::alley_penalty_;
   using TruckCost::country_crossing_cost_;

--- a/src/thor/astar_bss.cc
+++ b/src/thor/astar_bss.cc
@@ -147,10 +147,11 @@ void AStarBSSAlgorithm::ExpandForward(GraphReader& graphreader,
     // directed edge), if no access is allowed to this edge (based on costing method),
     // or if a complex restriction exists.
     uint8_t has_time_restrictions = -1;
+    uint8_t destonly_restriction_mask = 0;
     const bool is_dest = destinations_.find(edgeid) != destinations_.cend();
     if (current_es->set() == EdgeSet::kPermanent ||
         !current_costing->Allowed(directededge, is_dest, pred, tile, edgeid, 0, 0,
-                                  has_time_restrictions) ||
+                                  has_time_restrictions, destonly_restriction_mask) ||
         current_costing->Restricted(directededge, pred, edgelabels_, tile, edgeid, true)) {
       continue;
     }

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -1031,9 +1031,7 @@ void BidirectionalAStar::SetOrigin(GraphReader& graphreader,
 
     // we call this to find out if we're starting on access restrictions with a local traffic
     // exemption and push this info into the label
-    uint8_t destonly_restriction_mask = 0;
-    costing_->GetExemptedAccessRestrictions(access_mode_, directededge, tile, edgeid,
-                                            destonly_restriction_mask);
+    auto destonly_restriction_mask = costing_->GetExemptedAccessRestrictions(directededge, tile, edgeid);
 
     edgelabels_forward_.emplace_back(kInvalidLabel, edgeid, directededge, cost, sortcost, dist, mode_,
                                      kInvalidRestriction, !(costing_->IsClosed(directededge, tile)),
@@ -1138,9 +1136,7 @@ void BidirectionalAStar::SetDestination(GraphReader& graphreader,
 
     // we call this to find out if we're starting on access restrictions with a local traffic
     // exemption and push this info into the label
-    uint8_t destonly_restriction_mask = 0;
-    costing_->GetExemptedAccessRestrictions(access_mode_, directededge, tile, edgeid,
-                                            destonly_restriction_mask);
+    auto destonly_restriction_mask = costing_->GetExemptedAccessRestrictions(directededge, tile, edgeid);
 
     edgelabels_reverse_.emplace_back(kInvalidLabel, opp_edge_id, edgeid, opp_dir_edge, cost, sortcost,
                                      dist, mode_, c, !opp_dir_edge->not_thru(),

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -240,6 +240,7 @@ inline bool BidirectionalAStar::ExpandInner(baldr::GraphReader& graphreader,
   // if its not time dependent set to 0 for Allowed and Restricted methods below
   const uint64_t localtime = time_info.valid ? time_info.local_time : 0;
   uint8_t restriction_idx = kInvalidRestriction;
+  uint8_t destonly_restriction_mask = 0;
   if (FORWARD) {
     // Why is is_dest false?
     // We have to consider next cases:
@@ -250,14 +251,15 @@ inline bool BidirectionalAStar::ExpandInner(baldr::GraphReader& graphreader,
     // The result path will be correct, because there are cosing.Allowed calls inside recost_forward
     // function in second time.
     if (!costing_->Allowed(meta.edge, false, pred, tile, meta.edge_id, localtime,
-                           time_info.timezone_index, restriction_idx) ||
+                           time_info.timezone_index, restriction_idx, destonly_restriction_mask) ||
         costing_->Restricted(meta.edge, pred, edgelabels_forward_, tile, meta.edge_id, true,
                              &edgestatus_forward_, localtime, time_info.timezone_index)) {
       return false;
     }
   } else {
     if (!costing_->AllowedReverse(meta.edge, pred, opp_edge, t2, opp_edge_id, localtime,
-                                  time_info.timezone_index, restriction_idx) ||
+                                  time_info.timezone_index, restriction_idx,
+                                  destonly_restriction_mask) ||
         costing_->Restricted(meta.edge, pred, edgelabels_reverse_, tile, meta.edge_id, false,
                              &edgestatus_reverse_, localtime, time_info.timezone_index)) {
       return false;
@@ -334,7 +336,8 @@ inline bool BidirectionalAStar::ExpandInner(baldr::GraphReader& graphreader,
                                      restriction_idx, 0,
                                      meta.edge->destonly() ||
                                          (costing_->is_hgv() && meta.edge->destonly_hgv()),
-                                     meta.edge->forwardaccess() & kTruckAccess);
+                                     meta.edge->forwardaccess() & kTruckAccess,
+                                     pred.destonly_access_restr_mask() & destonly_restriction_mask);
     adjacencylist_forward_.add(idx);
   } else {
     idx = edgelabels_reverse_.size();
@@ -353,7 +356,8 @@ inline bool BidirectionalAStar::ExpandInner(baldr::GraphReader& graphreader,
                                      restriction_idx, 0,
                                      opp_edge->destonly() ||
                                          (costing_->is_hgv() && opp_edge->destonly_hgv()),
-                                     opp_edge->forwardaccess() & kTruckAccess);
+                                     opp_edge->forwardaccess() & kTruckAccess,
+                                     pred.destonly_access_restr_mask() & destonly_restriction_mask);
     adjacencylist_reverse_.add(idx);
   }
 
@@ -1024,13 +1028,21 @@ void BidirectionalAStar::SetOrigin(GraphReader& graphreader,
       // It will be used by hierarchy limits
       dist = astarheuristic_reverse_.GetDistance(nodeinfo->latlng(endtile->header()->base_ll()));
     }
+
+    // we call this to find out if we're starting on access restrictions with a local traffic
+    // exemption and push this info into the label
+    uint8_t destonly_restriction_mask = 0;
+    costing_->GetExemptedAccessRestrictions(access_mode_, directededge, tile, edgeid,
+                                            destonly_restriction_mask);
+
     edgelabels_forward_.emplace_back(kInvalidLabel, edgeid, directededge, cost, sortcost, dist, mode_,
                                      kInvalidRestriction, !(costing_->IsClosed(directededge, tile)),
                                      static_cast<bool>(flow_sources & kDefaultFlowMask),
                                      sif::InternalTurn::kNoTurn, 0,
                                      directededge->destonly() ||
                                          (costing_->is_hgv() && directededge->destonly_hgv()),
-                                     directededge->forwardaccess() & kTruckAccess);
+                                     directededge->forwardaccess() & kTruckAccess,
+                                     destonly_restriction_mask);
     adjacencylist_forward_.add(idx);
 
     // setting this edge as reached
@@ -1123,6 +1135,13 @@ void BidirectionalAStar::SetDestination(GraphReader& graphreader,
       // It will be used by hierarchy limits
       dist = astarheuristic_forward_.GetDistance(tile->get_node_ll(opp_dir_edge->endnode()));
     }
+
+    // we call this to find out if we're starting on access restrictions with a local traffic
+    // exemption and push this info into the label
+    uint8_t destonly_restriction_mask = 0;
+    costing_->GetExemptedAccessRestrictions(access_mode_, directededge, tile, edgeid,
+                                            destonly_restriction_mask);
+
     edgelabels_reverse_.emplace_back(kInvalidLabel, opp_edge_id, edgeid, opp_dir_edge, cost, sortcost,
                                      dist, mode_, c, !opp_dir_edge->not_thru(),
                                      !(costing_->IsClosed(directededge, tile)),
@@ -1130,7 +1149,8 @@ void BidirectionalAStar::SetDestination(GraphReader& graphreader,
                                      sif::InternalTurn::kNoTurn, kInvalidRestriction,
                                      directededge->destonly() ||
                                          (costing_->is_hgv() && directededge->destonly_hgv()),
-                                     directededge->forwardaccess() & kTruckAccess);
+                                     directededge->forwardaccess() & kTruckAccess,
+                                     destonly_restriction_mask);
     adjacencylist_reverse_.add(idx);
 
     // setting this edge as reached, sending the opposing because this is the reverse tree

--- a/src/thor/costmatrix.cc
+++ b/src/thor/costmatrix.cc
@@ -1099,9 +1099,7 @@ void CostMatrix::SetSources(GraphReader& graphreader,
 
       // we call this to find out if we're starting on access restrictions with a local traffic
       // exemption and push this info into the label
-      uint8_t destonly_restriction_mask = 0;
-      costing_->GetExemptedAccessRestrictions(access_mode_, directededge, tile, edgeid,
-                                              destonly_restriction_mask);
+    auto destonly_restriction_mask = costing_->GetExemptedAccessRestrictions(directededge, tile, edgeid);
 
       BDEdgeLabel edge_label(kInvalidLabel, edgeid, oppedgeid, directededge, cost, mode_, ec, d,
                              !directededge->not_thru(), !(costing_->IsClosed(directededge, tile)),
@@ -1196,9 +1194,7 @@ void CostMatrix::SetTargets(baldr::GraphReader& graphreader,
 
       // we call this to find out if we're starting on access restrictions with a local traffic
       // exemption and push this info into the label
-      uint8_t destonly_restriction_mask = 0;
-      costing_->GetExemptedAccessRestrictions(access_mode_, directededge, tile, edgeid,
-                                              destonly_restriction_mask);
+    auto destonly_restriction_mask = costing_->GetExemptedAccessRestrictions(directededge, tile, edgeid);
 
       BDEdgeLabel edge_label(kInvalidLabel, opp_edge_id, edgeid, opp_dir_edge, cost, mode_, ec, d,
                              !opp_dir_edge->not_thru(), !(costing_->IsClosed(directededge, tile)),

--- a/src/thor/dijkstras.cc
+++ b/src/thor/dijkstras.cc
@@ -179,7 +179,7 @@ void Dijkstras::ExpandInner(baldr::GraphReader& graphreader,
     // Check if the edge is allowed or if a restriction occurs
     EdgeStatus* todo = nullptr;
     uint8_t restriction_idx = kInvalidRestriction;
-    uint8_t destonly_restriction_mask = 0;
+    uint8_t destonly_restriction_mask = pred.destonly_access_restr_mask();
     // is_dest is false, because it is a traversal algorithm in this context, not a path search
     // algorithm. In other words, destination edges are not defined for this Dijkstra's algorithm.
     const bool is_dest = false;
@@ -258,7 +258,8 @@ void Dijkstras::ExpandInner(baldr::GraphReader& graphreader,
                                  restriction_idx, pred.path_id(),
                                  directededge->destonly() ||
                                      (costing_->is_hgv() && directededge->destonly_hgv()),
-                                 directededge->forwardaccess() & kTruckAccess);
+                                 directededge->forwardaccess() & kTruckAccess,
+                                 pred.destonly_access_restr_mask() & destonly_restriction_mask);
 
     } else {
       bdedgelabels_.emplace_back(pred_idx, edgeid, oppedgeid, directededge, newcost, mode_,
@@ -270,7 +271,8 @@ void Dijkstras::ExpandInner(baldr::GraphReader& graphreader,
                                  restriction_idx, pred.path_id(),
                                  opp_edge->destonly() ||
                                      (costing_->is_hgv() && opp_edge->destonly_hgv()),
-                                 opp_edge->forwardaccess() & kTruckAccess);
+                                 opp_edge->forwardaccess() & kTruckAccess,
+                                 pred.destonly_access_restr_mask() & destonly_restriction_mask);
     }
     adjacencylist_.add(idx);
   }
@@ -839,13 +841,16 @@ void Dijkstras::SetOriginLocations(GraphReader& graphreader,
       // Construct the edge label. Set the predecessor edge index to invalid
       // to indicate the origin of the path.
       uint32_t idx = bdedgelabels_.size();
+      auto destonly_restriction_mask = costing_->GetExemptedAccessRestrictions(directededge, tile, edgeid);
+
       bdedgelabels_.emplace_back(kInvalidLabel, edgeid, opp_edge_id, directededge, cost, mode_,
                                  Cost{}, path_dist, false, !(costing_->IsClosed(directededge, tile)),
                                  static_cast<bool>(flow_sources & kDefaultFlowMask),
                                  InternalTurn::kNoTurn, kInvalidRestriction, multipath_ ? path_id : 0,
                                  directededge->destonly() ||
                                      (costing_->is_hgv() && directededge->destonly_hgv()),
-                                 directededge->forwardaccess() & kTruckAccess);
+                                 directededge->forwardaccess() & kTruckAccess,
+                                 destonly_restriction_mask);
       // Set the origin flag
       bdedgelabels_.back().set_origin();
 
@@ -931,13 +936,20 @@ void Dijkstras::SetDestinationLocations(
       // we want is for the expansion to continue when it encounters the first
       // closure and stop when it exits the closure (which can span multiple
       // consecutive edges)
+
+      // we call this to find out if we're starting on access restrictions with a local traffic
+      // exemption and push this info into the label
+      auto destonly_restriction_mask =
+          costing_->GetExemptedAccessRestrictions(directededge, tile, edgeid);
+
       bdedgelabels_.emplace_back(kInvalidLabel, opp_edge_id, edgeid, opp_dir_edge, cost, mode_,
                                  Cost{}, path_dist, false, !(costing_->IsClosed(directededge, tile)),
                                  static_cast<bool>(flow_sources & kDefaultFlowMask),
                                  InternalTurn::kNoTurn, restriction_idx, multipath_ ? path_id : 0,
                                  directededge->destonly() ||
                                      (costing_->is_hgv() && directededge->destonly_hgv()),
-                                 directededge->forwardaccess() & kTruckAccess);
+                                 directededge->forwardaccess() & kTruckAccess,
+                                 destonly_restriction_mask);
       adjacencylist_.add(idx);
       edgestatus_.Set(opp_edge_id, EdgeSet::kTemporary, idx, opp_tile, multipath_ ? path_id : 0);
     }

--- a/src/thor/multimodal.cc
+++ b/src/thor/multimodal.cc
@@ -352,11 +352,13 @@ bool MultiModalPathAlgorithm::ExpandForward(GraphReader& graphreader,
     uint32_t tripid = 0;
     uint32_t blockid = 0;
     uint8_t restriction_idx = -1;
+    uint8_t destonly_restriction_mask = 0;
     const auto dest_edge_itr = destinations_.find(edgeid);
     const bool is_dest = dest_edge_itr != destinations_.cend();
     if (directededge->IsTransitLine()) {
       // Check if transit costing allows this edge
-      if (!tc->Allowed(directededge, is_dest, pred, tile, edgeid, 0, 0, restriction_idx)) {
+      if (!tc->Allowed(directededge, is_dest, pred, tile, edgeid, 0, 0, restriction_idx,
+                       destonly_restriction_mask)) {
         continue;
       }
       // check if excluded.
@@ -441,7 +443,8 @@ bool MultiModalPathAlgorithm::ExpandForward(GraphReader& graphreader,
 
       // Regular edge - use the appropriate costing and check if access is allowed
       // and the walking distance didn't exceed (can't check in Allowed())
-      if (!pc->Allowed(directededge, is_dest, pred, tile, edgeid, 0, 0, restriction_idx) ||
+      if (!pc->Allowed(directededge, is_dest, pred, tile, edgeid, 0, 0, restriction_idx,
+                       destonly_restriction_mask) ||
           walking_distance > max_walking_dist_) {
         continue;
       }
@@ -725,9 +728,11 @@ bool MultiModalPathAlgorithm::ExpandFromNode(baldr::GraphReader& graphreader,
     // Skip this edge if permanently labeled (best path already found to this directed edge) or
     // access is not allowed for this mode.
     uint8_t restriction_idx = -1;
+    uint8_t destonly_restriction_mask = 0;
     const bool is_dest = destinations_.find(edgeid) != destinations_.cend();
     if (es->set() == EdgeSet::kPermanent ||
-        !costing->Allowed(directededge, is_dest, pred, tile, edgeid, 0, 0, restriction_idx)) {
+        !costing->Allowed(directededge, is_dest, pred, tile, edgeid, 0, 0, restriction_idx,
+                          destonly_restriction_mask)) {
       continue;
     }
 

--- a/src/thor/timedistancebssmatrix.cc
+++ b/src/thor/timedistancebssmatrix.cc
@@ -96,16 +96,17 @@ void TimeDistanceBSSMatrix::Expand(GraphReader& graphreader,
     // directed edge), if no access is allowed to this edge (based on costing
     // method), or if a complex restriction prevents this path.
     uint8_t restriction_idx = kInvalidRestriction;
+    uint8_t destonly_restriction_mask = 0;
     const bool is_dest = dest_edges_.find(edgeid.value) != dest_edges_.cend();
     if (FORWARD) {
       if (!current_costing->Allowed(directededge, is_dest, pred, tile, edgeid, 0, 0,
-                                    restriction_idx) ||
+                                    restriction_idx, destonly_restriction_mask) ||
           current_costing->Restricted(directededge, pred, edgelabels_, tile, edgeid, true)) {
         continue;
       }
     } else {
       if (!current_costing->AllowedReverse(directededge, pred, opp_edge, t2, opp_edge_id, 0, 0,
-                                           restriction_idx) ||
+                                           restriction_idx, destonly_restriction_mask) ||
           (current_costing->Restricted(directededge, pred, edgelabels_, tile, edgeid, FORWARD))) {
         continue;
       }

--- a/src/thor/timedistancematrix.cc
+++ b/src/thor/timedistancematrix.cc
@@ -106,17 +106,19 @@ void TimeDistanceMatrix::Expand(GraphReader& graphreader,
     // directed edge), if no access is allowed to this edge (based on costing
     // method), or if a complex restriction prevents this path.
     uint8_t restriction_idx = kInvalidRestriction;
+    uint8_t destonly_restriction_mask = 0;
     const bool is_dest = dest_edges_.find(edgeid) != dest_edges_.cend();
     if (FORWARD) {
       if (!costing_->Allowed(directededge, is_dest, pred, tile, edgeid, offset_time.local_time,
-                             nodeinfo->timezone(), restriction_idx) ||
+                             nodeinfo->timezone(), restriction_idx, destonly_restriction_mask) ||
           costing_->Restricted(directededge, pred, edgelabels_, tile, edgeid, true, nullptr,
                                offset_time.local_time, nodeinfo->timezone())) {
         continue;
       }
     } else {
       if (!costing_->AllowedReverse(directededge, pred, opp_edge, t2, opp_edge_id,
-                                    offset_time.local_time, nodeinfo->timezone(), restriction_idx) ||
+                                    offset_time.local_time, nodeinfo->timezone(), restriction_idx,
+                                    destonly_restriction_mask) ||
           (costing_->Restricted(directededge, pred, edgelabels_, tile, edgeid, false, nullptr,
                                 offset_time.local_time, nodeinfo->timezone()))) {
         continue;

--- a/src/thor/unidirectional_astar.cc
+++ b/src/thor/unidirectional_astar.cc
@@ -231,16 +231,19 @@ inline bool UnidirectionalAStar<expansion_direction, FORWARD>::ExpandInner(
     // Skip shortcut edges for time dependent routes, if no access is allowed to this edge
     // (based on costing method)
     uint8_t restriction_idx = kInvalidRestriction;
+    uint8_t destonly_restriction_mask = 0;
     if (FORWARD) {
       if (!costing_->Allowed(meta.edge, dest_path_edge, pred, tile, meta.edge_id,
-                             time_info.local_time, nodeinfo->timezone(), restriction_idx) ||
+                             time_info.local_time, nodeinfo->timezone(), restriction_idx,
+                             destonly_restriction_mask) ||
           costing_->Restricted(meta.edge, pred, edgelabels_, tile, meta.edge_id, true, &edgestatus_,
                                time_info.local_time, nodeinfo->timezone())) {
         return false;
       }
     } else {
       if (!costing_->AllowedReverse(meta.edge, pred, opp_edge, endtile, opp_edge_id,
-                                    time_info.local_time, nodeinfo->timezone(), restriction_idx) ||
+                                    time_info.local_time, nodeinfo->timezone(), restriction_idx,
+                                    destonly_restriction_mask) ||
           costing_->Restricted(meta.edge, pred, edgelabels_, tile, meta.edge_id, false, &edgestatus_,
                                time_info.local_time, nodeinfo->timezone())) {
         return false;
@@ -324,16 +327,18 @@ inline bool UnidirectionalAStar<expansion_direction, FORWARD>::ExpandInner(
   if (meta.edge_status->set() == EdgeSet::kTemporary) {
     auto update_label = [&]() {
       uint8_t restriction_idx = kInvalidRestriction;
+      uint8_t destonly_restriction_mask = 0;
       if (FORWARD) {
         if (!costing_->Allowed(meta.edge, false, pred, tile, meta.edge_id, time_info.local_time,
-                               nodeinfo->timezone(), restriction_idx) ||
+                               nodeinfo->timezone(), restriction_idx, destonly_restriction_mask) ||
             costing_->Restricted(meta.edge, pred, edgelabels_, tile, meta.edge_id, true, &edgestatus_,
                                  time_info.local_time, nodeinfo->timezone())) {
           return false;
         }
       } else {
         if (!costing_->AllowedReverse(meta.edge, pred, opp_edge, endtile, opp_edge_id,
-                                      time_info.local_time, nodeinfo->timezone(), restriction_idx) ||
+                                      time_info.local_time, nodeinfo->timezone(), restriction_idx,
+                                      destonly_restriction_mask) ||
             costing_->Restricted(meta.edge, pred, edgelabels_, tile, meta.edge_id, false,
                                  &edgestatus_, time_info.local_time, nodeinfo->timezone())) {
           return false;

--- a/taginfo.json
+++ b/taginfo.json
@@ -2451,6 +2451,13 @@
       "description": "Sets the hazmat flag to true."
     },
     {
+      "key": "hazmat:conditional",
+      "object_types": [
+        "way"
+      ],
+      "description": "Exemptions for local traffic for hazmat access restrictions."
+    },
+    {
       "key": "hazmat",
       "value": "yes",
       "object_types": [
@@ -3862,11 +3869,25 @@
       "description": "Maxaxleload for hgv."
     },
     {
+      "key": "maxaxleload:conditional",
+      "object_types": [
+        "way"
+      ],
+      "description": "Exemptions for local traffic for maxaxleload for hgv."
+    },
+    {
       "key": "maxaxles",
       "object_types": [
         "way"
       ],
       "description": "Maxaxles for hgv."
+    },
+    {
+      "key": "maxaxles:conditional",
+      "object_types": [
+        "way"
+      ],
+      "description": "Exemptions for local traffic for maxaxles for hgv."
     },
     {
       "key": "maxheight",
@@ -3881,6 +3902,27 @@
         "way"
       ],
       "description": "Maxheight for hgv in forward direction."
+    },
+    {
+      "key": "maxheight:conditional",
+      "object_types": [
+        "way"
+      ],
+      "description": "Maxheight exemptions for local traffic."
+    },
+    {
+      "key": "maxheight:forward:conditional",
+      "object_types": [
+        "way"
+      ],
+      "description": "Maxheight exemptions for local traffic in forward direction."
+    },
+    {
+      "key": "maxheight:backward:conditional",
+      "object_types": [
+        "way"
+      ],
+      "description": "Maxheight exemptions for local traffic in backward direction."
     },
     {
       "key": "maxheight:backward",
@@ -3916,6 +3958,27 @@
         "way"
       ],
       "description": "Maxlength for hgv in backward direction."
+    },
+    {
+      "key": "maxlength:conditional",
+      "object_types": [
+        "way"
+      ],
+      "description": "Maxheight exemptions for local traffic."
+    },
+    {
+      "key": "maxlength:forward:conditional",
+      "object_types": [
+        "way"
+      ],
+      "description": "Maxheight exemptions for local traffic in forward direction."
+    },
+    {
+      "key": "maxlength:backward:conditional",
+      "object_types": [
+        "way"
+      ],
+      "description": "Maxheight exemptions for local traffic in backward direction."
     },
     {
       "key": "maxspeed",

--- a/test/gurka/test_ignore_restrictions.cc
+++ b/test/gurka/test_ignore_restrictions.cc
@@ -255,42 +255,6 @@ INSTANTIATE_TEST_SUITE_P(
       return res;
     }()));
 
-TEST(StandAlone, TestTruck) {
-  const gurka::ways ways = {
-      {"AB", {{"highway", "secondary"}}},
-      {"BC", {{"highway", "secondary"}}},
-      {"CD", {{"highway", "secondary"}}},
-      {"AE", {{"highway", "secondary"}}},
-      {"EF",
-       {{"highway", "secondary"},{"maxaxles", "1"} , {"hgv:conditional", "yes @ (09:00-18:00)"},}},
-  };
-
-    const std::string ascii_map = R"(
-      A----------B-----C----D
-      |
-      E
-      |
-      |
-      F
-    )";
-
-   auto layout = gurka::detail::map_to_coordinates(ascii_map, 100);
-
-  gurka::map map =
-      gurka::buildtiles(layout, ways, {}, {}, VALHALLA_BUILD_DIR "test/data/test_blah",
-                        {{"mjolnir.timezone", {VALHALLA_BUILD_DIR "test/data/tz.sqlite"}}});
-
-  // this one should fail not because of time constraint but because of maxaxles
-  try {
-    valhalla::Api route =
-        gurka::do_action(valhalla::Options::route, map, {"A", "F"}, "truck",
-                         {{"/date_time/type", "1"}, {"/date_time/value", "2020-10-10T16:00"}});
-    FAIL() << "Expected route to fail.";
-  } catch (const valhalla_exception_t& err) { EXPECT_EQ(err.code, 442); } catch (...) {
-    FAIL() << "Expected different error code.";
-  }
-}
-
 TEST(StandAlone, TestDestinationAR) {
   const std::string ascii_map = R"(
       A-6--B--7--C-8--D--9--E

--- a/test/gurka/test_ignore_restrictions.cc
+++ b/test/gurka/test_ignore_restrictions.cc
@@ -180,13 +180,12 @@ TEST(CommonRestrictionsFail, Truck) {
   }
 }
 
-
 using params_t =
     std::tuple<std::string, std::string, std::string, std::string, std::string, std::string>;
 class DestinationAccessRestrictionTest : public ::testing::TestWithParam<params_t> {};
 // class TestHierarchyLimits : public ::testing::TestWithParam<HierarchyLimitsTestParams> {};
 TEST_P(DestinationAccessRestrictionTest, DestinationAccessRestriction) {
-  std::string tag, value, conditional_value, costing, costing_key, costing_value; 
+  std::string tag, value, conditional_value, costing, costing_key, costing_value;
   std::tie(tag, value, conditional_value, costing, costing_key, costing_value) = GetParam();
 
   const std::string ascii_map = R"(
@@ -205,42 +204,49 @@ TEST_P(DestinationAccessRestrictionTest, DestinationAccessRestriction) {
 
   gurka::map map =
       gurka::buildtiles(layout, ways, {}, {}, "test/data/destination_access_restrictions",
-                        {{"mjolnir.timezone", {VALHALLA_BUILD_DIR "test/data/tz.sqlite"}}, {"thor.costmatrix.allow_second_pass", "1"} });
+                        {{"mjolnir.timezone", {VALHALLA_BUILD_DIR "test/data/tz.sqlite"}},
+                         {"thor.costmatrix.allow_second_pass", "1"}});
 
   // second pass
-  valhalla::Api route = gurka::do_action(valhalla::Options::route, map, {"A", "D"}, "truck",
-                                           {{"/costing_options/" + costing + "/" + costing_key, costing_value}});
+  valhalla::Api route =
+      gurka::do_action(valhalla::Options::route, map, {"A", "D"}, "truck",
+                       {{"/costing_options/" + costing + "/" + costing_key, costing_value}});
 
   // better yet, call costmatrix which gives us a warning on second pass
   route = gurka::do_action(valhalla::Options::sources_to_targets, map, {"A"}, {"D"}, "truck",
-                                           {{"/costing_options/" + costing + "/" + costing_key, costing_value}, {"/prioritize_bidirectional", "1"}});
+                           {{"/costing_options/" + costing + "/" + costing_key, costing_value},
+                            {"/prioritize_bidirectional", "1"}});
   ASSERT_TRUE(route.info().warnings().size() > 0);
   EXPECT_EQ(route.info().warnings(0).code(), 400);
-
 }
 
-INSTANTIATE_TEST_SUITE_P(DestinationAccessRestriction,
-                         DestinationAccessRestrictionTest,
-                         ::testing::ValuesIn([](){ 
-                           std::vector<params_t> res;
-                          std::array<std::string, 4> conditional_values = {"none @ destination", "none @ (destination)", "none @ delivery","no @ destination"};
-                           for (const auto& auto_opts : {"height", "length"}) {
-                              for (const auto& cv : conditional_values) {
+INSTANTIATE_TEST_SUITE_P(
+    DestinationAccessRestriction,
+    DestinationAccessRestrictionTest,
+    ::testing::ValuesIn([]() {
+      std::vector<params_t> res;
+      std::array<std::string, 4> conditional_values = {"none @ destination", "none @ (destination)",
+                                                       "none @ delivery", "no @ destination"};
+      for (const auto& auto_opts : {"height", "length"}) {
+        for (const auto& cv : conditional_values) {
 
-                              res.emplace_back("max" + std::string(auto_opts), "3", cv, "auto", auto_opts, "5");
-                              res.emplace_back("max" + std::string(auto_opts) + ":forward", "3", cv, "auto", auto_opts, "5");
-                              }
-                           }
+          res.emplace_back("max" + std::string(auto_opts), "3", cv, "auto", auto_opts, "5");
+          res.emplace_back("max" + std::string(auto_opts) + ":forward", "3", cv, "auto", auto_opts,
+                           "5");
+        }
+      }
 
-                           for (const auto& truck_opts : {"height", "length", "width", "weight", "axles"}) {
-                              for (const auto& cv : conditional_values) {
-                              res.emplace_back("max" + std::string(truck_opts), "3", cv, "truck", std::string(truck_opts) == "axles" ? "axle_count" : truck_opts, "5");
-                              if (std::string(truck_opts) != "axles")
-                                res.emplace_back("max" + std::string(truck_opts) + ":forward", "3", cv, "truck", std::string(truck_opts) == "axles" ? "axle_count" : truck_opts, "5");
-                              }
-                           }
+      for (const auto& truck_opts : {"height", "length", "width", "weight", "axles"}) {
+        for (const auto& cv : conditional_values) {
+          res.emplace_back("max" + std::string(truck_opts), "3", cv, "truck",
+                           std::string(truck_opts) == "axles" ? "axle_count" : truck_opts, "5");
+          if (std::string(truck_opts) != "axles")
+            res.emplace_back("max" + std::string(truck_opts) + ":forward", "3", cv, "truck",
+                             std::string(truck_opts) == "axles" ? "axle_count" : truck_opts, "5");
+        }
+      }
 
-                           // don't forget hazmat
-                           res.emplace_back("hazmat", "true", "none @ destination", "truck", "hazmat", "1");
-                           return res;
-                          }()));
+      // don't forget hazmat
+      res.emplace_back("hazmat", "true", "none @ destination", "truck", "hazmat", "1");
+      return res;
+    }()));

--- a/test/matrix.cc
+++ b/test/matrix.cc
@@ -44,7 +44,8 @@ public:
                const GraphId& edgeid,
                const uint64_t /*current_time*/,
                const uint32_t /*tz_index*/,
-               uint8_t& /*restriction_idx*/) const override {
+               uint8_t& /*restriction_idx*/,
+               uint8_t& /*destonly_access_restr_mask*/) const override {
     if (!IsAccessible(edge) || (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
         (pred.restrictions() & (1 << edge->localedgeidx())) ||
         edge->surface() == Surface::kImpassable || IsUserAvoidEdge(edgeid) ||
@@ -61,7 +62,8 @@ public:
                       const GraphId& opp_edgeid,
                       const uint64_t /*current_time*/,
                       const uint32_t /*tz_index*/,
-                      uint8_t& /*restriction_idx*/) const override {
+                      uint8_t& /*restriction_idx*/,
+                      uint8_t& /*destonly_access_restr_mask*/) const override {
     if (!IsAccessible(opp_edge) ||
         (!pred.deadend() && pred.opp_local_idx() == edge->localedgeidx()) ||
         (opp_edge->restrictions() & (1 << pred.opp_local_idx())) ||

--- a/valhalla/baldr/accessrestriction.h
+++ b/valhalla/baldr/accessrestriction.h
@@ -18,7 +18,8 @@ public:
   AccessRestriction(const uint32_t edgeindex,
                     const AccessType type,
                     const uint32_t modes,
-                    const uint64_t value);
+                    const uint64_t value,
+                    const bool except_destination);
 
   /**
    * Get the internal edge index to which this access restriction applies.
@@ -45,6 +46,20 @@ public:
   uint32_t modes() const;
 
   /**
+   * Get the flag telling Whether local traffic is exempted
+   * from this restriction.
+   *
+   * @return Returns whether or not local traffic can
+   * ignore this restriction.
+   */
+  bool except_destination() const;
+
+  /**
+   * Set the exemption flag for local traffic.
+   */
+  void set_except_destination(const bool except_destination);
+
+  /**
    * Get the value for this restriction.
    * @return  Returns the value
    */
@@ -66,11 +81,12 @@ public:
   bool operator<(const AccessRestriction& other) const;
 
 protected:
-  uint64_t edgeindex_ : 22; // Directed edge index. Max index is:
-                            // kMaxTileEdgeCount in nodeinfo.h: 22 bits.
-  uint64_t type_ : 6;       // Access type
-  uint64_t modes_ : 12;     // Mode(s) this access restriction applies to
-  uint64_t spare_ : 24;
+  uint64_t edgeindex_ : 22;         // Directed edge index. Max index is:
+                                    // kMaxTileEdgeCount in nodeinfo.h: 22 bits.
+  uint64_t type_ : 6;               // Access type
+  uint64_t modes_ : 12;             // Mode(s) this access restriction applies to
+  uint64_t except_destination_ : 1; // Whether local traffic is exempted from this restriction
+  uint64_t spare_ : 23;
 
   uint64_t value_; // Value for this restriction. Can take on
                    // different meanings per type

--- a/valhalla/baldr/graphconstants.h
+++ b/valhalla/baldr/graphconstants.h
@@ -2,6 +2,7 @@
 #define VALHALLA_BALDR_GRAPHCONSTANTS_H_
 
 #include <algorithm>
+#include <array>
 #include <cstdint>
 #include <limits>
 #include <string>
@@ -754,6 +755,27 @@ enum class AccessType : uint8_t {
   kDestinationAllowed = 8,
   kMaxAxles = 9
 };
+
+constexpr unsigned int kHazmatMask = 1;
+constexpr unsigned int kMaxHeightMask = 2;
+constexpr unsigned int kMaxWidthMask = 4;
+constexpr unsigned int kMaxLengthMask = 8;
+constexpr unsigned int kMaxWeightMask = 16;
+constexpr unsigned int kMaxAxleLoadMask = 32;
+constexpr unsigned int kMaxAxlesMask = 64;
+
+// convert between the enum value and the corresponding mask
+constexpr std::array<unsigned int, 10> kAccessRestrictionMasks{kHazmatMask,
+                                                               kMaxHeightMask,
+                                                               kMaxWidthMask,
+                                                               kMaxLengthMask,
+                                                               kMaxWeightMask,
+                                                               kMaxAxleLoadMask,
+                                                               0,
+                                                               0,
+                                                               0,
+                                                               kMaxAxlesMask};
+constexpr uint8_t kInvalidAccessRestrictionMask = std::numeric_limits<uint8_t>::max();
 
 // Minimum meters offset from start/end of shape for finding heading
 constexpr float kMinMetersOffsetForHeading = 15.0f;

--- a/valhalla/mjolnir/osmaccessrestriction.h
+++ b/valhalla/mjolnir/osmaccessrestriction.h
@@ -21,7 +21,7 @@ public:
   /**
    * Constructor
    */
-  OSMAccessRestriction() = default;
+  OSMAccessRestriction() : except_destination_(0) {};
 
   /**
    * Destructor.

--- a/valhalla/mjolnir/osmaccessrestriction.h
+++ b/valhalla/mjolnir/osmaccessrestriction.h
@@ -69,6 +69,16 @@ public:
    */
   void set_direction(AccessRestrictionDirection direction);
 
+  /** 
+   * Whether or not the restriction applies to local traffic
+   */
+  bool except_destination() const;
+
+  /** 
+   * Set flag for whether or not the restriction applies to local traffic
+   */
+  void set_except_destination(const bool except_destination);
+
 protected:
   uint64_t value_ = 0;
 
@@ -78,7 +88,9 @@ protected:
   };
   Attributes attributes_ = {0, 0};
   AccessRestrictionDirection direction_ = AccessRestrictionDirection::kBoth;
-  uint16_t spare_[2] = {0, 0};
+  uint16_t except_destination_ : 1;
+  uint16_t spare_ : 15;
+  uint16_t spare1_ = 0;
   uint8_t spare2_ = 0;
 };
 

--- a/valhalla/mjolnir/osmaccessrestriction.h
+++ b/valhalla/mjolnir/osmaccessrestriction.h
@@ -69,12 +69,12 @@ public:
    */
   void set_direction(AccessRestrictionDirection direction);
 
-  /** 
+  /**
    * Whether or not the restriction applies to local traffic
    */
   bool except_destination() const;
 
-  /** 
+  /**
    * Set flag for whether or not the restriction applies to local traffic
    */
   void set_except_destination(const bool except_destination);

--- a/valhalla/mjolnir/osmaccessrestriction.h
+++ b/valhalla/mjolnir/osmaccessrestriction.h
@@ -21,7 +21,7 @@ public:
   /**
    * Constructor
    */
-  OSMAccessRestriction() : except_destination_(0) {};
+  OSMAccessRestriction() : except_destination_(0){};
 
   /**
    * Destructor.

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -660,18 +660,17 @@ public:
                                                   baldr::DateTime::get_tz_db().from_index(tz_index));
   }
 
-  inline void GetExemptedAccessRestrictions(uint32_t access_mode,
-                                            const baldr::DirectedEdge* edge,
+  inline uint8_t GetExemptedAccessRestrictions(const baldr::DirectedEdge* edge,
                                             const graph_tile_ptr& tile,
-                                            const baldr::GraphId& edgeid,
-                                            uint8_t& destonly_access_restr_mask) {
+                                            const baldr::GraphId& edgeid) {
 
-    if (ignore_restrictions_ || !(edge->access_restriction() & access_mode) ||
+    uint8_t destonly_access_restr_mask;
+    if (ignore_restrictions_ || !(edge->access_restriction() & access_mask_) ||
         allow_destination_only_)
-      return;
+      return 0;
 
     const std::vector<baldr::AccessRestriction>& restrictions =
-        tile->GetAccessRestrictions(edgeid.id(), access_mode);
+        tile->GetAccessRestrictions(edgeid.id(), access_mask_);
 
     for (size_t i = 0; i < restrictions.size(); ++i) {
       const auto& restr = restrictions[i];
@@ -680,6 +679,7 @@ public:
             baldr::kAccessRestrictionMasks[static_cast<size_t>(restr.type())];
       }
     }
+    return destonly_access_restr_mask;
   }
 
   /***

--- a/valhalla/sif/edgelabel.h
+++ b/valhalla/sif/edgelabel.h
@@ -76,7 +76,8 @@ public:
             const InternalTurn internal_turn,
             const uint8_t path_id = 0,
             const bool destonly = false,
-            const bool hgv_access = false)
+            const bool hgv_access = false,
+            const uint8_t destonly_access_restr_mask = 0)
       : predecessor_(predecessor), path_distance_(path_distance), restrictions_(edge->restrictions()),
         edgeid_(edgeid), opp_index_(edge->opp_index()), opp_local_idx_(edge->opp_local_idx()),
         mode_(static_cast<uint32_t>(mode)), endnode_(edge->endnode()),
@@ -89,7 +90,8 @@ public:
         closure_pruning_(closure_pruning), path_id_(path_id), restriction_idx_(restriction_idx),
         internal_turn_(static_cast<uint8_t>(internal_turn)), unpaved_(edge->unpaved()),
         has_measured_speed_(has_measured_speed), hgv_access_(hgv_access), bridge_(edge->bridge()),
-        tunnel_(edge->tunnel()), cost_(cost), sortcost_(sortcost) {
+        tunnel_(edge->tunnel()), cost_(cost), sortcost_(sortcost),
+        destonly_access_restr_mask_(destonly_access_restr_mask) {
     dest_only_ = destonly ? destonly : edge->destonly();
     assert(path_id_ <= baldr::kMaxMultiPathId);
   }
@@ -397,6 +399,14 @@ public:
     return hgv_access_;
   }
 
+  /**
+   * Get the access restriction mask for restrictions with a local
+   * traffic exemption
+   */
+  uint8_t destonly_access_restr_mask() const {
+    return destonly_access_restr_mask_;
+  }
+
 protected:
   // predecessor_: Index to the predecessor edge label information.
   // Note: invalid predecessor value uses all 32 bits (so if this needs to
@@ -467,7 +477,11 @@ protected:
   // Flag indicating edge is a tunnel.
   uint32_t tunnel_ : 1;
 
-  uint32_t spare : 10;
+  // Mask indicating whether the path started on
+  // an access restriction with an exemption for local traffic
+  uint32_t destonly_access_restr_mask_ : 7;
+
+  uint32_t spare : 3;
 
   Cost cost_;      // Cost and elapsed time along the path.
   float sortcost_; // Sort cost - includes A* heuristic.
@@ -519,7 +533,8 @@ public:
                 const InternalTurn internal_turn,
                 const uint8_t path_id = 0,
                 const bool destonly = false,
-                const bool hgv_access = false)
+                const bool hgv_access = false,
+                const uint8_t destonly_access_restr_mask = 0)
       : EdgeLabel(predecessor,
                   edgeid,
                   edge,
@@ -533,7 +548,8 @@ public:
                   internal_turn,
                   path_id,
                   destonly,
-                  hgv_access),
+                  hgv_access,
+                  destonly_access_restr_mask),
         transition_cost_(transition_cost) {
     assert(path_id_ <= baldr::kMaxMultiPathId);
   }
@@ -604,7 +620,8 @@ public:
               const uint8_t restriction_idx,
               const uint8_t path_id = 0,
               const bool destonly = false,
-              const bool hgv_access = false)
+              const bool hgv_access = false,
+              const uint8_t destonly_access_restr_mask = 0)
       : EdgeLabel(predecessor,
                   edgeid,
                   edge,
@@ -618,7 +635,8 @@ public:
                   internal_turn,
                   path_id,
                   destonly,
-                  hgv_access),
+                  hgv_access,
+                  destonly_access_restr_mask),
         transition_cost_(transition_cost), opp_edgeid_(oppedgeid),
         not_thru_pruning_(not_thru_pruning), distance_(dist) {
   }
@@ -661,7 +679,8 @@ public:
               const uint8_t restriction_idx,
               const uint8_t path_id = 0,
               const bool destonly = false,
-              const bool hgv_access = false)
+              const bool hgv_access = false,
+              const uint8_t destonly_access_restr_mask = 0)
       : EdgeLabel(predecessor,
                   edgeid,
                   edge,
@@ -675,7 +694,8 @@ public:
                   internal_turn,
                   path_id,
                   destonly,
-                  hgv_access),
+                  hgv_access,
+                  destonly_access_restr_mask),
         transition_cost_(transition_cost), opp_edgeid_(oppedgeid),
         not_thru_pruning_(not_thru_pruning), distance_(0.0f) {
   }
@@ -713,7 +733,8 @@ public:
               const sif::InternalTurn internal_turn,
               const uint8_t path_id = 0,
               const bool destonly = false,
-              const bool hgv_access = false)
+              const bool hgv_access = false,
+              const uint8_t destonly_access_restr_mask = 0)
       : EdgeLabel(predecessor,
                   edgeid,
                   edge,
@@ -727,7 +748,8 @@ public:
                   internal_turn,
                   path_id,
                   destonly,
-                  hgv_access),
+                  hgv_access,
+                  destonly_access_restr_mask),
         transition_cost_({}), not_thru_pruning_(!edge->not_thru()), distance_(dist) {
     opp_edgeid_ = {};
   }


### PR DESCRIPTION
# Issue

fixes #5287 

I decided to open an additional PR for this, it's essentially an extension of #5354. It adds a bit mask to `PathLabel` to track whether certain access restrictions with local traffic exemptions can be ignored during expansion (similar to how it's done wrt regular destination only).  

## Tasklist

 - [x] Add tests
 - [x] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
