### PR TITLE
Fix missed argument in `BDEdgeLabel` c-tor in bidir a*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
    * FIXED: fix: `std::terminate` on unsupported request format for some actions [#5387](https://github.com/valhalla/valhalla/pull/5387)
    * FIXED: python installation issue in docker image [#5424](https://github.com/valhalla/valhalla/pull/5424)
    * FIXED: uk-UA translation issue with issue with "approach_verbal_alert" [#5182](https://github.com/valhalla/valhalla/pull/5182)
+   * FIXED: Missing argument in `BDEdgeLabel` constructor [#5444](https://github.com/valhalla/valhalla/pull/5444)
 * **Enhancement**
    * ADDED: Consider smoothness in all profiles that use surface [#4949](https://github.com/valhalla/valhalla/pull/4949)
    * ADDED: costing parameters to exclude certain edges `exclude_tolls`, `exclude_bridges`, `exclude_tunnels`, `exclude_highways`, `exclude_ferries`. They need to be enabled in the config with `service_limits.allow_hard_exclusions`. Also added location search filters `exclude_ferry` and `exclude_toll` to complement these changes. [#4524](https://github.com/valhalla/valhalla/pull/4524)

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -1125,7 +1125,7 @@ void BidirectionalAStar::SetDestination(GraphReader& graphreader,
                                      dist, mode_, c, !opp_dir_edge->not_thru(),
                                      !(costing_->IsClosed(directededge, tile)),
                                      static_cast<bool>(flow_sources & kDefaultFlowMask),
-                                     sif::InternalTurn::kNoTurn, kInvalidRestriction,
+                                     sif::InternalTurn::kNoTurn, kInvalidRestriction, 0,
                                      directededge->destonly() ||
                                          (costing_->is_hgv() && directededge->destonly_hgv()),
                                      directededge->forwardaccess() & kTruckAccess);


### PR DESCRIPTION
Found this while working on #5370. These long constructors that take lots of defaulted int/bool args are super dangerous, and the fact that `BDEdgeLabel` has like 3 similar overloads makes it even worse :smile: This passed `destonly` as the path ID, and `truck_access` as `destonly`. 