### PR TITLE
added use-curvature costing option for motorcycling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@
    * CHANGED: Use rapidjson for transit_available serializer [#5430](https://github.com/valhalla/valhalla/pull/5430)
    * CHANGED: Switch from CircleCI to Github Actions [#5427](https://github.com/valhalla/valhalla/pull/5427)
    * CHANGED: Use rapidjson for isochrone serializer [#5429](https://github.com/valhalla/valhalla/pull/5429)
+   * ADDED: `use_curvature` costing option for motorcycle costing [TODO](https://github.com/valhalla/valhalla/pull/TODO)
 
 ## Release Date: 2024-10-10 Valhalla 3.5.1
 * **Removed**

--- a/docs/docs/api/turn-by-turn/api-reference.md
+++ b/docs/docs/api/turn-by-turn/api-reference.md
@@ -218,6 +218,7 @@ The following options are available for motorcycle costing:
 | `use_trails` | A riders's desire for adventure in their routes.  This is a range of values from 0 to 1, where 0 will avoid trails, tracks, unclassified or bad surfaces and values towards 1 will tend to avoid major roads and route on secondary roads.  The default value is 0.0. |
 | `shortest` | Changes the metric to quasi-shortest, i.e. purely distance-based costing. Note, this will disable all other costings & penalties. Also note, `shortest` will not disable hierarchy pruning, leading to potentially sub-optimal routes for some costing models. The default is `false`. |
 | `disable_hierarchy_pruning` | Disable hierarchies to calculate the actual optimal route. The default is `false`. **Note:** This could be quite a performance drainer so there is a upper limit of distance. If the upper limit is exceeded, this option will always be `false`. |
+| `use_curvature` | This value indicates the preference for curvy roads over straight roads. 0 indicates no preference of curvy roads, 1 gives the curvature of the road a linear impact on the costing model. Higher values do exponentally increase the preference for curvy roads. Note that high values may even prefer dead end roads over through streets. The default value is 0. |
 
 ##### Pedestrian costing options
 

--- a/proto/options.proto
+++ b/proto/options.proto
@@ -343,6 +343,7 @@ message Costing {
     bool exclude_ferries = 91;
     map<uint32, HierarchyLimits> hierarchy_limits = 92;
     bool ignore_construction = 93;
+    float use_curvature = 94;
   }
 
   oneof has_options {

--- a/src/mjolnir/util.cc
+++ b/src/mjolnir/util.cc
@@ -432,7 +432,7 @@ uint32_t compute_curvature(const std::list<PointLL>& shape) {
     }
   }
   float average_score = (n == 0) ? 0.0f : total_score / n;
-  return average_score > 15.0f ? 15 : static_cast<uint32_t>(average_score);
+  return average_score > kMaxCurvature ? kMaxCurvature : static_cast<uint32_t>(average_score);
 }
 
 // Do the 2 shape vectors match (either direction).

--- a/src/sif/dynamiccost.cc
+++ b/src/sif/dynamiccost.cc
@@ -139,10 +139,9 @@ BaseCostingOptionsConfig::BaseCostingOptionsConfig()
                                                                                   kDefaultUseTracks,
                                                                                   1.f},
       use_living_streets_{0.f, kDefaultUseLivingStreets, 1.f}, use_lit_{0.f, kDefaultUseLit, 1.f},
-      use_curvature_{0.f, kDefaultUseCurvature, kMaxPenalty},
-      closure_factor_{kClosureFactorRange}, exclude_unpaved_(false), exclude_bridges_(false),
-      exclude_tunnels_(false), exclude_tolls_(false), exclude_highways_(false),
-      exclude_ferries_(false), has_excludes_(false),
+      use_curvature_{0.f, kDefaultUseCurvature, kMaxPenalty}, closure_factor_{kClosureFactorRange},
+      exclude_unpaved_(false), exclude_bridges_(false), exclude_tunnels_(false),
+      exclude_tolls_(false), exclude_highways_(false), exclude_ferries_(false), has_excludes_(false),
       exclude_cash_only_tolls_(false), include_hot_{false}, include_hov2_{false}, include_hov3_{
                                                                                       false} {
 }

--- a/src/sif/dynamiccost.cc
+++ b/src/sif/dynamiccost.cc
@@ -72,6 +72,9 @@ constexpr float kMaxLivingStreetFactor = 3.f;
 // min factor to apply when use lit
 constexpr float kMinLitFactor = 1.f;
 
+// min factor to apply when use curvature
+constexpr float kMinCurvatureFactor = 0.01f;
+
 constexpr float kMinFactor = 0.1f;
 constexpr float kMaxFactor = 100000.0f;
 
@@ -96,6 +99,7 @@ constexpr float kDefaultUseRailFerry = 0.4f;     // Default preference of using 
 constexpr float kDefaultUseTracks = 0.5f;        // Default preference of using tracks 0-1
 constexpr float kDefaultUseLivingStreets = 0.1f; // Default preference of using living streets 0-1
 constexpr float kDefaultUseLit = 0.f;            // Default preference of using lit ways 0-1
+constexpr float kDefaultUseCurvature = 0.f;      // Default preference of using curvy streets 0-1
 
 // How much to avoid generic service roads.
 constexpr float kDefaultServiceFactor = 1.0f;
@@ -135,6 +139,7 @@ BaseCostingOptionsConfig::BaseCostingOptionsConfig()
                                                                                   kDefaultUseTracks,
                                                                                   1.f},
       use_living_streets_{0.f, kDefaultUseLivingStreets, 1.f}, use_lit_{0.f, kDefaultUseLit, 1.f},
+      use_curvature_{0.f, kDefaultUseCurvature, kMaxPenalty},
       closure_factor_{kClosureFactorRange}, exclude_unpaved_(false), exclude_bridges_(false),
       exclude_tunnels_(false), exclude_tolls_(false), exclude_highways_(false),
       exclude_ferries_(false), has_excludes_(false),
@@ -387,6 +392,10 @@ void DynamicCost::set_use_lit(float use_lit) {
       use_lit < 0.5f ? kMinLitFactor + 2.f * use_lit : ((kMinLitFactor - 5.f) + 12.f * use_lit);
 }
 
+void DynamicCost::set_use_curvature(float use_curvature) {
+  curvature_factor_ = use_curvature;
+}
+
 void ParseBaseCostOptions(const rapidjson::Value& json,
                           Costing* c,
                           const BaseCostingOptionsConfig& cfg) {
@@ -528,6 +537,9 @@ void ParseBaseCostOptions(const rapidjson::Value& json,
 
   // use_lit
   JSON_PBF_RANGED_DEFAULT_V2(co, cfg.use_lit_, json, "/use_lit", use_lit);
+
+  // use_curvature
+  JSON_PBF_RANGED_DEFAULT_V2(co, cfg.use_curvature_, json, "/use_curvature", use_curvature);
 
   // closure_factor
   JSON_PBF_RANGED_DEFAULT(co, cfg.closure_factor_, json, "/closure_factor", closure_factor);

--- a/src/sif/motorcyclecost.cc
+++ b/src/sif/motorcyclecost.cc
@@ -3,10 +3,10 @@
 #include "baldr/graphconstants.h"
 #include "baldr/nodeinfo.h"
 #include "baldr/rapidjson_utils.h"
+#include "mjolnir/util.h"
 #include "proto_conversions.h"
 #include "sif/costconstants.h"
 #include "sif/osrm_car_duration.h"
-#include "mjolnir/util.h"
 
 #include <cassert>
 
@@ -14,8 +14,8 @@
 #include "test.h"
 #include "worker.h"
 
-#include <random>
 #include <cmath>
+#include <random>
 #endif
 
 using namespace valhalla::midgard;

--- a/src/sif/motorcyclecost.cc
+++ b/src/sif/motorcyclecost.cc
@@ -6,6 +6,7 @@
 #include "proto_conversions.h"
 #include "sif/costconstants.h"
 #include "sif/osrm_car_duration.h"
+#include "mjolnir/util.h"
 
 #include <cassert>
 
@@ -14,10 +15,12 @@
 #include "worker.h"
 
 #include <random>
+#include <cmath>
 #endif
 
 using namespace valhalla::midgard;
 using namespace valhalla::baldr;
+using namespace valhalla::mjolnir;
 
 namespace valhalla {
 namespace sif {
@@ -29,6 +32,8 @@ namespace {
 constexpr float kDefaultUseHighways = 0.5f; // Factor between 0 and 1
 constexpr float kDefaultUseTolls = 0.5f;    // Factor between 0 and 1
 constexpr float kDefaultUseTrails = 0.0f;   // Factor between 0 and 1
+
+constexpr float kDefaultUseCurvature = 0.f;
 
 constexpr Surface kMinimumMotorcycleSurface = Surface::kImpassable;
 
@@ -86,6 +91,7 @@ BaseCostingOptionsConfig GetBaseCostOptsConfig() {
   BaseCostingOptionsConfig cfg{};
   // override defaults
   cfg.disable_rail_ferry_ = true;
+  cfg.use_curvature_.def = kDefaultUseCurvature;
   return cfg;
 }
 
@@ -429,6 +435,8 @@ Cost MotorcycleCost::EdgeCost(const baldr::DirectedEdge* edge,
     // Add a penalty for traversing a closed edge
     factor *= closure_factor_;
   }
+
+  factor *= std::pow(1.f - edge->curvature() / (kMaxCurvature + 0.1f), curvature_factor_);
 
   return {sec * factor, sec};
 }

--- a/test/gurka/test_use_curvature.cc
+++ b/test/gurka/test_use_curvature.cc
@@ -1,0 +1,169 @@
+#include "baldr/graphconstants.h"
+#include "gurka.h"
+#include "test.h"
+
+#include <gtest/gtest.h>
+
+using namespace valhalla;
+
+class UseCurvatureTest : public ::testing::Test {
+protected:
+  static gurka::map map;
+  static gurka::map map_with_dead_end;
+
+  static void SetUpTestSuite() {
+    constexpr double gridsize = 50;
+
+    const std::string ascii_map = R"(
+      A---------G
+      |        /
+      B     E-F
+       \   /
+        C-D
+    )";
+
+    const gurka::ways ways = {{"AG", {{"highway", "primary"}, {"name", "Straight Road"}}},
+                              {"ABCDEFG", {{"highway", "primary"}, {"name", "Twisty Road"}}}};
+
+    /*
+    Why do my tests not work if setup like so?
+    const gurka::ways ways = {{"AG", {{"highway", "primary"}}},
+                              {"AB", {{"highway", "primary"}}},
+                              {"CD", {{"highway", "primary"}}},
+                              {"DE", {{"highway", "primary"}}},
+                              {"EF", {{"highway", "primary"}}},
+                              {"FG", {{"highway", "primary"}}}};
+    */
+
+    const auto layout = gurka::detail::map_to_coordinates(ascii_map, gridsize);
+    map = gurka::buildtiles(layout, ways, {}, {}, "test/data/usecurvature");
+
+    /*
+    Why do these tests not work as expected? (see output attached to tests below)
+    */
+    const std::string ascii_map_with_dead_end = R"(
+      A---------G
+      |        /
+      B     E-F-H     K
+       \   /     \   /
+        C-D       I-J
+    )";
+
+    const gurka::ways ways_with_dead_end = {{"AG", {{"highway", "primary"}, {"name", "Straight Road"}}},
+                                            {"ABCDEFG", {{"highway", "primary"}, {"name", "Twisty Road"}}},
+                                            {"FHIJK", {{"highway", "primary"}, {"name", "Dead End Road"}}}};
+
+    const auto layout_with_dead_end = gurka::detail::map_to_coordinates(ascii_map_with_dead_end, gridsize);
+    map_with_dead_end = gurka::buildtiles(layout_with_dead_end, ways_with_dead_end, {}, {}, "test/data/usecurvature_with_dead_end");
+  }
+
+  inline float getDuration(const valhalla::Api& route) {
+    return route.directions().routes(0).legs(0).summary().time();
+  }
+};
+
+gurka::map UseCurvatureTest::map = {};
+gurka::map UseCurvatureTest::map_with_dead_end = {};
+
+TEST_F(UseCurvatureTest, TestCurvyRoadWithValue0) {
+
+  std::unordered_map<std::string, std::string> options = 
+      {{"/costing_options/motorcycle/use_curvature", "0"}};
+
+  valhalla::Api default_route =
+      gurka::do_action(valhalla::Options::route, map, {"A", "G"}, "motorcycle");
+
+  valhalla::Api curvy_route =
+      gurka::do_action(valhalla::Options::route, map, {"A", "G"}, "motorcycle", options);
+
+  gurka::assert::raw::expect_path(default_route, {"Straight Road"});
+  gurka::assert::raw::expect_path(curvy_route, {"Straight Road"});
+}
+
+TEST_F(UseCurvatureTest, CurvyRoadWithValue1) {
+
+  std::unordered_map<std::string, std::string> options = 
+      {{"/costing_options/motorcycle/use_curvature", "1"}};
+
+  valhalla::Api default_route =
+      gurka::do_action(valhalla::Options::route, map, {"A", "G"}, "motorcycle");
+
+  valhalla::Api curvy_route =
+      gurka::do_action(valhalla::Options::route, map, {"A", "G"}, "motorcycle", options);
+
+  gurka::assert::raw::expect_path(default_route, {"Straight Road"});
+  gurka::assert::raw::expect_path(curvy_route, {"Twisty Road"});
+}
+
+TEST_F(UseCurvatureTest, CurvyRoadWithValue10) {
+
+  std::unordered_map<std::string, std::string> options = 
+      {{"/costing_options/motorcycle/use_curvature", "10"}};
+
+  valhalla::Api default_route =
+      gurka::do_action(valhalla::Options::route, map, {"A", "G"}, "motorcycle");
+
+  valhalla::Api curvy_route =
+      gurka::do_action(valhalla::Options::route, map, {"A", "G"}, "motorcycle", options);
+
+  gurka::assert::raw::expect_path(default_route, {"Straight Road"});
+  gurka::assert::raw::expect_path(curvy_route, {"Twisty Road"});
+}
+
+/*
+FAILS WITH
+valhalla-tests  | /src/valhalla/test/gurka/gurka.cc:1173: Failure
+valhalla-tests  | Expected equality of these values:
+valhalla-tests  |   actual_names
+valhalla-tests  |     Which is: { "Twisty Road", "Twisty Road" }
+valhalla-tests  |   expected_names
+valhalla-tests  |     Which is: { "Twisty Road" }
+valhalla-tests  | Actual path didn't match expected path.
+valhalla-tests  |
+valhalla-tests  | [  FAILED  ] UseCurvatureTest.CurvyRoadWithDeadEnd100 (6 ms)
+*/
+/*
+TEST_F(UseCurvatureTest, CurvyRoadOnMapWithDeadEndWithValue1) {
+
+  std::unordered_map<std::string, std::string> options = 
+      {{"/costing_options/motorcycle/use_curvature", "1"}};
+
+  valhalla::Api default_route =
+      gurka::do_action(valhalla::Options::route, map_with_dead_end, {"A", "G"}, "motorcycle");
+
+  valhalla::Api curvy_route =
+      gurka::do_action(valhalla::Options::route, map_with_dead_end, {"A", "G"}, "motorcycle", options);
+
+  gurka::assert::raw::expect_path(default_route, {"Straight Road"});
+  gurka::assert::raw::expect_path(curvy_route, {"Twisty Road"});
+}
+*/
+
+/*
+FAILS WITH
+valhalla-tests  | /src/valhalla/test/gurka/gurka.cc:1173: Failure
+valhalla-tests  | Expected equality of these values:
+valhalla-tests  |   actual_names
+valhalla-tests  |     Which is: { "Twisty Road", "Twisty Road" }
+valhalla-tests  |   expected_names
+valhalla-tests  |     Which is: { "Twisty Road", "Dead End Road" }
+valhalla-tests  | Actual path didn't match expected path.
+valhalla-tests  |
+valhalla-tests  | [  FAILED  ] UseCurvatureTest.CurvyRoadWithDeadEnd100 (6 ms)
+*/
+/*
+TEST_F(UseCurvatureTest, CurvyRoadOnMapWithDeadEndWithValue100) {
+
+  std::unordered_map<std::string, std::string> options = 
+      {{"/costing_options/motorcycle/use_curvature", "1"}};
+
+  valhalla::Api default_route =
+      gurka::do_action(valhalla::Options::route, map_with_dead_end, {"A", "G"}, "motorcycle");
+
+  valhalla::Api curvy_route =
+      gurka::do_action(valhalla::Options::route, map_with_dead_end, {"A", "G"}, "motorcycle", options);
+
+  gurka::assert::raw::expect_path(default_route, {"Straight Road"});
+  gurka::assert::raw::expect_path(curvy_route, {"Twisty Road", "Dead End Road"});
+}
+*/

--- a/test/gurka/test_use_curvature.cc
+++ b/test/gurka/test_use_curvature.cc
@@ -49,12 +49,15 @@ protected:
         C-D       I-J
     )";
 
-    const gurka::ways ways_with_dead_end = {{"AG", {{"highway", "primary"}, {"name", "Straight Road"}}},
-                                            {"ABCDEFG", {{"highway", "primary"}, {"name", "Twisty Road"}}},
-                                            {"FHIJK", {{"highway", "primary"}, {"name", "Dead End Road"}}}};
+    const gurka::ways ways_with_dead_end =
+        {{"AG", {{"highway", "primary"}, {"name", "Straight Road"}}},
+         {"ABCDEFG", {{"highway", "primary"}, {"name", "Twisty Road"}}},
+         {"FHIJK", {{"highway", "primary"}, {"name", "Dead End Road"}}}};
 
-    const auto layout_with_dead_end = gurka::detail::map_to_coordinates(ascii_map_with_dead_end, gridsize);
-    map_with_dead_end = gurka::buildtiles(layout_with_dead_end, ways_with_dead_end, {}, {}, "test/data/usecurvature_with_dead_end");
+    const auto layout_with_dead_end =
+        gurka::detail::map_to_coordinates(ascii_map_with_dead_end, gridsize);
+    map_with_dead_end = gurka::buildtiles(layout_with_dead_end, ways_with_dead_end, {}, {},
+                                          "test/data/usecurvature_with_dead_end");
   }
 
   inline float getDuration(const valhalla::Api& route) {
@@ -67,8 +70,8 @@ gurka::map UseCurvatureTest::map_with_dead_end = {};
 
 TEST_F(UseCurvatureTest, TestCurvyRoadWithValue0) {
 
-  std::unordered_map<std::string, std::string> options = 
-      {{"/costing_options/motorcycle/use_curvature", "0"}};
+  std::unordered_map<std::string, std::string> options = {
+      {"/costing_options/motorcycle/use_curvature", "0"}};
 
   valhalla::Api default_route =
       gurka::do_action(valhalla::Options::route, map, {"A", "G"}, "motorcycle");
@@ -82,8 +85,8 @@ TEST_F(UseCurvatureTest, TestCurvyRoadWithValue0) {
 
 TEST_F(UseCurvatureTest, CurvyRoadWithValue1) {
 
-  std::unordered_map<std::string, std::string> options = 
-      {{"/costing_options/motorcycle/use_curvature", "1"}};
+  std::unordered_map<std::string, std::string> options = {
+      {"/costing_options/motorcycle/use_curvature", "1"}};
 
   valhalla::Api default_route =
       gurka::do_action(valhalla::Options::route, map, {"A", "G"}, "motorcycle");
@@ -97,8 +100,8 @@ TEST_F(UseCurvatureTest, CurvyRoadWithValue1) {
 
 TEST_F(UseCurvatureTest, CurvyRoadWithValue10) {
 
-  std::unordered_map<std::string, std::string> options = 
-      {{"/costing_options/motorcycle/use_curvature", "10"}};
+  std::unordered_map<std::string, std::string> options = {
+      {"/costing_options/motorcycle/use_curvature", "10"}};
 
   valhalla::Api default_route =
       gurka::do_action(valhalla::Options::route, map, {"A", "G"}, "motorcycle");
@@ -125,14 +128,15 @@ valhalla-tests  | [  FAILED  ] UseCurvatureTest.CurvyRoadWithDeadEnd100 (6 ms)
 /*
 TEST_F(UseCurvatureTest, CurvyRoadOnMapWithDeadEndWithValue1) {
 
-  std::unordered_map<std::string, std::string> options = 
+  std::unordered_map<std::string, std::string> options =
       {{"/costing_options/motorcycle/use_curvature", "1"}};
 
   valhalla::Api default_route =
       gurka::do_action(valhalla::Options::route, map_with_dead_end, {"A", "G"}, "motorcycle");
 
   valhalla::Api curvy_route =
-      gurka::do_action(valhalla::Options::route, map_with_dead_end, {"A", "G"}, "motorcycle", options);
+      gurka::do_action(valhalla::Options::route, map_with_dead_end, {"A", "G"}, "motorcycle",
+options);
 
   gurka::assert::raw::expect_path(default_route, {"Straight Road"});
   gurka::assert::raw::expect_path(curvy_route, {"Twisty Road"});
@@ -154,14 +158,15 @@ valhalla-tests  | [  FAILED  ] UseCurvatureTest.CurvyRoadWithDeadEnd100 (6 ms)
 /*
 TEST_F(UseCurvatureTest, CurvyRoadOnMapWithDeadEndWithValue100) {
 
-  std::unordered_map<std::string, std::string> options = 
+  std::unordered_map<std::string, std::string> options =
       {{"/costing_options/motorcycle/use_curvature", "1"}};
 
   valhalla::Api default_route =
       gurka::do_action(valhalla::Options::route, map_with_dead_end, {"A", "G"}, "motorcycle");
 
   valhalla::Api curvy_route =
-      gurka::do_action(valhalla::Options::route, map_with_dead_end, {"A", "G"}, "motorcycle", options);
+      gurka::do_action(valhalla::Options::route, map_with_dead_end, {"A", "G"}, "motorcycle",
+options);
 
   gurka::assert::raw::expect_path(default_route, {"Straight Road"});
   gurka::assert::raw::expect_path(curvy_route, {"Twisty Road", "Dead End Road"});

--- a/valhalla/mjolnir/util.h
+++ b/valhalla/mjolnir/util.h
@@ -42,6 +42,7 @@ enum class BuildStage : int8_t {
 constexpr uint8_t kMinor = 1;
 constexpr uint8_t kStopSign = 2;
 constexpr uint8_t kYieldSign = 4;
+constexpr uint8_t kMaxCurvature = 15;
 
 // Convert string to BuildStage
 inline BuildStage string_to_buildstage(const std::string& s) {

--- a/valhalla/sif/dynamiccost.h
+++ b/valhalla/sif/dynamiccost.h
@@ -1045,6 +1045,12 @@ protected:
    */
   virtual void set_use_lit(float use_lit);
 
+  /**
+   * Calculate `curvature` costs based on curvature preference.
+   * @param use_curvature value of curvature preference in range [0; kMaxPenalty]
+   */
+  virtual void set_use_curvature(float use_curvature);
+
   // Algorithm pass
   uint32_t pass_;
 
@@ -1077,6 +1083,7 @@ protected:
   float service_factor_;       // Avoid service roads factor.
   float closure_factor_;       // Avoid closed edges factor.
   float unlit_factor_;         // Avoid unlit edges factor.
+  float curvature_factor_;     // Prefer curvy edges factor.
 
   // Transition costs
   sif::Cost country_crossing_cost_;
@@ -1217,6 +1224,9 @@ protected:
     // Calculate lit factor from costing options.
     set_use_lit(costing_options.use_lit());
 
+    // Calculate curvature factor from costing options.
+    set_use_curvature(costing_options.use_curvature());
+
     // Penalty and factor to use service roads
     service_penalty_ = costing_options.service_penalty();
     service_factor_ = costing_options.service_factor();
@@ -1344,6 +1354,8 @@ struct BaseCostingOptionsConfig {
   ranged_default_t<float> use_tracks_;
   ranged_default_t<float> use_living_streets_;
   ranged_default_t<float> use_lit_;
+
+  ranged_default_t<float> use_curvature_;
 
   ranged_default_t<float> closure_factor_;
 


### PR DESCRIPTION
# Issue

I have implemented a new `use_curvature` costing option as per discussion in #5223 .

Taking a lot of inspiration from @chrstnbwnkl `use_lit` PR (#3957), I have also implemented it in `dynamiccost.cc`. Currently, only the `motorcycling` costing model makes use of it, as this is what I am going to use it for in a personal project.

Here's an example route (bright green is the default route, blue-ish is the route with use_curvature enabled); interestingly it includes some of the roads that I do personally like a lot, so I'm pretty happy with that :-)

<img width="277" height="392" alt="use_curvy" src="https://github.com/user-attachments/assets/7d3585d9-6a6c-46fa-99c0-e8ba44f6a3a3" />

As I am not that familiar with C++, yet and haven't been involved in the valhalla project so far, I came across a few challenges and question that you guys can hopefully help me with while reviewing my merge request:

1.) My algorithm/calculation of the costing factor uses an exponential function (`factor *= std::pow(1.f - edge->curvature() / (kMaxCurvature + 0.1f), curvature_factor_)`) - Does this violate any guidelines of the project? For the most part I found linear equations, but the exponential approach seems to work quite well for this use case. For the edge cases that means:

`curvature_factor_ = 0 (default)` -> no modification, i.e. `factor *= 1`
`curvature_factor_ = 1` -> linear impact, `factor *= 1.f - edge->curvature() / (kMaxCurvature + 0.1f)`
`curvature_factor_ > 1` -> exponential impact, with idea of being able to outweigh other factors in favor of a curvy motocycle ride

2.) Since the existing implementation of curvature clamps the resulting value in an interval of [0, 15], I went with normalizing the value by dividing it by that maximum value. Since I like to avoid "magic numbers" in my code, I decided to create a `constexpr uint8_t kMaxCurvature = 15;` in `valhalla/mjolnir/util.h` which I then importet in my implementation in `motorcyclecost.cc`. However, I'm not sure about the implications or side effects of this import. Can you please take a look at it, let me know if it is a good idea or not and possibly explain why?

3.) When writing my tests I wanted to build a map that has a dead end road to play around with the `use_curvature` parameter and see at what point it outweighs the closed edge penalty. But for some reason, as soon as I add that road segment `FHIJK`/`Dead End Road` I get results like `{ "Twisty Road", "Twisty Road" }` instead of `{ "Twisty Road", "Dead End Road" }`. Maybe that's just a misunderstanding of how this entire gurka test engine treats these maps? I also tried defining individual edges like `{{"AB"}, {"BC"}, ...}` and tried that way. But then I would always get a result of `{"AG"}` back, which is the default, straight path. Can you please tell me what I'm doing wrong and how I can fix it?

## Tasklist

 - [x] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [x] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [ ] If you made changes to a translation file, [update transifex](docs/docs/locales.md) too

## Requirements / Relations

- #5223
- #3957
