### PR TITLE
fix: `-Werror` by clang in meili

### DIFF
--- a/src/meili/match_route.cc
+++ b/src/meili/match_route.cc
@@ -1,8 +1,12 @@
 #include "meili/map_matcher.h"
-#include "midgard/logging.h"
 
 #include <cassert>
 #include <vector>
+
+// `ValidateRoute` is only used in debug mode
+#ifndef NDEBUG
+
+#include "midgard/logging.h"
 
 namespace {
 
@@ -46,6 +50,7 @@ bool ValidateRoute(baldr::GraphReader& graphreader,
 }
 
 }; // namespace
+#endif
 
 namespace valhalla {
 namespace meili {

--- a/valhalla/meili/transition_cost_model.h
+++ b/valhalla/meili/transition_cost_model.h
@@ -89,8 +89,6 @@ private:
 
   // Cost for each degree in [0, 180]
   float turn_cost_table_[181];
-
-  bool match_on_restrictions_{false};
 };
 
 } // namespace meili


### PR DESCRIPTION
This PR fixes compilation errors introduced in https://github.com/valhalla/valhalla/pull/5548

```
valhalla/src/meili/match_route.cc:13:6: error: unused function 'ValidateRoute' [-Werror,-Wunused-function]
   13 | bool ValidateRoute(baldr::GraphReader& graphreader,
      |      ^~~~~~~~~~~~~
1 error generated.
...
valhalla/valhalla/meili/transition_cost_model.h:93:8: error: private field 'match_on_restrictions_' is not used [-Werror,-Wunused-private-field]
   93 |   bool match_on_restrictions_{false};
      |        ^
1 error generated.
```

# Issue

What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [ ] If you made changes to a translation file, [update transifex](docs/docs/locales.md) too

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
