### PR TITLE
Add Rust polyline decoding example

### DIFF
--- a/docs/docs/decoding.md
+++ b/docs/docs/decoding.md
@@ -283,3 +283,57 @@ func decodePolyline(encoded *string, precisionOptional ...int) [][]float64 {
 	return coordinates
 }
 ```
+
+## Rust
+
+```rust
+/// Decode a polyline string.
+fn decode_polyline(polyline: &str, precision: f64) -> Vec<(f64, f64)> {
+    let mut shape = Vec::new();
+
+    let mut chars = polyline.chars();
+    let mut last_lat = 0;
+    let mut last_lon = 0;
+
+    // Get the next latitude/longitude tuple.
+    let mut next_coordinates = || {
+        last_lat = parse_polyline_coordinate(&mut chars, last_lat)?;
+        last_lon = parse_polyline_coordinate(&mut chars, last_lon)?;
+        Some((last_lat, last_lon))
+    };
+
+    while let Some((lat, lon)) = next_coordinates() {
+        shape.push((lat as f64 / precision, lon as f64 / precision));
+    }
+
+    shape
+}
+
+/// Parse the next latitude or longitude in the polyline string.
+fn parse_polyline_coordinate(mut chars: impl Iterator<Item = char>, previous: i32) -> Option<i32> {
+    let mut byte = None;
+    let mut result = 0;
+    let mut shift = 0;
+
+    while byte.is_none_or(|b| b >= 0x20) {
+        let byte = *byte.insert(chars.next()? as i32 - 63);
+        result |= (byte & 0x1f) << shift;
+        shift += 5;
+    }
+
+    let value = if result & 1 != 0 {
+        previous + !(result >> 1)
+    } else {
+        previous + (result >> 1)
+    };
+
+    Some(value)
+}
+
+#[test]
+fn decode_polyline6() {
+    let x = decode_polyline("e~epoA|jfpOiDaK", 1E6);
+    let decoded = vec![(42.225139, -8.670911), (42.225224, -8.670718)];
+    assert_eq!(x, decoded);
+}
+```


### PR DESCRIPTION
This adds a Rust implementation to the documentation on decoding a route shape.

While other implementations only add the function itself, this patch also adds a simple test to demonstrate working behavior. A language implementation might not be the correct place for this, but providing examples for correct behavior seems useful as a reference for people looking to implement this themselves.

---

I'm not sure if the goal of this documentation page is to provide an implementation for all languages, but since I've written a Rust implementation anyway I thought I might as well send a patch. Feel free to close if you believe the existing languages are sufficient, they certainly were sufficient for making this Rust implementation trivial.

While the existing languages should be sufficient, I certainly found that a tiny example for expected encoded/decoded data would have been helpful. Google's documentation on polylines provides some example data for `1E5` precision, but this documentation only provides a link to the demo tool, which requires an encoded line to begin with (so I had to pull a shape from the valhalla API first). If you want me to add *just* an example, or add the example as something other than a Rust test, please let me know.