### PR TITLE
fix: Unity build for iOS should not include `date/src/ios.mm`

### DIFF
--- a/src/baldr/CMakeLists.txt
+++ b/src/baldr/CMakeLists.txt
@@ -110,6 +110,7 @@ list(APPEND sources_with_warnings
 #ios we have more work to make use of system tzdb
 if(APPLE)
   list(APPEND sources ${VALHALLA_SOURCE_DIR}/third_party/date/src/ios.mm)
+  set_source_files_properties(${VALHALLA_SOURCE_DIR}/third_party/date/src/ios.mm PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 endif()
 
 valhalla_module(NAME baldr


### PR DESCRIPTION
_Please don't force-push once you received the first review._

# Issue

Mixing Objective-C++ and C++ files in a single unit (I'm stoked that cmake is so stupid to actually do that) obviously lead to compilation errors. At the same time, unity builds help quite a lot with compilation times in cases where caching is not an option.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [ ] If you made changes to a translation file, [update transifex](docs/docs/locales.md) too

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
