### PR TITLE
perf: Use pre-increment for iteration over buckets in `DoubleBucketQueue::clear()`

### DIFF
--- a/valhalla/baldr/double_bucket_queue.h
+++ b/valhalla/baldr/double_bucket_queue.h
@@ -107,7 +107,7 @@ public:
     overflowbucket_.clear();
     while (currentbucket_ != buckets_.end()) {
       currentbucket_->clear();
-      currentbucket_++;
+      ++currentbucket_;
     }
 
     // Reset current bucket and cost


### PR DESCRIPTION
# Issue

While playing with `actor_t` functionality I've noticed that `thor_worker.clenup()` takes unreasonably long and when I looked into this cought my eye

<img width="581" height="374" alt="image" src="https://github.com/user-attachments/assets/af71f1e5-2292-41a3-883f-9c3b62bf71cd" />

To get the perspective of numbers, `DoubleBucketQueue::clear()` takes 8% from `thor_worker_t::route()` on master

<img width="1512" height="354" alt="image" src="https://github.com/user-attachments/assets/f8635040-b775-40b0-9013-fd95d617377f" />

... and similar times when doing `thor_worker.clenup()` after the request processing.

Seems (at least on my mac) compiler is unable to properly optimize post-increment operations thus wasting CPU cycles for nothing.

## After this PR

<img width="1510" height="341" alt="image" src="https://github.com/user-attachments/assets/07fafa68-89f9-490d-b0d5-fb2c5d7f39d6" />

*Here one can see that with pre-increment `DoubleBucketQueue::clear()` takes only 2% out of `thor_worker_t::route()` time*

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too.

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
