### PR TITLE
chore: fix path for valhalla_version in the docker image

### DIFF
--- a/docker/Dockerfile-scripted
+++ b/docker/Dockerfile-scripted
@@ -56,7 +56,7 @@ ENV default_speeds_config_url="https://raw.githubusercontent.com/OpenStreetMapSp
 # Smoke tests
 RUN python -c "import valhalla,sys; print (sys.version, valhalla)" \
   && valhalla_build_config | jq type \
-  && cat /usr/local/src/valhalla_version \
+  && cat /usr/local/valhalla_version \
   && valhalla_build_tiles -v \
   && ls -la /usr/local/bin/valhalla*
 


### PR DESCRIPTION
Fixing the docker image which got broken in https://github.com/valhalla/valhalla/pull/5396 by specifying the wrong path of the `valhalla_version` file in the `Dockerfile-scripted` image.