### PR TITLE
Introduce generic level change maneuver type

### DIFF
--- a/locales/ar-SA.json
+++ b/locales/ar-SA.json
@@ -2309,6 +2309,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Enter the building.",

--- a/locales/bg-BG.json
+++ b/locales/bg-BG.json
@@ -2309,6 +2309,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Enter the building.",

--- a/locales/ca-ES.json
+++ b/locales/ca-ES.json
@@ -2309,6 +2309,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Entra a l'edifici.",

--- a/locales/cs-CZ.json
+++ b/locales/cs-CZ.json
@@ -2309,6 +2309,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Enter the building.",

--- a/locales/da-DK.json
+++ b/locales/da-DK.json
@@ -2309,6 +2309,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Enter the building.",

--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -2309,6 +2309,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "In das Gebäude eintreten.",

--- a/locales/el-GR.json
+++ b/locales/el-GR.json
@@ -2309,6 +2309,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Enter the building.",

--- a/locales/en-AU.json
+++ b/locales/en-AU.json
@@ -2309,6 +2309,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Enter the building.",

--- a/locales/en-GB.json
+++ b/locales/en-GB.json
@@ -2307,6 +2307,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Enter the building.",

--- a/locales/en-US-x-pirate.json
+++ b/locales/en-US-x-pirate.json
@@ -2309,6 +2309,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Enter the building.",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -2309,6 +2309,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Enter the building.",

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -2309,6 +2309,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Entre al edificio.",

--- a/locales/et-EE.json
+++ b/locales/et-EE.json
@@ -2309,6 +2309,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Sisene hoonesse.",

--- a/locales/fi-FI.json
+++ b/locales/fi-FI.json
@@ -2309,6 +2309,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Enter the building.",

--- a/locales/fr-FR.json
+++ b/locales/fr-FR.json
@@ -2309,6 +2309,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Entrez dans le bâtiment.",

--- a/locales/hi-IN.json
+++ b/locales/hi-IN.json
@@ -2309,6 +2309,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Enter the building.",

--- a/locales/hu-HU.json
+++ b/locales/hu-HU.json
@@ -2309,6 +2309,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Lépjen be az épületbe.",

--- a/locales/it-IT.json
+++ b/locales/it-IT.json
@@ -2309,6 +2309,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Enter the building.",

--- a/locales/ja-JP.json
+++ b/locales/ja-JP.json
@@ -2309,6 +2309,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Enter the building.",

--- a/locales/mn-MN.json
+++ b/locales/mn-MN.json
@@ -2309,6 +2309,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Барилга руу ор.",

--- a/locales/nb-NO.json
+++ b/locales/nb-NO.json
@@ -2309,6 +2309,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Enter the building.",

--- a/locales/nl-NL.json
+++ b/locales/nl-NL.json
@@ -2309,6 +2309,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Ga het gebouw in.",

--- a/locales/pl-PL.json
+++ b/locales/pl-PL.json
@@ -2309,6 +2309,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Wejdź do budynku.",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -2307,6 +2307,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Enter the building.",

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -2309,6 +2309,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Enter the building.",

--- a/locales/ro-RO.json
+++ b/locales/ro-RO.json
@@ -2309,6 +2309,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Enter the building.",

--- a/locales/ru-RU.json
+++ b/locales/ru-RU.json
@@ -2309,6 +2309,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Войдите в здание.",

--- a/locales/sk-SK.json
+++ b/locales/sk-SK.json
@@ -2309,6 +2309,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Vojdite do budovy.",

--- a/locales/sl-SI.json
+++ b/locales/sl-SI.json
@@ -2309,6 +2309,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Enter the building.",

--- a/locales/sv-SE.json
+++ b/locales/sv-SE.json
@@ -2309,6 +2309,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Enter the building.",

--- a/locales/tr-TR.json
+++ b/locales/tr-TR.json
@@ -2309,6 +2309,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Enter the building.",

--- a/locales/uk-UA.json
+++ b/locales/uk-UA.json
@@ -2309,6 +2309,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Увійдіть в будівлю.",

--- a/locales/vi-VN.json
+++ b/locales/vi-VN.json
@@ -2309,6 +2309,16 @@
         ]
       }
     },
+    "level_change": {
+      "phrases": {
+        "0": "Change to <LEVEL>."
+      },
+      "example_phrases": {
+        "0": [
+          "Change to Level 2."
+        ]
+      }
+    },
     "enter_building": {
       "phrases": {
         "0": "Đi vào toà nhà.",

--- a/proto/directions.proto
+++ b/proto/directions.proto
@@ -83,6 +83,7 @@ message DirectionsLeg {
       kEscalatorEnter = 41;
       kBuildingEnter = 42;
       kBuildingExit = 43;
+      kGenericLevelChange = 44;
     }
 
     enum BssManeuverType{

--- a/src/odin/maneuver.cc
+++ b/src/odin/maneuver.cc
@@ -135,10 +135,10 @@ Maneuver::Maneuver()
       roundabout_exit_turn_degree_(0), roundabout_exit_shape_index_(0),
       has_collapsed_small_end_ramp_fork_(false), has_collapsed_merge_maneuver_(false),
       has_long_street_name_(false), elevator_(false), indoor_steps_(false), escalator_(false),
-      building_enter_(false), building_exit_(false), end_level_ref_(""), transit_connection_(false),
-      travel_mode_(TravelMode::kDrive), rail_(false), bus_(false), vehicle_type_(VehicleType::kCar),
-      pedestrian_type_(PedestrianType::kFoot), bicycle_type_(BicycleType::kRoad),
-      transit_type_(TransitType::kRail),
+      building_enter_(false), building_exit_(false), has_level_changes_(false), end_level_ref_(""),
+      transit_connection_(false), travel_mode_(TravelMode::kDrive), rail_(false), bus_(false),
+      vehicle_type_(VehicleType::kCar), pedestrian_type_(PedestrianType::kFoot),
+      bicycle_type_(BicycleType::kRoad), transit_type_(TransitType::kRail),
       bss_maneuver_type_(DirectionsLeg_Maneuver_BssManeuverType_kNoneAction) {
   street_names_ = std::make_unique<StreetNames>();
   begin_street_names_ = std::make_unique<StreetNames>();
@@ -1226,6 +1226,13 @@ const std::vector<RouteLandmark>& Maneuver::landmarks() const {
 void Maneuver::set_landmarks(const std::vector<RouteLandmark>& landmarks) {
   landmarks_ = landmarks;
 }
+
+const bool Maneuver::has_level_changes() const {
+  return has_level_changes_;
+};
+void Maneuver::set_has_level_changes(const bool has_level_changes) {
+  has_level_changes_ = has_level_changes;
+};
 
 #ifdef LOGGING_LEVEL_TRACE
 std::string Maneuver::ToString() const {

--- a/src/odin/narrative_dictionary.cc
+++ b/src/odin/narrative_dictionary.cc
@@ -336,6 +336,10 @@ void NarrativeDictionary::Load(const boost::property_tree::ptree& narrative_pt) 
   LOG_TRACE("Populate exit_building_subset");
   // Populate exit_building_subset
   Load(exit_building_subset, narrative_pt.get_child(kExitBuildingKey));
+
+  LOG_TRACE("Populate level_change_subset");
+  // Populate level_change_subset
+  Load(level_change_subset, narrative_pt.get_child(kLevelChangeKey));
 }
 
 void NarrativeDictionary::Load(PhraseSet& phrase_handle,

--- a/src/odin/narrativebuilder.cc
+++ b/src/odin/narrativebuilder.cc
@@ -508,6 +508,9 @@ void NarrativeBuilder::Build(std::list<Maneuver>& maneuvers) {
         maneuver.set_instruction(FormExitBuildingInstruction(maneuver));
         break;
       }
+      case DirectionsLeg_Maneuver_Type_kGenericLevelChange:
+        maneuver.set_instruction(FormGenericLevelChangeInstruction(maneuver));
+        break;
       case DirectionsLeg_Maneuver_Type_kContinue:
       default: {
         if (maneuver.has_node_type()) {
@@ -4242,6 +4245,29 @@ std::string NarrativeBuilder::FormStepsInstruction(Maneuver& maneuver) {
 
   // Set instruction to the determined tagged phrase
   instruction = dictionary_.steps_subset.phrases.at(std::to_string(phrase_id));
+
+  // Replace phrase tags with values
+  boost::replace_all(instruction, kLevelTag, end_level);
+
+  return instruction;
+}
+
+std::string NarrativeBuilder::FormGenericLevelChangeInstruction(Maneuver& maneuver) {
+  // "0": "Change to <LEVEL>",
+
+  std::string instruction;
+  instruction.reserve(kInstructionInitialCapacity);
+
+  // Determine which phrase to use
+  uint8_t phrase_id = 0;
+  std::string end_level;
+
+  if (!maneuver.end_level_ref().empty()) {
+    end_level = maneuver.end_level_ref();
+  }
+
+  // Set instruction to the determined tagged phrase
+  instruction = dictionary_.level_change_subset.phrases.at(std::to_string(phrase_id));
 
   // Replace phrase tags with values
   boost::replace_all(instruction, kLevelTag, end_level);

--- a/valhalla/odin/maneuver.h
+++ b/valhalla/odin/maneuver.h
@@ -409,6 +409,9 @@ public:
   const std::vector<RouteLandmark>& landmarks() const;
   void set_landmarks(const std::vector<RouteLandmark>& landmarks);
 
+  const bool has_level_changes() const;
+  void set_has_level_changes(const bool has_level_changes);
+
 #ifdef LOGGING_LEVEL_TRACE
   std::string ToString() const;
 
@@ -496,6 +499,7 @@ protected:
   bool escalator_;
   bool building_enter_;
   bool building_exit_;
+  bool has_level_changes_;
   std::string end_level_ref_;
 
   // Landmarks correlated to the maneuver

--- a/valhalla/odin/narrative_dictionary.h
+++ b/valhalla/odin/narrative_dictionary.h
@@ -83,6 +83,7 @@ constexpr auto kEscalatorKey = "instructions.escalator";
 constexpr auto kEnterBuildingKey = "instructions.enter_building";
 constexpr auto kExitBuildingKey = "instructions.exit_building";
 constexpr auto kPosixLocaleKey = "posix_locale";
+constexpr auto kLevelChangeKey = "instructions.level_change";
 
 // Variable keys
 constexpr auto kPhrasesKey = "phrases";
@@ -401,6 +402,9 @@ public:
 
   // Escalator
   PhraseSet escalator_subset;
+
+  // Level Change
+  PhraseSet level_change_subset;
 
   // Enter Building
   EnterBuildingSubset enter_building_subset;

--- a/valhalla/odin/narrativebuilder.h
+++ b/valhalla/odin/narrativebuilder.h
@@ -420,6 +420,8 @@ protected:
 
   std::string FormExitBuildingInstruction(Maneuver& maneuver);
 
+  std::string FormGenericLevelChangeInstruction(Maneuver& maneuver);
+
   /////////////////////////////////////////////////////////////////////////////
   /**
    * Returns the transit stop count label based on the value of the specified


### PR DESCRIPTION
# Issue

Valhalla currently produces instructions that prompt level changes only for a few types of edges (notably steps and escalators). These are not all the level changing linear features, though, and I think the user would benefit from having a generic level change instructions when there is a level change somewhere along the way (could be a ramp inside a parking garage, a wheelchair ramp, a bicycle ramp, or some other type of incline). Instead of having a fallback continue instruction, or even worse, having the maneuver be combined with whatever comes before, it would be more meaningful to communicate this level change in the broadest way possible (i.e. have a generic instruction that says "Move to level so and so"). 

This PR is an attempt at just that. This was fairly easy to implement, and I am open to discuss whether it would be better to simply identify all the other types of linear features that could change levels, but I feel like that might be easier said than done. We could always add more specific instructions in the future for different types of ramps, but this gives at least some base. Also, we would have to sacrifice some of the remaining values in `baldr::Use`, and since there are only a handful left, I wouldn't want to crowd them. 

   

## Tasklist

 - [x] Add tests
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to a translation file, [update transifex](docs/docs/locales.md) too

