### PR TITLE
perf: Avoid resolving reachability for trace points

### DIFF
--- a/src/loki/trace_route_action.cc
+++ b/src/loki/trace_route_action.cc
@@ -174,6 +174,9 @@ void loki_worker_t::locations_from_shape(Api& request) {
     for (auto& location : *options.mutable_locations()) {
       location.set_node_snap_tolerance(0.f);
       location.set_radius(10);
+      // Reachability test is not needed for trace_route and trace_attributes because either
+      // - edge_walk relies on the shape that was produced by route
+      // - map_snap performs a Viterbi search that organically biases towards reachable edges
       location.set_minimum_reachability(0);
     }
     parse_locations(options.mutable_locations(), request);


### PR DESCRIPTION
_Please don't force-push once you received the first review._

# Issue

Before https://github.com/valhalla/valhalla/pull/5906 trace route action always used `minimum_reachability = 0` as it is a default in the protobuf field - https://github.com/valhalla/valhalla/blob/2b1e693c68e9e31f42022a2cc1a98e067b24dd5d/valhalla/baldr/pathlocation.h#L188-L198

This PR restores old behaviour.

Follow https://github.com/valhalla/valhalla/pull/5906#discussion_r2934194616 for more details

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [ ] If you made changes to a translation file, [update transifex](docs/docs/locales.md) too

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
