### PR TITLE
Fix error response when consecutive through locations snap to the same edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
    * FIXED: Fix overestimated number of entries in `UnorderedIdTable::deserialize` [#5969](https://github.com/valhalla/valhalla/pull/5969)
    * FIXED: cleanup pkg-config to set the right variables [#5965](https://github.com/valhalla/valhalla/pull/5965)
    * FIXED: super trivial connections snapping to excluded edges in CostMatrix [#5996](https://github.com/valhalla/valhalla/pull/5996)
+   * FIXED: error response when consecutive through locations snap to the same edge [#6015](https://github.com/valhalla/valhalla/pull/6015)
 * **Enhancement**
    * ADDED: multimodal costing `auto_pedestrian` [#5780](https://github.com/valhalla/valhalla/pull/5780)
    * CHANGED: remove `baldr::{Location,PathLocation}` and use their protobuf versions instead [#5906](https://github.com/valhalla/valhalla/pull/5906) 

--- a/src/thor/triplegbuilder.cc
+++ b/src/thor/triplegbuilder.cc
@@ -475,7 +475,7 @@ void CopyLocations(TripLeg& trip_path,
     valhalla::Location* tp_intermediate = trip_path.add_location();
     tp_intermediate->CopyFrom(intermediate);
     // we can grab the right edge index in the path because we temporarily set it for trimming
-    if (last_shape_index && intermediate.correlation().leg_shape_index() <= *last_shape_index) {
+    if (last_shape_index && intermediate.correlation().leg_shape_index() < *last_shape_index) {
       throw std::logic_error("leg_shape_index not set for intermediate location");
     }
     last_shape_index = intermediate.correlation().leg_shape_index();

--- a/test/gurka/test_via_waypoints.cc
+++ b/test/gurka/test_via_waypoints.cc
@@ -220,6 +220,37 @@ TEST_P(IntermediateLocations, test_back_to_back_via_uturns) {
   EXPECT_NEAR(d["routes"][0]["distance"].GetDouble(), total_dist, 1.0);
 }
 
+// Regression test: consecutive through locations that snap to the same node on an edge
+// should not cause a 500 error. Before the fix, equal leg_shape_index values triggered
+// "leg_shape_index not set for intermediate location" due to a strict monotonicity check.
+TEST_P(IntermediateLocations, test_consecutive_through_at_same_node) {
+  std::string date_time_type;
+  std::string intermediate_type;
+  std::tie(date_time_type, intermediate_type) = GetParam();
+
+  // This test targets the through-location bug fix; via locations at the same node cause a u-turn
+  // which is correct via behavior but not what we're testing here
+  if (intermediate_type == "via")
+    GTEST_SKIP() << "via locations at the same node produce a u-turn by design";
+
+  // Two intermediate through locations both at node B — they snap to the same point on the same edge
+  auto result = gurka::do_action(valhalla::Options::route, map, {"A", "B", "B", "C"}, "auto",
+                                 {
+                                     {"/locations/0/type", "break"},
+                                     {"/locations/1/type", "through"},
+                                     {"/locations/2/type", "through"},
+                                     {"/locations/3/type", "break"},
+                                     {"/date_time/type", date_time_type},
+                                     {"/date_time/value", "2111-11-11T11:11"},
+                                 });
+  auto d = gurka::convert_to_json(result, valhalla::Options_Format_osrm);
+
+  EXPECT_EQ(d["routes"].Size(), 1);
+  EXPECT_EQ(d["routes"][0]["legs"].Size(), 1);
+  EXPECT_EQ(d["routes"][0]["legs"][0]["via_waypoints"].Size(), 2);
+  EXPECT_NEAR(d["routes"][0]["distance"].GetDouble(), distance("A", "C"), 1.0);
+}
+
 // 1 is depart_at and 2 is arrive_by and 3 is invariant
 INSTANTIATE_TEST_SUITE_P(ViaWaypoints,
                          IntermediateLocations,


### PR DESCRIPTION
## Summary
- When closely-spaced through locations snap to a node on the same edge, `path.pop_back()` + inserting a single-edge `temp_path` keeps `path.size()` constant, causing consecutive intermediates to get the same `leg_shape_index`
- The strict monotonicity check (`<=` instead of `<`) then throws `"leg_shape_index not set for intermediate location"`, resulting in a 500/499 error response
- Equal `leg_shape_index` values are legitimate when two through locations are on the same edge — this PR relaxes the check to allow them

## Test plan
- [x] Route with two consecutive through locations that snap to the same edge — should return a valid response instead of 500
- [x] Verify existing route tests still pass