### PR TITLE
Add test to check restrictions covered by middle location

### DIFF
--- a/test/gurka/test_route.cc
+++ b/test/gurka/test_route.cc
@@ -552,6 +552,71 @@ TEST(Standalone, DontIgnoreRestrictionUnderMiddleLocation) {
   }
 }
 
+TEST(Standalone, DontIgnoreLongRestrictionUnderMiddleLocation) {
+  const std::string ascii_map = R"(
+                D----F----G
+               /
+      A----B--C
+           |
+      H----E
+)";
+
+  const gurka::ways ways = {
+      {"GF", {{"highway", "secondary"}, {"oneway", "yes"}}},
+      {"FD", {{"highway", "secondary"}, {"oneway", "yes"}}},
+      {"DC", {{"highway", "secondary"}, {"oneway", "yes"}}},
+      {"CB", {{"highway", "secondary"}, {"oneway", "yes"}}},
+      {"BE", {{"highway", "primary"}, {"oneway", "yes"}}},
+      {"EH", {{"highway", "primary"}, {"oneway", "yes"}}},
+      {"BA", {{"highway", "primary"}, {"oneway", "yes"}}}
+  };
+
+  const gurka::relations relations = {
+      {{
+           {gurka::way_member, "FD", "from"},
+           {gurka::way_member, "DC", "via"},
+           {gurka::way_member, "CB", "via"},
+           {gurka::way_member, "BE", "to"},
+       },
+       {
+           {"type", "restriction"},
+           {"restriction", "no_entry"},
+       }},
+  };
+
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100);
+  auto map = gurka::buildtiles(layout, ways, {}, relations, "test/data/dont_ignore_restriction_under_middle_location",
+                               {{"mjolnir.concurrency", "1"}});
+
+  try {
+    auto result = gurka::do_action(valhalla::Options::route, map, {"G", "C", "H"}, "auto", {}, {}, nullptr, "break_through");
+    gurka::assert::raw::expect_path(result, {"Unexpected path found"});
+  } catch (const std::runtime_error& e) {
+    EXPECT_STREQ(e.what(), "No path could be found for input");
+  }
+
+  try {
+    auto result = gurka::do_action(valhalla::Options::route, map, {"G", "C", "H"}, "auto", {}, {}, nullptr, "through");
+    gurka::assert::raw::expect_path(result, {"Unexpected path found"});
+  } catch (const std::runtime_error& e) {
+    EXPECT_STREQ(e.what(), "No path could be found for input");
+  }
+
+  try {
+    auto result = gurka::do_action(valhalla::Options::route, map, {"G", "C", "H"}, "auto", {}, {}, nullptr, "via");
+    gurka::assert::raw::expect_path(result, {"Unexpected path found"});
+  } catch (const std::runtime_error& e) {
+    EXPECT_STREQ(e.what(), "No path could be found for input");
+  }
+
+  try {
+    auto result = gurka::do_action(valhalla::Options::route, map, {"G", "C", "H"}, "auto", {}, {}, nullptr, "break");
+    gurka::assert::raw::expect_path(result, {"Unexpected path found"});
+  } catch (const std::runtime_error& e) {
+    EXPECT_STREQ(e.what(), "No path could be found for input");
+  }
+}
+
 TEST(Standalone, BridgingEdgeIsRestricted) {
   const std::string ascii_map = R"(
    A----B----C--------D----E----F-----G


### PR DESCRIPTION
# Issue

Test to check problem with complex restrictions covered by middle location #5562.

It looks like _"break_through"_ and _"through"_ middle location works well, but with _"break"_ and _"via"_ middle location type covered restriction incorrectly ignored.


## Tasklist

 - [x] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [ ] If you made changes to a translation file, [update transifex](docs/docs/locales.md) too

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
