### PR TITLE
Fix format-truncation warning in TimeStamp function

### DIFF
--- a/src/midgard/logging.cc
+++ b/src/midgard/logging.cc
@@ -43,7 +43,16 @@ std::string TimeStamp() {
   int ret = snprintf(buffer.data(), buffer.size(), "%04d/%02d/%02d %02d:%02d:%09.6f",
                      gmt.tm_year + 1900, gmt.tm_mon + 1, gmt.tm_mday, gmt.tm_hour, gmt.tm_min,
                      fractional_seconds.count());
-  return std::string(buffer.data(), ret > 0 ? static_cast<size_t>(ret) : 0);
+  if (ret < 0) {
+    // Encoding or formatting error
+    return std::string();
+  }
+  std::size_t len = static_cast<std::size_t>(ret);
+  if (len >= buffer.size()) {
+    // Output was truncated; cap length to the buffer capacity minus null terminator
+    len = buffer.size() - 1;
+  }
+  return std::string(buffer.data(), len);
 }
 
 // the Log levels we support


### PR DESCRIPTION
Use std::array<char, 64> instead of std::string with fixed size to avoid
GCC's -Werror=format-truncation warning. The compiler was warning that
snprintf could theoretically write more bytes than the buffer size in
worst-case scenarios with large int values.

The new implementation:
- Uses a 64-byte buffer (more than enough for the timestamp format)
- Constructs the return string with the exact length from snprintf
- Adds #include <array> for std::array

_Please don't force-push once you received the first review._

# Issue

What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [ ] If you made changes to a translation file, [update transifex](docs/docs/locales.md) too


