### PR TITLE
chore(docker): less rebuilding/invalidating layer cache

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,9 +6,20 @@ on:
     tags:
       - "*"
     paths-ignore:
+      - ".circleci"
+      - ".github"
+      - "!.github/workflows/docker-build.yml"
       - ".gitignore"
       - "**.md"
-      - "test/"
+      - "**test**"
+      - "docs/"
+      - "**vcpkg**"
+      - "run_route_scripts/"
+      - ".*"
+      - "pyproject.toml"
+      - "*.cfg"
+      - "setup.py"
+      - "taginfo.json"
 jobs:
   build_and_publish:
     strategy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,5 @@
-# TODO: we should make use of BUILDPLATFORM and TARGETPLATFORM to figure out cross compiling
-#  as mentioned here: docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide
-#  then we could use the host architecture to simply compile to the target architecture without
-#  emulating the target architecture (thereby making the build hyper slow). the general gist is
-#  we add arm (or whatever architecture) repositories to apt and then install our dependencies
-#  with the architecture suffix, eg. :arm64. then we just need to set a bunch of cmake variables
-#  probably with the use of a cmake toolchain file so that cmake can make sure to use the
-#  binaries that can target the target architecture. from there bob is your uncle maybe..
-
-####################################################################
 FROM ubuntu:24.04 AS builder
 LABEL org.opencontainers.image.authors="Kevin Kreiser <kevinkreiser@gmail.com>"
-
-ARG CONCURRENCY
-ARG ADDITIONAL_TARGETS
-ARG VERSION_MODIFIER=""
 
 # set paths
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH
@@ -21,29 +7,41 @@ ENV LD_LIBRARY_PATH=/usr/local/lib:/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-g
 RUN export DEBIAN_FRONTEND=noninteractive && apt update && apt install -y sudo
 
 # install deps
-WORKDIR /usr/local/src/valhalla
-COPY ./scripts/install-linux-deps.sh /usr/local/src/valhalla/scripts/install-linux-deps.sh
-RUN bash /usr/local/src/valhalla/scripts/install-linux-deps.sh
-RUN rm -rf /var/lib/apt/lists/*
+WORKDIR /src/valhalla
+COPY scripts/install-linux-deps.sh scripts/install-linux-deps.sh
+RUN bash ./scripts/install-linux-deps.sh
 
-# get the code into the right place and prepare to build it
-ADD . .
-RUN ls -la
-RUN git submodule sync && git submodule update --init --recursive
-RUN rm -rf build && mkdir build
+# get the code into the right place explicitly (for layer caching) and prepare to build it
+COPY cmake cmake/
+COPY date_time/ date_time/
+COPY locales/ locales/
+COPY lua/ lua/
+COPY proto/ proto/
+COPY scripts/ scripts/
+COPY src/ src/
+COPY third_party/ third_party/
+COPY valhalla/ valhalla/
+COPY CMakeLists.txt .
+COPY libvalhalla.pc.in .
+COPY LICENSE.md .
+COPY CHANGELOG.md .
+COPY COPYING .
+COPY README.md .
 
-# configure the build with symbols turned on so that crashes can be triaged
-WORKDIR /usr/local/src/valhalla/build
+ARG CONCURRENCY
+ARG ADDITIONAL_TARGETS
+# this arg will always compile the full project on every build bcs it's a commit hash
+# but we only build the docker image in GHA if relevant files changed (extensive paths-ignore in GHA workflow)
+ARG VERSION_MODIFIER=""
 # switch back to -DCMAKE_BUILD_TYPE=RelWithDebInfo and uncomment the block below if you want debug symbols
-RUN cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc -DENABLE_SINGLE_FILES_WERROR=Off -DVALHALLA_VERSION_MODIFIER=${VERSION_MODIFIER}
-RUN make all ${ADDITIONAL_TARGETS} -j${CONCURRENCY:-$(nproc)}
-RUN make install
+RUN cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc -DENABLE_TESTS=Off -DENABLE_SINGLE_FILES_WERROR=Off -DVALHALLA_VERSION_MODIFIER=${VERSION_MODIFIER} && \
+  make -C build all ${ADDITIONAL_TARGETS} -j${CONCURRENCY:-$(nproc)} && \
+  make -C build install
 
-# we wont leave the source around but we'll drop the commit hash we'll also keep the locales
+# we wont leave the source around but we'll drop the commit hash and we'll also keep the locales
 WORKDIR /usr/local/src
-RUN cd valhalla && echo "https://github.com/valhalla/valhalla/tree/$(git rev-parse HEAD)" > ../valhalla_version
-RUN for f in valhalla/locales/*.json; do cat ${f} | python3 -c 'import sys; import json; print(json.load(sys.stdin)["posix_locale"])'; done > valhalla_locales
-RUN rm -rf valhalla
+RUN echo "$VERSION_MODIFIER" > /usr/local/valhalla_version && \
+  for f in /src/valhalla/locales/*.json; do cat ${f} | python3 -c 'import sys; import json; print(json.load(sys.stdin)["posix_locale"])'; done > valhalla_locales
 
 # the binaries are huge with all the symbols so we strip them but keep the debug there if we need it
 #WORKDIR /usr/local/bin
@@ -74,7 +72,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt update && \
   libcurl4 libczmq4 libluajit-5.1-2 libgdal34 \
   libprotobuf-lite32 libsqlite3-0 libsqlite3-mod-spatialite libzmq5 zlib1g \
   curl gdb locales parallel python3-minimal python-is-python3 python3-shapely python3-requests \
-  spatialite-bin unzip wget && rm -rf /var/lib/apt/lists/*
+  spatialite-bin unzip wget
 
 # grab the builder stages artifacts
 COPY --from=builder /usr/local /usr/local


### PR DESCRIPTION
closes #5395 

Mostly achieved by:
- moving `ARG`s to the place where they're needed
- extend `paths-ignore` in the GHA

Other than that I just cleaned up a bit to make it more succinct (well, IMO..).