### PR TITLE
chore(vcpkg): remove robin-hood-hashing from vcpkg,

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -27,7 +27,6 @@
     "pkgconf",
     "pybind11",
     "rapidjson",
-    "robin-hood-hashing",
     "spatialite-tools",
     "luajit",
     "lz4",


### PR DESCRIPTION
currently the win master ci is failing when installing robin-hood-hashing due to some network hiccup.

we replaced that with 'unordered_dense' as a submodule, let's remove it. also the new library is not available on vcpkg yet.