### PR TITLE
chore(CI): add GHA to create PR for release

### DIFF
--- a/.github/workflows/quarterly_release_pr.yml
+++ b/.github/workflows/quarterly_release_pr.yml
@@ -5,9 +5,11 @@ on:
     # every first of the month
     - cron: "0 0 1 * *"
   workflow_dispatch:
-  push:
-    branches:
-      - nn-release-check-gha
+    inputs:
+      new_tag:
+        type: string
+        description: "The new release tag"
+        required: true
 
 permissions:
   contents: write
@@ -29,9 +31,14 @@ jobs:
         id: get_tag
         run: |
           set -euo pipefail
-          latest_tag=$(git describe --tags --abbrev=0)
-          new_tag=$(echo "$latest_tag" | awk -F. -v OFS=. '{$3 = $3 + 1; print}')
-          echo "new_tag=$new_tag" >> $GITHUB_OUTPUT
+          # manually triggered will take the passed version string
+          if [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
+            echo "new_tag=${{ inputs.new_tag }}" >> $GITHUB_OUTPUT
+          else
+            latest_tag=$(git describe --tags --abbrev=0)
+            new_tag=$(echo "$latest_tag" | awk -F. -v OFS=. '{$3 = $3 + 1; print}')
+            echo "new_tag=$new_tag" >> $GITHUB_OUTPUT
+          fi
 
       - name: Raise PR
         run: |


### PR DESCRIPTION
this will create a PR on every 1st of the month with all relevant files prepared (CHANGELOG.md & valhalla/valhalla.h). it only adds to patch version, so might need to elevate to minor version, e.g. the coming release would probably better be 3.6.0, not 3.5.2. in that case it might be easiest to close the PR and re-trigger the workflow manually where it requires to set a version string as input. then the branch name is also the correct one.

example is here: https://github.com/valhalla/valhalla/pull/5567