### PR TITLE
tiniest refactor, simple move

### DIFF
--- a/src/baldr/graphreader.cc
+++ b/src/baldr/graphreader.cc
@@ -43,41 +43,39 @@ tile_gone_error_t::tile_gone_error_t(std::string prefix, baldr::GraphId edgeid)
 
 GraphReader::tile_extract_t::tile_extract_t(const boost::property_tree::ptree& pt,
                                             bool traffic_readonly) {
-
-  // Initializes a map of tile id to tile address in the tar mmap
+  // Populates a tile map from a tar entry.
   // If the tar contains an index.bin entry, uses it for fast offset-based loading.
-  // Otherwise falls back to scanning all entries and parsing filenames as GraphIds.
-  // Returns the number of corrupt blocks encountered.
-  auto map_tiles = [](midgard::tar& tar,
-                      std::unordered_map<uint64_t, std::pair<char*, size_t>>& tiles) {
-    return tar.for_each([&](const std::string& name, const char* data, size_t size) {
-      // if it's our specially named index.bin file - load all entries from it
-      if (name == "index.bin") {
-        auto entries =
-            std::span<tile_index_entry>(reinterpret_cast<tile_index_entry*>(const_cast<char*>(data)),
-                                        size / sizeof(tile_index_entry));
-        tiles.clear(); // just in case if somehow index.bin is not the first one
-        tiles.reserve(entries.size());
-        for (const auto& entry : entries) {
-          tiles.emplace(std::piecewise_construct, std::forward_as_tuple(entry.tile_id),
-                        std::forward_as_tuple(const_cast<char*>(tar.mm.get() + entry.offset),
-                                              entry.size));
-        }
-        return false; // index loaded, stop scanning
-      }
+  // Otherwise falls back to parsing filenames as GraphIds.
+  auto map_tiles = [](const char* mmap_base, const std::string& name, const char* data, size_t size,
+                      void* context) -> bool {
+    // we inject our own use-case-specific context which gets carried along with the context
+    auto& tiles = *static_cast<std::unordered_map<uint64_t, std::pair<char*, size_t>>*>(context);
 
-      try {
-        auto id = valhalla::baldr::GraphTile::GetTileId(name);
-        tiles[id] = std::make_pair(const_cast<char*>(data), size);
-      } catch (...) {
-        // It's possible to put non-tile files inside the tarfile.  As we're only
-        // parsing the file *name* as a GraphId here, we will just silently skip
-        // any file paths that can't be parsed by GraphId::GetTileId()
-        // If we end up with *no* recognizable tile files in the tarball at all,
-        // checks lower down will warn on that.
+    // if it's our specially named index.bin file - load all entries from it
+    if (name == "index.bin") {
+      auto entries =
+          std::span<tile_index_entry>(reinterpret_cast<tile_index_entry*>(const_cast<char*>(data)),
+                                      size / sizeof(tile_index_entry));
+      tiles.clear(); // just in case if somehow index.bin is not the first one
+      tiles.reserve(entries.size());
+      for (const auto& entry : entries) {
+        tiles.emplace(std::piecewise_construct, std::forward_as_tuple(entry.tile_id),
+                      std::forward_as_tuple(const_cast<char*>(mmap_base + entry.offset), entry.size));
       }
-      return true;
-    });
+      return false; // index loaded, stop scanning
+    }
+
+    try {
+      auto id = valhalla::baldr::GraphTile::GetTileId(name);
+      tiles[id] = std::make_pair(const_cast<char*>(data), size);
+    } catch (...) {
+      // It's possible to put non-tile files inside the tarfile.  As we're only
+      // parsing the file *name* as a GraphId here, we will just silently skip
+      // any file paths that can't be parsed by GraphId::GetTileId()
+      // If we end up with *no* recognizable tile files in the tarball at all,
+      // checks lower down will warn on that.
+    }
+    return true;
   };
 
   bool scan_tar = pt.get<bool>("data_processing.scan_tar", false);
@@ -86,7 +84,7 @@ GraphReader::tile_extract_t::tile_extract_t(const boost::property_tree::ptree& p
   if (pt.get_optional<std::string>("tile_extract")) {
     try {
       archive = std::make_shared<midgard::tar>(pt.get<std::string>("tile_extract"));
-      auto corrupt_blocks = map_tiles(*archive, tiles);
+      auto corrupt_blocks = archive->for_each(map_tiles, &tiles);
       if (scan_tar) {
         checksum = 0;
         for (const auto& kv : tiles) {
@@ -115,7 +113,7 @@ GraphReader::tile_extract_t::tile_extract_t(const boost::property_tree::ptree& p
       // load the tar
       traffic_archive =
           std::make_shared<midgard::tar>(pt.get<std::string>("traffic_extract"), traffic_readonly);
-      auto corrupt_blocks = map_tiles(*traffic_archive, traffic_tiles);
+      auto corrupt_blocks = traffic_archive->for_each(map_tiles, &traffic_tiles);
       // couldn't load it
       if (traffic_tiles.empty()) {
         LOG_WARN("Traffic tile extract contained no usable tiles");

--- a/valhalla/midgard/sequence.h
+++ b/valhalla/midgard/sequence.h
@@ -670,12 +670,17 @@ struct tar {
     mm.map(tar_file, s.st_size, POSIX_MADV_NORMAL, readonly);
   }
 
-  // Callback per entry: (name, data_ptr, size). Return true to continue, false to stop.
-  using entry_visitor_t = std::function<bool(const std::string& name, const char* data, size_t size)>;
+  // Callback per entry: (mmap_base, name, data_ptr, size, context).
+  // Return true to continue, false to stop.
+  using entry_visitor_t = std::function<bool(const char* mmap_base,
+                                             const std::string& name,
+                                             const char* data,
+                                             size_t size,
+                                             void* context)>;
 
   // Traverse all entries, calling visitor for each regular file.
   // Returns the number of corrupt blocks encountered.
-  size_t for_each(const entry_visitor_t& visitor) {
+  size_t for_each(const entry_visitor_t& visitor, void* context = nullptr) {
     // rip through the tar to see whats in it noting that most tars end with 2 empty blocks
     // but we can concatenate tars and get empty blocks in between so we'll just be pretty
     // lax about it and we'll count the ones we cant make sense of
@@ -695,7 +700,7 @@ struct tar {
         // tar doesn't automatically update path separators based on OS, so we need to do it...
         std::filesystem::path filepath{h->name};
         filepath.make_preferred();
-        if (!visitor(filepath.string(), position, size)) {
+        if (!visitor(mm.get(), filepath.string(), position, size, context)) {
           break;
         }
       }


### PR DESCRIPTION
over in #5995 there was some excellent cleanup, removing unneeded bookkeeping in the tar object and adding a new method which simply lets one iterate over the contents on the fly. to make use of it we added a little helper function in an anonymous namespace but to me it seems a bit strange to have a helper when you can just make a local lambda and call that. so this tiny refactor simply moves that inline lambda in the helper to a local lambda in the function where its called. tiny quality of life improvement

longer discussion here: https://github.com/valhalla/valhalla/pull/5995/changes#r3000947621