### PR TITLE
chore(ci): fix osx

### DIFF
--- a/.github/workflows/osx_win_python_builds.yml
+++ b/.github/workflows/osx_win_python_builds.yml
@@ -165,6 +165,9 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # see https://github.com/actions/runner-images/issues/12912
+          brew uninstall cmake
+          brew untap local/pinned
           HOMEBREW_NO_AUTO_UPDATE=1 brew install python autoconf automake protobuf cmake ccache libtool sqlite3 libspatialite luajit curl wget czmq lz4 spatialite-tools unzip boost gdal
           export PATH="$(brew --prefix python)/libexec/bin:$PATH"
           sudo python -m pip install --break-system-packages requests shapely


### PR DESCRIPTION
somehow cmake is installed locally on OSX recenty, see https://github.com/actions/runner-images/issues/12912.

seems now all GHA nodes run on that PR and it's always breaking. trying here what the OP did.