### PR TITLE
chore(deps): upgrade pybind11 to v3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@
    * ADDED: support for destination exceptions for access restrictions [#5370](https://github.com/valhalla/valhalla/pull/5370)
    * ADDED: Add log rolling support for the file logger [#5477](https://github.com/valhalla/valhalla/pull/5477)
    * ADDED: Add Korean (`ko-KR`) locale [#5501](https://github.com/valhalla/valhalla/pull/5501)
+   * UPGRADED: pybind11 from 2.11.1 to 3.0.1 [#5539](https://github.com/valhalla/valhalla/pull/5539)
 
 ## Release Date: 2024-10-10 Valhalla 3.5.1
 * **Removed**


### PR DESCRIPTION
hopefully closing https://github.com/valhalla/valhalla/issues/5534

bumps to 3.0.1 (from 2.11.1), worked locally. let's try, can't hurt.
