### PR TITLE
chore(config): add a global logging config to replace all module-level ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
    * ADDED: incidents to locate JSON response [#5968](https://github.com/valhalla/valhalla/pull/5968)
    * ADDED: `--region` to `valhalla_build_extract` to create tars by Geofabrik region
    * ADDED: more warnings for clamped costing options, second pass, bidir fallback and matrix_locations for CostMatrix [#3833](https://github.com/valhalla/valhalla/pull/3833)
-   * ADDED: a global one `logging` config to replace all module-level ones
+   * ADDED: a global `logging` config to replace all module-level ones
 
 ## Release Date: 2026-02-19 Valhalla 3.6.3
 * **Removed**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## UNRELEASED
 * **Removed**
    * REMOVED: Removed ability to set ISO:3166 country/state code per OSM Node [#5747](https://github.com/valhalla/valhalla/pull/5747)
+   * REMOVED: all module-level `logging` config in favor of a global one
 * **Bug Fix**
    * FIXED: Clamp grades on bridges and tunnels. [#5728](https://github.com/valhalla/valhalla/pull/5728)
    * FIXED: use pedestrian costing on end location in `auto_pedestrian` costing [#5903](https://github.com/valhalla/valhalla/pull/5903)
@@ -24,6 +25,7 @@
    * ADDED: incidents to locate JSON response [#5968](https://github.com/valhalla/valhalla/pull/5968)
    * ADDED: `--region` to `valhalla_build_extract` to create tars by Geofabrik region
    * ADDED: more warnings for clamped costing options, second pass, bidir fallback and matrix_locations for CostMatrix [#3833](https://github.com/valhalla/valhalla/pull/3833)
+   * ADDED: a global one `logging` config to replace all module-level ones
 
 ## Release Date: 2026-02-19 Valhalla 3.6.3
 * **Removed**

--- a/scripts/valhalla_build_config
+++ b/scripts/valhalla_build_config
@@ -172,14 +172,6 @@ config = {
             "use_rest_area": False,
             "scan_tar": False,
         },
-        "logging": {
-            "__deprecated__": "Per-module logging is deprecated. Use top-level 'logging' instead.",
-            "type": "std_out",
-            "color": True,
-            "file_name": "path_to_some_file.log",
-            "max_file_size": Optional(int),
-            "max_archived_files": Optional(int),
-        },
     },
     "additional_data": {
         "elevation": "/data/valhalla/elevation/",
@@ -216,25 +208,9 @@ config = {
             "mvt_cache_min_zoom": 11,
             "mvt_max_age": "1800",
         },
-        "logging": {
-            "__deprecated__": "Per-module logging is deprecated. Use top-level 'logging' instead.",
-            "type": "std_out",
-            "color": True,
-            "file_name": "path_to_some_file.log",
-            "max_file_size": Optional(int),
-            "max_archived_files": Optional(int),
-        },
         "service": {"proxy": "ipc:///tmp/loki"},
     },
     "thor": {
-        "logging": {
-            "__deprecated__": "Per-module logging is deprecated. Use top-level 'logging' instead.",
-            "type": "std_out",
-            "color": True,
-            "file_name": "path_to_some_file.log",
-            "max_file_size": Optional(int),
-            "max_archived_files": Optional(int),
-        },
         "source_to_target_algorithm": "select_optimal",
         "service": {"proxy": "ipc:///tmp/thor"},
         "max_reserved_labels_count_astar": 2000000,
@@ -280,14 +256,6 @@ config = {
         },
     },
     "odin": {
-        "logging": {
-            "__deprecated__": "Per-module logging is deprecated. Use top-level 'logging' instead.",
-            "type": "std_out",
-            "color": True,
-            "file_name": "path_to_some_file.log",
-            "max_file_size": Optional(int),
-            "max_archived_files": Optional(int),
-        },
         "service": {"proxy": "ipc:///tmp/odin"},
         "markup_formatter": {
             "markup_enabled": False,
@@ -326,14 +294,6 @@ config = {
         "pedestrian": {"turn_penalty_factor": 100, "search_radius": 50},
         "bicycle": {"turn_penalty_factor": 140},
         "multimodal": {"turn_penalty_factor": 70},
-        "logging": {
-            "__deprecated__": "Per-module logging is deprecated. Use top-level 'logging' instead.",
-            "type": "std_out",
-            "color": True,
-            "file_name": "path_to_some_file.log",
-            "max_file_size": Optional(int),
-            "max_archived_files": Optional(int),
-        },
         "service": {"proxy": "ipc:///tmp/meili"},
         "grid": {"size": 500, "cache_size": 100240},
     },
@@ -549,14 +509,6 @@ help_text = {
             "use_rest_area": "bool indicating whether or not to use the rest/service area tag on the ways",
             "scan_tar": "bool indicating whether or not to pre-scan the tar ball(s) when loading an extract with an index file, to warm up the OS page cache.",
         },
-        "logging": {
-            "__deprecated__": "Per-module logging is deprecated. Use top-level 'logging' instead.",
-            "type": "Type of logger either std_out or file",
-            "color": "Use colored log level in std_out logger",
-            "file_name": "Output log file for the file logger",
-            "max_file_size": "Maximum file size in bytes before rolling to a new file (0 = disabled)",
-            "max_archived_files": "Maximum number of archived log files to keep (0 = disabled)",
-        },
     },
     "additional_data": {
         "elevation": "Location of elevation tiles",
@@ -579,25 +531,9 @@ help_text = {
             "mvt_cache_min_zoom": "The minimum zoom level which will be cached, the maximum will be determined by mvt_min_zoom_road_class",
             "mvt_max_age": "The value used for 'max-age' in the Cache-Control response header for the MVT end point",
         },
-        "logging": {
-            "__deprecated__": "Per-module logging is deprecated. Use top-level 'logging' instead.",
-            "type": "Type of logger either std_out or file",
-            "color": "Use colored log level in std_out logger",
-            "file_name": "Output log file for the file logger",
-            "max_file_size": "Maximum file size in bytes before rolling to a new file (0 = disabled)",
-            "max_archived_files": "Maximum number of archived log files to keep (0 = disabled)",
-        },
         "service": {"proxy": "IPC linux domain socket file location"},
     },
     "thor": {
-        "logging": {
-            "__deprecated__": "Per-module logging is deprecated. Use top-level 'logging' instead.",
-            "type": "Type of logger either std_out or file",
-            "color": "Use colored log level in std_out logger",
-            "file_name": "Output log file for the file logger",
-            "max_file_size": "Maximum file size in bytes before rolling to a new file (0 = disabled)",
-            "max_archived_files": "Maximum number of archived log files to keep (0 = disabled)",
-        },
         "source_to_target_algorithm": 'Which matrix algorithm should be used, one of "timedistancematrix" or "costmatrix". If blank, the optimal will be selected.',
         "service": {"proxy": "IPC linux domain socket file location"},
         "max_reserved_labels_count_astar": "Maximum capacity allowed to keep reserved for unidirectional A*.",
@@ -656,14 +592,6 @@ help_text = {
         },
     },
     "odin": {
-        "logging": {
-            "__deprecated__": "Per-module logging is deprecated. Use top-level 'logging' instead.",
-            "type": "Type of logger either std_out or file",
-            "color": "Use colored log level in std_out logger",
-            "file_name": "Output log file for the file logger",
-            "max_file_size": "Maximum file size in bytes before rolling to a new file (0 = disabled)",
-            "max_archived_files": "Maximum number of archived log files to keep (0 = disabled)",
-        },
         "service": {"proxy": "IPC linux domain socket file location"},
         "markup_formatter": {
             "markup_enabled": "Boolean flag to use markup formatting",
@@ -701,14 +629,6 @@ help_text = {
         },
         "multimodal": {
             "turn_penalty_factor": "A non-negative value to penalize turns from one road segment to next"
-        },
-        "logging": {
-            "__deprecated__": "Per-module logging is deprecated. Use top-level 'logging' instead.",
-            "type": "Type of logger either std_out or file",
-            "color": "Use colored log level in std_out logger",
-            "file_name": "Output log file for the file logger",
-            "max_file_size": "Maximum file size in bytes before rolling to a new file (0 = disabled)",
-            "max_archived_files": "Maximum number of archived log files to keep (0 = disabled)",
         },
         "service": {"proxy": "IPC linux domain socket file location"},
         "grid": {

--- a/scripts/valhalla_build_config
+++ b/scripts/valhalla_build_config
@@ -112,6 +112,13 @@ class Optional:
 
 # global default configuration
 config = {
+    "logging": {
+        "type": "std_out",
+        "color": True,
+        "file_name": "path_to_some_file.log",
+        "max_file_size": Optional(int),
+        "max_archived_files": Optional(int),
+    },
     "mjolnir": {
         "max_cache_size": 1000000000,
         "id_table_size": 1300000000,
@@ -166,6 +173,7 @@ config = {
             "scan_tar": False,
         },
         "logging": {
+            "__deprecated__": "Per-module logging is deprecated. Use top-level 'logging' instead.",
             "type": "std_out",
             "color": True,
             "file_name": "path_to_some_file.log",
@@ -209,10 +217,10 @@ config = {
             "mvt_max_age": "1800",
         },
         "logging": {
+            "__deprecated__": "Per-module logging is deprecated. Use top-level 'logging' instead.",
             "type": "std_out",
             "color": True,
             "file_name": "path_to_some_file.log",
-            "long_request": 100.0,
             "max_file_size": Optional(int),
             "max_archived_files": Optional(int),
         },
@@ -220,10 +228,10 @@ config = {
     },
     "thor": {
         "logging": {
+            "__deprecated__": "Per-module logging is deprecated. Use top-level 'logging' instead.",
             "type": "std_out",
             "color": True,
             "file_name": "path_to_some_file.log",
-            "long_request": 110.0,
             "max_file_size": Optional(int),
             "max_archived_files": Optional(int),
         },
@@ -273,6 +281,7 @@ config = {
     },
     "odin": {
         "logging": {
+            "__deprecated__": "Per-module logging is deprecated. Use top-level 'logging' instead.",
             "type": "std_out",
             "color": True,
             "file_name": "path_to_some_file.log",
@@ -318,6 +327,7 @@ config = {
         "bicycle": {"turn_penalty_factor": 140},
         "multimodal": {"turn_penalty_factor": 70},
         "logging": {
+            "__deprecated__": "Per-module logging is deprecated. Use top-level 'logging' instead.",
             "type": "std_out",
             "color": True,
             "file_name": "path_to_some_file.log",
@@ -475,6 +485,17 @@ config = {
 }
 
 help_text = {
+    "logging": {
+        "__note__": (
+            "Process-wide logging configuration. The file logger is not suitable for "
+            "multi-processing mode. Log rolling in particular may cause race conditions and crashes."
+        ),
+        "type": "Type of logger either std_out or file",
+        "color": "Use colored log level in std_out logger",
+        "file_name": "Output log file for the file logger",
+        "max_file_size": "Maximum file size in bytes before rolling to a new file (0 = disabled)",
+        "max_archived_files": "Maximum number of archived log files to keep (0 = disabled)",
+    },
     "mjolnir": {
         "max_cache_size": "Number of bytes per thread used to store tile data in memory",
         "id_table_size": "Value controls the initial size of the Id table",
@@ -529,12 +550,9 @@ help_text = {
             "scan_tar": "bool indicating whether or not to pre-scan the tar ball(s) when loading an extract with an index file, to warm up the OS page cache.",
         },
         "logging": {
-            "__note__": (
-                "The file logger is not suitable for multi-processing mode. "
-                "Log rolling in particular may cause race conditions and crashes."
-            ),
+            "__deprecated__": "Per-module logging is deprecated. Use top-level 'logging' instead.",
             "type": "Type of logger either std_out or file",
-            "color": "User colored log level in std_out logger",
+            "color": "Use colored log level in std_out logger",
             "file_name": "Output log file for the file logger",
             "max_file_size": "Maximum file size in bytes before rolling to a new file (0 = disabled)",
             "max_archived_files": "Maximum number of archived log files to keep (0 = disabled)",
@@ -562,14 +580,10 @@ help_text = {
             "mvt_max_age": "The value used for 'max-age' in the Cache-Control response header for the MVT end point",
         },
         "logging": {
-            "__note__": (
-                "The file logger is not suitable for multi-processing mode. "
-                "Log rolling in particular may cause race conditions and crashes."
-            ),
+            "__deprecated__": "Per-module logging is deprecated. Use top-level 'logging' instead.",
             "type": "Type of logger either std_out or file",
-            "color": "User colored log level in std_out logger",
+            "color": "Use colored log level in std_out logger",
             "file_name": "Output log file for the file logger",
-            "long_request": "Value used in processing to determine whether it took too long",
             "max_file_size": "Maximum file size in bytes before rolling to a new file (0 = disabled)",
             "max_archived_files": "Maximum number of archived log files to keep (0 = disabled)",
         },
@@ -577,14 +591,10 @@ help_text = {
     },
     "thor": {
         "logging": {
-            "__note__": (
-                "The file logger is not suitable for multi-processing mode. "
-                "Log rolling in particular may cause race conditions and crashes."
-            ),
+            "__deprecated__": "Per-module logging is deprecated. Use top-level 'logging' instead.",
             "type": "Type of logger either std_out or file",
-            "color": "User colored log level in std_out logger",
+            "color": "Use colored log level in std_out logger",
             "file_name": "Output log file for the file logger",
-            "long_request": "Value used in processing to determine whether it took too long",
             "max_file_size": "Maximum file size in bytes before rolling to a new file (0 = disabled)",
             "max_archived_files": "Maximum number of archived log files to keep (0 = disabled)",
         },
@@ -647,12 +657,9 @@ help_text = {
     },
     "odin": {
         "logging": {
-            "__note__": (
-                "The file logger is not suitable for multi-processing mode. "
-                "Log rolling in particular may cause race conditions and crashes."
-            ),
+            "__deprecated__": "Per-module logging is deprecated. Use top-level 'logging' instead.",
             "type": "Type of logger either std_out or file",
-            "color": "User colored log level in std_out logger",
+            "color": "Use colored log level in std_out logger",
             "file_name": "Output log file for the file logger",
             "max_file_size": "Maximum file size in bytes before rolling to a new file (0 = disabled)",
             "max_archived_files": "Maximum number of archived log files to keep (0 = disabled)",
@@ -696,12 +703,9 @@ help_text = {
             "turn_penalty_factor": "A non-negative value to penalize turns from one road segment to next"
         },
         "logging": {
-            "__note__": (
-                "The file logger is not suitable for multi-processing mode. "
-                "Log rolling in particular may cause race conditions and crashes."
-            ),
+            "__deprecated__": "Per-module logging is deprecated. Use top-level 'logging' instead.",
             "type": "Type of logger either std_out or file",
-            "color": "User colored log level in std_out logger",
+            "color": "Use colored log level in std_out logger",
             "file_name": "Output log file for the file logger",
             "max_file_size": "Maximum file size in bytes before rolling to a new file (0 = disabled)",
             "max_archived_files": "Maximum number of archived log files to keep (0 = disabled)",

--- a/src/argparse_utils.h
+++ b/src/argparse_utils.h
@@ -59,13 +59,7 @@ bool parse_common_args(const std::string& program,
     }
 
     // configure logging
-    auto logging_subtree = conf->get_child_optional(log);
-    if (!log.empty() && logging_subtree) {
-      auto logging_config = valhalla::midgard::ToMap<const boost::property_tree::ptree&,
-                                                     std::unordered_map<std::string, std::string>>(
-          logging_subtree.get());
-      valhalla::midgard::logging::Configure(logging_config);
-    }
+    valhalla::midgard::logging::Configure(*conf, log);
   }
 
   if (use_threads) {

--- a/src/argparse_utils.h
+++ b/src/argparse_utils.h
@@ -13,13 +13,12 @@
  * Parses common command line arguments across executables. It
  * - alters the config ptree and sets the concurrency config, where it favors the command line arg,
  * then falls back to the config and finally to all threads
- * - sets the logging configuration
+ * - sets the logging configuration from the top-level "logging" section
  *
  * @param program The executable's name
  * @param opts    The command line options
  * @param result  The parsed result
  * @param config  The config which will be populated here
- * @param log     The logging config node's key. If empty, logging will not be configured.
  * @param use_threads Whether this program multi-threads
  * @param extra_help Optional function pointer to print more stuff to the end of the help message.
  *
@@ -30,7 +29,6 @@ bool parse_common_args(const std::string& program,
                        const cxxopts::Options& opts,
                        const cxxopts::ParseResult& result,
                        boost::property_tree::ptree* conf,
-                       const std::string& log,
                        const bool use_threads = false,
                        std::function<void()> extra_help = nullptr) {
 
@@ -59,7 +57,7 @@ bool parse_common_args(const std::string& program,
     }
 
     // configure logging
-    valhalla::midgard::logging::Configure(*conf, log);
+    valhalla::midgard::logging::Configure(*conf);
   }
 
   if (use_threads) {

--- a/src/argparse_utils.h
+++ b/src/argparse_utils.h
@@ -57,7 +57,7 @@ bool parse_common_args(const std::string& program,
     }
 
     // configure logging
-    valhalla::midgard::logging::Configure(*conf);
+    valhalla::midgard::logging::ConfigureFromPtree(*conf);
   }
 
   if (use_threads) {

--- a/src/bindings/nodejs/src/valhalla.cc
+++ b/src/bindings/nodejs/src/valhalla.cc
@@ -43,7 +43,7 @@ const boost::property_tree::ptree configure(const std::string& config) {
     std::stringstream stream(config);
     rapidjson::read_json(stream, pt);
 
-    valhalla::midgard::logging::Configure(pt, "mjolnir.logging");
+    valhalla::midgard::logging::Configure(pt);
   } catch (...) { throw std::runtime_error("Failed to load config"); }
 
   return pt;

--- a/src/bindings/nodejs/src/valhalla.cc
+++ b/src/bindings/nodejs/src/valhalla.cc
@@ -43,7 +43,7 @@ const boost::property_tree::ptree configure(const std::string& config) {
     std::stringstream stream(config);
     rapidjson::read_json(stream, pt);
 
-    valhalla::midgard::logging::Configure(pt);
+    valhalla::midgard::logging::ConfigureFromPtree(pt);
   } catch (...) { throw std::runtime_error("Failed to load config"); }
 
   return pt;

--- a/src/bindings/nodejs/src/valhalla.cc
+++ b/src/bindings/nodejs/src/valhalla.cc
@@ -43,13 +43,7 @@ const boost::property_tree::ptree configure(const std::string& config) {
     std::stringstream stream(config);
     rapidjson::read_json(stream, pt);
 
-    auto logging_subtree = pt.get_child_optional("mjolnir.logging");
-    if (logging_subtree) {
-      auto logging_config = valhalla::midgard::ToMap<const boost::property_tree::ptree&,
-                                                     std::unordered_map<std::string, std::string>>(
-          logging_subtree.get());
-      valhalla::midgard::logging::Configure(logging_config);
-    }
+    valhalla::midgard::logging::Configure(pt, "mjolnir.logging");
   } catch (...) { throw std::runtime_error("Failed to load config"); }
 
   return pt;

--- a/src/bindings/python/src/_valhalla.cc
+++ b/src/bindings/python/src/_valhalla.cc
@@ -22,13 +22,7 @@ const boost::property_tree::ptree configure(const std::string& config) {
     // parse the config and configure logging
     rapidjson::read_json(config, pt);
 
-    auto logging_subtree = pt.get_child_optional("mjolnir.logging");
-    if (logging_subtree) {
-      auto logging_config = valhalla::midgard::ToMap<const boost::property_tree::ptree&,
-                                                     std::unordered_map<std::string, std::string>>(
-          logging_subtree.get());
-      valhalla::midgard::logging::Configure(logging_config);
-    }
+    valhalla::midgard::logging::Configure(pt, "mjolnir.logging");
   } catch (...) { throw std::runtime_error("Failed to load config from: " + config); }
 
   return pt;

--- a/src/bindings/python/src/_valhalla.cc
+++ b/src/bindings/python/src/_valhalla.cc
@@ -22,7 +22,7 @@ const boost::property_tree::ptree configure(const std::string& config) {
     // parse the config and configure logging
     rapidjson::read_json(config, pt);
 
-    valhalla::midgard::logging::Configure(pt);
+    valhalla::midgard::logging::ConfigureFromPtree(pt);
   } catch (...) { throw std::runtime_error("Failed to load config from: " + config); }
 
   return pt;

--- a/src/bindings/python/src/_valhalla.cc
+++ b/src/bindings/python/src/_valhalla.cc
@@ -22,7 +22,7 @@ const boost::property_tree::ptree configure(const std::string& config) {
     // parse the config and configure logging
     rapidjson::read_json(config, pt);
 
-    valhalla::midgard::logging::Configure(pt, "mjolnir.logging");
+    valhalla::midgard::logging::Configure(pt);
   } catch (...) { throw std::runtime_error("Failed to load config from: " + config); }
 
   return pt;

--- a/src/bindings/python/src/graph_id.cc
+++ b/src/bindings/python/src/graph_id.cc
@@ -154,7 +154,7 @@ void init_graphid(nb::module_& m) {
             } catch (...) { throw std::runtime_error("Failed to parse config JSON"); }
 
             // Configure logging
-            vm::logging::Configure(pt);
+            vm::logging::ConfigureFromPtree(pt);
 
             // Create GraphReader with mjolnir subtree
             new (self) vb::GraphReader(pt.get_child("mjolnir"));

--- a/src/bindings/python/src/graph_id.cc
+++ b/src/bindings/python/src/graph_id.cc
@@ -154,7 +154,7 @@ void init_graphid(nb::module_& m) {
             } catch (...) { throw std::runtime_error("Failed to parse config JSON"); }
 
             // Configure logging
-            vm::logging::Configure(pt, "mjolnir.logging");
+            vm::logging::Configure(pt);
 
             // Create GraphReader with mjolnir subtree
             new (self) vb::GraphReader(pt.get_child("mjolnir"));

--- a/src/bindings/python/src/graph_id.cc
+++ b/src/bindings/python/src/graph_id.cc
@@ -153,14 +153,8 @@ void init_graphid(nb::module_& m) {
               }
             } catch (...) { throw std::runtime_error("Failed to parse config JSON"); }
 
-            // Configure logging like Actor does (suppress WARN/INFO messages)
-            auto logging_subtree = pt.get_child_optional("mjolnir.logging");
-            if (logging_subtree) {
-              auto logging_config =
-                  vm::ToMap<const boost::property_tree::ptree&,
-                            std::unordered_map<std::string, std::string>>(logging_subtree.get());
-              vm::logging::Configure(logging_config);
-            }
+            // Configure logging
+            vm::logging::Configure(pt, "mjolnir.logging");
 
             // Create GraphReader with mjolnir subtree
             new (self) vb::GraphReader(pt.get_child("mjolnir"));

--- a/src/midgard/logging.cc
+++ b/src/midgard/logging.cc
@@ -369,15 +369,14 @@ void logging::Configure(const LoggingConfig& config) {
 }
 
 // configure logging from the top-level "logging" section of a boost property tree config
+// if the section is missing, uses the default logger (std_out with color)
 void logging::ConfigureFromPtree(const boost::property_tree::ptree& config) {
-  try {
-    const auto& logging_subtree = config.get_child("logging");
+  auto logging_subtree = config.get_child_optional("logging");
+  if (logging_subtree) {
     Configure(ToMap<const boost::property_tree::ptree&, std::unordered_map<std::string, std::string>>(
-        logging_subtree));
-  } catch (const boost::property_tree::ptree_bad_path&) {
-    throw std::runtime_error(
-        "Missing top-level 'logging' section in config. "
-        "Per-module logging (e.g. 'mjolnir.logging', 'loki.logging') is no longer supported.");
+        logging_subtree.get()));
+  } else {
+    LOG_WARN("No top-level 'logging' section in config, using default logger.");
   }
 }
 

--- a/src/midgard/logging.cc
+++ b/src/midgard/logging.cc
@@ -375,9 +375,9 @@ void logging::ConfigureFromPtree(const boost::property_tree::ptree& config) {
   if (logging_subtree) {
     Configure(ToMap<const boost::property_tree::ptree&, std::unordered_map<std::string, std::string>>(
         logging_subtree.get()));
-  } else {
-    LOG_WARN("No top-level 'logging' section in config, using default logger.");
+    return;
   }
+  LOG_WARN("No top-level 'logging' section in config, using default logger.");
 }
 
 } // namespace midgard

--- a/src/midgard/logging.cc
+++ b/src/midgard/logging.cc
@@ -369,7 +369,7 @@ void logging::Configure(const LoggingConfig& config) {
 }
 
 // configure logging from the top-level "logging" section of a boost property tree config
-void logging::Configure(const boost::property_tree::ptree& config) {
+void logging::ConfigureFromPtree(const boost::property_tree::ptree& config) {
   try {
     const auto& logging_subtree = config.get_child("logging");
     Configure(ToMap<const boost::property_tree::ptree&, std::unordered_map<std::string, std::string>>(

--- a/src/midgard/logging.cc
+++ b/src/midgard/logging.cc
@@ -1,6 +1,8 @@
 #include "midgard/logging.h"
 #include "midgard/util.h"
 
+#include <boost/property_tree/ptree.hpp>
+
 #include <chrono>
 #include <filesystem>
 #include <fstream>
@@ -364,6 +366,23 @@ void logging::Log(const std::string& message, const std::string& custom_directiv
 // statically configure logging
 void logging::Configure(const LoggingConfig& config) {
   GetLogger(config);
+}
+
+// configure logging from a boost property tree config
+void logging::Configure(const boost::property_tree::ptree& config,
+                        const std::string& deprecated_key) {
+  auto logging_subtree = config.get_child_optional("logging");
+  if (!logging_subtree && !deprecated_key.empty()) {
+    logging_subtree = config.get_child_optional(deprecated_key);
+    if (logging_subtree) {
+      std::cerr << "[WARN] Per-module logging config '" << deprecated_key
+                << "' is deprecated. Use top-level 'logging' instead." << std::endl;
+    }
+  }
+  if (logging_subtree) {
+    Configure(ToMap<const boost::property_tree::ptree&, std::unordered_map<std::string, std::string>>(
+        logging_subtree.get()));
+  }
 }
 
 } // namespace midgard

--- a/src/midgard/logging.cc
+++ b/src/midgard/logging.cc
@@ -368,20 +368,16 @@ void logging::Configure(const LoggingConfig& config) {
   GetLogger(config);
 }
 
-// configure logging from a boost property tree config
-void logging::Configure(const boost::property_tree::ptree& config,
-                        const std::string& deprecated_key) {
-  auto logging_subtree = config.get_child_optional("logging");
-  if (!logging_subtree && !deprecated_key.empty()) {
-    logging_subtree = config.get_child_optional(deprecated_key);
-    if (logging_subtree) {
-      std::cerr << "[WARN] Per-module logging config '" << deprecated_key
-                << "' is deprecated. Use top-level 'logging' instead." << std::endl;
-    }
-  }
-  if (logging_subtree) {
+// configure logging from the top-level "logging" section of a boost property tree config
+void logging::Configure(const boost::property_tree::ptree& config) {
+  try {
+    const auto& logging_subtree = config.get_child("logging");
     Configure(ToMap<const boost::property_tree::ptree&, std::unordered_map<std::string, std::string>>(
-        logging_subtree.get()));
+        logging_subtree));
+  } catch (const boost::property_tree::ptree_bad_path&) {
+    throw std::runtime_error(
+        "Missing top-level 'logging' section in config. "
+        "Per-module logging (e.g. 'mjolnir.logging', 'loki.logging') is no longer supported.");
   }
 }
 

--- a/src/mjolnir/valhalla_add_elevation.cc
+++ b/src/mjolnir/valhalla_add_elevation.cc
@@ -86,7 +86,7 @@ int main(int argc, char** argv) {
     // clang-format on
 
     const auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, &config, "mjolnir.logging", true))
+    if (!parse_common_args(program, options, result, &config, true))
       return EXIT_SUCCESS;
 
     if (!result.count("tiles")) {

--- a/src/mjolnir/valhalla_add_landmarks.cc
+++ b/src/mjolnir/valhalla_add_landmarks.cc
@@ -28,7 +28,7 @@ int main(int argc, char** argv) {
     // clang-format on
 
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, &config, "mjolnir.logging", true))
+    if (!parse_common_args(program, options, result, &config, true))
       return EXIT_SUCCESS;
   } catch (cxxopts::exceptions::exception& e) {
     std::cerr << e.what() << std::endl;

--- a/src/mjolnir/valhalla_add_predicted_traffic.cc
+++ b/src/mjolnir/valhalla_add_predicted_traffic.cc
@@ -36,7 +36,7 @@ int main(int argc, char** argv) {
     options.parse_positional({"traffic-tile-dir"});
     options.positional_help("Traffic tile dir");
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, &config, "mjolnir.logging", true))
+    if (!parse_common_args(program, options, result, &config, true))
       return EXIT_SUCCESS;
     if (!result.count("traffic-tile-dir")) {
       std::cout << "You must provide a tile directory to read the csv tiles from.\n";

--- a/src/mjolnir/valhalla_assign_speeds.cc
+++ b/src/mjolnir/valhalla_assign_speeds.cc
@@ -98,7 +98,7 @@ int main(int argc, char** argv) {
     // clang-format on
 
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, &config, "mjolnir.logging", true))
+    if (!parse_common_args(program, options, result, &config, true))
       return EXIT_SUCCESS;
   } catch (cxxopts::exceptions::exception& e) {
     std::cerr << e.what() << std::endl;

--- a/src/mjolnir/valhalla_benchmark_admins.cc
+++ b/src/mjolnir/valhalla_benchmark_admins.cc
@@ -182,7 +182,7 @@ int main(int argc, char** argv) {
     // clang-format on
 
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, &config, "mjolnir.logging"))
+    if (!parse_common_args(program, options, result, &config))
       return EXIT_SUCCESS;
 
     if (result.count("version")) {

--- a/src/mjolnir/valhalla_build_admins.cc
+++ b/src/mjolnir/valhalla_build_admins.cc
@@ -32,7 +32,7 @@ int main(int argc, char** argv) {
     options.parse_positional({"input_files"});
     options.positional_help("OSM PBF file(s)");
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, &config, "mjolnir.logging"))
+    if (!parse_common_args(program, options, result, &config))
       return EXIT_SUCCESS;
 
     // input files are positional

--- a/src/mjolnir/valhalla_build_connectivity.cc
+++ b/src/mjolnir/valhalla_build_connectivity.cc
@@ -61,7 +61,7 @@ int main(int argc, char** argv) {
     // clang-format on
 
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, &config, "mjolnir.logging"))
+    if (!parse_common_args(program, options, result, &config))
       return EXIT_SUCCESS;
   } catch (cxxopts::exceptions::exception& e) {
     std::cerr << e.what() << std::endl;

--- a/src/mjolnir/valhalla_build_landmarks.cc
+++ b/src/mjolnir/valhalla_build_landmarks.cc
@@ -31,7 +31,7 @@ int main(int argc, char** argv) {
     options.parse_positional({"input_files"});
     options.positional_help("OSM PBF file(s)");
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, &config, "mjolnir.logging"))
+    if (!parse_common_args(program, options, result, &config))
       return EXIT_SUCCESS;
 
     // input files are positional

--- a/src/mjolnir/valhalla_build_statistics.cc
+++ b/src/mjolnir/valhalla_build_statistics.cc
@@ -585,7 +585,7 @@ int main(int argc, char** argv) {
     // clang-format on
 
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, &config, "mjolnir.logging", true))
+    if (!parse_common_args(program, options, result, &config, true))
       return EXIT_SUCCESS;
   } catch (cxxopts::exceptions::exception& e) {
     std::cerr << e.what() << std::endl;

--- a/src/mjolnir/valhalla_build_tiles.cc
+++ b/src/mjolnir/valhalla_build_tiles.cc
@@ -54,7 +54,7 @@ int main(int argc, char** argv) {
     options.parse_positional({"input_files"});
     options.positional_help("OSM PBF file(s)");
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, &config, "mjolnir.logging", true, &list_stages))
+    if (!parse_common_args(program, options, result, &config, true, &list_stages))
       return EXIT_SUCCESS;
 
     // Convert stage strings to BuildStage

--- a/src/mjolnir/valhalla_convert_transit.cc
+++ b/src/mjolnir/valhalla_convert_transit.cc
@@ -34,7 +34,7 @@ int main(int argc, char** argv) {
     // clang-format on
 
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, &config, "mjolnir.logging", true))
+    if (!parse_common_args(program, options, result, &config, true))
       return EXIT_SUCCESS;
 
     if (result.count("target_directory")) {

--- a/src/mjolnir/valhalla_ingest_transit.cc
+++ b/src/mjolnir/valhalla_ingest_transit.cc
@@ -26,7 +26,7 @@ int main(int argc, char** argv) {
     // clang-format on
 
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, &config, "mjolnir.logging", true))
+    if (!parse_common_args(program, options, result, &config, true))
       return EXIT_SUCCESS;
   } catch (cxxopts::exceptions::exception& e) {
     std::cerr << e.what() << std::endl;

--- a/src/mjolnir/valhalla_query_transit.cc
+++ b/src/mjolnir/valhalla_query_transit.cc
@@ -383,7 +383,7 @@ int main(int argc, char* argv[]) {
     // clang-format on
 
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, &config, "mjolnir.logging", true))
+    if (!parse_common_args(program, options, result, &config, true))
       return EXIT_SUCCESS;
 
     for (const auto& arg : std::vector<std::string>{"o_onestop_id", "o_lat", "o_lng"}) {

--- a/src/mjolnir/valhalla_validate_transit.cc
+++ b/src/mjolnir/valhalla_validate_transit.cc
@@ -34,7 +34,7 @@ int main(int argc, char** argv) {
     // clang-format on
 
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, &config, "mjolnir.logging", true))
+    if (!parse_common_args(program, options, result, &config, true))
       return EXIT_SUCCESS;
   } catch (cxxopts::exceptions::exception& e) {
     std::cerr << e.what() << std::endl;

--- a/src/mjolnir/valhalla_ways_to_edges.cc
+++ b/src/mjolnir/valhalla_ways_to_edges.cc
@@ -36,7 +36,7 @@ int main(int argc, char** argv) {
     // clang-format on
 
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, &config, "mjolnir.logging"))
+    if (!parse_common_args(program, options, result, &config))
       return EXIT_SUCCESS;
 
   } catch (cxxopts::exceptions::exception& e) {

--- a/src/valhalla_expand_bounding_box.cc
+++ b/src/valhalla_expand_bounding_box.cc
@@ -33,7 +33,7 @@ int main(int argc, char** argv) {
     // clang-format on
 
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, &config, "mjolnir.logging"))
+    if (!parse_common_args(program, options, result, &config))
       return EXIT_SUCCESS;
 
     if (!result.count("bounding-box")) {

--- a/src/valhalla_export_edges.cc
+++ b/src/valhalla_export_edges.cc
@@ -177,8 +177,7 @@ int main(int argc, char* argv[]) {
   }
 
   // configure logging here, we want it to go to stderr
-  valhalla::midgard::logging::Configure(
-      valhalla::midgard::logging::LoggingConfig{{"type", "std_err"}, {"color", "true"}});
+  valhalla::midgard::logging::Configure({{"type", "std_err"}, {"color", "true"}});
 
   // get something we can use to fetch tiles
   valhalla::baldr::GraphReader reader(config.get_child("mjolnir"));

--- a/src/valhalla_export_edges.cc
+++ b/src/valhalla_export_edges.cc
@@ -177,7 +177,8 @@ int main(int argc, char* argv[]) {
   }
 
   // configure logging here, we want it to go to stderr
-  valhalla::midgard::logging::Configure({{"type", "std_err"}, {"color", "true"}});
+  valhalla::midgard::logging::Configure(
+      valhalla::midgard::logging::LoggingConfig{{"type", "std_err"}, {"color", "true"}});
 
   // get something we can use to fetch tiles
   valhalla::baldr::GraphReader reader(config.get_child("mjolnir"));

--- a/src/valhalla_export_edges.cc
+++ b/src/valhalla_export_edges.cc
@@ -165,7 +165,7 @@ int main(int argc, char* argv[]) {
     // clang-format on
 
     auto result = options.parse(argc, argv);
-    if (!parse_common_args(program, options, result, &config, ""))
+    if (!parse_common_args(program, options, result, &config))
       return EXIT_SUCCESS;
   } catch (cxxopts::exceptions::exception& e) {
     std::cerr << e.what() << std::endl;

--- a/src/valhalla_service.cc
+++ b/src/valhalla_service.cc
@@ -75,7 +75,8 @@ int main(int argc, char** argv) {
   // one shot direct request mode
   if (pos_args.size() == 3) {
     // because we want the program output to go only to stdout we force any logging to be stderr
-    valhalla::midgard::logging::Configure({{"type", "std_err"}});
+    valhalla::midgard::logging::Configure(
+        valhalla::midgard::logging::LoggingConfig{{"type", "std_err"}});
 
     const std::string &action_arg = pos_args[1], request_arg = pos_args[2];
 
@@ -195,7 +196,7 @@ int main(int argc, char** argv) {
   }
 
   // configure logging
-  valhalla::midgard::logging::Configure(config);
+  valhalla::midgard::logging::ConfigureFromPtree(config);
 
   // number of workers to use at each stage
   auto worker_concurrency =

--- a/src/valhalla_service.cc
+++ b/src/valhalla_service.cc
@@ -195,13 +195,7 @@ int main(int argc, char** argv) {
   }
 
   // configure logging
-  auto logging_subtree = config.get_child_optional("loki.logging");
-  if (logging_subtree) {
-    auto logging_config =
-        valhalla::midgard::ToMap<const boost::property_tree::ptree&,
-                                 std::unordered_map<std::string, std::string>>(logging_subtree.get());
-    valhalla::midgard::logging::Configure(logging_config);
-  }
+  valhalla::midgard::logging::Configure(config, "loki.logging");
 
   // number of workers to use at each stage
   auto worker_concurrency =

--- a/src/valhalla_service.cc
+++ b/src/valhalla_service.cc
@@ -45,7 +45,7 @@ int main(int argc, char** argv) {
     options.positional_help("CONFIG_JSON [CONCURRENCY] or CONFIG_JSON ACTION JSON_REQUEST");
     auto result = options.parse(argc, argv);
     // We set up conf & num_threads ourselves
-    if (!parse_common_args(program, options, result, nullptr, "", false))
+    if (!parse_common_args(program, options, result, nullptr, false))
       return EXIT_SUCCESS;
 
 #ifdef ENABLE_SERVICES
@@ -195,7 +195,7 @@ int main(int argc, char** argv) {
   }
 
   // configure logging
-  valhalla::midgard::logging::Configure(config, "loki.logging");
+  valhalla::midgard::logging::Configure(config);
 
   // number of workers to use at each stage
   auto worker_concurrency =

--- a/src/valhalla_service.cc
+++ b/src/valhalla_service.cc
@@ -75,8 +75,7 @@ int main(int argc, char** argv) {
   // one shot direct request mode
   if (pos_args.size() == 3) {
     // because we want the program output to go only to stdout we force any logging to be stderr
-    valhalla::midgard::logging::Configure(
-        valhalla::midgard::logging::LoggingConfig{{"type", "std_err"}});
+    valhalla::midgard::logging::Configure({{"type", "std_err"}});
 
     const std::string &action_arg = pos_args[1], request_arg = pos_args[2];
 

--- a/test/bindings/valhalla.json
+++ b/test/bindings/valhalla.json
@@ -1,4 +1,9 @@
 {
+  "logging": {
+    "type": "std_out",
+    "color": true,
+    "file_name": "path_to_some_file.log"
+  },
   "mjolnir": {
     "max_cache_size": 1000000000,
     "id_table_size": 1300000000,
@@ -33,11 +38,6 @@
       "use_urban_tag": false,
       "use_rest_area": false,
       "scan_tar": false
-    },
-    "logging": {
-      "type": "std_out",
-      "color": true,
-      "file_name": "path_to_some_file.log"
     }
   },
   "additional_data": {
@@ -71,23 +71,11 @@
       "mvt_min_zoom_road_class": [7, 7, 8, 10, 11, 11, 13, 14],
       "mvt_cache_min_zoom": 11
     },
-    "logging": {
-      "type": "std_out",
-      "color": true,
-      "file_name": "path_to_some_file.log",
-      "long_request": 100.0
-    },
     "service": {
       "proxy": "ipc:///tmp/loki"
     }
   },
   "thor": {
-    "logging": {
-      "type": "std_out",
-      "color": true,
-      "file_name": "path_to_some_file.log",
-      "long_request": 110.0
-    },
     "source_to_target_algorithm": "select_optimal",
     "service": {
       "proxy": "ipc:///tmp/thor"
@@ -136,11 +124,6 @@
     }
   },
   "odin": {
-    "logging": {
-      "type": "std_out",
-      "color": true,
-      "file_name": "path_to_some_file.log"
-    },
     "service": {
       "proxy": "ipc:///tmp/odin"
     },
@@ -190,11 +173,6 @@
     },
     "multimodal": {
       "turn_penalty_factor": 70
-    },
-    "logging": {
-      "type": "std_out",
-      "color": true,
-      "file_name": "path_to_some_file.log"
     },
     "service": {
       "proxy": "ipc:///tmp/meili"

--- a/test/test.cc
+++ b/test/test.cc
@@ -174,6 +174,10 @@ boost::property_tree::ptree make_config(const std::string& path_prefix,
 
   std::string defaults = R"(
     {
+      "logging": {
+        "color": false,
+        "type": "std_out"
+      },
       "additional_data": {
         "elevation": "%%/elevation/"
       },
@@ -199,10 +203,6 @@ boost::property_tree::ptree make_config(const std::string& path_prefix,
           "centroid",
           "status"
         ],
-        "logging": {
-          "color": false,
-          "type": "std_out"
-        },
         "service": {
           "proxy": "ipc://%%/loki"
         },
@@ -296,10 +296,6 @@ boost::property_tree::ptree make_config(const std::string& path_prefix,
         "include_construction": true,
         "include_driving": true,
         "include_pedestrian": true,
-        "logging": {
-          "color": false,
-          "type": "std_out"
-        },
         "lru_mem_cache_hard_control": false,
         "max_cache_size": 1000000000,
         "max_concurrent_reader_users": 1,
@@ -314,10 +310,6 @@ boost::property_tree::ptree make_config(const std::string& path_prefix,
         "use_lru_mem_cache": false
       },
       "odin": {
-        "logging": {
-          "color": false,
-          "type": "std_out"
-        },
         "service": {
           "proxy": "ipc://%%/odin"
         }
@@ -457,11 +449,6 @@ boost::property_tree::ptree make_config(const std::string& path_prefix,
         }
       },
       "thor": {
-        "logging": {
-          "color": false,
-          "long_request": 110.0,
-          "type": "std_out"
-        },
         "service": {
           "proxy": "ipc://%%/thor"
         },

--- a/test/win/valhalla.json
+++ b/test/win/valhalla.json
@@ -1,4 +1,9 @@
 {
+  "logging": {
+    "color": true,
+    "file_name": "path_to_some_file.log",
+    "type": "std_out"
+  },
   "additional_data": {
     "elevation": "/data/valhalla/elevation/"
   },
@@ -25,12 +30,6 @@
       "status",
       "tile"
     ],
-    "logging": {
-      "color": true,
-      "file_name": "path_to_some_file.log",
-      "long_request": 100.0,
-      "type": "std_out"
-    },
     "service": {
       "proxy": "ipc:///tmp/loki"
     },
@@ -83,11 +82,6 @@
       "cache_size": 100240,
       "size": 500
     },
-    "logging": {
-      "color": true,
-      "file_name": "path_to_some_file.log",
-      "type": "std_out"
-    },
     "mode": "auto",
     "multimodal": {
       "turn_penalty_factor": 70
@@ -106,11 +100,6 @@
     "landmarks": "test\\data\\landmarks.sqlite",
     "hierarchy": true,
     "include_driveways": true,
-    "logging": {
-      "color": true,
-      "file_name": "path_to_some_file.log",
-      "type": "std_out"
-    },
     "max_cache_size": 1000000000,
     "shortcuts": true,
     "tile_dir": "test\\data\\utrecht_tiles",
@@ -120,11 +109,6 @@
     "transit_feeds_dir": ""
   },
   "odin": {
-    "logging": {
-      "color": true,
-      "file_name": "path_to_some_file.log",
-      "type": "std_out"
-    },
     "service": {
       "proxy": "ipc:///tmp/odin"
     }
@@ -243,12 +227,6 @@
     }
   },
   "thor": {
-    "logging": {
-      "color": true,
-      "file_name": "path_to_some_file.log",
-      "long_request": 110.0,
-      "type": "std_out"
-    },
     "service": {
       "proxy": "ipc:///tmp/thor"
     },

--- a/valhalla/midgard/logging.h
+++ b/valhalla/midgard/logging.h
@@ -71,7 +71,7 @@ void Log(const std::string&, const std::string& custom_directive = " [TRACE] ");
 void Configure(const LoggingConfig& config);
 
 // configure logging from the top-level "logging" section of a boost property tree config
-void Configure(const boost::property_tree::ptree& config);
+void ConfigureFromPtree(const boost::property_tree::ptree& config);
 
 // guarding against redefinitions
 #ifndef LOG_ERROR

--- a/valhalla/midgard/logging.h
+++ b/valhalla/midgard/logging.h
@@ -1,6 +1,8 @@
 #ifndef VALHALLA_MIDGARD_LOGGING_H_
 #define VALHALLA_MIDGARD_LOGGING_H_
 
+#include <boost/property_tree/ptree_fwd.hpp>
+
 #include <format>
 #include <mutex>
 #include <string>
@@ -67,6 +69,10 @@ void Log(const std::string&, const std::string& custom_directive = " [TRACE] ");
 // logging::Configure({ {"type", "std_out"}, {"color", ""} })
 // logging::Configure({ {"type", "file"}, {"file_name", "test.log"}, {"reopen_interval", "1"} })
 void Configure(const LoggingConfig& config);
+
+// configure logging from a boost property tree config
+// reads top-level "logging" section, falls back to deprecated_key if provided
+void Configure(const boost::property_tree::ptree& config, const std::string& deprecated_key = {});
 
 // guarding against redefinitions
 #ifndef LOG_ERROR

--- a/valhalla/midgard/logging.h
+++ b/valhalla/midgard/logging.h
@@ -70,9 +70,8 @@ void Log(const std::string&, const std::string& custom_directive = " [TRACE] ");
 // logging::Configure({ {"type", "file"}, {"file_name", "test.log"}, {"reopen_interval", "1"} })
 void Configure(const LoggingConfig& config);
 
-// configure logging from a boost property tree config
-// reads top-level "logging" section, falls back to deprecated_key if provided
-void Configure(const boost::property_tree::ptree& config, const std::string& deprecated_key = {});
+// configure logging from the top-level "logging" section of a boost property tree config
+void Configure(const boost::property_tree::ptree& config);
 
 // guarding against redefinitions
 #ifndef LOG_ERROR


### PR DESCRIPTION
closes #5962 

also removes `logging.long_request` config, which wasn't used in c++ code. should we implement it properly or just drop it @kevinkreiser ? IMO with statsd, we (probably) get that metric anyways if we want it, where it's much more useful than in some WARN log (which also needs _some_ kind of metric analytics to be useful). WDYT?

done by claude with some mods by me. not sure about the inclusion of  `property_tree` in logging.cc though..