### PR TITLE
Removal of the rent/return bike instruction in the case of BSS

### DIFF
--- a/src/odin/narrativebuilder.cc
+++ b/src/odin/narrativebuilder.cc
@@ -539,8 +539,7 @@ void NarrativeBuilder::Build(std::list<Maneuver>& maneuvers) {
         break;
       }
     }
-    maneuver.set_instruction(FormBssManeuverType(maneuver.bss_maneuver_type()) +
-                             maneuver.instruction());
+    maneuver.set_instruction(maneuver.instruction());
 
     // Update previous maneuver
     prev_maneuver = &maneuver;
@@ -4924,19 +4923,6 @@ std::string NarrativeBuilder_ruRU::GetPluralCategory(size_t count) {
     return kPluralCategoryFewKey;
   }
   return kPluralCategoryOtherKey;
-}
-
-std::string NarrativeBuilder::FormBssManeuverType(DirectionsLeg_Maneuver_BssManeuverType type) {
-  switch (type) {
-    case DirectionsLeg_Maneuver_BssManeuverType_kRentBikeAtBikeShare: {
-      return "Then rent a bike at BSS. ";
-    }
-    case DirectionsLeg_Maneuver_BssManeuverType_kReturnBikeAtBikeShare: {
-      return "Then return the bike to BSS. ";
-    }
-    default:
-      return "";
-  }
 }
 } // namespace odin
 } // namespace valhalla

--- a/valhalla/odin/narrativebuilder.h
+++ b/valhalla/odin/narrativebuilder.h
@@ -635,8 +635,6 @@ protected:
    * @return true if the specified maneuver is within the mulit-cue bounds.
    */
   bool IsWithinVerbalMultiCueBounds(Maneuver& maneuver);
-
-  std::string FormBssManeuverType(DirectionsLeg_Maneuver_BssManeuverType);
   /**
    * Combines a simple preposition and a definite article for certain languages.
    */


### PR DESCRIPTION
Hi,
I work for HOVE, the official publisher of the [Navitia product](https://github.com/hove-io/navitia).
In the context of BSS, I'd like to remove the two strings (FormBssManeuverType function ) we introduced in [PR](https://github.com/valhalla/valhalla/pull/2031), as they are causing a problem.

Would you be open to removing these two strings, considering they are most likely only used by HOVE?

I'm using language=fr-FR as an example:

<img width="1433" height="346" alt="image" src="https://github.com/user-attachments/assets/0922d2ab-cfbb-416a-9711-e5c4e4be42ce" />

