### PR TITLE
Add OSM node id into BSS info

### DIFF
--- a/proto/common.proto
+++ b/proto/common.proto
@@ -189,6 +189,7 @@ message BikeShareStationInfo {
   string operator = 5;
   float rent_cost = 6;
   float return_cost = 7;
+  uint64 osm_node_id= 8;
 }
 
 message TransitPlatformInfo {

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -2004,6 +2004,7 @@ struct graph_parser {
     n.set_latlng(node.location().lon(), node.location().lat());
     n.set_type(NodeType::kBikeShare);
     valhalla::BikeShareStationInfo bss_info;
+    bss_info.set_osm_node_id(osmid);
 
     for (auto& key_value : tags) {
       if (key_value.first == "name") {
@@ -4210,7 +4211,7 @@ struct graph_parser {
                   return; // should not make it here; has to be bad data.
                 }
               } // else
-            }   // if (condition.empty())
+            } // if (condition.empty())
 
             std::vector<std::string> conditions = GetTagTokens(condition, ';');
 
@@ -4237,7 +4238,7 @@ struct graph_parser {
             }
             return;
           } // if (isConditional)
-        }   // end turning into complex restriction
+        } // end turning into complex restriction
 
         restriction.set_modes(modes);
 


### PR DESCRIPTION
Hi, I am Vivien from the Hove company. We'd like to add the OSM node id in the output  protocol buffer that describes the BikeShareStation. Let me know if that's OK for you!

_Please don't force-push once you received the first review._

# Issue

What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [ ] If you made changes to a translation file, [update transifex](docs/docs/locales.md) too

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
