### PR TITLE
chore: Replace `oneof bool` to `bool` for default false options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,7 @@
    * ADDED: Add log rolling support for the file logger [#5477](https://github.com/valhalla/valhalla/pull/5477)
    * ADDED: Add Korean (`ko-KR`) locale [#5501](https://github.com/valhalla/valhalla/pull/5501)
    * UPGRADED: pybind11 from 2.11.1 to 3.0.1 [#5539](https://github.com/valhalla/valhalla/pull/5539)
+   * CHANGED: Replace `oneof bool` to `bool` for default false options [#5541](https://github.com/valhalla/valhalla/pull/5541)
 
 ## Release Date: 2024-10-10 Valhalla 3.5.1
 * **Removed**

--- a/proto/options.proto
+++ b/proto/options.proto
@@ -80,7 +80,7 @@ message AvoidEdge {
 message HierarchyLimits {
  uint32 up_transition_count = 1;   // Keep track of # of upward transitions
                                    // Internal use only, remember to clear on incoming requests
- uint32 max_up_transitions = 2;    // Maximum number of upward transitions before 
+ uint32 max_up_transitions = 2;    // Maximum number of upward transitions before
                                    // expansion is stopped on a level.
  float expand_within_dist = 3; // Distance (m) to destination within which
                                    // expansion of a hierarchy level is
@@ -206,9 +206,7 @@ message Costing {
     oneof has_low_class_penalty {
       float low_class_penalty = 34;
     }
-    oneof has_hazmat {
-      bool hazmat = 35;
-    }
+    bool hazmat = 35;
     oneof has_weight {
       float weight = 36;
     }
@@ -227,12 +225,8 @@ message Costing {
     oneof has_cycling_speed {
       float cycling_speed = 41;
     }
-    oneof has_wheelchair {
-      bool wheelchair = 42;
-    }
-    oneof has_bicycle {
-      bool bicycle = 43;
-    }
+    bool wheelchair = 42;
+    bool bicycle = 43;
     oneof has_use_bus {
       float use_bus = 44;
     }
@@ -269,21 +263,13 @@ message Costing {
     oneof has_use_rail_ferry {
       float use_rail_ferry = 59;
     }
-    oneof has_ignore_restrictions {
-      bool ignore_restrictions = 60;
-    }
-    oneof has_ignore_oneways {
-      bool ignore_oneways = 61;
-    }
-    oneof has_ignore_access {
-      bool ignore_access = 62;
-    }
+    bool ignore_restrictions = 60;
+    bool ignore_oneways = 61;
+    bool ignore_access = 62;
     oneof has_ignore_closures {
       bool ignore_closures = 63;
     }
-    oneof has_shortest {
-      bool shortest = 64;
-    }
+    bool shortest = 64;
     oneof has_service_penalty {
       float service_penalty = 65;
     }
@@ -305,21 +291,11 @@ message Costing {
     oneof has_private_access_penalty {
       float private_access_penalty = 71;
     }
-    oneof has_exclude_unpaved {
-      bool exclude_unpaved = 72;
-    }
-    oneof has_include_hot {
-      bool include_hot = 73;
-    }
-    oneof has_include_hov2 {
-      bool include_hov2 = 74;
-    }
-    oneof has_include_hov3 {
-      bool include_hov3 = 75;
-    }
-    oneof has_exclude_cash_only_tolls {
-      bool exclude_cash_only_tolls = 76;
-    }
+    bool exclude_unpaved = 72;
+    bool include_hot = 73;
+    bool include_hov2 = 74;
+    bool include_hov3 = 75;
+    bool exclude_cash_only_tolls = 76;
     oneof has_restriction_probability {
       uint32 restriction_probability = 77;
     }
@@ -425,9 +401,7 @@ message Options {
   }
   Action action = 8;                                               // Action signifying the request type
   //deprecated = 9;
-  oneof has_range {
-    bool range = 10;                                               // Used in /height if the range between points should be serialized  [default = false]
-  }
+  bool range = 10;                                                 // Used in /height if the range between points should be serialized  [default = false]
   // verbose needs to stay oneof, so that matrix serializer can default to true
   oneof has_verbose {
     bool verbose = 11;                                             // Used in /locate & /status request to give back extensive information [default = false]
@@ -447,18 +421,14 @@ message Options {
     double resample_distance = 21;                                 // Resampling shape at regular intervals
   }
   repeated Contour contours = 22;                                  // List of isochrone contours
-  oneof has_polygons {
-    bool polygons = 23;                                            // Boolean value to determine whether to return geojson polygons or linestrings as the contours
-  }
+  bool polygons = 23;                                              // Boolean value to determine whether to return geojson polygons or linestrings as the contours
   oneof has_denoise {
     float denoise = 24;                                            // A floating point value from 0 to 1 which can be used to remove smaller contours (default 1.0)
   }
   oneof has_generalize {
     float generalize = 25;                                         // Meters used as the tolerance for Douglas-Peucker generalization
   }
-  oneof has_show_locations {
-    bool show_locations = 26;                                      // Add original locations to the isochrone geojson response
-  }
+  bool show_locations = 26;                                        // Add original locations to the isochrone geojson response
   repeated Location trace = 27;                                    // Trace points for map matching
   ShapeMatch shape_match = 28;                                     // The matching algorithm based on the type of input [default = walk_or_snap]
   //deprecated = 29;
@@ -476,9 +446,7 @@ message Options {
   oneof has_breakage_distance {
     float breakage_distance = 36;                                  // Map-matching breaking distance (distance between GPS trace points)
   }
-  oneof has_use_timestamps {
-    bool use_timestamps = 37;                                      // Use timestamps to compute elapsed time for trace_route and trace_attributes [default = false]
-  }
+  bool use_timestamps = 37;                                        // Use timestamps to compute elapsed time for trace_route and trace_attributes [default = false]
   oneof has_shape_format {
     ShapeFormat shape_format = 38;                                 // Shape format, defaults to polyline6 encoding for OSRM/height, and no_shape for matrix
   }
@@ -488,9 +456,7 @@ message Options {
   oneof has_interpolation_distance {
     float interpolation_distance = 40;                             // Map-matching interpolation distance beyond which trace points are merged
   }
-  oneof has_guidance_views {
-    bool guidance_views = 41;                                      // Whether to return guidance_views in the response
-  }
+  bool guidance_views = 41;                                        // Whether to return guidance_views in the response
   // 42 is reserved
   oneof has_height_precision {
     uint32 height_precision = 43;                                  // Number of digits precision for heights returned [default = 0]
@@ -498,20 +464,14 @@ message Options {
   oneof has_roundabout_exits {
     bool roundabout_exits = 44;                                    // Whether to announce roundabout exit maneuvers [default = true]
   }
-  oneof has_linear_references {
-    bool linear_references = 45;                                   // Include linear references for graph edges returned in certain responses.
-  }
+  bool linear_references = 45;                                     // Include linear references for graph edges returned in certain responses.
   repeated Costing recostings = 46;                                // CostingType options to use to recost a path after it has been found
   repeated Ring exclude_polygons = 47;                                    // Rings/polygons to exclude entire areas during path finding
-  oneof has_prioritize_bidirectional {
-    bool prioritize_bidirectional = 48;                            // Prioritize bidirectional a*/matrix when depart_at date_time.type is specified [default = false]
-  }
+  bool prioritize_bidirectional = 48;                              // Prioritize bidirectional a*/matrix when depart_at date_time.type is specified [default = false]
   oneof has_expansion_action {
     Action expansion_action = 49;                                  // Meta action for /expansion endpoint
   }
-  oneof has_skip_opposites {
-    bool skip_opposites = 50;                                      // Whether to return opposite edges encountered during expansion
-  }
+  bool skip_opposites = 50;                                        // Whether to return opposite edges encountered during expansion
   repeated ExpansionProperties expansion_properties = 51;          // The array keys (ExpansionTypes enum) to return in the /expansions's GeoJSON "properties"
   PbfFieldSelector pbf_field_selector = 52;                        // Which pbf fields to include in the pbf format response
   bool reverse = 53;                                               // should the isochrone expansion be done in the reverse direction, ignored for multimodal isochrones

--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -1074,7 +1074,7 @@ namespace {
 
 class TestAutoCost : public AutoCost {
 public:
-  TestAutoCost(const Costing& costing_options) : AutoCost(costing_options) {};
+  TestAutoCost(const Costing& costing_options) : AutoCost(costing_options){};
 
   using AutoCost::alley_penalty_;
   using AutoCost::country_crossing_cost_;

--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -708,9 +708,9 @@ void ParseAutoCostOptions(const rapidjson::Document& doc,
   JSON_PBF_RANGED_DEFAULT(co, kAutoWidthRange, json, "/width", width);
   JSON_PBF_RANGED_DEFAULT(co, kProbabilityRange, json, "/restriction_probability",
                           restriction_probability);
-  JSON_PBF_DEFAULT(co, false, json, "/include_hot", include_hot);
-  JSON_PBF_DEFAULT(co, false, json, "/include_hov2", include_hov2);
-  JSON_PBF_DEFAULT(co, false, json, "/include_hov3", include_hov3);
+  JSON_PBF_DEFAULT_V2(co, false, json, "/include_hot", include_hot);
+  JSON_PBF_DEFAULT_V2(co, false, json, "/include_hov2", include_hov2);
+  JSON_PBF_DEFAULT_V2(co, false, json, "/include_hov3", include_hov3);
   JSON_PBF_RANGED_DEFAULT(co, kVehicleSpeedRange, json, "/top_speed", top_speed);
 }
 
@@ -1074,7 +1074,7 @@ namespace {
 
 class TestAutoCost : public AutoCost {
 public:
-  TestAutoCost(const Costing& costing_options) : AutoCost(costing_options){};
+  TestAutoCost(const Costing& costing_options) : AutoCost(costing_options) {};
 
   using AutoCost::alley_penalty_;
   using AutoCost::country_crossing_cost_;

--- a/src/sif/dynamiccost.cc
+++ b/src/sif/dynamiccost.cc
@@ -511,7 +511,7 @@ void ParseBaseCostOptions(const rapidjson::Value& json,
   JSON_PBF_DEFAULT_V2(co, cfg.exclude_ferries_, json, "/exclude_ferries", exclude_ferries);
 
   JSON_PBF_DEFAULT_V2(co, cfg.exclude_cash_only_tolls_, json, "/exclude_cash_only_tolls",
-                   exclude_cash_only_tolls);
+                      exclude_cash_only_tolls);
 
   // service_penalty
   JSON_PBF_RANGED_DEFAULT(co, cfg.service_penalty_, json, "/service_penalty", service_penalty);

--- a/src/sif/dynamiccost.cc
+++ b/src/sif/dynamiccost.cc
@@ -408,16 +408,16 @@ void ParseBaseCostOptions(const rapidjson::Value& json,
   }
 
   // various traversability flags
-  JSON_PBF_DEFAULT(co, false, json, "/ignore_restrictions", ignore_restrictions);
-  JSON_PBF_DEFAULT(co, false, json, "/ignore_oneways", ignore_oneways);
-  JSON_PBF_DEFAULT(co, false, json, "/ignore_access", ignore_access);
-  JSON_PBF_DEFAULT(co, false, json, "/ignore_closures", ignore_closures);
+  JSON_PBF_DEFAULT_V2(co, false, json, "/ignore_restrictions", ignore_restrictions);
+  JSON_PBF_DEFAULT_V2(co, false, json, "/ignore_oneways", ignore_oneways);
+  JSON_PBF_DEFAULT_V2(co, false, json, "/ignore_access", ignore_access);
+  JSON_PBF_DEFAULT_V2(co, false, json, "/ignore_closures", ignore_closures);
   JSON_PBF_DEFAULT_V2(co, false, json, "/ignore_construction", ignore_construction);
   JSON_PBF_DEFAULT_V2(co, false, json, "/ignore_non_vehicular_restrictions",
                       ignore_non_vehicular_restrictions);
 
   // shortest
-  JSON_PBF_DEFAULT(co, false, json, "/shortest", shortest);
+  JSON_PBF_DEFAULT_V2(co, false, json, "/shortest", shortest);
 
   // disable hierarchy pruning
   co->set_disable_hierarchy_pruning(
@@ -502,7 +502,7 @@ void ParseBaseCostOptions(const rapidjson::Value& json,
     JSON_PBF_RANGED_DEFAULT(co, cfg.use_rail_ferry_, json, "/use_rail_ferry", use_rail_ferry);
   }
 
-  JSON_PBF_DEFAULT(co, cfg.exclude_unpaved_, json, "/exclude_unpaved", exclude_unpaved);
+  JSON_PBF_DEFAULT_V2(co, cfg.exclude_unpaved_, json, "/exclude_unpaved", exclude_unpaved);
 
   JSON_PBF_DEFAULT_V2(co, cfg.exclude_bridges_, json, "/exclude_bridges", exclude_bridges);
   JSON_PBF_DEFAULT_V2(co, cfg.exclude_tunnels_, json, "/exclude_tunnels", exclude_tunnels);
@@ -510,7 +510,7 @@ void ParseBaseCostOptions(const rapidjson::Value& json,
   JSON_PBF_DEFAULT_V2(co, cfg.exclude_highways_, json, "/exclude_highways", exclude_highways);
   JSON_PBF_DEFAULT_V2(co, cfg.exclude_ferries_, json, "/exclude_ferries", exclude_ferries);
 
-  JSON_PBF_DEFAULT(co, cfg.exclude_cash_only_tolls_, json, "/exclude_cash_only_tolls",
+  JSON_PBF_DEFAULT_V2(co, cfg.exclude_cash_only_tolls_, json, "/exclude_cash_only_tolls",
                    exclude_cash_only_tolls);
 
   // service_penalty
@@ -533,9 +533,9 @@ void ParseBaseCostOptions(const rapidjson::Value& json,
   JSON_PBF_RANGED_DEFAULT(co, cfg.closure_factor_, json, "/closure_factor", closure_factor);
 
   // HOT/HOV
-  JSON_PBF_DEFAULT(co, cfg.include_hot_, json, "/include_hot", include_hot);
-  JSON_PBF_DEFAULT(co, cfg.include_hov2_, json, "/include_hov2", include_hov2);
-  JSON_PBF_DEFAULT(co, cfg.include_hov3_, json, "/include_hov3", include_hov3);
+  JSON_PBF_DEFAULT_V2(co, cfg.include_hot_, json, "/include_hot", include_hot);
+  JSON_PBF_DEFAULT_V2(co, cfg.include_hov2_, json, "/include_hov2", include_hov2);
+  JSON_PBF_DEFAULT_V2(co, cfg.include_hov3_, json, "/include_hov3", include_hov3);
 
   JSON_PBF_RANGED_DEFAULT_V2(co, kFixedSpeedRange, json, "/fixed_speed", fixed_speed);
 }

--- a/src/sif/transitcost.cc
+++ b/src/sif/transitcost.cc
@@ -648,8 +648,8 @@ void ParseTransitCostOptions(const rapidjson::Document& doc,
   // TODO: no base costing parsing because transit doesnt care about any of those options?
 
   JSON_PBF_RANGED_DEFAULT(co, kModeFactorRange, json, "/mode_factor", mode_factor);
-  JSON_PBF_DEFAULT(co, false, json, "/wheelchair", wheelchair);
-  JSON_PBF_DEFAULT(co, false, json, "/bicycle", bicycle);
+  JSON_PBF_DEFAULT_V2(co, false, json, "/wheelchair", wheelchair);
+  JSON_PBF_DEFAULT_V2(co, false, json, "/bicycle", bicycle);
   JSON_PBF_RANGED_DEFAULT(co, kUseBusRange, json, "/use_bus", use_bus);
   JSON_PBF_RANGED_DEFAULT(co, kUseRailRange, json, "/use_rail", use_rail);
   JSON_PBF_RANGED_DEFAULT(co, kUseTransfersRange, json, "/use_transfers", use_transfers);

--- a/src/sif/truckcost.cc
+++ b/src/sif/truckcost.cc
@@ -746,7 +746,7 @@ void ParseTruckCostOptions(const rapidjson::Document& doc,
 
   ParseBaseCostOptions(json, c, kBaseCostOptsConfig);
   JSON_PBF_RANGED_DEFAULT(co, kLowClassPenaltyRange, json, "/low_class_penalty", low_class_penalty);
-  JSON_PBF_DEFAULT(co, false, json, "/hazmat", hazmat);
+  JSON_PBF_DEFAULT_V2(co, false, json, "/hazmat", hazmat);
   JSON_PBF_RANGED_DEFAULT(co, kTruckWeightRange, json, "/weight", weight);
   JSON_PBF_RANGED_DEFAULT(co, kTruckAxleLoadRange, json, "/axle_load", axle_load);
   JSON_PBF_RANGED_DEFAULT(co, kTruckHeightRange, json, "/height", height);

--- a/test/parse_request.cc
+++ b/test/parse_request.cc
@@ -163,14 +163,6 @@ void validate(const std::string& key, const bool expected_value, const bool pbf_
   EXPECT_EQ(pbf_value, expected_value) << "incorrect " << key;
 }
 
-void validate(const std::string& key,
-              const bool expected_value,
-              const bool has_pbf_value,
-              const bool pbf_value) {
-  ASSERT_TRUE(has_pbf_value) << "bool value not found in pbf for key=" + key;
-  EXPECT_EQ(pbf_value, expected_value) << "incorrect " << key;
-}
-
 void validate(const std::string& key, const float expected_value, const float pbf_value) {
   EXPECT_EQ(pbf_value, expected_value) << "incorrect " << key;
 }
@@ -386,7 +378,7 @@ void test_polygons_parsing(const bool expected_value,
                            const Options::Action action = Options::isochrone) {
   const std::string key = "polygons";
   Api request = get_request(get_request_str(key, expected_value), action);
-  validate(key, expected_value, request.options().has_polygons_case(), request.options().polygons());
+  validate(key, expected_value, request.options().polygons());
 }
 
 void test_denoise_parsing(const float expected_value,
@@ -408,8 +400,7 @@ void test_show_locations_parsing(const bool expected_value,
                                  const Options::Action action = Options::isochrone) {
   const std::string key = "show_locations";
   Api request = get_request(get_request_str(key, expected_value), action);
-  validate(key, expected_value, request.options().has_show_locations_case(),
-           request.options().show_locations());
+  validate(key, expected_value, request.options().show_locations());
 }
 
 void test_shape_match_parsing(const ShapeMatch expected_value, const Options::Action action) {


### PR DESCRIPTION
# Issue

This PR does a minor cleanup in the proto interface by replacing `oneof bool` to `bool` for all options where default is `false` and there is no logic if that options is set to `false` explicitly by user.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [ ] If you made changes to a translation file, [update transifex](docs/docs/locales.md) too

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
