### PR TITLE
chore: use hetzner S3 bucket for caching GHA artifacts

### DIFF
--- a/.github/workflows/clean_cache.yml
+++ b/.github/workflows/clean_cache.yml
@@ -19,15 +19,15 @@ jobs:
       - name: Remove matching cache objects
         run: |
           # filter objects to ones matching this branch
-          all_objects=$(mc ls --quiet gha-cache/gha-cache | awk '{ print $6 }')
+          all_objects=$(mc ls --quiet hetzner/gha-cache | awk '{ print $6 }')
           filtered=()
           # -n $line: if there's no \newline at the end, read will miss the last line
           echo $all_objects | while read -r line || [ -n "$line" ]; do
-            if [[ "$line" == *"${{ github.head_ref }}" ]]; then
+            if [[ "$line" =~ "^.*{{ github.head_ref }}[-[0-9]*]?$" ]]; then
               filtered+=($line)
             fi
           done
 
           for entry in $filtered; do
-            mc rm gha-cache/gha-cache/${entry} || echo "couldn't find $entry"
+            mc rm hetzner/gha-cache/${entry} || echo "couldn't find $entry"
           done

--- a/.github/workflows/clean_cache.yml
+++ b/.github/workflows/clean_cache.yml
@@ -29,5 +29,5 @@ jobs:
           done
 
           for entry in $filtered; do
-            mc rm hetzner/gha-cache/${entry} || echo "couldn't find $entry"
+            mc rm --recursive --force hetzner/gha-cache/${entry} || echo "couldn't find $entry"
           done

--- a/.github/workflows/clean_cache.yml
+++ b/.github/workflows/clean_cache.yml
@@ -1,0 +1,33 @@
+on:
+  pull_request:
+    branches: 
+      - master
+    types:
+      - closed
+
+jobs:
+  clear_cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install and setup mc client
+        run: |
+          wget https://dl.min.io/client/mc/release/linux-amd64/mc
+          chmod +x mc
+          mc --help
+          mc alias set hetzner https://hel1.your-objectstorage.com {{ secrets.HETZNER_S3_ACCESS_KEY }} ${{ secrets.HETZNER_S3_ACCESS_SECRET }}
+      
+      - name: Remove matching cache objects
+        run: |
+          # filter objects to ones matching this branch
+          all_objects=$(mc ls --quiet gha-cache/gha-cache | awk '{ print $6 }')
+          filtered=()
+          # -n $line: if there's no \newline at the end, read will miss the last line
+          echo $all_objects | while read -r line || [ -n "$line" ]; do
+            if [[ "$line" == *"${{ github.head_ref }}" ]]; then
+              filtered+=($line)
+            fi
+          done
+
+          for entry in $filtered; do
+            mc rm gha-cache/gha-cache/${entry} || echo "couldn't find $entry"
+          done

--- a/.github/workflows/clean_cache.yml
+++ b/.github/workflows/clean_cache.yml
@@ -13,13 +13,13 @@ jobs:
         run: |
           wget https://dl.min.io/client/mc/release/linux-amd64/mc
           chmod +x mc
-          mc --help
-          mc alias set hetzner https://hel1.your-objectstorage.com {{ secrets.HETZNER_S3_ACCESS_KEY }} ${{ secrets.HETZNER_S3_ACCESS_SECRET }}
+          ./mc --help
+          ./mc alias set hetzner https://hel1.your-objectstorage.com {{ secrets.HETZNER_S3_ACCESS_KEY }} ${{ secrets.HETZNER_S3_ACCESS_SECRET }}
       
       - name: Remove matching cache objects
         run: |
           # filter objects to ones matching this branch
-          all_objects=$(mc ls --quiet hetzner/gha-cache | awk '{ print $6 }')
+          all_objects=$(./mc ls --quiet hetzner/gha-cache | awk '{ print $6 }')
           filtered=()
           # -n $line: if there's no \newline at the end, read will miss the last line
           echo $all_objects | while read -r line || [ -n "$line" ]; do
@@ -29,5 +29,5 @@ jobs:
           done
 
           for entry in $filtered; do
-            mc rm --recursive --force hetzner/gha-cache/${entry} || echo "couldn't find $entry"
+            ./mc rm --recursive --force hetzner/gha-cache/${entry} || echo "couldn't find $entry"
           done

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -78,10 +78,14 @@ jobs:
           echo "TIMESTAMP=$(date +"%s")" >> $GITHUB_ENV
           echo "CCACHE_DIR=$(ccache --get-config cache_dir)" >> $GITHUB_ENV
 
-      - name: Restore cache
+      - name: Restore ccache
+        uses: tespkg/actions-cache/restore@v1
         id: cache-ccache-restore
-        uses: actions/cache/restore@v4
         with:
+          endpoint: hel1.your-objectstorage.com
+          accessKey: ${{ secrets.HETZNER_S3_ACCESS_KEY }}
+          secretKey: ${{ secrets.HETZNER_S3_ACCESS_SECRET }}
+          bucket: gha-cache
           path: /home/runner/.cache/ccache
           key: ccache-release-linux-x86_64-${{ env.BRANCH_NAME }}
           restore-keys: |
@@ -97,10 +101,15 @@ jobs:
           make -C build -j$(nproc)
           make -C build -j$(nproc) utrecht_tiles
           make -C build -j$(nproc) tests gurka
-      
-      - name: Save cache
-        uses: actions/cache/save@v4
+
+      - name: Save ccache
+        if: always()
+        uses: tespkg/actions-cache/save@v1
         with:
+          endpoint: hel1.your-objectstorage.com
+          accessKey: ${{ secrets.HETZNER_S3_ACCESS_KEY }}
+          secretKey: ${{ secrets.HETZNER_S3_ACCESS_SECRET }}
+          bucket: gha-cache
           path: /home/runner/.cache/ccache
           key: ccache-release-linux-x86_64-${{ env.BRANCH_NAME }}-${{ env.TIMESTAMP }}
 
@@ -136,10 +145,14 @@ jobs:
           echo "TIMESTAMP=$(date +"%s")" >> $GITHUB_ENV
           echo "CCACHE_DIR=$(ccache --get-config cache_dir)" >> $GITHUB_ENV
 
-      - name: Restore cache
+      - name: Restore ccache
+        uses: tespkg/actions-cache/restore@v1
         id: cache-ccache-restore
-        uses: actions/cache/restore@v4
         with:
+          endpoint: hel1.your-objectstorage.com
+          accessKey: ${{ secrets.HETZNER_S3_ACCESS_KEY }}
+          secretKey: ${{ secrets.HETZNER_S3_ACCESS_SECRET }}
+          bucket: gha-cache
           path: /home/runner/.cache/ccache
           key: ccache-debug-linux-x86_64-${{ env.BRANCH_NAME }}
           restore-keys: |
@@ -156,10 +169,15 @@ jobs:
           make -C build -j$(nproc)
           make -C build -j$(nproc) utrecht_tiles
           make -C build -j$(nproc) tests gurka
-      
-      - name: Save cache
-        uses: actions/cache/save@v4
+
+      - name: Save ccache
+        if: always()
+        uses: tespkg/actions-cache/save@v1
         with:
+          endpoint: hel1.your-objectstorage.com
+          accessKey: ${{ secrets.HETZNER_S3_ACCESS_KEY }}
+          secretKey: ${{ secrets.HETZNER_S3_ACCESS_SECRET }}
+          bucket: gha-cache
           path: /home/runner/.cache/ccache
           key: ccache-debug-linux-x86_64-${{ env.BRANCH_NAME }}-${{ env.TIMESTAMP }}
       
@@ -206,10 +224,14 @@ jobs:
           echo "TIMESTAMP=$(date +"%s")" >> $GITHUB_ENV
           echo "CCACHE_DIR=$(ccache --get-config cache_dir)" >> $GITHUB_ENV
 
-      - name: Restore cache
+      - name: Restore ccache
+        uses: tespkg/actions-cache/restore@v1
         id: cache-ccache-restore
-        uses: actions/cache/restore@v4
         with:
+          endpoint: hel1.your-objectstorage.com
+          accessKey: ${{ secrets.HETZNER_S3_ACCESS_KEY }}
+          secretKey: ${{ secrets.HETZNER_S3_ACCESS_SECRET }}
+          bucket: gha-cache
           path: /home/runner/.cache/ccache
           key: ccache-release-linux-aarch64-${{ env.BRANCH_NAME }}
           restore-keys: |
@@ -223,10 +245,15 @@ jobs:
           make -C build -j$(nproc)
           # make -C build -j$(nproc) utrecht_tiles
           make -C build -j$(nproc) gurka
-      
-      - name: Save cache
-        uses: actions/cache/save@v4
+
+      - name: Save ccache
+        if: always()
+        uses: tespkg/actions-cache/save@v1
         with:
+          endpoint: hel1.your-objectstorage.com
+          accessKey: ${{ secrets.HETZNER_S3_ACCESS_KEY }}
+          secretKey: ${{ secrets.HETZNER_S3_ACCESS_SECRET }}
+          bucket: gha-cache
           path: /home/runner/.cache/ccache
           key: ccache-release-linux-aarch64-${{ env.BRANCH_NAME }}-${{ env.TIMESTAMP }}
       

--- a/.github/workflows/osx_win_python_builds.yml
+++ b/.github/workflows/osx_win_python_builds.yml
@@ -353,7 +353,7 @@ jobs:
 
       - name: Save vcpkg packages (always, to avoid redundant rebuilds)
         if: always()
-        uses: tespkg/actions-cache/save@v3
+        uses: tespkg/actions-cache/save@v1
         with:
           accessKey: ${{ secrets.HETZNER_S3_ACCESS_KEY }}
           secretKey: ${{ secrets.HETZNER_S3_ACCESS_SECRET }}

--- a/.github/workflows/osx_win_python_builds.yml
+++ b/.github/workflows/osx_win_python_builds.yml
@@ -292,10 +292,26 @@ jobs:
 
       # make sure we save vcpkg packages even if build fails
       # note, we don't use vcpkg "command line" mode, but "cmake manifest" mode
+      # - name: Restore vcpkg packages
+      #   id: vcpkg-restore
+      #   uses: actions/cache/restore@v3
+      #   with:
+      #     key: vcpkg=${{ env.VCPKG_VERSION }}-msvc=${{ env.MSVC_VERSION }}-json=${{ hashFiles('vcpkg.json') }}
+      #     path: |
+      #       vcpkg/*
+      #       !vcpkg/downloads
+      #       !vcpkg/docs
+      #       !vcpkg/buildtrees
+      #       vcpkg/downloads/tools
+
       - name: Restore vcpkg packages
+        uses: tespkg/actions-cache/restore@v1
         id: vcpkg-restore
-        uses: actions/cache/restore@v3
         with:
+          accessKey: ${{ secrets.HETZNER_S3_ACCESS_KEY }}
+          secretKey: ${{ secrets.HETZNER_S3_ACCESS_SECRET }}
+          bucket: gha-cache
+          # actions/cache compatible properties: https://github.com/actions/cache
           key: vcpkg=${{ env.VCPKG_VERSION }}-msvc=${{ env.MSVC_VERSION }}-json=${{ hashFiles('vcpkg.json') }}
           path: |
             vcpkg/*
@@ -337,8 +353,11 @@ jobs:
 
       - name: Save vcpkg packages (always, to avoid redundant rebuilds)
         if: always()
-        uses: actions/cache/save@v3
+        uses: tespkg/actions-cache/save@v3
         with:
+          accessKey: ${{ secrets.HETZNER_S3_ACCESS_KEY }}
+          secretKey: ${{ secrets.HETZNER_S3_ACCESS_SECRET }}
+          bucket: gha-cache
           key: ${{ steps.vcpkg-restore.outputs.cache-primary-key }}
           path: |
             vcpkg/*

--- a/.github/workflows/osx_win_python_builds.yml
+++ b/.github/workflows/osx_win_python_builds.yml
@@ -308,6 +308,7 @@ jobs:
         uses: tespkg/actions-cache/restore@v1
         id: vcpkg-restore
         with:
+          endpoint: hel1.your-objectstorage.com
           accessKey: ${{ secrets.HETZNER_S3_ACCESS_KEY }}
           secretKey: ${{ secrets.HETZNER_S3_ACCESS_SECRET }}
           bucket: gha-cache
@@ -355,6 +356,7 @@ jobs:
         if: always()
         uses: tespkg/actions-cache/save@v1
         with:
+          endpoint: hel1.your-objectstorage.com
           accessKey: ${{ secrets.HETZNER_S3_ACCESS_KEY }}
           secretKey: ${{ secrets.HETZNER_S3_ACCESS_SECRET }}
           bucket: gha-cache

--- a/.github/workflows/osx_win_python_builds.yml
+++ b/.github/workflows/osx_win_python_builds.yml
@@ -97,10 +97,15 @@ jobs:
           fi
           echo "VALHALLA_RELEASE_PKG=${VALHALLA_RELEASE_PKG}" >> $GITHUB_ENV
 
-      - name: Restore cache
+      - name: Restore ccache
+        uses: tespkg/actions-cache/restore@v1
         id: cache-ccache-restore
-        uses: actions/cache/restore@v4
         with:
+          endpoint: hel1.your-objectstorage.com
+          accessKey: ${{ secrets.HETZNER_S3_ACCESS_KEY }}
+          secretKey: ${{ secrets.HETZNER_S3_ACCESS_SECRET }}
+          bucket: gha-cache
+          # actions/cache compatible properties: https://github.com/actions/cache
           path: /home/runner/.cache/ccache
           key: ccache-manylinux_2_28_x86_64
 
@@ -114,20 +119,19 @@ jobs:
             VALHALLA_BUILD_BIN_DIR="build_manylinux"
           # uncomment when testing
           # CIBW_BUILD: cp313-*
+      
+      # TODO: probably need to delete the key first, since it's just a single key
 
-      - name: Delete cache to save the latest
-        run: |
-          KEY="${{ steps.cache-ccache-restore.outputs.cache-primary-key }}"
-          gh cache delete ${KEY} || true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Save cache
+      - name: Save ccache
         if: always()
-        uses: actions/cache/save@v4
+        uses: tespkg/actions-cache/save@v1
         with:
+          endpoint: hel1.your-objectstorage.com
+          accessKey: ${{ secrets.HETZNER_S3_ACCESS_KEY }}
+          secretKey: ${{ secrets.HETZNER_S3_ACCESS_SECRET }}
+          bucket: gha-cache
           path: /home/runner/.cache/ccache
-          key: ${{ steps.cache-ccache-restore.outputs.cache-primary-key }}
+          key: ccache-manylinux_2_28_x86_64
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -174,14 +178,19 @@ jobs:
         run: echo "version_modifier=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Restore ccache
+        uses: tespkg/actions-cache/restore@v1
         id: cache-ccache-restore
-        uses: actions/cache/restore@v4
         with:
-          path: ~/Library/Caches/ccache
-          key: ccache-osx-${{ env.VALHALLA_BRANCH }}-v2
+          endpoint: hel1.your-objectstorage.com
+          accessKey: ${{ secrets.HETZNER_S3_ACCESS_KEY }}
+          secretKey: ${{ secrets.HETZNER_S3_ACCESS_SECRET }}
+          bucket: gha-cache
+          # actions/cache compatible properties: https://github.com/actions/cache
+          key: ccache-osx-${{ env.VALHALLA_BRANCH }}
           restore-keys: |
             ccache-osx-master
             ccache-osx-
+          path: ~/Library/Caches/ccache
 
       - name: Configure CMake
         run: cmake -B build -DENABLE_SINGLE_FILES_WERROR=OFF -DENABLE_GDAL=ON -DVALHALLA_VERSION_MODIFIFER=${{ steps.vars.outputs.version_modifier || '' }}
@@ -200,10 +209,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Save ccache
-        uses: actions/cache/save@v4
+        uses: tespkg/actions-cache/save@v1
         with:
+          endpoint: hel1.your-objectstorage.com
+          accessKey: ${{ secrets.HETZNER_S3_ACCESS_KEY }}
+          secretKey: ${{ secrets.HETZNER_S3_ACCESS_SECRET }}
+          bucket: gha-cache
+          key: ccache-osx-${{ env.VALHALLA_BRANCH }}
           path: ~/Library/Caches/ccache
-          key: ${{ steps.cache-ccache-restore.outputs.cache-primary-key }}
 
       - name: Run Tests
         run: make -C build -j$(sysctl -n hw.logicalcpu) check
@@ -289,20 +302,6 @@ jobs:
           echo "set(VCPKG_BUILD_TYPE release)" >> "$TRIPLET_FILE"
           echo "set(VCPKG_DISABLE_COMPILER_TRACKING $VCPKG_DISABLE_COMPILER_TRACKING)" >> "$TRIPLET_FILE"
           cmd.exe /c bootstrap-vcpkg.bat
-
-      # make sure we save vcpkg packages even if build fails
-      # note, we don't use vcpkg "command line" mode, but "cmake manifest" mode
-      # - name: Restore vcpkg packages
-      #   id: vcpkg-restore
-      #   uses: actions/cache/restore@v3
-      #   with:
-      #     key: vcpkg=${{ env.VCPKG_VERSION }}-msvc=${{ env.MSVC_VERSION }}-json=${{ hashFiles('vcpkg.json') }}
-      #     path: |
-      #       vcpkg/*
-      #       !vcpkg/downloads
-      #       !vcpkg/docs
-      #       !vcpkg/buildtrees
-      #       vcpkg/downloads/tools
 
       - name: Restore vcpkg packages
         uses: tespkg/actions-cache/restore@v1

--- a/.github/workflows/osx_win_python_builds.yml
+++ b/.github/workflows/osx_win_python_builds.yml
@@ -358,7 +358,7 @@ jobs:
           accessKey: ${{ secrets.HETZNER_S3_ACCESS_KEY }}
           secretKey: ${{ secrets.HETZNER_S3_ACCESS_SECRET }}
           bucket: gha-cache
-          key: ${{ steps.vcpkg-restore.outputs.cache-primary-key }}
+          key: vcpkg=${{ env.VCPKG_VERSION }}-msvc=${{ env.MSVC_VERSION }}-json=${{ hashFiles('vcpkg.json') }}
           path: |
             vcpkg/*
             !vcpkg/downloads


### PR DESCRIPTION
I'm very sick of this 10 GB cache on Github. No offense, 10 GB for each project is really generous, but it's just not cutting it for big C++ projects. 

I created a S3 bucket on Hetzner, it's basically for free bcs I already use Hetzner storage and 1 TB is included in the base price, I only use 250 GB so far, which is likely not gonna grow too much. When we're past 750 GB, then we have to purge some. But I'll get alerted (I think), the latest on the bill ;)

IMPORTANT caveat: I just realized, because it's using secrets, this won't work on forks. It's generally fine bcs it'll use GHA cache as fallback. @kinkard feel free to switch to the upstream remote:)