### PR TITLE
Fix broken link to documentation in Actor class

### DIFF
--- a/src/bindings/python/valhalla/actor.py
+++ b/src/bindings/python/valhalla/actor.py
@@ -36,7 +36,7 @@ class Actor(_Actor):
         created.
 
         For details on parameters for each function consult Valhalla's documentation:
-        https://github.com/valhalla/valhalla/blob/master/docs/api
+        https://github.com/valhalla/valhalla/blob/master/docs/docs/api
         """
         # make sure there's a valhalla.json file
         if isinstance(config, dict):


### PR DESCRIPTION
The actor class description contains a broken link to the Valhalla API. Updated to https://github.com/valhalla/valhalla/blob/master/docs/docs/api.

# Issue

Bad API link in Actor class #5392. https://github.com/valhalla/valhalla/issues/5392

## Tasklist

No tasks are needed. Confirm that https://github.com/valhalla/valhalla/blob/master/docs/docs/api is the correct link.

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

N/A
