### PR TITLE
feat: use rapidjson for transit_available serializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@
    * CHANGED: set`check_reverse_connection` default value to `true` [#5404](https://github.com/valhalla/valhalla/pull/5404)
    * CHANGED: updated translation files and added mn-MN lang [#5425](https://github.com/valhalla/valhalla/pull/5425)
    * CHANGED: Use rapidjson for height serializer [#5277](https://github.com/valhalla/valhalla/pull/5277)
+   * CHANGED: Use rapidjson for transit_available serializer [#5430](https://github.com/valhalla/valhalla/pull/5430)
 
 ## Release Date: 2024-10-10 Valhalla 3.5.1
 * **Removed**

--- a/src/tyr/transit_available_serializer.cc
+++ b/src/tyr/transit_available_serializer.cc
@@ -10,13 +10,15 @@ using namespace valhalla::baldr;
 
 namespace {
 
-json::MapPtr serialize(const PathLocation& location, bool istransit) {
+void serialize(rapidjson::writer_wrapper_t& writer, const PathLocation& location, bool istransit) {
   // serialze all the edges
-  auto json = json::map({{"input_lat", json::fixed_t{location.latlng_.lat(), 6}},
-                         {"input_lon", json::fixed_t{location.latlng_.lng(), 6}},
-                         {"radius", static_cast<uint64_t>(location.radius_)}});
-  json->emplace("istransit", istransit);
-  return json;
+  writer.set_precision(tyr::kCoordinatePrecision);
+  writer.start_object();
+  writer("input_lat", location.latlng_.lat());
+  writer("input_lon", location.latlng_.lng());
+  writer("radius", static_cast<uint64_t>(location.radius_));
+  writer("istransit", istransit);
+  writer.end_object();
 }
 } // namespace
 
@@ -26,13 +28,13 @@ namespace tyr {
 std::string serializeTransitAvailable(const Api& /* request */,
                                       const std::vector<baldr::Location>& locations,
                                       const std::unordered_set<baldr::Location>& found) {
-  auto json = json::array({});
+  rapidjson::writer_wrapper_t writer(4096);
+  writer.start_array();
   for (const auto& location : locations) {
-    json->emplace_back(serialize(location, found.find(location) != found.cend()));
+    serialize(writer, location, found.find(location) != found.cend());
   }
-  std::stringstream ss;
-  ss << *json;
-  return ss.str();
+  writer.end_array();
+  return writer.get_buffer();
 }
 
 } // namespace tyr

--- a/src/tyr/transit_available_serializer.cc
+++ b/src/tyr/transit_available_serializer.cc
@@ -1,5 +1,5 @@
-#include "baldr/json.h"
 #include "baldr/pathlocation.h"
+#include "baldr/rapidjson_utils.h"
 #include "tyr/serializers.h"
 
 #include <cstdint>


### PR DESCRIPTION
# Issue

This PR addresses [issue #5190](https://github.com/valhalla/valhalla/issues/5190) by migrating the `transit_available `API serializer from the legacy `json::` implementation to `rapidjson` for improved performance and consistency.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [ ] If you made changes to a translation file, [update transifex](docs/docs/locales.md) too

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
