### PR TITLE
chore: new badge for linux jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Valhalla is an open source routing engine and accompanying libraries for use wit
 
 | Linux | macOS & Windows | Code Coverage |
 | ----- | --------------- | ------------- |
-| [![Circle CI](https://circleci.com/gh/valhalla/valhalla/tree/master.svg?style=svg)](https://circleci.com/gh/valhalla/valhalla/tree/master) | [![Windows & macOS CI](https://github.com/valhalla/valhalla/actions/workflows/osx_win_python_builds.yml/badge.svg)](https://github.com/valhalla/valhalla/actions/workflows/osx_win_python_builds.yml) | [![codecov](https://codecov.io/gh/valhalla/valhalla/branch/master/graph/badge.svg)](https://codecov.io/gh/valhalla/valhalla) |
+| [![Build Linux](https://github.com/valhalla/valhalla/actions/workflows/linux.yml/badge.svg)](https://github.com/valhalla/valhalla/actions/workflows/linux.yml) | [![Windows & macOS CI](https://github.com/valhalla/valhalla/actions/workflows/osx_win_python_builds.yml/badge.svg)](https://github.com/valhalla/valhalla/actions/workflows/osx_win_python_builds.yml) | [![codecov](https://codecov.io/gh/valhalla/valhalla/branch/master/graph/badge.svg)](https://codecov.io/gh/valhalla/valhalla) |
 
 
 ## License


### PR DESCRIPTION
Also not sure how to get rid of the circleci failure notices. I thought merging to master now and removing all circleci jobs from branch protection rule for `master` would do the job, but it's still showing up in master. I don't see what's still talking to circleci.. But maybe I first merged and then removed those jobs from the settings. Let's see after this merged.

@kevinkreiser any idea?