### PR TITLE
fix(odin): adjust pedestrian mode in roundabout logic

### DIFF
--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -1391,7 +1391,6 @@ void ManeuversBuilder::UpdateManeuver(Maneuver& maneuver, int node_index) {
         (prev_edge->IsRoadUse())) {
       mode = TravelMode::kDrive;
     }
-    // TODO might have to adjust for pedestrian too
 
     IntersectingEdgeCounts xedge_counts;
     trip_path_->GetEnhancedNode(node_index)

--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -1387,7 +1387,8 @@ void ManeuversBuilder::UpdateManeuver(Maneuver& maneuver, int node_index) {
     TravelMode mode = prev_edge->travel_mode();
 
     // Adjust bicycle travel mode if roundabout is a road
-    if ((mode == TravelMode::kBicycle) && (prev_edge->IsRoadUse())) {
+    if ((mode == TravelMode::kBicycle || mode == TravelMode::kPedestrian) &&
+        (prev_edge->IsRoadUse())) {
       mode = TravelMode::kDrive;
     }
     // TODO might have to adjust for pedestrian too


### PR DESCRIPTION
This PR addresses a long-standing TODO in maneuversbuilder.cc. It ensures that when a pedestrian is traversing a roundabout that is classified as a road, the travel mode is adjusted to kDrive to ensure consistent exit count calculations, similar to the existing bicycle logic