### PR TITLE
fix: `--version` program options to print _only_ the version string 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
    * CHANGED: Templatize CostMatrix connection check [#5729](https://github.com/valhalla/valhalla/pull/5729)
    * ADDED: /tile endpoint to serve MVT (BETA) [#5663](https://github.com/valhalla/valhalla/pull/5663)
    * ADDED: `valhalla-dev` image [#5739](https://github.com/valhalla/valhalla/pull/5739)
+   * CHANGED: --version program options to print _only_ the version string and omit the program name [#5769](https://github.com/valhalla/valhalla/pull/5769)
 
 ## Release Date: 2025-11-14 Valhalla 3.6.1
 * **Removed**

--- a/src/argparse_utils.h
+++ b/src/argparse_utils.h
@@ -43,7 +43,7 @@ bool parse_common_args(const std::string& program,
   }
 
   if (result.count("version")) {
-    std::cout << std::string(program) << " " << VALHALLA_PRINT_VERSION << "\n";
+    std::cout << VALHALLA_PRINT_VERSION << "\n";
     return false;
   }
 


### PR DESCRIPTION
it's redundant to print the program name + version on e.g. `valhalla_service -v`. but it's mostly clumsy to use the version in scripting.

`valhalla_service -v` before:

```
valhalla_service 3.6.1-aabbccdd
```

after:

```
3.6.1-aabbccdd
```