### PR TITLE
Add format instructions to contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,14 @@ We appreciate the community picking up and fixing bugs or even implementing new 
 Before opening a PR we'd ask you to format & lint the code:
 
 ```bash
-# installs the pre-commit hook
+# NOTE: This works on x86_64 Linux, but not much else
 ./scripts/format.sh
+# If you're developing on Apple Silicon, an ARM-based Linux box,
+# or anything else that doesn't have support for the formatting tools,
+# You can run it in docker like this (note the --platform flag!):
+docker run --rm --platform linux/amd64 -v "$(pwd)":/data -w /data python:latest bash -c "apt-get update && apt-get install -y sudo && ./scripts/format.sh && git status"
+
+# Run the pre-commit hooks
 pre-commit run --all-files
 
 # optionally run clang-tidy


### PR DESCRIPTION
# Issue

The current stack of formatting tools requires a highly specific configuration, which is probably partially responsible for many PRs getting stalled ;) I finally found the right Docker incantation to get this to work.

## Tasklist

All are N/A for this PR

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [ ] If you made changes to a translation file, [update transifex](docs/docs/locales.md) too

## Requirements / Relations

N/A