### PR TITLE
fix: docker python installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
    * FIXED: Narrowing bug leading to nodes being misplaced in wrong tiles [#5364](https://github.com/valhalla/valhalla/pull/5364)
    * FIXED: wrong integer types in expansion properties [#5380](https://github.com/valhalla/valhalla/pull/5380)
    * FIXED: fix: `std::terminate` on unsupported request format for some actions [#5387](https://github.com/valhalla/valhalla/pull/5387)
+   * FIXED: python installation issue in docker image [#5424](https://github.com/valhalla/valhalla/pull/5424)
 * **Enhancement**
    * ADDED: Consider smoothness in all profiles that use surface [#4949](https://github.com/valhalla/valhalla/pull/4949)
    * ADDED: costing parameters to exclude certain edges `exclude_tolls`, `exclude_bridges`, `exclude_tunnels`, `exclude_highways`, `exclude_ferries`. They need to be enabled in the config with `service_limits.allow_hard_exclusions`. Also added location search filters `exclude_ferry` and `exclude_toll` to complement these changes. [#4524](https://github.com/valhalla/valhalla/pull/4524)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,7 +52,7 @@ RUN echo "$VERSION_MODIFIER" > /usr/local/valhalla_version && \
 #RUN strip /usr/local/lib/libvalhalla.a
 #RUN strip /usr/local/lib/python3.12/dist-packages/valhalla/_valhalla*.so
 
-####################################################################
+###################################################################
 # copy the important stuff from the build stage to the runner image
 FROM ubuntu:24.04 AS runner
 LABEL org.opencontainers.image.authors="Kevin Kreiser <kevinkreiser@gmail.com>"
@@ -76,9 +76,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt update && \
 
 # grab the builder stages artifacts
 COPY --from=builder /usr/local /usr/local
-COPY --from=builder /usr/local/lib/python3.12/dist-packages/valhalla/* /usr/local/lib/python3.12/dist-packages/valhalla/
+COPY --from=builder /usr/local/lib/python3.12/dist-packages/valhalla /usr/local/lib/python3.12/dist-packages/valhalla/
 
 RUN cat /usr/local/src/valhalla_locales | xargs -d '\n' -n1 locale-gen
 
 # python smoke test
-RUN python3 -c "import valhalla,sys; print(sys.version, valhalla)"
+RUN python3 -c "import valhalla; import sys; print(sys.version, valhalla)"

--- a/docker/Dockerfile-scripted
+++ b/docker/Dockerfile-scripted
@@ -54,7 +54,7 @@ ENV traffic_name=""
 ENV default_speeds_config_url="https://raw.githubusercontent.com/OpenStreetMapSpeeds/schema/master/default_speeds.json"
 
 # Smoke tests
-RUN python -c "import valhalla,sys; print (sys.version, valhalla)" \
+RUN python -c "from valhalla import Actor; import sys; print(sys.version, valhalla)" \
   && valhalla_build_config | jq type \
   && cat /usr/local/valhalla_version \
   && valhalla_build_tiles -v \

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -382,7 +382,7 @@ if(ENABLE_PYTHON_BINDINGS AND ENABLE_DATA_TOOLS)
       LOCPATH=${VALHALLA_SOURCE_DIR}/locales
       PYTHONPATH=${CMAKE_BINARY_DIR}/src/bindings/python
       ASAN_OPTIONS=verify_asan_link_order=0:detect_leaks=0
-      /bin/bash -cx "${Python_EXECUTABLE} -m unittest discover -s ${VALHALLA_SOURCE_DIR}/test/bindings/python -v > ${CMAKE_BINARY_DIR}/test/python_valhalla.log 2>&1 || cat ${CMAKE_BINARY_DIR}/test/python_valhalla.log"
+      /bin/bash -cx "${Python_EXECUTABLE} -m unittest discover -s ${VALHALLA_SOURCE_DIR}/test/bindings/python -v > ${CMAKE_BINARY_DIR}/test/python_valhalla.log 2>&1 || (cat ${CMAKE_BINARY_DIR}/test/python_valhalla.log && exit 1)"
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     DEPENDS
       ${VALHALLA_SOURCE_DIR}/test/bindings/python/test_actor.py

--- a/test/bindings/python/test_actor.py
+++ b/test/bindings/python/test_actor.py
@@ -6,8 +6,7 @@ from pathlib import Path
 import re
 from tempfile import NamedTemporaryFile
 import unittest
-from valhalla import Actor, get_config, VALHALLA_PYTHON_PACKAGE, VALHALLA_PRINT_VERSION, __version__
-from valhalla.__version__ import __version_tuple__
+from valhalla import Actor, get_config, VALHALLA_PYTHON_PACKAGE, VALHALLA_PRINT_VERSION
 
 
 PWD = Path(os.path.dirname(os.path.abspath(__file__)))
@@ -36,6 +35,14 @@ class TestBindings(unittest.TestCase):
 
     def test_version_python_package_constant(self):
         self.assertIn("pyvalhalla", VALHALLA_PYTHON_PACKAGE)
+
+        # The CMake build of course doesn't have the setuptools-scm generated __version__.py
+        try:
+            from valhalla import __version__
+            from valhalla.__version__ import __version_tuple__
+        except ModuleNotFoundError:
+            return
+        
         self.assertEqual(".".join([str(x) for x in __version_tuple__[:3]]), VALHALLA_PRINT_VERSION)
 
         version_modifier = VALHALLA_PRINT_VERSION[VALHALLA_PRINT_VERSION.find("-"):]


### PR DESCRIPTION
closes #5422 

the main issue was the stupid docker `COPY` command which does very weird stuff with wildcards. basically it copied the whole contents of `valhalla/utils` into `valhalla/` and overwrote the `__init__.py` with an empty file.

this also fixes that CI isn't failing when the python tests are failing.

before `ls -l /usr/local/lib/python3.12/dist-packages/valhalla/`:

```
-rw-r--r-- 1 root root        0 Jul 30 20:26 __init__.py
drwxr-xr-x 2 root root     4096 Jul 30 20:50 __pycache__
-rw-r--r-- 1 root root 10567416 Jul 30 20:29 _valhalla.cpython-312-x86_64-linux-gnu.so
-rw-r--r-- 1 root root     4303 Jul 30 20:26 actor.py
-rw-r--r-- 1 root root     1738 Jul 30 20:26 config.py
-rw-r--r-- 1 root root     1954 Jul 30 20:26 decode_polyline.py
-rw-r--r-- 1 root root   628200 Jul 30 20:29 graph_utils.cpython-312-x86_64-linux-gnu.so
-rw-r--r-- 1 root root     3161 Jul 30 20:26 graph_utils.pyi
drwxr-xr-x 2 root root     4096 Jul 30 20:29 utils
-rw-r--r-- 1 root root    42506 Jul 30 20:26 valhalla_build_config.py
``` 

after `ls -l /usr/local/lib/python3.12/dist-packages/valhalla/`:

```
-rw-r--r-- 1 root root      706 Jul 30 20:26 __init__.py
drwxr-xr-x 2 root root     4096 Jul 30 20:49 __pycache__
-rw-r--r-- 1 root root 10567416 Jul 30 20:29 _valhalla.cpython-312-x86_64-linux-gnu.so
-rw-r--r-- 1 root root     4303 Jul 30 20:26 actor.py
-rw-r--r-- 1 root root     1738 Jul 30 20:26 config.py
drwxr-xr-x 1 root root     4096 Jul 30 20:29 utils
-rw-r--r-- 1 root root    42506 Jul 30 20:26 valhalla_build_config.py
```

