### PR TITLE
feat: add a HEAD function to the tilegetter/curler etc

### DIFF
--- a/src/baldr/curler.cc
+++ b/src/baldr/curler.cc
@@ -79,11 +79,31 @@ struct curler_t::pimpl_t {
                 "Failed to disable host verification ");
   }
 
+  HEAD_response_t head(const std::string& url, header_mask_t header_mask) {
+    const bool wants_last_modified = header_mask & tile_getter_t::kHeaderLastModified;
+
+    assert_curl(curl_easy_setopt(connection.get(), CURLOPT_URL, url.c_str()), "Failed to set URL for HEAD");
+    assert_curl(curl_easy_setopt(connection.get(), CURLOPT_NOBODY, 1L), "Failed to set HEAD");  // HEAD request
+    if (wants_last_modified)
+      assert_curl(curl_easy_setopt(connection.get(), CURLOPT_FILETIME, 1L), "Failed to enable last-modified header");
+    
+
+    HEAD_response_t result;
+    assert_curl(curl_easy_perform(connection.get()), "Failed to get URL");
+    // grab the return code & last-modified time
+    curl_easy_getinfo(connection.get(), CURLINFO_RESPONSE_CODE, &result.http_code_);
+    if (wants_last_modified)
+      curl_easy_getinfo(connection.get(), CURLINFO_FILETIME_T, &result.last_modified_time_);
+
+    return result;
+  }
+
   // TODO: retries?
-  std::vector<char> fetch(const std::string& url,
-                          long& http_code,
+  GET_response_t get(const std::string& url,
                           bool gzipped,
-                          const curler_t::interrupt_t* interrupt) const {
+                          const interrupt_t* interrupt,
+                          const uint64_t range_offset,
+                          const uint64_t range_size) const {
     if (interrupt) {
       assert_curl(curl_easy_setopt(connection.get(), CURLOPT_XFERINFOFUNCTION, progress_callback),
                   "Failed to set custom progress callback ");
@@ -91,6 +111,14 @@ struct curler_t::pimpl_t {
                   "Failed to set custom progress data");
       assert_curl(curl_easy_setopt(connection.get(), CURLOPT_NOPROGRESS, 0L),
                   "Failed to turn the progress callback on ");
+    }
+
+    // are we doing a range request to load tiles from a tar?
+    if (range_size) {
+      const std::string range =
+          std::to_string(range_offset) + "-" + std::to_string(range_offset + range_size - 1);
+      assert_curl(curl_easy_setopt(connection.get(), CURLOPT_RANGE, range.c_str()),
+                  "Failed to set HTTP Range");
     }
 
     // use gzip compression in any case
@@ -109,13 +137,14 @@ struct curler_t::pimpl_t {
     // set the url
     assert_curl(curl_easy_setopt(connection.get(), CURLOPT_URL, url.c_str()), "Failed to set URL ");
     // set the location of the result
-    std::vector<char> result;
-    assert_curl(curl_easy_setopt(connection.get(), CURLOPT_WRITEDATA, &result),
+    GET_response_t result;
+    std::vector<char> temp;
+    assert_curl(curl_easy_setopt(connection.get(), CURLOPT_WRITEDATA, &temp),
                 "Failed to set write data ");
     // get the url
     assert_curl(curl_easy_perform(connection.get()), "Failed to get URL ");
     // grab the return code
-    curl_easy_getinfo(connection.get(), CURLINFO_RESPONSE_CODE, &http_code);
+    curl_easy_getinfo(connection.get(), CURLINFO_RESPONSE_CODE, &result.http_code_);
     // hand over the results
     return result;
   }
@@ -136,11 +165,16 @@ struct curler_t::pimpl_t {
 curler_t::curler_t(const std::string& user_agent) : pimpl(new pimpl_t(user_agent)) {
 }
 
-std::vector<char> curler_t::operator()(const std::string& url,
-                                       long& http_code,
+curler_t::GET_response_t curler_t::get(const std::string& url,
                                        bool gzipped,
-                                       const curler_t::interrupt_t* interrupt) const {
-  return pimpl->fetch(url, http_code, gzipped, interrupt);
+                                       const curler_t::interrupt_t* interrupt,
+                                       uint64_t range_offset,
+                                       uint64_t range_size) const {
+  return pimpl->get(url, gzipped, interrupt, range_offset, range_size);
+}
+
+curler_t::HEAD_response_t curler_t::head(const std::string& url, header_mask_t header_mask) {
+  return pimpl->head(url, header_mask);
 }
 
 // curler_pool_t

--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -234,9 +234,7 @@ graph_tile_ptr GraphTile::CacheTileURL(const std::string& tile_url,
     return nullptr;
   }
 
-  auto fname = valhalla::baldr::GraphTile::FileSuffix(graphid.Tile_Base(),
-                                                      valhalla::baldr::SUFFIX_NON_COMPRESSED, false);
-  auto result = tile_getter->get(baldr::make_single_point_url(tile_url, fname));
+  tile_getter_t::GET_response_t result;
   if (result.status_ != tile_getter_t::status_code_t::SUCCESS) {
     return nullptr;
   }

--- a/valhalla/baldr/curl_tilegetter.h
+++ b/valhalla/baldr/curl_tilegetter.h
@@ -23,27 +23,32 @@ public:
       : curlers_(pool_size, user_agent), gzipped_(gzipped) {
   }
 
-  using response_t = tile_getter_t::response_t;
-
-  response_t get(const std::string& url) override {
+  GET_response_t get(const std::string& url,
+                 const uint64_t range_offset = 0,
+                 const uint64_t range_size = 0) override {
     scoped_curler_t curler(curlers_);
-    long http_code = 0;
-    auto tile_data = curler.get()(url, http_code, gzipped_, interrupt_);
-    response_t result;
+    auto result = curler.get().get(url, gzipped_, interrupt_, range_offset, range_size);
     // TODO: Check other codes.
-    if (http_code == 200) {
-      result.bytes_ = std::move(tile_data);
+    if (result.http_code_ == 200 || result.http_code_ == 206) {
       result.status_ = tile_getter_t::status_code_t::SUCCESS;
     }
 
     return result;
   }
 
+  HEAD_response_t head(const std::string& url, header_mask_t header_mask) {
+    scoped_curler_t curler(curlers_);
+    auto result = curler.get().head(url, header_mask);
+    if (result.http_code_ == 200 || result.http_code_ == 206) {
+      result.status_ = tile_getter_t::status_code_t::SUCCESS;
+    }
+    
+    return result;
+  }
+
   bool gzipped() const override {
     return gzipped_;
   }
-
-  using interrupt_t = tile_getter_t::interrupt_t;
 
   void set_interrupt(const interrupt_t* interrupt) override {
     interrupt_ = interrupt;

--- a/valhalla/baldr/curler.h
+++ b/valhalla/baldr/curler.h
@@ -20,19 +20,33 @@ struct curler_t {
   explicit curler_t(const std::string& user_agent);
 
   using interrupt_t = tile_getter_t::interrupt_t;
+  using HEAD_response_t = tile_getter_t::HEAD_response_t;
+  using GET_response_t = tile_getter_t::GET_response_t;
+  using header_mask_t = tile_getter_t::header_mask_t;
+
   /**
    * Fetch a url and return the bytes that we got
    *
    * @param  url                the url to fetch
-   * @param  http_code          the code we got back when fetching
    * @param  gzipped            whether to request for gzip compressed data
    * @param  interrupt          throws if request should be interrupted
+   * @param  range_offset       the HTTP Range start offset
+   * @param  range_size       the HTTP Range size
    * @return the bytes we fetched
    */
-  std::vector<char> operator()(const std::string& url,
-                               long& http_code,
+  GET_response_t get(const std::string& url,
                                bool gzipped,
-                               const interrupt_t* interrupt) const;
+                               const interrupt_t* interrupt,
+                               const uint64_t range_offset,
+                               const uint64_t range_size) const;
+  /**
+   * Performs a HEAD request.
+   * 
+   * @param url         The URL to query
+   * @param http_code   What we got back from the server
+   * @param header_mask Which response headers should be recorded
+   */
+  HEAD_response_t head(const std::string& url, header_mask_t header_mask);
 
   /**
    * Allow only moves and forbid copies. We don't want

--- a/valhalla/baldr/tilegetter.h
+++ b/valhalla/baldr/tilegetter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <string>
 #include <vector>
@@ -19,6 +20,14 @@ public:
   enum class status_code_t { SUCCESS, FAILURE };
 
   /**
+   * Mask for response headers
+   */
+  using header_mask_t = uint16_t;
+  const static header_mask_t kHeaderNone = 0;
+  const static header_mask_t kHeaderLastModified = 1;
+  // const static header_mask_t kHeaderContentLength = 2;
+
+  /**
    * Raw bytes we get as a response.
    */
   using bytes_t = std::vector<char>;
@@ -26,15 +35,25 @@ public:
   /**
    * The result of synchronous operation. Contains raw data and operations result code.
    */
-  struct response_t {
+  struct GET_response_t {
     bytes_t bytes_;
     status_code_t status_ = status_code_t::FAILURE;
+    long http_code_;
+  };
+
+  struct HEAD_response_t {
+    uint64_t last_modified_time_;
+    status_code_t status_ = status_code_t::FAILURE;
+    long http_code_;
   };
 
   /**
    * Makes a synchronous request to the corresponding url and returns response_t object.
    * */
-  virtual response_t get(const std::string& url) = 0;
+  virtual GET_response_t
+  get(const std::string& url, const uint64_t offset = 0, const uint64_t size = 0) = 0;
+
+  virtual HEAD_response_t head(const std::string& url, header_mask_t header_mask) = 0;
 
   /**
    * Whether tiles are with .gz extension.


### PR DESCRIPTION
This adds a HEAD HTTP request method to the `tilegetter`. 

In #5465 I'd like to use the `Last-Modified` response header to identify whether it's attempting to download the right tar file in the right `tile_dir`.