### PR TITLE
feat: implement local optimality validation for alternate routes

### DIFF
--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -1377,7 +1377,7 @@ std::vector<std::vector<PathInfo>> BidirectionalAStar::FormPath(GraphReader& gra
     // For the first path just add it for subsequent paths only add if it passes viability tests
     if (paths.empty() || (validate_alternate_by_sharing(shared_edgeids, paths, path, max_sharing) &&
                           validate_alternate_by_stretch(paths.front(), path) &&
-                          validate_alternate_by_local_optimality(path))) {
+                          validate_alternate_by_local_optimality(paths.front(), path))) {
       paths.emplace_back(std::move(path));
     }
   }

--- a/valhalla/thor/alternates.h
+++ b/valhalla/thor/alternates.h
@@ -18,6 +18,7 @@ bool validate_alternate_by_sharing(std::vector<std::unordered_set<baldr::GraphId
                                    const std::vector<PathInfo>& candidate_path,
                                    float at_most_shared);
 
-bool validate_alternate_by_local_optimality(const std::vector<PathInfo>& candidate_path);
+bool validate_alternate_by_local_optimality(const std::vector<PathInfo>& optimal_path,
+                                            const std::vector<PathInfo>& candidate_path);
 } // namespace thor
 } // namespace valhalla


### PR DESCRIPTION
This PR implements the `validate_alternate_by_local_optimality` function to complete the three-criteria validation for alternate routes initially introduced in [PR #2626](https://github.com/valhalla/valhalla/pull/2626). 


 **Updated Function Signature:** Modified `validate_alternate_by_local_optimality` to accept both the optimal and candidate paths.
 
**Segment Comparison:** Implemented validation using the `find_diff_segment` helper to isolate and compare the specific costs of the diverging segments.

**Strict Local Optimality Check:** Enabled the `kAtLeastOptimal` threshold (`0.2f` / 20%). The algorithm now explicitly rejects any alternate route where the diverging segment exceeds 1.2× the cost of the corresponding optimal segment.

**Proof** 
I built it successfully and ran the alternate test

<img width="884" height="92" alt="image (1)" src="https://github.com/user-attachments/assets/357ad978-6743-4ba7-a08f-ed4e68858ad2" />


<img width="883" height="596" alt="image" src="https://github.com/user-attachments/assets/24904792-9eff-418d-be1d-cca7527d30ee" />

AI contribution
I used AI to write most of the committed code.
