### PR TITLE
fix: unused variables in `valhalla/src/mjolnir/util.cc` [-Werror,-Wunused-const-variable]

### DIFF
--- a/src/mjolnir/util.cc
+++ b/src/mjolnir/util.cc
@@ -40,15 +40,12 @@ const std::string nodes_file = "nodes.bin";
 const std::string edges_file = "edges.bin";
 const std::string tile_manifest_file = "tile_manifest.json";
 const std::string access_file = "access.bin";
-const std::string pronunciation_file = "pronunciation.bin";
 const std::string bss_nodes_file = "bss_nodes.bin";
 const std::string linguistic_node_file = "linguistics_node.bin";
 const std::string cr_from_file = "complex_from_restrictions.bin";
 const std::string cr_to_file = "complex_to_restrictions.bin";
 const std::string new_to_old_file = "new_nodes_to_old_nodes.bin";
 const std::string old_to_new_file = "old_nodes_to_new_nodes.bin";
-const std::string intersections_file = "intersections.bin";
-const std::string shapes_file = "shapes.bin";
 
 uint64_t get_pbf_checksum(std::vector<std::string> paths, const std::string& tile_dir) {
   std::sort(paths.begin(), paths.end());


### PR DESCRIPTION
_Please don't force-push once you received the first review._

# Issue

```
$ cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo && cmake --build . -j 14
-- The CXX compiler identification is AppleClang 17.0.0.17000013
-- The C compiler identification is AppleClang 17.0.0.17000013
...
FAILED: [code=1] src/mjolnir/CMakeFiles/valhalla-mjolnir.dir/util.cc.o
ccache /usr/bin/c++ -DAUTO_DOWNLOAD=0 -DBOOST_ALLOW_DEPRECATED_HEADERS -DBOOST_BIND_GLOBAL_PLACEHOLDERS -DBOOST_NO_CXX11_SCOPED_ENUMS -DDATA_TOOLS -DHAS_REMOTE_API=0 -DVALHALLA_BUILD_DIR=./valhalla/build -DVALHALLA_SOURCE_DIR=./valhalla -I./valhalla -I./valhalla/valhalla -I./valhalla/build/src/mjolnir -I./valhalla/build/src/mjolnir/valhalla -I./valhalla/build/src -I./valhalla/build/src/valhalla -I/opt/homebrew/Cellar/geos/3.14.0/include -I/opt/homebrew/Cellar/libspatialite/5.1.0_1/include -I/opt/homebrew/opt/sqlite/include -I/opt/homebrew/Cellar/luajit/2.1.1760617492/include/luajit-2.1 -I/opt/homebrew/Cellar/openssl@3/3.6.0/include -isystem ./valhalla/third_party/date/include -isystem ./valhalla/third_party/rapidjson/include -isystem ./valhalla/third_party/date/include/date -isystem ./valhalla/third_party/just_gtfs/include -isystem ./valhalla/third_party/unordered_dense/include -isystem ./valhalla/third_party/libosmium/include -isystem ./valhalla/third_party/protozero/include -isystem /opt/homebrew/include -fcolor-diagnostics  -O2 -g -DNDEBUG -std=gnu++20 -arch arm64 -fPIC -Werror -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wno-cpp -MD -MT src/mjolnir/CMakeFiles/valhalla-mjolnir.dir/util.cc.o -MF src/mjolnir/CMakeFiles/valhalla-mjolnir.dir/util.cc.o.d -o src/mjolnir/CMakeFiles/valhalla-mjolnir.dir/util.cc.o -c ./valhalla/src/mjolnir/util.cc
./valhalla/src/mjolnir/util.cc:43:19: error: unused variable 'pronunciation_file' [-Werror,-Wunused-const-variable]
   43 | const std::string pronunciation_file = "pronunciation.bin";
      |                   ^~~~~~~~~~~~~~~~~~
./valhalla/src/mjolnir/util.cc:50:19: error: unused variable 'intersections_file' [-Werror,-Wunused-const-variable]
   50 | const std::string intersections_file = "intersections.bin";
      |                   ^~~~~~~~~~~~~~~~~~
./valhalla/src/mjolnir/util.cc:51:19: error: unused variable 'shapes_file' [-Werror,-Wunused-const-variable]
   51 | const std::string shapes_file = "shapes.bin";
      |                   ^~~~~~~~~~~
3 errors generated.
```

What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [ ] If you made changes to a translation file, [update transifex](docs/docs/locales.md) too

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
