### PR TITLE
perf: Use `ankerl::unordered_dense` for `loki::Reach()` for faster search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@
    * ADDED: Distribute C++ executables for Windows Python bindings [#5348](https://github.com/valhalla/valhalla/pull/5348)
    * ADDED: Distribute C++ executables for OSX Python bindings [#5301](https://github.com/valhalla/valhalla/pull/5301)
    * ADDED: `trace_attributes` now also returns all the speed informations on edges when `edge.speeds_faded` or `edge.speeds_non_faded` is set in request. Also `edge.speed_type` returns how the edge speed was set [#5324](https://github.com/valhalla/valhalla/pull/5324)
+   * CHANGED: Use `ankerl::unordered_dense` for `loki::Reach()` for faster search [#5384](https://github.com/valhalla/valhalla/pull/5384)
 
 ## Release Date: 2024-10-10 Valhalla 3.5.1
 * **Removed**

--- a/src/loki/CMakeLists.txt
+++ b/src/loki/CMakeLists.txt
@@ -21,7 +21,7 @@ set(sources_with_warnings
   trace_route_action.cc
   worker.cc)
 
-set(system_includes 
+set(system_includes
   ${date_include_dir}
   $<$<BOOL:${WIN32}>:${dirent_include_dir}>)
 
@@ -39,6 +39,8 @@ valhalla_module(NAME loki
   SYSTEM_INCLUDE_DIRECTORIES
     PUBLIC
       ${system_includes}
+    PRIVATE
+      ${unordered_dense_include_dir}
   DEPENDS
     valhalla::skadi
     valhalla::sif

--- a/valhalla/loki/reach.h
+++ b/valhalla/loki/reach.h
@@ -3,6 +3,8 @@
 #include <valhalla/loki/search.h>
 #include <valhalla/thor/dijkstras.h>
 
+#include <ankerl/unordered_dense.h>
+
 #include <cstdint>
 
 constexpr uint8_t kInbound = 1;
@@ -97,7 +99,7 @@ protected:
   virtual void Clear() override;
 
   google::protobuf::RepeatedPtrField<Location> locations_;
-  std::unordered_set<uint64_t> queue_, done_;
+  ankerl::unordered_dense::set<uint64_t> queue_, done_;
   uint32_t max_reach_{};
   size_t transitions_{};
 };


### PR DESCRIPTION
# Issue

While playing with benchmarks I've noticed that noticeable (10%) amound of time spend in Loki worker was related to `std::unordered_set` operations. This small change speed ups the `/locate` processing by approx. 10%, also speeding up all other operations that rely on `loki::Search()` (everything except `/status`).

## Before this PR

<img width="1511" height="373" alt="image" src="https://github.com/user-attachments/assets/50b7800c-884c-473f-ad36-fd28532e7469" />

*On this screenshot it can be seen that `loki::Reach()` takes 20% of the time spent in `loki::Search()`*

## After this PR

<img width="1512" height="372" alt="image" src="https://github.com/user-attachments/assets/d66038b5-779c-497b-a1b6-4c9322548a92" />

*On this screenshot it can be seen that `loki::Reach()` takes 10% of the time spent in `loki::Search()`*

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
