### PR TITLE
docker-entrypoint: display Valhalla version on container start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
    * FIXED: Respect future hierarchy level during graph filtering [#5878](https://github.com/valhalla/valhalla/pull/5878)
    * FIXED: UK had drive on right incorrectly set after admin changes [#5882](https://github.com/valhalla/valhalla/pull/5882)
 * **Enhancement**
+   * ADDED: docker-entrypoint logs Valhalla version on container start [#5884](https://github.com/valhalla/valhalla/pull/5884)
    * ADDED: `GraphUtils` class to Python bindings for low-level graph tile access [#5819](https://github.com/valhalla/valhalla/pull/5819)
    * ADDED: `predicted_speeds` module to Python bindings for DCT-2 speed compression utilities [#5819](https://github.com/valhalla/valhalla/pull/5819)
    * ADDED: Clean up boost::geometry types [#5818](https://github.com/valhalla/valhalla/pull/5818)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@
    * FIXED: Respect future hierarchy level during graph filtering [#5878](https://github.com/valhalla/valhalla/pull/5878)
    * FIXED: UK had drive on right incorrectly set after admin changes [#5882](https://github.com/valhalla/valhalla/pull/5882)
 * **Enhancement**
-   * ADDED: docker-entrypoint logs Valhalla version on container start [#5884](https://github.com/valhalla/valhalla/pull/5884)
    * ADDED: `GraphUtils` class to Python bindings for low-level graph tile access [#5819](https://github.com/valhalla/valhalla/pull/5819)
    * ADDED: `predicted_speeds` module to Python bindings for DCT-2 speed compression utilities [#5819](https://github.com/valhalla/valhalla/pull/5819)
    * ADDED: Clean up boost::geometry types [#5818](https://github.com/valhalla/valhalla/pull/5818)
@@ -31,6 +30,7 @@
    * CHANGED: don't throw a 442 error when matrix found no results [#5871](https://github.com/valhalla/valhalla/pull/5871)
    * ADDED: added `GraphId` binding for the nodejs package [#5874](https://github.com/valhalla/valhalla/pull/5874)
    * CHANGED: return trivial shape when source == target in CostMatrix [#5872](https://github.com/valhalla/valhalla/pull/5872)
+   * ADDED: docker-entrypoint logs Valhalla version on container start [#5884](https://github.com/valhalla/valhalla/pull/5884)
 
 ## Release Date: 2026-01-15 Valhalla 3.6.2
 * **Removed**

--- a/docker/scripts/docker-entrypoint.sh
+++ b/docker/scripts/docker-entrypoint.sh
@@ -7,12 +7,7 @@ set -o errexit -o pipefail -o nounset
 
 # logging valhalla version
 VALHALLA_VERSION=$(valhalla_service --version | tr -d '\n')
-
-echo ""
-echo "============"
-echo "= Valhalla ="
-echo "============"
-echo "Version: ${VALHALLA_VERSION}"
+echo "Valhalla version: ${VALHALLA_VERSION}"
 echo ""
 
 do_build_tar() {

--- a/docker/scripts/docker-entrypoint.sh
+++ b/docker/scripts/docker-entrypoint.sh
@@ -5,6 +5,16 @@ set -o errexit -o pipefail -o nounset
 # source the helpers for globals and functions
 . /valhalla/scripts/helpers.sh
 
+# logging valhalla version
+VALHALLA_VERSION=$(valhalla_service --version | tr -d '\n')
+
+echo ""
+echo "===================="
+echo "= Valhalla version ="
+echo "===================="
+echo "Valhalla version: ${VALHALLA_VERSION}"
+echo ""
+
 do_build_tar() {
   local build_tar_local=$1
   if ([[ "${build_tar_local}" == "True" && ! -f $TILE_TAR ]]) || [[ "${build_tar_local}" == "Force" ]]; then

--- a/docker/scripts/docker-entrypoint.sh
+++ b/docker/scripts/docker-entrypoint.sh
@@ -9,10 +9,10 @@ set -o errexit -o pipefail -o nounset
 VALHALLA_VERSION=$(valhalla_service --version | tr -d '\n')
 
 echo ""
-echo "===================="
-echo "= Valhalla version ="
-echo "===================="
-echo "Valhalla version: ${VALHALLA_VERSION}"
+echo "============"
+echo "= Valhalla ="
+echo "============"
+echo "Version: ${VALHALLA_VERSION}"
 echo ""
 
 do_build_tar() {


### PR DESCRIPTION
This PR extends `docker-entrypoint.sh` in order to print the valhalla version when starting the docker container. 

The version gets displayed according to the standard header format:
```
====================
= Valhalla version =
====================

Valhalla version: 3.6.2-5f5b4cb7a
```

Fixes #5721