### PR TITLE
chore: add `.git-blame-ignore-revs` to ignore some commits in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# huge/first formatting commit
+1230f09d784cb5fa734d21afa0576eef54705ee3

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,4 @@
 # huge/first formatting commit
 1230f09d784cb5fa734d21afa0576eef54705ee3
+# huge/first clang-tidy commit
+4a691800566a97526f1ad8b05d2d49702cbeb024


### PR DESCRIPTION
I got pretty sick traveling back in time because of 2 crazy huge commits and found that one can at least have `git blame` ignore specified commits.

the new file will cause github to hide the commits in blame view. to make this available locally: `git config blame.ignoreRevsFile .git-blame-ignore-revs`.

e.g. before
<img width="1408" height="407" alt="image" src="https://github.com/user-attachments/assets/9d3bae98-12e0-450d-9f70-b2c3aff9f378" />

after
<img width="1408" height="407" alt="image" src="https://github.com/user-attachments/assets/33bb5508-1950-49c1-b2e3-ff921e756d59" />

