### PR TITLE
Fix build errors with different log levels and some warnings

### DIFF
--- a/src/meili/CMakeLists.txt
+++ b/src/meili/CMakeLists.txt
@@ -1,20 +1,18 @@
 file(GLOB headers ${VALHALLA_SOURCE_DIR}/valhalla/meili/*.h)
 
 set(sources
-  topk_search.cc
-  routing.cc
+  candidate_search.cc
+  config.cc
   geometry_helpers.cc
   map_matcher_factory.cc
-  config.cc)
-
-set(sources_with_warnings
-  candidate_search.cc
   map_matcher.cc
   match_route.cc
+  routing.cc
+  topk_search.cc
   transition_cost_model.cc
   viterbi_search.cc)
 
-set(system_includes 
+set(system_includes
   ${date_include_dir}
   $<$<BOOL:${WIN32}>:${dirent_include_dir}>)
 

--- a/src/meili/candidate_search.cc
+++ b/src/meili/candidate_search.cc
@@ -171,7 +171,7 @@ void IndexBin(const graph_tile_ptr& tile,
 CandidateGridQuery::CandidateGridQuery(baldr::GraphReader& reader,
                                        float cell_width,
                                        float cell_height)
-    : reader_(reader), cell_width_(cell_width), cell_height_(cell_height), grid_cache_() {
+    : cell_width_(cell_width), cell_height_(cell_height), reader_(reader) {
   bin_level_ = baldr::TileHierarchy::levels().back().level;
 }
 

--- a/src/meili/map_matcher.cc
+++ b/src/meili/map_matcher.cc
@@ -4,6 +4,7 @@
 #include "meili/routing.h"
 #include "meili/transition_cost_model.h"
 #include "midgard/distanceapproximator.h"
+#include "midgard/logging.h"
 #include "worker.h"
 
 #include <array>
@@ -29,6 +30,7 @@ inline float ClockDistance(const Measurement& left, const Measurement& right) {
                                                          : right.epoch_time() - left.epoch_time();
 }
 
+#ifdef LOGGING_LEVEL_TRACE
 std::string print_result(const StateContainer& container,
                          const std::vector<StateId>& original_state_ids) {
   std::string result = R"({"type":"FeatureCollection","features":[)";
@@ -40,6 +42,7 @@ std::string print_result(const StateContainer& container,
   result += R"(]})";
   return result;
 }
+#endif
 
 struct Interpolation {
   midgard::PointLL projected;

--- a/src/meili/viterbi_search.cc
+++ b/src/meili/viterbi_search.cc
@@ -7,7 +7,7 @@ namespace valhalla {
 namespace meili {
 
 StateLabel::StateLabel(double costsofar, const StateId& stateid, const StateId& predecessor)
-    : costsofar_(costsofar), stateid_(stateid), predecessor_(predecessor) {
+    : stateid_(stateid), predecessor_(predecessor), costsofar_(costsofar) {
   if (!stateid.IsValid()) {
     throw std::invalid_argument("expect valid stateid");
   }

--- a/src/mjolnir/dataquality.cc
+++ b/src/mjolnir/dataquality.cc
@@ -93,6 +93,7 @@ void DataQuality::LogIssues() const {
   dupfile.close();
 
   // Log the unconnected link edges
+#ifdef LOGGING_LEVEL_WARN
   if (unconnectedlinks_.size() > 0) {
     LOG_WARN("Link edges that are not connected. OSM Way Ids");
     for (const auto& wayid : unconnectedlinks_) {
@@ -107,6 +108,7 @@ void DataQuality::LogIssues() const {
       LOG_WARN(std::to_string(wayid));
     }
   }
+#endif
 }
 
 } // namespace mjolnir

--- a/src/mjolnir/ferry_connections.cc
+++ b/src/mjolnir/ferry_connections.cc
@@ -1,5 +1,6 @@
 #include "mjolnir/ferry_connections.h"
 #include "baldr/graphconstants.h"
+#include "midgard/logging.h"
 #include "midgard/util.h"
 #include "mjolnir/node_expander.h"
 #include "mjolnir/osmdata.h"
@@ -338,7 +339,9 @@ void ReclassifyFerryConnections(const std::string& ways_file,
         !ShortFerry(node_itr.position(), bundle, edges, nodes, way_nodes)) {
       bool inbound_path_found = false;
       bool outbound_path_found = false;
+#ifdef LOGGING_LEVEL_WARN
       PointLL ll = (*nodes[node_itr.position()]).node.latlng();
+#endif
 
       // Form shortest path from node along each edge connected to the ferry,
       // track until the specified RC is reached
@@ -425,6 +428,7 @@ void ReclassifyFerryConnections(const std::string& ways_file,
       // Log cases where reclassification fails
       if (!inbound_path_found && !outbound_path_found) {
         missed_both++;
+#ifdef LOGGING_LEVEL_WARN
       } else {
         if (!inbound_path_found) {
           LOG_WARN("Reclassification fails inbound to ferry at LL =" + std::to_string(ll.lat()) +
@@ -434,6 +438,7 @@ void ReclassifyFerryConnections(const std::string& ways_file,
           LOG_WARN("Reclassification fails outbound from ferry at LL =" + std::to_string(ll.lat()) +
                    "," + std::to_string(ll.lng()));
         }
+#endif
       }
     }
 

--- a/src/mjolnir/ferry_connections.cc
+++ b/src/mjolnir/ferry_connections.cc
@@ -339,9 +339,7 @@ void ReclassifyFerryConnections(const std::string& ways_file,
         !ShortFerry(node_itr.position(), bundle, edges, nodes, way_nodes)) {
       bool inbound_path_found = false;
       bool outbound_path_found = false;
-#ifdef LOGGING_LEVEL_WARN
-      PointLL ll = (*nodes[node_itr.position()]).node.latlng();
-#endif
+      [[maybe_unused]] const PointLL ll = (*nodes[node_itr.position()]).node.latlng();
 
       // Form shortest path from node along each edge connected to the ferry,
       // track until the specified RC is reached

--- a/src/mjolnir/graphvalidator.cc
+++ b/src/mjolnir/graphvalidator.cc
@@ -209,6 +209,7 @@ uint32_t GetOpposingEdgeIndex(const GraphId& startnode,
                std::to_string(nodeinfo->stop_index()) + " has " +
                std::to_string(nodeinfo->edge_count())); */
     } else if (startnode.level() != transit_level) {
+#ifdef LOGGING_LEVEL_ERROR
       PointLL ll = end_tile->get_node_ll(endnode);
       if (edge.is_shortcut()) {
         LOG_ERROR(
@@ -223,6 +224,7 @@ uint32_t GetOpposingEdgeIndex(const GraphId& startnode,
                    edge.edgeinfo_offset())
                       .str());
       }
+#endif
 
       uint32_t n = 0;
       directededge = end_tile->directededge(nodeinfo->edge_index());

--- a/src/mjolnir/restrictionbuilder.cc
+++ b/src/mjolnir/restrictionbuilder.cc
@@ -62,9 +62,11 @@ GraphId GetOpposingEdge(GraphReader& reader,
       return opp_id;
     }
   }
+#ifdef LOGGING_LEVEL_ERROR
   PointLL ll = nodeinfo->latlng(end_node_tile->header()->base_ll());
   LOG_ERROR("Opposing directed edge not found at LL= " + std::to_string(ll.lat()) + "," +
             std::to_string(ll.lng()));
+#endif
   return {};
 }
 

--- a/src/mjolnir/shortcutbuilder.cc
+++ b/src/mjolnir/shortcutbuilder.cc
@@ -164,9 +164,11 @@ GraphId GetOpposingEdge(const GraphId& node,
       return edgeid;
     }
   }
+#ifdef LOGGING_LEVEL_ERROR
   PointLL ll = nodeinfo->latlng(tile->header()->base_ll());
   LOG_ERROR("Opposing directed edge not found at LL= " + std::to_string(ll.lat()) + "," +
             std::to_string(ll.lng()));
+#endif
   return GraphId(0, 0, 0);
 }
 
@@ -462,9 +464,8 @@ std::pair<uint32_t, uint32_t> AddShortcutEdges(GraphReader& reader,
           // Break out of loop. This case can happen when a shortcut edge
           // enters another shortcut edge (but is not drivable in reverse
           // direction from the node).
-          const DirectedEdge* de = tile->directededge(next_edge_id);
           LOG_ERROR("Edge not found in edge pairs. WayID = " +
-                    std::to_string(tile->edgeinfo(de).wayid()));
+                    std::to_string(tile->edgeinfo(tile->directededge(next_edge_id)).wayid()));
           break;
         }
 

--- a/src/mjolnir/shortcutbuilder.cc
+++ b/src/mjolnir/shortcutbuilder.cc
@@ -580,6 +580,7 @@ std::pair<uint32_t, uint32_t> AddShortcutEdges(GraphReader& reader,
     }
   }
 
+#ifdef LOGGING_LEVEL_WARN
   // Log a warning (with the node lat,lon) if the max number of shortcuts from a node
   // is exceeded. This is not serious (see NOTE above) but good to know where it occurs.
   if (shortcut_count > kMaxShortcutsFromNode) {
@@ -587,6 +588,7 @@ std::pair<uint32_t, uint32_t> AddShortcutEdges(GraphReader& reader,
     LOG_WARN("Exceeding max shortcut edges from a node at LL = " + std::to_string(ll.lat()) + "," +
              std::to_string(ll.lng()));
   }
+#endif
   return {shortcut_count, total_edge_count};
 }
 

--- a/src/mjolnir/valhalla_build_statistics.cc
+++ b/src/mjolnir/valhalla_build_statistics.cc
@@ -376,7 +376,7 @@ void build(const boost::property_tree::ptree& pt,
 
     // Point tiles to the set we need for current level
     auto level = tile_id.level();
-    if (TileHierarchy::levels().back().level + 1 == level) {
+    if (TileHierarchy::levels().back().level + 1u == level) {
       level = TileHierarchy::levels().back().level;
     }
 

--- a/src/mjolnir/valhalla_query_transit.cc
+++ b/src/mjolnir/valhalla_query_transit.cc
@@ -94,8 +94,7 @@ void LogDepartures(const Transit& transit, const GraphId& stopid, std::string& f
 
         // Iterate through the stop pairs in this tile and form Valhalla departure
         // records
-        uint32_t tileid;
-        for (uint32_t i = 0; i < spp.stop_pairs_size(); i++) {
+        for (int i = 0; i < spp.stop_pairs_size(); i++) {
           const Transit_StopPair& sp = spp.stop_pairs(i);
 
           // Skip stop pair if either stop graph Id is invalid
@@ -264,7 +263,7 @@ void LogSchedule(const std::string& transit_dir,
         uint32_t tileid;
         GraphId orig_graphid;
         std::string origin_time;
-        for (uint32_t i = 0; i < spp.stop_pairs_size(); i++) {
+        for (int i = 0; i < spp.stop_pairs_size(); i++) {
           const Transit_StopPair& sp = spp.stop_pairs(i);
 
           // Skip stop pair if either stop graph Id is invalid
@@ -336,14 +335,14 @@ void LogSchedule(const std::string& transit_dir,
 // Log the list of routes within the tile
 void LogRoutes(const Transit& transit) {
   LOG_INFO("Routes:");
-  for (uint32_t i = 0; i < transit.routes_size(); i++) {
+  for (int i = 0; i < transit.routes_size(); i++) {
     const Transit_Route& r = transit.routes(i);
     LOG_INFO("Route idx = " + std::to_string(i) + ": " + r.name() + "," + r.route_long_name());
   }
 }
 
 GraphId GetGraphId(Transit& transit, const std::string& onestop_id) {
-  for (uint32_t i = 0; i < transit.nodes_size(); i++) {
+  for (int i = 0; i < transit.nodes_size(); i++) {
     const Transit_Node& node = transit.nodes(i);
     if (node.onestop_id() == onestop_id) {
       LOG_INFO("Node: " + node.name());

--- a/src/odin/enhancedtrippath.cc
+++ b/src/odin/enhancedtrippath.cc
@@ -25,85 +25,6 @@ constexpr uint32_t kBackwardTurnDegreeLowerBound = 124;
 constexpr uint32_t kBackwardTurnDegreeUpperBound = 236;
 
 #ifdef LOGGING_LEVEL_TRACE
-const std::string& Pronunciation_Alphabet_Name(valhalla::Pronunciation_Alphabet alphabet) {
-  static const std::unordered_map<valhalla::Pronunciation_Alphabet, std::string>
-      values{{valhalla::Pronunciation_Alphabet::Pronunciation_Alphabet_kIpa, "kIpa"},
-             {valhalla::Pronunciation_Alphabet::Pronunciation_Alphabet_kKatakana, "kKatakana"},
-             {valhalla::Pronunciation_Alphabet::Pronunciation_Alphabet_kJeita, "kJeita"},
-             {valhalla::Pronunciation_Alphabet::Pronunciation_Alphabet_kNtSampa, "kNtSampa"}};
-  auto f = values.find(alphabet);
-  if (f == values.cend())
-    throw std::runtime_error("Missing value in protobuf Pronunciation_Alphabet enum to string");
-  return f->second;
-}
-
-const std::string& RoadClass_Name(int v) {
-  static const std::unordered_map<int, std::string> values{
-      {0, "kMotorway"}, {1, "kTrunk"},        {2, "kPrimary"},     {3, "kSecondary"},
-      {4, "kTertiary"}, {5, "kUnclassified"}, {6, "kResidential"}, {7, "kServiceOther"},
-  };
-  auto f = values.find(v);
-  if (f == values.cend())
-    throw std::runtime_error("Missing value in protobuf enum to string");
-  return f->second;
-}
-
-const std::string& TripLeg_Traversability_Name(int v) {
-  static const std::unordered_map<int, std::string> values{
-      {0, "kNone"},
-      {1, "kForward"},
-      {2, "kward"},
-      {3, "kBoth"},
-  };
-  auto f = values.find(v);
-  if (f == values.cend())
-    throw std::runtime_error("Missing value in protobuf enum to string");
-  return f->second;
-}
-
-const std::string& TripLeg_Use_Name(int v) {
-  static const std::unordered_map<int, std::string> values{
-      {0, "kRoadUse"},
-      {1, "kRampUse"},
-      {2, "kTurnChannelUse"},
-      {3, "kUse"},
-      {4, "kDrivewayUse"},
-      {5, "kAlleyUse"},
-      {6, "kingAisleUse"},
-      {7, "kEmergencyAccessUse"},
-      {8, "kDriveThruUse"},
-      {9, "kCuldesacUse"},
-      {10, "kLivingStreetUse"},
-      {11, "kServiceRoadUse"},
-      {20, "kCyclewayUse"},
-      {21, "kMountainBikeUse"},
-      {24, "kSidewalkUse"},
-      {25, "kFootwayUse"},
-      {26, "kStepsUse"},
-      {27, "kPathUse"},
-      {28, "kPedestrianUse"},
-      {29, "kBridlewayUse"},
-      {30, "kRestAreaUse"},
-      {31, "kServiceAreaUse"},
-      {32, "kPedestrianCrossingUse"},
-      {33, "kElevatorUse"},
-      {34, "kEscalatorUse"},
-      {40, "kOtherUse"},
-      {41, "kFerryUse"},
-      {42, "kRailFerryUse"},
-      {43, "kConstructionUse"},
-      {50, "kRailUse"},
-      {51, "kBusUse"},
-      {52, "kEgressConnectionUse"},
-      {53, "kPlatformConnectionUse"},
-      {54, "kTransitConnectionUse"},
-  };
-  auto f = values.find(v);
-  if (f == values.cend())
-    throw std::runtime_error("Missing value in protobuf enum to string");
-  return f->second;
-}
-
 const std::string& TripLeg_TravelMode_Name(int v) {
   static const std::unordered_map<int, std::string> values{
       {0, "kDrive"},
@@ -154,32 +75,6 @@ const std::string& TripLeg_TransitType_Name(int v) {
   static const std::unordered_map<int, std::string> values{
       {0, "kTram"},  {1, "kMetro"},    {2, "kRail"},    {3, "kBus"},
       {4, "kFerry"}, {5, "kCableCar"}, {6, "kGondola"}, {7, "kFunicular"},
-  };
-  auto f = values.find(v);
-  if (f == values.cend())
-    throw std::runtime_error("Missing value in protobuf enum to string");
-  return f->second;
-}
-
-const std::string& TripLeg_CycleLane_Name(int v) {
-  static const std::unordered_map<int, std::string> values{
-      {0, "kNoCycleLane"},
-      {1, "kShared"},
-      {2, "kDedicated"},
-      {3, "kSeparated"},
-  };
-  auto f = values.find(v);
-  if (f == values.cend())
-    throw std::runtime_error("Missing value in protobuf enum to string");
-  return f->second;
-}
-
-const std::string& TripLeg_Sidewalk_Name(int v) {
-  static const std::unordered_map<int, std::string> values{
-      {0, "kNoSidewalk"},
-      {1, "kLeft"},
-      {2, "kRight"},
-      {3, "kBothSides"},
   };
   auto f = values.find(v);
   if (f == values.cend())

--- a/src/odin/maneuver.cc
+++ b/src/odin/maneuver.cc
@@ -1158,70 +1158,6 @@ void Maneuver::set_has_level_changes(const bool has_level_changes) {
 
 #ifdef LOGGING_LEVEL_TRACE
 namespace {
-const std::string& DirectionsLeg_Maneuver_Type_Name(int v) {
-  static const std::unordered_map<int, std::string> values{{0, "kNone"},
-                                                           {1, "kStart"},
-                                                           {2, "kStartRight"},
-                                                           {3, "kStartLeft"},
-                                                           {4, "kDestination"},
-                                                           {5, "kDestinationRight"},
-                                                           {6, "kDestinationLeft"},
-                                                           {7, "kBecomes"},
-                                                           {8, "kContinue"},
-                                                           {9, "kSlightRight"},
-                                                           {10, "kRight"},
-                                                           {11, "kSharpRight"},
-                                                           {12, "kUturnRight"},
-                                                           {13, "kUturnLeft"},
-                                                           {14, "kSharpLeft"},
-                                                           {15, "kLeft"},
-                                                           {16, "kSlightLeft"},
-                                                           {17, "kRampStraight"},
-                                                           {18, "kRampRight"},
-                                                           {19, "kRampLeft"},
-                                                           {20, "kExitRight"},
-                                                           {21, "kExitLeft"},
-                                                           {22, "kStayStraight"},
-                                                           {23, "kStayRight"},
-                                                           {24, "kStayLeft"},
-                                                           {25, "kMerge"},
-                                                           {26, "kRoundaboutEnter"},
-                                                           {27, "kRoundaboutExit"},
-                                                           {28, "kFerryEnter"},
-                                                           {29, "kFerryExit"},
-                                                           {30, "kTransit"},
-                                                           {31, "kTransitTransfer"},
-                                                           {32, "kTransitRemainOn"},
-                                                           {33, "kTransitConnectionStart"},
-                                                           {34, "kTransitConnectionTransfer"},
-                                                           {35, "kTransitConnectionDestination"},
-                                                           {36, "kPostTransitConnectionDestination"},
-                                                           {37, "kMergeRight"},
-                                                           {38, "kMergeLeft"},
-                                                           {39, "kElevatorEnter"},
-                                                           {40, "kStepsEnter"},
-                                                           {41, "kEscalatorEnter"},
-                                                           {42, "kBuildingEnter"},
-                                                           {43, "kBuildingExit"}};
-  auto f = values.find(v);
-  if (f == values.cend())
-    throw std::runtime_error(
-        "Missing DirectionsLeg_Maneuver_Type_Name value in protobuf enum to string");
-  return f->second;
-}
-
-const std::string& DirectionsLeg_Maneuver_CardinalDirection_Name(int v) {
-  static const std::unordered_map<int, std::string> values{{0, "kNorth"}, {1, "kNorthEast"},
-                                                           {2, "kEast"},  {3, "kSouthEast"},
-                                                           {4, "kSouth"}, {5, "kSouthWest"},
-                                                           {6, "kWest"},  {7, "kNorthWest"}};
-  auto f = values.find(v);
-  if (f == values.cend())
-    throw std::runtime_error(
-        "Missing DirectionsLeg_Maneuver_CardinalDirection_Name value in protobuf enum to string");
-  return f->second;
-}
-
 const std::string& TrailType_Name(int v) {
   static const std::unordered_map<int, std::string> values{{0, "kNone"},
                                                            {1, "kNamedCycleway"},
@@ -1235,7 +1171,6 @@ const std::string& TrailType_Name(int v) {
     throw std::runtime_error("Missing TrailType_Name value in protobuf enum to string");
   return f->second;
 }
-
 } // namespace
 
 std::string Maneuver::ToString() const {

--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -255,7 +255,7 @@ std::list<Maneuver> ManeuversBuilder::Produce() {
     LOG_TRACE(std::string("  curr_edge=") + (curr_edge ? curr_edge->ToString() : "NONE"));
     LOG_TRACE(std::string("  prev2curr_turn_degree=") + std::to_string(prev2curr_turn_degree) +
               " is a " + Turn::GetTypeString(Turn::GetType(prev2curr_turn_degree)));
-    for (size_t z = 0; z < node->intersecting_edge_size(); ++z) {
+    for (int z = 0; z < node->intersecting_edge_size(); ++z) {
       auto intersecting_edge = node->GetIntersectingEdge(z);
       auto xturn_degree = GetTurnDegree(prev_edge->end_heading(), intersecting_edge->begin_heading());
       LOG_TRACE(std::string("    intersectingEdge=") + intersecting_edge->ToString());
@@ -327,12 +327,12 @@ std::list<Maneuver> ManeuversBuilder::Produce() {
             (curr_edge ? curr_edge->ToParameterString() : "NONE"));
   LOG_TRACE(std::string("  curr_edge=") + (curr_edge ? curr_edge->ToString() : "NONE"));
   auto node = trip_path_->GetEnhancedNode(0);
-  for (size_t z = 0; z < node->intersecting_edge_size(); ++z) {
+  for (int z = 0; z < node->intersecting_edge_size(); ++z) {
     auto intersecting_edge = node->GetIntersectingEdge(z);
     LOG_TRACE(std::string("    intersectingEdge=") + intersecting_edge->ToString());
   }
   LOG_TRACE("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@");
-  for (size_t z = 0; z < trip_path_->admin_size(); ++z) {
+  for (int z = 0; z < trip_path_->admin_size(); ++z) {
     auto admin = trip_path_->GetAdmin(z);
     LOG_TRACE("ADMIN " + std::to_string(z) + ": " + admin->ToString());
   }

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -1297,8 +1297,9 @@ std::vector<std::vector<PathInfo>> BidirectionalAStar::FormPath(GraphReader& gra
     // bidirectional a* has a bug where it fails trivial routes in which you are on a one way edge and
     // the origin is near the end of the edge and the destination is near the beginning, in other
     // words a route that looks trivial but actually needs to go around the block to complete
-    if (path_edges.size() == 1)
+    if (path_edges.size() == 1) {
       LOG_WARN("Trivial route with bidirectional A* should not be allowed");
+    }
 
     // once we recovered the whole path we should construct list of PathInfo objects
     std::vector<PathInfo> path;

--- a/src/valhalla_run_matrix.cc
+++ b/src/valhalla_run_matrix.cc
@@ -45,9 +45,9 @@ void LogResults(const bool optimize,
 
   if (log_details) {
     LOG_INFO("Results:");
-    uint32_t idx1 = 0;
-    uint32_t idx2 = 0;
-    for (uint32_t i = 0; i < matrix.times().size(); i++) {
+    int idx1 = 0;
+    int idx2 = 0;
+    for (int i = 0; i < matrix.times().size(); i++) {
       auto distance = matrix.distances().Get(i);
       LOG_INFO(std::to_string(idx1) + "," + std::to_string(idx2) + ": Distance= " +
                std::to_string(distance) + " Time= " + GetFormattedTime(matrix.times().Get(i)) +
@@ -195,7 +195,7 @@ int main(int argc, char* argv[]) {
 
   // If the sources and targets are equal we can run optimize
   if (optimize && options.sources_size() == options.targets_size()) {
-    for (uint32_t i = 0; i < options.sources_size(); ++i) {
+    for (int i = 0; i < options.sources_size(); ++i) {
       if (options.sources(i).ll().lat() != options.targets(i).ll().lat() ||
           options.sources(i).ll().lng() != options.targets(i).ll().lng()) {
         LOG_WARN("Targets differ from sources, skipping optimization...");

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -543,7 +543,7 @@ void parse_locations(const rapidjson::Document& doc,
     auto request_locations =
         rapidjson::get_optional<rapidjson::Value::ConstArray>(doc, std::string("/" + node).c_str());
     if (request_locations) {
-      uint32_t last_loc_idx = request_locations->Size() - 1;
+      int last_loc_idx = static_cast<int>(request_locations->Size()) - 1;
       for (const auto& r_loc : *request_locations) {
         auto* loc = locations->Add();
         auto loc_idx = locations->size() - 1;
@@ -555,7 +555,7 @@ void parse_locations(const rapidjson::Document& doc,
       }
     } // maybe its deserialized pbf
     else if (!locations->empty()) {
-      int i = 0;
+      uint32_t i = 0;
       uint32_t locs_amount = locations->size() - 1;
       for (auto& loc : *locations) {
         bool is_last_edge = i == locs_amount;

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -1431,10 +1431,10 @@ parse_hierarchy_limits_from_config(const boost::property_tree::ptree& config,
     default_hierarchy_limits.push_back(default_hl);
   }
 
-  if (!found)
+  if (!found) {
     LOG_WARN("Incomplete config for hierarchy limits found for " + algorithm +
              ". Falling back to defaults");
-
+  }
   return {max_hierarchy_limits, default_hierarchy_limits};
 };
 

--- a/test/gurka/test_osrm_serializer.cc
+++ b/test/gurka/test_osrm_serializer.cc
@@ -574,14 +574,15 @@ gurka::map VoiceInstructions::map = {};
 TEST_F(VoiceInstructions, VoiceInstructionsPresent) {
   auto json = json_request("A", "F");
   auto steps = json["routes"][0]["legs"][0]["steps"].GetArray();
+  ASSERT_TRUE(steps.Size() > 0);
   // Validate that each step (except the last one) has voiceInstructions with announcement,
   // ssmlAnnouncement and distanceAlongGeometry
-  for (int step = 0; step < steps.Size() - 1; ++step) {
+  for (uint32_t step = 0; step < steps.Size() - 1; ++step) {
     ASSERT_TRUE(steps[step].HasMember("voiceInstructions"));
     ASSERT_TRUE(steps[step]["voiceInstructions"].IsArray());
 
     EXPECT_GT(steps[step]["voiceInstructions"].Size(), 0);
-    for (int instr = 0; instr < steps[step]["voiceInstructions"].GetArray().Size(); ++instr) {
+    for (uint32_t instr = 0; instr < steps[step]["voiceInstructions"].GetArray().Size(); ++instr) {
       ASSERT_TRUE(steps[step]["voiceInstructions"][instr].HasMember("announcement"));
       ASSERT_TRUE(steps[step]["voiceInstructions"][instr].HasMember("ssmlAnnouncement"));
       ASSERT_TRUE(steps[step]["voiceInstructions"][instr].HasMember("distanceAlongGeometry"));
@@ -701,7 +702,7 @@ TEST_F(VoiceInstructions, DefaultVoiceLocalePresent) {
   auto json = json_request("A", "F");
   auto routes = json["routes"].GetArray();
   // Validate that each route has the default voiceLocale
-  for (int route = 0; route < routes.Size(); ++route) {
+  for (uint32_t route = 0; route < routes.Size(); ++route) {
     ASSERT_TRUE(routes[route].HasMember("voiceLocale"));
     EXPECT_STREQ(routes[route]["voiceLocale"].GetString(), "en-US");
   }
@@ -711,7 +712,7 @@ TEST_F(VoiceInstructions, VoiceLocalePresent) {
   auto json = json_request("A", "F", "de-DE");
   auto routes = json["routes"].GetArray();
   // Validate that each route has the voiceLocale from the options
-  for (int route = 0; route < routes.Size(); ++route) {
+  for (uint32_t route = 0; route < routes.Size(); ++route) {
     ASSERT_TRUE(routes[route].HasMember("voiceLocale"));
     EXPECT_STREQ(routes[route]["voiceLocale"].GetString(), "de-DE");
   }
@@ -765,13 +766,14 @@ TEST(Standalone, BannerInstructions) {
   auto json = gurka::convert_to_json(result, Options::Format::Options_Format_osrm);
 
   auto steps = json["routes"][0]["legs"][0]["steps"].GetArray();
+  ASSERT_TRUE(steps.Size() > 0);
 
   // Validate that each step (except the last one) has bannerInstructions with primary
-  for (int step = 0; step < steps.Size() - 1; ++step) {
+  for (uint32_t step = 0; step < steps.Size() - 1; ++step) {
     ASSERT_TRUE(steps[step].HasMember("bannerInstructions"));
     ASSERT_TRUE(steps[step]["bannerInstructions"].IsArray());
     EXPECT_GT(steps[step]["bannerInstructions"].GetArray().Size(), 0);
-    for (int instr = 0; instr < steps[step]["bannerInstructions"].GetArray().Size(); ++instr) {
+    for (uint32_t instr = 0; instr < steps[step]["bannerInstructions"].GetArray().Size(); ++instr) {
       ASSERT_TRUE(steps[step]["bannerInstructions"][instr].HasMember("distanceAlongGeometry"));
       ASSERT_TRUE(steps[step]["bannerInstructions"][instr].HasMember("primary"));
       ASSERT_TRUE(steps[step]["bannerInstructions"][instr]["primary"].HasMember("type"));
@@ -863,7 +865,7 @@ TEST(Standalone, BannerInstructions) {
   ASSERT_TRUE(sub_0.HasMember("components"));
   ASSERT_TRUE(sub_0["components"].IsArray());
   EXPECT_EQ(sub_0["components"].GetArray().Size(), 2);
-  for (int component = 0; component < sub_0["components"].GetArray().Size(); ++component) {
+  for (uint32_t component = 0; component < sub_0["components"].GetArray().Size(); ++component) {
     EXPECT_STREQ(sub_0["components"][component]["type"].GetString(), "lane");
     ASSERT_TRUE(sub_0["components"][component]["directions"].IsArray());
   }
@@ -917,7 +919,7 @@ TEST(Standalone, BannerInstructions) {
   ASSERT_TRUE(sub_1.HasMember("components"));
   ASSERT_TRUE(sub_1["components"].IsArray());
   EXPECT_EQ(sub_1["components"].GetArray().Size(), 2);
-  for (int component = 0; component < sub_1["components"].GetArray().Size(); ++component) {
+  for (uint32_t component = 0; component < sub_1["components"].GetArray().Size(); ++component) {
     EXPECT_STREQ(sub_1["components"][component]["type"].GetString(), "lane");
     ASSERT_TRUE(sub_1["components"][component]["directions"].IsArray());
   }
@@ -978,13 +980,14 @@ TEST(Standalone, BannerInstructionsRoundabout) {
   auto json = gurka::convert_to_json(result, Options::Format::Options_Format_osrm);
 
   auto steps = json["routes"][0]["legs"][0]["steps"].GetArray();
+  ASSERT_TRUE(steps.Size() > 0);
 
   // Validate that each step (except the last one) has bannerInstructions with primary
-  for (int step = 0; step < steps.Size() - 1; ++step) {
+  for (uint32_t step = 0; step < steps.Size() - 1; ++step) {
     ASSERT_TRUE(steps[step].HasMember("bannerInstructions"));
     ASSERT_TRUE(steps[step]["bannerInstructions"].IsArray());
     EXPECT_GT(steps[step]["bannerInstructions"].GetArray().Size(), 0);
-    for (int instr = 0; instr < steps[step]["bannerInstructions"].GetArray().Size(); ++instr) {
+    for (uint32_t instr = 0; instr < steps[step]["bannerInstructions"].GetArray().Size(); ++instr) {
       ASSERT_TRUE(steps[step]["bannerInstructions"][instr].HasMember("distanceAlongGeometry"));
       ASSERT_TRUE(steps[step]["bannerInstructions"][instr].HasMember("primary"));
       ASSERT_TRUE(steps[step]["bannerInstructions"][instr]["primary"].HasMember("type"));


### PR DESCRIPTION
The removed functions from `odin/enhancedtrippath.cc` and `odin/maneuver.cc` were apparently not unused. There are implementations with the same name in `common.pb.cc`, `directions.pb.cc`, and `trip.pb.cc`. The unused functions caused build error with trace logging enabled since #5523.

With lower log levels (error/none) there were also some build errors due to unused variables only that were only used for logging. Also runtime errors existed because of if statements without braces for `LOG_WARN()` which expands to nothing on lower log levels, causing the `if` statement being applied to the following statement instead.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [ ] If you made changes to a translation file, [update transifex](docs/docs/locales.md) too
