### PR TITLE
Fix windows build

### DIFF
--- a/src/mjolnir/linkclassification.cc
+++ b/src/mjolnir/linkclassification.cc
@@ -6,6 +6,8 @@
 
 #ifdef LOGGING_LEVEL_DEBUG
 #include "baldr/json.h"
+
+#include <sstream>
 #endif
 
 #include <optional>

--- a/test/test.cc
+++ b/test/test.cc
@@ -5,6 +5,7 @@
 #include "baldr/rapidjson_utils.h"
 #include "baldr/traffictile.h"
 #include "microtar.h"
+#include "midgard/sequence.h"
 #include "mjolnir/graphtilebuilder.h"
 
 #include <boost/algorithm/string.hpp>


### PR DESCRIPTION
# Issue
It didn't compile for me on windows.

`#include <sstream>` is needed for `std::ostringstream`
`#include "midgard/sequence.h"` is needed for `mmap` / `munmap`