### PR TITLE
chore(ci): add more excluded sources to codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,6 @@
 coverage:
   ignore:
     - third_party/.*
-    # test code
-    - test/.*
     # executables (not library code)
     - src/valhalla_*
     - src/mjolnir/valhalla_*


### PR DESCRIPTION
remember how all of a sudden we dropped code coverage by 7-8% after https://github.com/valhalla/valhalla/pull/5427?

still pisses me off :D this excludes a bunch of more sources. proto sources should be fine as they live in the build directory and shouldn't inflate coverage.