### PR TITLE
tyr: return 501 for format=pbf on /locate and /height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * **Removed**
    * REMOVED: Removed ability to set ISO:3166 country/state code per OSM Node [#5747](https://github.com/valhalla/valhalla/pull/5747)
 * **Bug Fix**
+   * FIXED: `/locate` and `/height` now return HTTP 501 instead of silently ignoring `format=pbf` and returning JSON. [#XXXX](https://github.com/valhalla/valhalla/pull/XXXX)
    * FIXED: Clamp grades on bridges and tunnels. [#5728](https://github.com/valhalla/valhalla/pull/5728)
    * FIXED: use pedestrian costing on end location in `auto_pedestrian` costing [#5903](https://github.com/valhalla/valhalla/pull/5903)
    * FIXED: Point at `begin_shape_index` should be on the edge even if trace has discontinuities [#5908](https://github.com/valhalla/valhalla/pull/5908)

--- a/src/tyr/height_serializer.cc
+++ b/src/tyr/height_serializer.cc
@@ -1,6 +1,7 @@
 #include "skadi/sample.h"
 #include "tyr/serializers.h"
 #include "valhalla/baldr/rapidjson_utils.h"
+#include "valhalla/exceptions.h"
 
 using namespace valhalla;
 using namespace valhalla::midgard;
@@ -89,6 +90,8 @@ namespace tyr {
 std::string serializeHeight(const Api& request,
                             const std::vector<double>& heights,
                             const std::vector<double>& ranges) {
+  if (request.options().format() == Options_Format_pbf)
+    throw valhalla_exception_t{107};
   rapidjson::writer_wrapper_t writer(4096);
   writer.start_object();
 

--- a/src/tyr/locate_serializer.cc
+++ b/src/tyr/locate_serializer.cc
@@ -4,6 +4,7 @@
 #include "baldr/rapidjson_utils.h"
 #include "baldr/time_info.h"
 #include "tyr/serializers.h"
+#include "valhalla/exceptions.h"
 
 #include <cstdint>
 
@@ -295,6 +296,8 @@ std::string serializeLocate(const Api& request,
                             const std::vector<baldr::Location>& locations,
                             const std::unordered_map<baldr::Location, PathLocation>& projections,
                             GraphReader& reader) {
+  if (request.options().format() == Options_Format_pbf)
+    throw valhalla_exception_t{107};
   rapidjson::writer_wrapper_t writer(4096);
   writer.start_array();
 

--- a/test/gurka/test_pbf_api.cc
+++ b/test/gurka/test_pbf_api.cc
@@ -165,3 +165,20 @@ TEST(pbf_api, pbf_error) {
     api.mutable_options()->set_action(Options::route);
   }
 }
+
+TEST(pbf_api, pbf_locate_height_not_implemented) {
+  const std::string ascii_map = R"(
+    A----B)";
+  const gurka::ways ways = {{"AB", {{"highway", "primary"}}}};
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100);
+  auto map = gurka::buildtiles(layout, ways, {}, {}, VALHALLA_BUILD_DIR "test/data/gurka_pbf_501");
+
+  for (auto action : {Options::locate, Options::height}) {
+    try {
+      gurka::do_action(action, map, {"A", "B"}, "auto", {{"/format", "pbf"}});
+      FAIL() << "Expected valhalla_exception_t for action " << action;
+    } catch (const valhalla_exception_t& e) {
+      EXPECT_EQ(e.code, 107);
+    }
+  }
+}


### PR DESCRIPTION
serializeLocate and serializeHeight silently return JSON when format=pbf is requested. Add an explicit valhalla_exception_t{107} guard in both, consistent with all other serializers. Full pbf support is tracked in proto/api.proto (TODO: locate/height).



# Issue

this was discovered while auditing pbf format support across
all endpoints. The root cause is visible in `proto/api.proto` lines 25–26:



## Tasklist

 - [X] Add tests
 - [X] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [ ] If you made changes to a translation file, [update transifex](docs/docs/locales.md) too


## Requirements / Relations

- Error code `107` ("Not Implemented", HTTP 501) is already defined in
  [`src/exceptions.cc`](src/exceptions.cc) and used in
  [`src/loki/worker.cc`](src/loki/worker.cc) for the same purpose.
- When [`proto/api.proto`](proto/api.proto) gains `Locate` and `Height` message
  definitions (and `PbfFieldSelector` in [`proto/options.proto`](proto/options.proto)
  gains `locate`/`height` fields), the two guards added here can simply be removed.

fixes #5920 