### PR TITLE
docs: add missing protobuf dependency for macOS build

### DIFF
--- a/docs/docs/building.md
+++ b/docs/docs/building.md
@@ -142,10 +142,9 @@ To install Valhalla on macOS, you need to install its dependencies with [Homebre
 
 ```bash
 # install dependencies (automake & czmq are required by prime_server)
-brew install automake cmake libtool protobuf-c libspatialite pkg-config sqlite3 jq curl wget czmq lz4 spatialite-tools unzip luajit boost
+brew install automake cmake libtool protobuf protobuf-c libspatialite pkg-config sqlite3 jq curl wget czmq lz4 spatialite-tools unzip luajit boost
 # following packages are needed for running Linux compatible scripts
 brew install bash coreutils binutils
-# Update your PATH env variable to include /usr/local/opt/binutils/bin:/usr/local/opt/coreutils/libexec/gnubin
 ```
 
 Now, clone the Valhalla repository


### PR DESCRIPTION
Fixes #5924

## Changes

- Add missing `protobuf` package to the macOS build dependencies.
- Remove non-executable PATH comment from code block

## Issue

Building Valhalla on macOS M1 failed at the cmake configuration step with:
```
Could NOT find Protobuf (missing: Protobuf_LIBRARIES Protobuf_INCLUDE_DIR)
```

The docs only listed `protobuf-c` but Valhalla also needs the C++ protobuf library. Had to install it manually with `brew install protobuf` to get the build working.

## Tasklist

 - [x] Add #fixes with the issue number that this PR addresses
 - [x] Update the docs with any new request parameters or changes to behavior described
 - [ ] Add tests - N/A (documentation only)
 - [ ] Update the changelog - N/A (minor doc fix)
 - [ ] If you made changes to the lua files, update the taginfo too - N/A
 - [ ] If you made changes to a translation file, update transifex too - N/A

## Requirements / Relations

None