### PR TITLE
fix: variable `contained_bin_count` set but not used [-Werror,-Wunused-but-set-variable]

### DIFF
--- a/src/loki/polygon_search.cc
+++ b/src/loki/polygon_search.cc
@@ -139,7 +139,7 @@ std::unordered_set<GraphId> edges_in_rings(const Options& options,
   // keep track which tile's bins intersect which rings
   std::unordered_set<GraphId> avoid_edge_ids;
   bins_collector_t contained_bins;
-  uint32_t contained_bin_count = 0;
+  [[maybe_unused]] uint32_t contained_bin_count = 0;
   contained_bins.reserve(200); // TODO: approximate based on polygon size?
   bins_collector_t bins_intersected;
 


### PR DESCRIPTION
# Issue

```
$ cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo && cmake --build . -j 12
-- The CXX compiler identification is AppleClang 17.0.0.17000603
-- The C compiler identification is AppleClang 17.0.0.17000603
...
valhalla/src/loki/polygon_search.cc:142:12: error: variable 'contained_bin_count' set but not used [-Werror,-Wunused-but-set-variable]
  142 |   uint32_t contained_bin_count = 0;
      |            ^
1 error generated.
```

happens because `LOG_DEBUG` is not enabled in the default configuration 

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [ ] If you made changes to a translation file, [update transifex](docs/docs/locales.md) too

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
