### PR TITLE
Fix: overestimated entries in UnorderedIdTable::deserialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
    * FIXED: Point at `begin_shape_index` should be on the edge even if trace has discontinuities [#5908](https://github.com/valhalla/valhalla/pull/5908)
    * FIXED: Empty "edges" in `/trace_attributes` response for `walk_or_snap`, that also causes SIGSEGV if elevation requested [#5945](https://github.com/valhalla/valhalla/pull/5945)
    * FIXED: keep `highway=platform` routable while classifying it as `service_other` instead of `primary` [#5913](https://github.com/valhalla/valhalla/pull/5913)
+   * FIXED:  Fix overestimated number of entries in `UnorderedIdTable::deserialize` [#5969](https://github.com/valhalla/valhalla/pull/5969)
+
 
 * **Enhancement**
    * ADDED: multimodal costing `auto_pedestrian` [#5780](https://github.com/valhalla/valhalla/pull/5780)
@@ -20,7 +22,6 @@
    * ADDED: OSM XML format support for tile building [#5934](https://github.com/valhalla/valhalla/pull/5934)
    * ADDED: access restriction layer in MVT [#5912](https://github.com/valhalla/valhalla/pull/5912)
    * ADDED: incidents to locate JSON response [#5968](https://github.com/valhalla/valhalla/pull/5968)
-   * CHANGED:  Fix overestimated number of entries in `UnorderedIdTable::deserialize` [#5969](https://github.com/valhalla/valhalla/pull/5969)
 
 ## Release Date: 2026-02-19 Valhalla 3.6.3
 * **Removed**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
    * CHANGED: Optimize `get_service_days` in servicedays.cc [#5952](https://github.com/valhalla/valhalla/pull/5952)
    * ADDED: OSM XML format support for tile building [#5934](https://github.com/valhalla/valhalla/pull/5934)
    * ADDED: access restriction layer in MVT [#5912](https://github.com/valhalla/valhalla/pull/5912)
+   * CHANGED:  Fix overestimated number of entries in `UnorderedIdTable::deserialize` [#XXXX](https://github.com/valhalla/valhalla/pull/XXXX)
 
 ## Release Date: 2026-02-19 Valhalla 3.6.3
 * **Removed**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
    * FIXED: keep `highway=platform` routable while classifying it as `service_other` instead of `primary` [#5913](https://github.com/valhalla/valhalla/pull/5913)
    * FIXED:  Fix overestimated number of entries in `UnorderedIdTable::deserialize` [#5969](https://github.com/valhalla/valhalla/pull/5969)
 
-
 * **Enhancement**
    * ADDED: multimodal costing `auto_pedestrian` [#5780](https://github.com/valhalla/valhalla/pull/5780)
    * CHANGED: remove `baldr::{Location,PathLocation}` and use their protobuf versions instead [#5906](https://github.com/valhalla/valhalla/pull/5906) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
    * CHANGED: Optimize `get_service_days` in servicedays.cc [#5952](https://github.com/valhalla/valhalla/pull/5952)
    * ADDED: OSM XML format support for tile building [#5934](https://github.com/valhalla/valhalla/pull/5934)
    * ADDED: access restriction layer in MVT [#5912](https://github.com/valhalla/valhalla/pull/5912)
-   * CHANGED:  Fix overestimated number of entries in `UnorderedIdTable::deserialize` [#XXXX](https://github.com/valhalla/valhalla/pull/XXXX)
+   * CHANGED:  Fix overestimated number of entries in `UnorderedIdTable::deserialize` [#5969](https://github.com/valhalla/valhalla/pull/5969)
 
 ## Release Date: 2026-02-19 Valhalla 3.6.3
 * **Removed**

--- a/src/mjolnir/idtable.h
+++ b/src/mjolnir/idtable.h
@@ -74,7 +74,7 @@ public:
     if (!file.is_open()) {
       return false;
     }
-    uint64_t entries = static_cast<uint64_t>(file.tellg()) / 2;
+    uint64_t entries = static_cast<uint64_t>(file.tellg()) / (2 * sizeof(uint64_t));
     file.seekg(0, std::ios::beg);
 
     // TODO: do more than one entry at a time, buffer 10k of them into a vector and read that


### PR DESCRIPTION
Closes #5966 
## Issue

I have changed entries declaration/assignment in `idtable.h`, here the number of entries was overestimated, with the fix it reserves 8x less memory. I have implemented it by changing this:

- Old implementation: `uint64_t entries = static_cast<uint64_t>(file.tellg()) / 2;`. 
- New implementation: `uint64_t entries = static_cast<uint64_t>(file.tellg()) / (2 * sizeof(uint64_t));`

It is easy to see that dividing the file by the entry size, creates the perfect number of entries. 
This issue, may have not been seen before and did not cause any bigger problems due to the loop `while (file && entries--) { . . .`
which ends at EOF.

A numeric example to see the real count of entries saved (already exposed in the issue #5966):

```cpp
File = 112 bytes
Each entry = key + value = 8 bytes + 8 bytes = 16 bytes per entry

Current code:
Entries = 112 / 2 = 56;

New code:
Entries = 112 / 16 = 7;

The total entries are reduced x8 times.
```
Now see memory savings after applying this change:

Each entry costs at least 16 bytes (key + value). So checking the test file `test/idtable.cc` the `SerializeDeserialize` test uses 1000 nodes which serialize creating the file "foo.bar". Running `ls -la foo.bar` we can see that this file for 1000 nodes is around 512 bytes. Here is the memory of each case:
- Old implementation (512/2 entries): 256 entries x ~16 bytes = ~4096 reserved bytes
- New implementation (512/16 entries): 32 entries x ~16 bytes = ~512 reserved bytes

So for the test of 1000 nodes we are saving ~3.5KB.


Moreover in the test file it is noted that `1300000000 nodes` is about how many there are in real life. So if the planet has that amount of nodes, the file might be enormous, saving a lot of memory.
## GSoC

This is my second contribution as a GSoC applicant, following the [GSoC Guidelines](https://github.com/valhalla/valhalla/wiki/GSoC-Guidelines) I state I have not used AI during the issue or the PR, I have written every sentence in the PR, Issue or code.

In my last PR #5952 I demonstrated how I set up the Valhalla project and compile it. Now I demonstrate how I have performed to apply this change:
- In order to update up to date my project, first at my fork I did `git fetch` and `git rebase origin master`. After this I compiled and built to make sure that everything was okay `cmake -B build -DCMAKE_BUILD_TYPE=Release` and `make -C build -j$(nproc)`, moreover I tested the file `idtable.h` before changing it to be sure it was fine with: `./build/test/idtable` .
- Now that everything is set up I replaced the code to the new implementation, compile and ran on it the tests again with the procedure mentioned above.

