### PR TITLE
don't throw a 442 on an empty matrix result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
    * FIXED: replace `shutting_seconds` with `shutdown_seconds` [#5854](https://github.com/valhalla/valhalla/pull/5854)
    * FIXED: MVT attributes were erroneously cast to uint32_t for booleans and others [#5861](https://github.com/valhalla/valhalla/pull/5861)
    * FIXED: small bug in valhalla_add_landmarks [#5859](https://github.com/valhalla/valhalla/pull/5859)
+   * FIXED: replace dry-run with report arg in `valhalla_build_config` [#5875](https://github.com/valhalla/valhalla/pull/5875)
 * **Enhancement**
    * ADDED: `GraphUtils` class to Python bindings for low-level graph tile access [#5819](https://github.com/valhalla/valhalla/pull/5819)
    * ADDED: `predicted_speeds` module to Python bindings for DCT-2 speed compression utilities [#5819](https://github.com/valhalla/valhalla/pull/5819)
@@ -23,6 +24,7 @@
    * CHANGED: Added `mjolnir.data_quality_dir` as optional config to control the directory for e.g. duplicateways.txt
    * CHANGED: extended `valhalla_build_config` script to optionally merge config with an existing one [#5857](https://github.com/valhalla/valhalla/pull/5857)
    * ADDED: congestion in shape attributes [#5865](https://github.com/valhalla/valhalla/pull/5865)
+   * CHANGED: release GIL for Actor methods, `get_edge_shape` & `get_tile_ids_from_bbox` [#5868](https://github.com/valhalla/valhalla/pull/5868)
    * CHANGED: don't throw a 442 error when matrix found no results [#5871](https://github.com/valhalla/valhalla/pull/5871)
 
 ## Release Date: 2026-01-15 Valhalla 3.6.2

--- a/scripts/valhalla_build_config
+++ b/scripts/valhalla_build_config
@@ -953,10 +953,10 @@ parser.add_argument(
     "With arguments (JSON dot notation, e.g. 'mjolnir.logging'), removes only those keys.",
 )
 parser.add_argument(
-    "-d",
-    "--dry-run",
+    "-p",
+    "--report",
     action="store_true",
-    help="When merging, only print the report of changes without outputting the config.",
+    help="When merging, print the merge report.",
 )
 
 # entry point to program
@@ -985,14 +985,11 @@ if __name__ == "__main__":
         # args.remove_old is None if not specified, [] if specified without args, or a list of keys
         output_config = merge_json(existing_config, config, report, args.remove_old)
 
-    # dry-run mode: only print report, no output
-    if args.dry_run:
+    if args.report:
         if report:
             report.print_report()
         elif not args.merge_config:
-            print("Error: --dry-run requires --merge-config", file=sys.stderr)
-            sys.exit(1)
-        sys.exit(0)
+            print("Warn: --report requires --merge-config", file=sys.stderr)
 
     # format output
     output_json = json.dumps(output_config, indent=2)

--- a/src/bindings/python/src/_valhalla.cc
+++ b/src/bindings/python/src/_valhalla.cc
@@ -49,47 +49,60 @@ NB_MODULE(_valhalla, m) {
           nb::arg("config"))
       .def(
           "route", [](vt::actor_t& self, std::string& req) { return self.route(req); },
-          "Calculates a route.")
+          "Calculates a route.", nb::call_guard<nb::gil_scoped_release>())
       .def(
           "locate", [](vt::actor_t& self, std::string& req) { return self.locate(req); },
-          "Provides information about nodes and edges.")
+          "Provides information about nodes and edges.", nb::call_guard<nb::gil_scoped_release>())
       .def(
           "optimized_route",
           [](vt::actor_t& self, std::string& req) { return self.optimized_route(req); },
-          "Optimizes the order of a set of waypoints by time.")
+          "Optimizes the order of a set of waypoints by time.",
+          nb::call_guard<nb::gil_scoped_release>())
       .def(
           "matrix", [](vt::actor_t& self, std::string& req) { return self.matrix(req); },
-          "Computes the time and distance between a set of locations and returns them as a matrix table.")
+          "Computes the time and distance between a set of locations and returns them as a matrix table.",
+          nb::call_guard<nb::gil_scoped_release>())
       .def(
           "isochrone", [](vt::actor_t& self, std::string& req) { return self.isochrone(req); },
-          "Calculates isochrones and isodistances.")
+          "Calculates isochrones and isodistances.", nb::call_guard<nb::gil_scoped_release>())
       .def(
           "trace_route", [](vt::actor_t& self, std::string& req) { return self.trace_route(req); },
-          "Map-matching for a set of input locations, e.g. from a GPS.")
+          "Map-matching for a set of input locations, e.g. from a GPS.",
+          nb::call_guard<nb::gil_scoped_release>())
       .def(
           "trace_attributes",
           [](vt::actor_t& self, std::string& req) { return self.trace_attributes(req); },
-          "Returns detailed attribution along each portion of a route calculated from a set of input locations, e.g. from a GPS trace.")
+          "Returns detailed attribution along each portion of a route calculated from a set of input locations, e.g. from a GPS trace.",
+          nb::call_guard<nb::gil_scoped_release>())
       .def(
           "height", [](vt::actor_t& self, std::string& req) { return self.height(req); },
-          "Provides elevation data for a set of input geometries.")
+          "Computes the height for a set of input geometries.",
+          nb::call_guard<nb::gil_scoped_release>())
       .def(
           "transit_available",
           [](vt::actor_t& self, std::string& req) { return self.transit_available(req); },
-          "Lookup if transit stops are available in a defined radius around a set of input locations.")
+          "Lookup if transit stops are available in a defined radius around a set of input locations.",
+          nb::call_guard<nb::gil_scoped_release>())
       .def(
           "expansion", [](vt::actor_t& self, std::string& req) { return self.expansion(req); },
-          "Returns all road segments which were touched by the routing algorithm during the graph traversal.")
+          "Returns all road segments which were touched by the routing algorithm during the graph traversal.",
+          nb::call_guard<nb::gil_scoped_release>())
       .def(
           "centroid", [](vt::actor_t& self, std::string& req) { return self.centroid(req); },
-          "Returns routes from all the input locations to the minimum cost meeting point of those paths.")
+          "Returns routes from all the input locations to the minimum cost meeting point of those paths.",
+          nb::call_guard<nb::gil_scoped_release>())
       .def(
           "status", [](vt::actor_t& self, std::string& req) { return self.status(req); },
-          "Returns nothing or optionally details about Valhalla's configuration.")
+          "Returns nothing or optionally details about Valhalla's configuration.",
+          nb::call_guard<nb::gil_scoped_release>())
       .def(
           "tile",
           [](vt::actor_t& self, std::string& req) -> nb::bytes {
-            auto result = self.tile(req);
+            std::string result;
+            {
+              nb::gil_scoped_release release;
+              result = self.tile(req);
+            }
             return nb::bytes(result.c_str(), result.size());
           },
           "Returns a vector tile (MVT binary data) with a bounding box feature for the given z/x/y tile coordinates.");

--- a/src/bindings/python/src/graph_id.cc
+++ b/src/bindings/python/src/graph_id.cc
@@ -119,7 +119,7 @@ void init_graphid(nb::module_& m) {
         return tile_ids;
       },
       nb::arg("minx"), nb::arg("miny"), nb::arg("maxx"), nb::arg("maxy"),
-      nb::arg("levels") = std::vector<uint32_t>{});
+      nb::arg("levels") = std::vector<uint32_t>{}, nb::call_guard<nb::gil_scoped_release>());
 
   // GraphUtils class - manages GraphReader for efficient edge access
   nb::class_<vb::GraphReader>(m, "_GraphUtils")
@@ -153,7 +153,8 @@ void init_graphid(nb::module_& m) {
           nb::arg("config"))
       .def(
           "get_edge_shape",
-          [](vb::GraphReader& self, const vb::GraphId& edge_id) {
+          [](vb::GraphReader& self,
+             const vb::GraphId& edge_id) -> std::vector<std::tuple<double, double>> {
             // Get the tile containing this edge
             auto tile = self.GetGraphTile(edge_id);
             if (!tile) {
@@ -176,14 +177,14 @@ void init_graphid(nb::module_& m) {
             }
 
             // Convert to list of (lon, lat) tuples
-            std::vector<nb::tuple> result;
+            std::vector<std::tuple<double, double>> result;
             result.reserve(shape.size());
             for (const auto& pt : shape) {
-              result.push_back(nb::make_tuple(pt.lng(), pt.lat()));
+              result.emplace_back(pt.lng(), pt.lat());
             }
 
             return result;
           },
-          nb::arg("edge_id"));
+          nb::arg("edge_id"), nb::call_guard<nb::gil_scoped_release>());
 }
 } // namespace pyvalhalla


### PR DESCRIPTION
Fixes #5870 

Will return all `null`s instead: 

<details><summary>plain</summary>

```json 
{
	"sources_to_targets": {
		"durations": [
			[
				null
			]
		],
		"distances": [
			[
				null
			]
		]
	},
	"units": "kilometers",
	"algorithm": "costmatrix"
}
```

</details>

<details><summary>verbose</summary>

```json 
{
	"sources_to_targets": [
		[
			{
				"from_index": 0,
				"to_index": 0,
				"time": null,
				"distance": null
			}
		]
	],
	"sources": [
		{
			"lat": 52.524722,
			"lon": 13.414611
		}
	],
	"targets": [
		{
			"lat": 52.551296,
			"lon": 13.294776
		}
	],
	"units": "kilometers",
	"algorithm": "costmatrix"
}
```

</details>


<details><summary>osrm</summary>

```json 
{
	"code": "Ok",
	"sources": [
		{
			"location": [
				13.414611,
				52.524722
			],
			"name": "Alex-Wedding-Straße",
			"distance": 15.771
		}
	],
	"destinations": [
		{
			"location": [
				13.294776,
				52.551296
			],
			"name": "PE",
			"distance": 22.012
		}
	],
	"durations": [
		[
			null
		]
	],
	"distances": [
		[
			null
		]
	],
	"algorithm": "costmatrix"
}
```

</details>