### PR TITLE
fix: default to no `destination_only_penalty` for pedestrian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
    * ADDED: sort operator for GraphId which is ideal for mmap & edge_id loop cache [#5839](https://github.com/valhalla/valhalla/pull/5839)
    * ADDED: support for `filters` & `verbose` in `/tile` endpoint [#5806](https://github.com/valhalla/valhalla/pull/5806)
    * CHANGED: Timestamp log format changed from year/mo/dy hr:mn:sc.micros to year-mo-dy hr:mn:sc.nanosecnd [#5856](https://github.com/valhalla/valhalla/pull/5856)
+   * CHANGED: default to no `destination_only_penalty` for pedestrian 
 
 ## Release Date: 2026-01-15 Valhalla 3.6.2
 * **Removed**

--- a/src/sif/pedestriancost.cc
+++ b/src/sif/pedestriancost.cc
@@ -31,6 +31,7 @@ constexpr float kDefaultPrivateAccessPenalty = 600.0f; // Seconds
 constexpr float kDefaultBssCost = 120.0f;              // Seconds
 constexpr float kDefaultBssPenalty = 0.0f;             // Seconds
 constexpr float kDefaultServicePenalty = 0.0f;         // Seconds
+constexpr float kDefaultDestOnlyPenalty = 0.0f;        // Seconds
 
 // Maximum route distances
 constexpr uint32_t kMaxDistanceFoot = 100000;      // 100 km
@@ -162,6 +163,7 @@ BaseCostingOptionsConfig GetBaseCostOptsConfig() {
   cfg.use_ferry_.def = kDefaultUseFerry;
   cfg.use_living_streets_.def = kDefaultUseLivingStreets;
   cfg.use_lit_.def = kDefaultUseLit;
+  cfg.dest_only_penalty_.def = kDefaultDestOnlyPenalty;
   return cfg;
 }
 
@@ -1044,6 +1046,15 @@ TEST(PedestrianCost, testPedestrianCostParams) {
                 test::IsBetween(defaults.country_crossing_penalty_.min,
                                 defaults.country_crossing_penalty_.max +
                                     defaults.country_crossing_cost_.def));
+  }
+
+  // destination_only_penalty_
+  real_distributor.reset(make_distributor_from_range(defaults.dest_only_penalty_));
+  for (unsigned i = 0; i < testIterations; ++i) {
+    ctorTester.reset(make_pedestriancost_from_json("destination_only_penalty",
+                                                   (*real_distributor)(generator), "foot"));
+    EXPECT_THAT(ctorTester->destination_only_penalty_,
+                test::IsBetween(defaults.dest_only_penalty_.min, defaults.dest_only_penalty_.max));
   }
 
   // Wheelchair tests


### PR DESCRIPTION
fixes part of #5858 

default `destination_only_penalty` for pedestrian to 0 secs.