### PR TITLE
Fix URL of style.json example in Tile API docs

### DIFF
--- a/docs/docs/api/tile/api-reference.md
+++ b/docs/docs/api/tile/api-reference.md
@@ -21,7 +21,7 @@ We support the usual GET & POST with the common "Slippy Map"/XYZ request pattern
 
 Most often software supporting MVT lets you specify a URL pattern expecting placeholders like `{z}/{x}/{y}?<query_params>`. For consistency's sake, we use our common `/?json=<post_json>` notation. Sadly that inteferes with placeholder parsing and the `<post_json>` usually has to be URL encoded for use in Maplibre/QGIS et al, e.g. `http://localhost:8002/tile?json=%7B%22tile%22%3A%7B%22z%22%3A{z}%2C%22x%22%3A{x}%2C%22y%22%3A{y}%7D%7D`. Note how x/y/z `{}` placeholders aren't encoded.
 
-See an example `style.json` [here](https://github.com/valhalla/valhalla/blob/master/docs/docs/tile/default_style.json).
+See an example `style.json` [here](https://github.com/valhalla/valhalla/blob/master/docs/docs/api/tile/default_style.json).
 
 ### Error/status codes and messages
 


### PR DESCRIPTION
Fixes broken link in Tiles API docs