### PR TITLE
Add support for parking entrance tags in node parsing

### DIFF
--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -2178,7 +2178,10 @@ struct graph_parser {
         ref_katakana_ = tag.second;
       } else if (tag.first == "ref:pronunciation:jeita") {
         ref_jeita_ = tag.second;
-      } else if (tag.first == "amenity" && tag.second == "parking") {
+      } else if ((tag.first == "amenity" && tag.second == "parking") ||
+                (tag.first == "entrance" && tag.second == "parking") ||
+                (tag.first == "amenity" && tag.second == "parking_entrance")
+                ) {
         osmdata_.edge_count += !intersection;
         intersection = true;
         n.set_type(NodeType::kParking);

--- a/test/gurka/test_multimodal_astar.cc
+++ b/test/gurka/test_multimodal_astar.cc
@@ -162,3 +162,53 @@ TEST(Standalone, TrivialRoute) {
   EXPECT_EQ(leg.maneuver(0).travel_mode(), TravelMode::kDrive);
   EXPECT_EQ(leg.maneuver(leg.maneuver_size() - 1).travel_mode(), TravelMode::kPedestrian);
 }
+
+
+
+TEST(Standalone, ParkingEntranceTagSupport) {
+  const std::string ascii_map = R"(
+      A--------------B-----------C
+  )";
+
+  const gurka::ways ways = {
+      {"AB", {{"highway", "residential"}}},
+      {"BC", {{"highway", "residential"}}},
+  };
+
+  const gurka::nodes nodes = {
+      {"B", {{"entrance", "parking"}}}
+  };
+
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100);
+  auto map = gurka::buildtiles(layout, ways, nodes, {},
+      VALHALLA_BUILD_DIR "test/data/gurka_parking_entrance");
+
+  auto reader = test::make_clean_graphreader(map.config.get_child("mjolnir"));
+  auto node = gurka::findNode(*reader, layout, "B");
+  auto nodeinfo = reader->nodeinfo(node);
+
+  EXPECT_EQ(nodeinfo->type(), baldr::NodeType::kParking)
+      << "Expected parking from entrance tag, got "
+      << baldr::to_string(nodeinfo->type());
+
+  auto result = gurka::do_action(
+      valhalla::Options::route,
+      map,
+      {"A", "C"},
+      "auto_pedestrian",
+      {}
+  );
+
+  gurka::assert::raw::expect_maneuvers(
+      result,
+      {
+          DirectionsLeg_Maneuver_Type::DirectionsLeg_Maneuver_Type_kStart,
+          DirectionsLeg_Maneuver_Type::DirectionsLeg_Maneuver_Type_kParkVehicle,
+          DirectionsLeg_Maneuver_Type::DirectionsLeg_Maneuver_Type_kDestination,
+      }
+  );
+
+  auto& leg = result.directions().routes(0).legs(0);
+  EXPECT_EQ(leg.maneuver(0).travel_mode(), TravelMode::kDrive);
+  EXPECT_EQ(leg.maneuver(leg.maneuver_size() - 1).travel_mode(), TravelMode::kPedestrian);
+}


### PR DESCRIPTION
## Summary

This PR extends parking node detection in Valhalla to support additional OSM tagging patterns.

Currently, only `amenity=parking` nodes are mapped to `NodeType::kParking`. However, in real-world OSM data, parking entrances are also commonly tagged as:

- entrance=parking
- amenity=parking_entrance

This PR adds support for these tags.

## Changes

- Updated node parsing in `src/mjolnir/pbfgraphparser.cc`
- Added detection for:
  - entrance=parking
  - amenity=parking_entrance

## Impact

- Improves multimodal routing (`auto_pedestrian`)
- Enables correct parking-based mode transitions
- Produces accurate `kParkVehicle` maneuvers

## Testing

- Added Gurka test: `ParkingEntranceTagSupport`
- Validates:
  - NodeType::kParking assignment
  - Multimodal mode switching
  - kParkVehicle maneuver generation

All existing tests pass.

## Notes

This change is backward-compatible and reuses existing routing logic based on `NodeType::kParking`.