### PR TITLE
perf: Use `ankerl::unordered_dense::map/set` in `bin_handler_t`

### DIFF
--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -262,12 +262,12 @@ struct bin_handler_t {
   cost_ptr_t costing;
   unsigned int max_reach_limit;
   std::vector<candidate_t> bin_candidates;
-  std::unordered_set<uint64_t> correlated_edges;
+  ankerl::unordered_dense::set<uint64_t> correlated_edges;
   Reach reach_finder;
 
   // keep track of edges whose reachability we've already computed
   // TODO: dont use pointers as keys, its safe for now but fancy caching one day could be bad
-  std::unordered_map<const DirectedEdge*, directed_reach> directed_reaches;
+  ankerl::unordered_dense::map<const DirectedEdge*, directed_reach> directed_reaches;
 
   bin_handler_t(vb::GraphReader& reader) : reader(reader), max_reach_limit(0) {
   }


### PR DESCRIPTION
_Please don't force-push once you received the first review._

# Issue

`std::unordered_set` is notoriously slow for construction/destruction.

<img width="1512" height="302" alt="image" src="https://github.com/user-attachments/assets/176da95e-df47-413a-90e1-5704ac2f5c5a" />
<img width="496" height="437" alt="image" src="https://github.com/user-attachments/assets/ff4bc35f-3653-456f-903f-ab79d66dc536" />


This PR replaces `std::unordered_set`/`std::unordered_map` in the `bin_handler_t` by the `ankerl::unordered_dense` equivalents.

<img width="1512" height="297" alt="image" src="https://github.com/user-attachments/assets/c4d7af1a-d4eb-4f78-be2b-a6f6ca48a024" />
<img width="459" height="425" alt="image" src="https://github.com/user-attachments/assets/e5362adf-854a-40e2-b491-867acab356c9" />


## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [ ] If you made changes to a translation file, [update transifex](docs/docs/locales.md) too

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
