### PR TITLE
Add log rolling support for the file logger

### DIFF
--- a/test/logging.cc
+++ b/test/logging.cc
@@ -89,6 +89,98 @@ TEST(Logging, FileLoggerTest) {
   EXPECT_EQ(custom, 8);
 }
 
+TEST(Logging, FileLoggerRollingTest) {
+  // Clean up any existing test files
+  std::string base_path = "test/rolling_test.log";
+  std::remove(base_path.c_str());
+  for (int i = 1; i <= 5; ++i) {
+    std::remove((base_path + "." + std::to_string(i)).c_str());
+  }
+
+  logging::Configure({{"type", "file"},
+                      {"file_name", base_path},
+                      {"max_file_size", "500"}, // Small size to trigger rolling
+                      {"max_archived_files", "3"}});
+
+  std::string message =
+      "This message should be long enough to trigger log rolling when multiple are written.";
+
+  for (int i = 0; i < 15; ++i) {
+    LOG_INFO("Test message " + std::to_string(i) + ": " + message);
+  }
+
+  // Give logger time to finish writing
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  // Verify rolling occurred
+  bool current_exists = std::filesystem::exists(base_path);
+  EXPECT_TRUE(current_exists) << "Current log file should exist";
+
+  // Check for archived files
+  size_t archived_count = 0;
+  for (int i = 1; i <= 5; ++i) {
+    std::string archived_file = base_path + "." + std::to_string(i);
+    if (std::filesystem::exists(archived_file)) {
+      archived_count++;
+    }
+  }
+
+  EXPECT_GT(archived_count, 0) << "Should have at least one archived file";
+
+  // Clean up
+  std::remove(base_path.c_str());
+  for (int i = 1; i <= 5; ++i) {
+    std::remove((base_path + "." + std::to_string(i)).c_str());
+  }
+}
+
+Test invalid configurations throw exceptions TEST(Logging, FileLoggerInvalidConfigTest1) {
+  EXPECT_THROW(logging::Configure(
+                   {{"type", "file"}, {"file_name", "test.log"}, {"max_file_size", "0"}}),
+               std::runtime_error);
+}
+
+TEST(Logging, FileLoggerInvalidConfigTest2) {
+  EXPECT_THROW(logging::Configure(
+                   {{"type", "file"}, {"file_name", "test.log"}, {"max_file_size", "-100"}}),
+               std::runtime_error);
+}
+
+TEST(Logging, FileLoggerInvalidConfigTest3) {
+  EXPECT_THROW(logging::Configure(
+                   {{"type", "file"}, {"file_name", "test.log"}, {"max_archived_files", "0"}}),
+               std::runtime_error);
+}
+
+TEST(Logging, FileLoggerNoRollingTest) {
+  // Test that no rolling occurs when max_file_size is large
+  std::remove("test/no_rolling_test.log");
+
+  logging::Configure({{"type", "file"},
+                      {"file_name", "test/no_rolling_test.log"},
+                      {"max_file_size", "1000000"}}); // Very large size
+
+  // Write some data
+  for (int i = 0; i < 10; ++i) {
+    LOG_INFO("Test message without rolling: " + std::to_string(i));
+  }
+
+  // Verify no archived files were created
+  EXPECT_TRUE(std::filesystem::exists("test/no_rolling_test.log"));
+
+  bool has_archives = false;
+  for (int i = 1; i <= 3; ++i) {
+    if (std::filesystem::exists("test/no_rolling_test.log." + std::to_string(i))) {
+      has_archives = true;
+      break;
+    }
+  }
+
+  EXPECT_FALSE(has_archives) << "No archived files should exist when under size limit";
+
+  std::remove("test/no_rolling_test.log");
+}
+
 } // namespace
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
# Issue

This PR adds log rolling support for the `FileLogger` class. It addresses this TODO:https://github.com/valhalla/valhalla/blob/49985ad593df413f62dd54555a389670a67f9dcf/src/midgard/logging.cc#L194

Note: we can't reconfigure the current logger, so to make tests pass we must run each test separately. So far I have 2 ideas in mind to be able to run all tests together: 
- make the current logger configurable
- or we can combine all tests in one test

Let me know your thoughts.

## Tasklist

 - [x] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [ ] If you made changes to a translation file, [update transifex](docs/docs/locales.md) too

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
