### PR TITLE
fix(odin): use costing options for pedestrian/bicycle speed

### DIFF
--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -3072,11 +3072,10 @@ void ManeuversBuilder::UpdateInternalTurnCount(Maneuver& maneuver, int node_inde
 }
 
 float ManeuversBuilder::GetSpeed(TravelMode travel_mode, float edge_speed) const {
-  // TODO use pedestrian and bicycle speeds from costing options?
   if (travel_mode == TravelMode::kPedestrian) {
-    return 5.1f;
+    return options_.costings().find(Costing::pedestrian)->second.options().walking_speed();
   } else if (travel_mode == TravelMode::kBicycle) {
-    return 20.0f;
+    return options_.costings().find(Costing::bicycle)->second.options().cycling_speed();
   } else {
     return edge_speed;
   }


### PR DESCRIPTION
Closes #5984

# Issue

`ManeuversBuilder::GetSpeed` returned hardcoded speeds regardless of what the user set in costing options.

This PR replaces the hardcoded constants with lookups from `options_.costings()`. When no speed is specified by the user, the correct defaults are written into the PBF by `JSON_PBF_RANGED_DEFAULT`. 

Note: 5.1 km/h remains the default for pedestrians. For cycling, since hybrid is the default bicycle type, the default changes from the old hardcoded 20 km/h to 18 km/h.

## Tasklist

 - [ ] Add tests
 - [X] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [ ] If you made changes to a translation file, [update transifex](docs/docs/locales.md) too
