### PR TITLE
Forward snapping information to Protobuf PathEdge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
    * FIXED: "access": "no" + specific overrides for ferries [#5476](https://github.com/valhalla/valhalla/pull/5476)
    * FIXED: Build libspatialite for vcpkg with librttopo support for valhalla_build_admins [#5475](https://github.com/valhalla/valhalla/pull/5475)
    * FIXED: CMake install target: for PREFER_EXTERNAL_DEPS=ON, no gtest installation, python bindings [#5455](https://github.com/valhalla/valhalla/pull/5455)
+   * Set node snap flags properly in PBF PathEDGE [#5508](https://github.com/valhalla/valhalla/pull/5508)
 * **Enhancement**
    * ADDED: Consider smoothness in all profiles that use surface [#4949](https://github.com/valhalla/valhalla/pull/4949)
    * ADDED: costing parameters to exclude certain edges `exclude_tolls`, `exclude_bridges`, `exclude_tunnels`, `exclude_highways`, `exclude_ferries`. They need to be enabled in the config with `service_limits.allow_hard_exclusions`. Also added location search filters `exclude_ferry` and `exclude_toll` to complement these changes. [#4524](https://github.com/valhalla/valhalla/pull/4524)

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -81,7 +81,6 @@ message PathEdge {
   int32 outbound_reach = 11;
   int32 inbound_reach = 12;
   float heading = 13;
-  bool snapped = 14;
 }
 
 // Output information about how the location object below is correlated to the graph or to the route etc

--- a/valhalla/baldr/pathlocation.h
+++ b/valhalla/baldr/pathlocation.h
@@ -138,8 +138,8 @@ public:
       auto* edge = path_edges->Add();
       edge->set_graph_id(e.id);
       edge->set_percent_along(e.percent_along);
-      edge->set_begin_node(e.percent_along == 0.0f);
-      edge->set_end_node(e.percent_along == 1.0f);
+      edge->set_begin_node(e.percent_along == 0.0f && e.snapped);
+      edge->set_end_node(e.percent_along == 1.0f && e.snapped);
       edge->mutable_ll()->set_lng(e.projected.first);
       edge->mutable_ll()->set_lat(e.projected.second);
       edge->set_side_of_street(e.sos == PathLocation::LEFT
@@ -149,7 +149,6 @@ public:
       edge->set_distance(e.distance);
       edge->set_outbound_reach(e.outbound_reach);
       edge->set_inbound_reach(e.inbound_reach);
-      edge->set_snapped(e.snapped);
       for (const auto& n : reader.edgeinfo(e.id).GetNames()) {
         edge->mutable_names()->Add()->assign(n);
       }


### PR DESCRIPTION
Addendum to #5451: I forgot we convert between our PathEdge and its protobuf representation. So this just forwards the information about whether a location actually snapped.
 