### PR TITLE
chore(ci): use trusted publisher auth for node package publishing

### DIFF
--- a/.github/workflows/nodejs_bindings.yml
+++ b/.github/workflows/nodejs_bindings.yml
@@ -228,6 +228,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [verify_nodejs_package]
     if: ${{ (startsWith(github.ref, 'refs/tags/') || (github.event_name == 'schedule')) && (github.repository_owner == 'valhalla') }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -252,8 +255,5 @@ jobs:
           fi
           
           echo "[INFO] Publishing to NPM with tag: ${NPM_TAG}..."
-          npm publish *.tgz --access public --tag ${NPM_TAG}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
+          npm publish *.tgz --access public --tag ${NPM_TAG} --provenance
 


### PR DESCRIPTION
3.6.2 didn't get released for nodejs, bcs there was an auth failure. I changed auth to work with "trusted publishers", which will work as long as the gha workflow file doesn't get renamed.