### PR TITLE
Allow skipping protobuf->string serialization

### DIFF
--- a/proto/options.proto
+++ b/proto/options.proto
@@ -395,6 +395,15 @@ message Options {
     mvt = 5;  // we set this ourselves and throw if it's set by the user
   }
 
+  // Extended formatting options for the formats above.
+  message FormatOptions {
+    // Skips serialization of protobuf message to string and only populates the in memory Api request.
+    // Normally if we call actor.act(...) with a request in protobuf format, it will both fill the request
+    // object and serialize it to a string in the response.
+    // If this flag is set to true, then the final string serialization is skipped.
+    bool skip_pbf_to_string = 1;
+  }
+
   enum Action {
     no_action = 0;
     route = 1;
@@ -545,4 +554,5 @@ message Options {
   TileOptions tile_options = 64;                                   // additional /tile specific options
   repeated Levels exclude_levels = 65;                             // Levels to exclude within the exclude_polygon at the same index
   uint32 expansion_max_distance = 66;                              // Maximum path distance in meters for expansion. 0 = disabled.
+  FormatOptions format_options = 67;                               // Control formatting options for each of the given formats.
 }

--- a/src/tyr/serializers.cc
+++ b/src/tyr/serializers.cc
@@ -220,10 +220,16 @@ std::string serializePbf(Api& request) {
   // if they dont want the options object but its a service request we have to work around it
   bool skip_options = !request.options().pbf_field_selector().options() && request.has_info() &&
                       request.info().is_service();
+  const bool skip_to_string = request.options().format_options().skip_pbf_to_string();
   Options dummy;
   if (skip_options) {
     request.mutable_options()->Swap(&dummy);
   }
+  const auto skip_options_guard = midgard::make_finally([&request, &dummy, skip_options]() {
+    if (skip_options) {
+      request.mutable_options()->Swap(&dummy);
+    }
+  });
 
   // disable all the stuff we need to disable, options must be last since we are referencing it
   if (!selection.trip())
@@ -241,15 +247,14 @@ std::string serializePbf(Api& request) {
   if (!selection.expansion())
     request.clear_expansion();
 
-  // serialize the bytes
-  auto bytes = request.SerializeAsString();
-
-  // we do need to keep the options object though because downstream request handling relies on it
-  if (skip_options) {
-    request.mutable_options()->Swap(&dummy);
+  if (skip_to_string) {
+    // If they only want to use the in memory PBF without conversion to string then
+    // we can just return an empty string.
+    return "";
   }
 
-  return bytes;
+  // serialize the bytes
+  return request.SerializeAsString();
 }
 
 // Generate leg shape in geojson format.

--- a/test/actor.cc
+++ b/test/actor.cc
@@ -212,6 +212,40 @@ TEST(Actor, SupportedFormats) {
   }
 }
 
+TEST(Actor, IsochroneSkipPbfToStringKeepsApiData) {
+  Api base;
+  Options* options = base.mutable_options();
+  options->set_action(Options::isochrone);
+  options->set_format(Options_Format_pbf);
+  options->set_costing_type(Costing_Type::Costing_Type_auto_);
+  auto* contour = options->mutable_contours()->Add();
+  contour->set_time(5.0f);
+  auto* location = options->mutable_locations()->Add();
+  location->mutable_ll()->set_lat(40.546115);
+  location->mutable_ll()->set_lng(-76.385076);
+
+  tyr::actor_t actor(conf);
+
+  Api without_skip = base;
+  Api with_skip = base;
+  with_skip.mutable_options()->mutable_format_options()->set_skip_pbf_to_string(true);
+
+  const std::string serialized_without_skip = actor.act(without_skip);
+  actor.cleanup();
+  const std::string serialized_with_skip = actor.act(with_skip);
+  actor.cleanup();
+
+  EXPECT_FALSE(serialized_without_skip.empty());
+  EXPECT_TRUE(serialized_with_skip.empty());
+  EXPECT_TRUE(without_skip.isochrone().intervals_size() > 0 ||
+              with_skip.isochrone().intervals_size() > 0);
+  // Skip flag should only change serialization behavior, not the computed payload.
+  without_skip.clear_info();
+  with_skip.clear_info();
+
+  EXPECT_TRUE(test::pbf_equals(without_skip, with_skip));
+}
+
 } // namespace
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
In certain usecases with high throughput for actor.act API with a protobuf we want to skip serialization at the end since we already receive the response within the Api object itself.

Doing that can save ~5% of time depending on the map or workload.

_Please don't force-push once you received the first review._

# Issue

Partially Fixes: #4923

## Tasklist

 - [x] Add tests
 - [x] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [ ] If you made changes to a translation file, [update transifex](docs/docs/locales.md) too

## Requirements / Relations

None.
