### PR TITLE
fix: Mark variables used only in logging as `[[maybe_unused]]`

### DIFF
--- a/src/baldr/incident_singleton.h
+++ b/src/baldr/incident_singleton.h
@@ -242,7 +242,7 @@ protected:
       // this happens when the tile is updated during the loop. in that case its possible that
       // the current iteration will load the tile and that it will again be loaded in the next
       auto current_scan = time(nullptr);
-      size_t update_count = 0;
+      [[maybe_unused]] size_t update_count = 0;
       seen.clear();
 
       // we are in memory map mode

--- a/src/mjolnir/add_predicted_speeds.cc
+++ b/src/mjolnir/add_predicted_speeds.cc
@@ -225,8 +225,8 @@ void UpdateTiles(const std::string& tile_dir,
   thread_name << std::this_thread::get_id();
 
   // Iterate through the tiles and parse them
-  size_t total = tile_end - tile_start;
-  double count = 0;
+  [[maybe_unused]] size_t total = tile_end - tile_start;
+  [[maybe_unused]] double count = 0;
   TrafficStats stat{};
   for (; tile_start != tile_end; ++tile_start) {
     LOG_INFO(thread_name.str() + " parsing traffic data for " + std::to_string(tile_start->first));
@@ -270,8 +270,8 @@ void GenerateSummary(const boost::property_tree::ptree& config) {
   mutable_config.get_child("mjolnir").erase("tile_extract");
 
   GraphReader reader(mutable_config.get_child("mjolnir"));
-  int shortcuts_with_speed = 0;
-  int non_dr_with_speed = 0;
+  [[maybe_unused]] int shortcuts_with_speed = 0;
+  [[maybe_unused]] int non_dr_with_speed = 0;
   std::vector<uint32_t> dr_class_edges_links(8);
   std::vector<uint32_t> dr_road_class_edges(8);
   std::vector<uint32_t> pred_road_class_edges(8);
@@ -333,7 +333,7 @@ void GenerateSummary(const boost::property_tree::ptree& config) {
   LOG_INFO("non drivable with speed = " + std::to_string(non_dr_with_speed));
   LOG_INFO("Shortcuts with speed = " + std::to_string(shortcuts_with_speed));
 
-  uint32_t totaldrivable = 0, totalpt = 0, totalff = 0, totaldrivablelink = 0;
+  [[maybe_unused]] uint32_t totaldrivable = 0, totalpt = 0, totalff = 0, totaldrivablelink = 0;
   for (uint32_t i = 0; i < 8; i++) {
     float pct1 = 100.0f * (float)pred_road_class_edges[i] / dr_road_class_edges[i];
     float pct2 = 100.0f * (float)ff_road_class_edges[i] / dr_road_class_edges[i];

--- a/src/mjolnir/adminbuilder.cc
+++ b/src/mjolnir/adminbuilder.cc
@@ -504,7 +504,7 @@ bool BuildAdminFromPBF(const boost::property_tree::ptree& pt,
   geos_helper_t::get();
 
   // for each admin area (relation)
-  uint32_t count = 0;
+  [[maybe_unused]] uint32_t count = 0;
   for (const auto& admin : admin_data.admins) {
     std::pair<std::string, uint64_t> admin_info(admin_data.name_offset_map.name(admin.name_index),
                                                 admin.id);

--- a/src/mjolnir/convert_transit.cc
+++ b/src/mjolnir/convert_transit.cc
@@ -549,7 +549,7 @@ void AddToGraph(GraphTileBuilder& tilebuilder_transit,
   // stations and platforms are connected by platformconnections
 
   // Iterate through the platform and their edges
-  uint32_t transitedges = 0;
+  [[maybe_unused]] uint32_t transitedges = 0;
   for (const auto& stop_edges : stop_edge_map) {
     // Get the platform information
     GraphId platform_graphid = stop_edges.second.origin_pbf_graphid;
@@ -1292,7 +1292,7 @@ std::unordered_set<GraphId> convert_transit(const ptree& pt) {
   }
 
   if (total_dep_count) {
-    float percent =
+    [[maybe_unused]] float percent =
         static_cast<float>(total_midnight_dep_count) / static_cast<float>(total_dep_count);
     percent *= 100;
 

--- a/src/mjolnir/ferry_connections.cc
+++ b/src/mjolnir/ferry_connections.cc
@@ -325,9 +325,9 @@ void ReclassifyFerryConnections(const std::string& ways_file,
 
   // Iterate through nodes and find any that connect to both a ferry and a
   // regular (non-ferry) edge. Skip short ferry edges (river crossing?)
-  uint32_t ferry_endpoint_count = 0;
-  uint32_t total_count = 0;
-  uint32_t missed_both = 0;
+  [[maybe_unused]] uint32_t ferry_endpoint_count = 0;
+  [[maybe_unused]] uint32_t total_count = 0;
+  [[maybe_unused]] uint32_t missed_both = 0;
   sequence<Node>::iterator node_itr = nodes.begin();
   while (node_itr != nodes.end()) {
     auto bundle = collect_node_edges(node_itr, nodes, edges);

--- a/src/mjolnir/landmarks.cc
+++ b/src/mjolnir/landmarks.cc
@@ -514,7 +514,7 @@ bool AddLandmarks(const boost::property_tree::ptree& pt) {
   }
 
   // collect and log the stats
-  size_t tiles = 0, edges = 0, landmarks = 0;
+  [[maybe_unused]] size_t tiles = 0, edges = 0, landmarks = 0;
   for (std::promise<std::tuple<size_t, size_t, size_t>>& s : stats_info) {
     std::tuple<size_t, size_t, size_t> data = s.get_future().get();
     tiles += std::get<0>(data);

--- a/src/mjolnir/linkclassification.cc
+++ b/src/mjolnir/linkclassification.cc
@@ -908,8 +908,8 @@ void ReclassifyLinks(const std::string& ways_file,
 
   // Iterate through the exit node list by classification so exits from major
   // roads are considered before exits from minor roads.
-  uint32_t reclass_count = 0;
-  uint32_t tc_count = 0;
+  [[maybe_unused]] uint32_t reclass_count = 0;
+  [[maybe_unused]] uint32_t tc_count = 0;
 
   for (uint32_t classification = 0; classification < kMaxClassification; classification++) {
     for (auto& node : exit_nodes[classification]) {

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -123,7 +123,7 @@ private:
 
   // Sets "culdesac" labels to loop roads and saves ways.
   void fix(sequence<OSMWay>& osm_way_seq) {
-    size_t number_of_culdesac = 0;
+    [[maybe_unused]] size_t number_of_culdesac = 0;
     for (const auto& loop_way_id_to_meta : loops_meta_) {
       const auto& meta = loop_way_id_to_meta.second;
       if (meta.is_culdesac()) {

--- a/src/mjolnir/restrictionbuilder.cc
+++ b/src/mjolnir/restrictionbuilder.cc
@@ -780,8 +780,8 @@ void RestrictionBuilder::Build(const boost::property_tree::ptree& pt,
 
     HandleOnlyRestrictionProperties(results, hierarchy_properties);
 
-    uint32_t forward_restrictions_count = 0;
-    uint32_t reverse_restrictions_count = 0;
+    [[maybe_unused]] uint32_t forward_restrictions_count = 0;
+    [[maybe_unused]] uint32_t reverse_restrictions_count = 0;
 
     for (const auto& stat : results) {
       forward_restrictions_count += stat.forward_restrictions_count + stat.restrictions.size();


### PR DESCRIPTION
# Issue

This PR fixes all compilation warnings/errors produced with `-DLOGGING_LEVEL=NONE`.

```
cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLOGGING_LEVEL=NONE && cmake --build . -j 14
```

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
