### PR TITLE
make linguist ignore ipynb

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -23,3 +23,4 @@
 # Declare changelog to be union merged, as that's tyically
 # how you want to deal with conflicts in a changelog
 /CHANGELOG.md merge=union
+*.ipynb linguist-vendored


### PR DESCRIPTION
Just a minor detail, on the GitHub repo it says Valhalla is 20% written in Jupyter Notebooks :smile: this line excludes notebooks from those stats. 