### PR TITLE
fix: `curl_tile_getter_t::head` overrides a member function but is not marked `override`

### DIFF
--- a/valhalla/baldr/curl_tilegetter.h
+++ b/valhalla/baldr/curl_tilegetter.h
@@ -36,7 +36,7 @@ public:
     return result;
   }
 
-  HEAD_response_t head(const std::string& url, header_mask_t header_mask) {
+  HEAD_response_t head(const std::string& url, header_mask_t header_mask) override {
     scoped_curler_t curler(curlers_);
     auto result = curler.get().head(url, header_mask);
     if (result.http_code_ == 200 || result.http_code_ == 206) {


### PR DESCRIPTION
Compilation on MacOS fails for `cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo && cmake --build . -j 14` after https://github.com/valhalla/valhalla/pull/5470

```
-- The CXX compiler identification is AppleClang 17.0.0.17000013
-- The C compiler identification is AppleClang 17.0.0.17000013
....
[65/298] Building CXX object src/baldr/CMakeFiles/valhalla-baldr.dir/graphtile.cc.o
FAILED: [code=1] src/baldr/CMakeFiles/valhalla-baldr.dir/graphtile.cc.o
ccache /usr/bin/c++ -DAUTO_DOWNLOAD=0 -DBOOST_ALLOW_DEPRECATED_HEADERS -DBOOST_BIND_GLOBAL_PLACEHOLDERS -DBOOST_NO_CXX11_SCOPED_ENUMS -DDATA_TOOLS -DENABLE_HTTP -DHAS_REMOTE_API=0 -DPROTOBUF_USE_DLLS -DVALHALLA_BUILD_DIR=/Users/kinkard/Developer/valhalla/build -DVALHALLA_SOURCE_DIR=/Users/kinkard/Developer/valhalla -I/Users/kinkard/Developer/valhalla -I/Users/kinkard/Developer/valhalla/valhalla -I/Users/kinkard/Developer/valhalla/build/src/baldr/src/baldr -I/Users/kinkard/Developer/valhalla/build/src/baldr -I/Users/kinkard/Developer/valhalla/build/src -I/Users/kinkard/Developer/valhalla/build/src/valhalla -isystem /Users/kinkard/Developer/valhalla/third_party/date/include -isystem /Users/kinkard/Developer/valhalla/third_party/rapidjson/include -isystem /opt/homebrew/include -fcolor-diagnostics  -O2 -g -DNDEBUG -std=gnu++17 -arch arm64 -fPIC -Werror -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wno-cpp -MD -MT src/baldr/CMakeFiles/valhalla-baldr.dir/graphtile.cc.o -MF src/baldr/CMakeFiles/valhalla-baldr.dir/graphtile.cc.o.d -o src/baldr/CMakeFiles/valhalla-baldr.dir/graphtile.cc.o -c /Users/kinkard/Developer/valhalla/src/baldr/graphtile.cc
In file included from /Users/kinkard/Developer/valhalla/src/baldr/graphtile.cc:3:
/Users/kinkard/Developer/valhalla/valhalla/baldr/curl_tilegetter.h:39:19: error: 'head' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
   39 |   HEAD_response_t head(const std::string& url, header_mask_t header_mask) {
      |                   ^
/Users/kinkard/Developer/valhalla/valhalla/baldr/tilegetter.h:56:27: note: overridden virtual function is here
   56 |   virtual HEAD_response_t head(const std::string& url, header_mask_t header_mask) = 0;
      |                           ^
1 error generated.
[74/298] Building CXX object src/baldr/CMakeFiles/valhalla-baldr.dir/graphreader.cc.o
FAILED: [code=1] src/baldr/CMakeFiles/valhalla-baldr.dir/graphreader.cc.o
ccache /usr/bin/c++ -DAUTO_DOWNLOAD=0 -DBOOST_ALLOW_DEPRECATED_HEADERS -DBOOST_BIND_GLOBAL_PLACEHOLDERS -DBOOST_NO_CXX11_SCOPED_ENUMS -DDATA_TOOLS -DENABLE_HTTP -DHAS_REMOTE_API=0 -DPROTOBUF_USE_DLLS -DVALHALLA_BUILD_DIR=/Users/kinkard/Developer/valhalla/build -DVALHALLA_SOURCE_DIR=/Users/kinkard/Developer/valhalla -I/Users/kinkard/Developer/valhalla -I/Users/kinkard/Developer/valhalla/valhalla -I/Users/kinkard/Developer/valhalla/build/src/baldr/src/baldr -I/Users/kinkard/Developer/valhalla/build/src/baldr -I/Users/kinkard/Developer/valhalla/build/src -I/Users/kinkard/Developer/valhalla/build/src/valhalla -isystem /Users/kinkard/Developer/valhalla/third_party/date/include -isystem /Users/kinkard/Developer/valhalla/third_party/rapidjson/include -isystem /opt/homebrew/include -fcolor-diagnostics  -O2 -g -DNDEBUG -std=gnu++17 -arch arm64 -fPIC -Werror -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wno-cpp -MD -MT src/baldr/CMakeFiles/valhalla-baldr.dir/graphreader.cc.o -MF src/baldr/CMakeFiles/valhalla-baldr.dir/graphreader.cc.o.d -o src/baldr/CMakeFiles/valhalla-baldr.dir/graphreader.cc.o -c /Users/kinkard/Developer/valhalla/src/baldr/graphreader.cc
In file included from /Users/kinkard/Developer/valhalla/src/baldr/graphreader.cc:2:
/Users/kinkard/Developer/valhalla/valhalla/baldr/curl_tilegetter.h:39:19: error: 'head' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
   39 |   HEAD_response_t head(const std::string& url, header_mask_t header_mask) {
      |                   ^
/Users/kinkard/Developer/valhalla/valhalla/baldr/tilegetter.h:56:27: note: overridden virtual function is here
   56 |   virtual HEAD_response_t head(const std::string& url, header_mask_t header_mask) = 0;
      |                           ^
1 error generated.
```

# Issue

What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [ ] If you made changes to a translation file, [update transifex](docs/docs/locales.md) too

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
