### PR TITLE
Fix wrong integer type in expansion edge id properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
    * FIXED: unknowns should be 500 and not 400 [#5359](https://github.com/valhalla/valhalla/pull/5359)
    * FIXED: Cover **all** nodes in the current tile by density index [#5338](https://github.com/valhalla/valhalla/pull/5338)
    * FIXED: Narrowing bug leading to nodes being misplaced in wrong tiles [#5364](https://github.com/valhalla/valhalla/pull/5364)
+   * FIXED: wrong integer types in expansion properties [#5380](https://github.com/valhalla/valhalla/pull/5380)
 * **Enhancement**
    * ADDED: Consider smoothness in all profiles that use surface [#4949](https://github.com/valhalla/valhalla/pull/4949)
    * ADDED: costing parameters to exclude certain edges `exclude_tolls`, `exclude_bridges`, `exclude_tunnels`, `exclude_highways`, `exclude_ferries`. They need to be enabled in the config with `service_limits.allow_hard_exclusions`. Also added location search filters `exclude_ferry` and `exclude_toll` to complement these changes. [#4524](https://github.com/valhalla/valhalla/pull/4524)

--- a/proto/expansion.proto
+++ b/proto/expansion.proto
@@ -24,11 +24,10 @@ message Expansion {
   repeated uint32 durations = 2 [packed=true];
   repeated uint32 distances = 3 [packed=true];
   repeated EdgeStatus edge_status = 4;
-  // deprecated = 5 
-  // deprecated = 6 
+  repeated uint64 edge_id = 5 [packed=true];
+  repeated uint64 pred_edge_id = 6 [packed=true];
   repeated ExpansionType expansion_type = 8;
-  repeated uint64 edge_id = 9 [packed=true];
-  repeated uint64 pred_edge_id = 10 [packed=true];
 
   repeated Geometry geometries = 7;
 }
+

--- a/proto/expansion.proto
+++ b/proto/expansion.proto
@@ -24,9 +24,11 @@ message Expansion {
   repeated uint32 durations = 2 [packed=true];
   repeated uint32 distances = 3 [packed=true];
   repeated EdgeStatus edge_status = 4;
-  repeated uint32 edge_id = 5 [packed=true];
-  repeated uint32 pred_edge_id = 6 [packed=true];
+  // deprecated = 5 
+  // deprecated = 6 
   repeated ExpansionType expansion_type = 8;
+  repeated uint64 edge_id = 9 [packed=true];
+  repeated uint64 pred_edge_id = 10 [packed=true];
 
   repeated Geometry geometries = 7;
 }

--- a/src/thor/expansion_action.cc
+++ b/src/thor/expansion_action.cc
@@ -47,9 +47,9 @@ void writeExpansionProgress(Expansion* expansion,
   if (exp_props.count(Options_ExpansionProperties_edge_status))
     expansion->add_edge_status(status);
   if (exp_props.count(Options_ExpansionProperties_edge_id))
-    expansion->add_edge_id(static_cast<uint32_t>(edgeid));
+    expansion->add_edge_id(static_cast<uint64_t>(edgeid));
   if (exp_props.count(Options_ExpansionProperties_pred_edge_id))
-    expansion->add_pred_edge_id(static_cast<uint32_t>(prev_edgeid));
+    expansion->add_pred_edge_id(static_cast<uint64_t>(prev_edgeid));
   if (exp_props.count(Options_ExpansionProperties_expansion_type))
     expansion->add_expansion_type(expansion_type);
 }


### PR DESCRIPTION
I accidentally set the type for the `edge_id` and `prev_edge_id` expansion properties to unsigned 32-bit instead of unsigned 64-bit in #4614. Makes me wonder how often this feature is used for debugging :smile: I remember this not biting me when I last used it a couple months ago, must have been pure luck.  