### PR TITLE
feat: Ability to override driving side by `driving_side` tag without setting `use_admin_db` to `false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
    * CHANGED: Microoptimisation in EdgeInfo. [#5733](https://github.com/valhalla/valhalla/pull/5733)
    * CHANGED: Merge cost and tyr inline tests into single executable [#5735](https://github.com/valhalla/valhalla/pull/5735) 
    * ADDED: Add option `edge.hov_type` to trace attributes [#5741](https://github.com/valhalla/valhalla/pull/5741)
+   * ADDED: Ability to override driving side by `driving_side` tag without setting `use_admin_db` to `false` [#5748](https://github.com/valhalla/valhalla/pull/5748)
 
 ## Release Date: 2025-11-14 Valhalla 3.6.1
 * **Removed**

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -608,8 +608,10 @@ void BuildTileSet(const std::string& ways_file,
             std::swap(source, target);
           }
 
-          if (!use_admin_db)
+          // Allow specific tag to override drive on right
+          if (w.has_driving_side()) {
             dor = w.drive_on_right();
+          }
 
           // Validate speed. Set speed limit and truck speed.
           uint32_t speed = w.speed();

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -185,9 +185,7 @@ struct graph_parser {
     empty_relation_tags_ = lua_.Transform(OSMType::kRelation, 0, {});
 
     tag_handlers_["driving_side"] = [this]() {
-      if (!use_admin_db_) {
-        way_.set_drive_on_right(tag_.second == "right" ? true : false);
-      }
+      way_.set_drive_on_right(tag_.second == "right" ? true : false);
     };
     tag_handlers_["internal_intersection"] = [this]() {
       if (!infer_internal_intersections_) {
@@ -2559,8 +2557,6 @@ struct graph_parser {
 
     const auto& tracktype_exists = tags.find("tracktype");
     has_tracktype_tag_ = (tracktype_exists != tags.end());
-
-    way_.set_drive_on_right(true); // default
 
     for (const auto& kv : tags) {
       tag_ = {kv.first, kv.second};

--- a/valhalla/mjolnir/osmway.h
+++ b/valhalla/mjolnir/osmway.h
@@ -2156,6 +2156,15 @@ struct OSMWay {
    */
   void set_drive_on_right(const bool drive_on_right) {
     drive_on_right_ = drive_on_right;
+    has_driving_side_ = true;
+  }
+
+  /**
+   * Indicates if the drive on right tag is present.
+   * @return  Returns true if the drive on right tag is present.
+   */
+  bool has_driving_side() const {
+    return has_driving_side_;
   }
 
   /**
@@ -2645,7 +2654,7 @@ struct OSMWay {
   uint32_t toll_ : 1;
   uint32_t bridge_ : 1;
   uint32_t multiple_levels_ : 1;
-  uint32_t drive_on_right_ : 1;
+  uint32_t drive_on_right_ : 1; // Drive side override. Set if `has_driving_side_` is true.
   uint32_t bike_network_ : 4;
   uint32_t exit_ : 1;
   uint32_t tagged_speed_ : 1;
@@ -2708,7 +2717,8 @@ struct OSMWay {
   uint16_t bike_backward_ : 1;
   uint16_t lit_ : 1;
   uint16_t destination_only_hgv_ : 1;
-  uint16_t spare2_ : 2;
+  uint16_t has_driving_side_ : 1;
+  uint16_t spare_ : 1;
 
   uint16_t nodecount_;
 


### PR DESCRIPTION
_Please don't force-push once you received the first review._

# Issue

A proper https://wiki.openstreetmap.org/wiki/Key:driving_side tag support for rare cases where diriving side of the particular road is different from the general rule.

Previously that tag was handled only if `"mjolnir.data_processing.use_admin_db"` was set to `"false"`.

The main motivation for this PR is to reduce amount of logic around `use_admin_db` flag.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [ ] If you made changes to a translation file, [update transifex](docs/docs/locales.md) too

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
