### PR TITLE
Disable std::pmr in CostMatrix::ReachedMap on mobile platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
    * FIXED: Fix overestimated number of entries in `UnorderedIdTable::deserialize` [#5969](https://github.com/valhalla/valhalla/pull/5969)
    * FIXED: cleanup pkg-config to set the right variables [#5965](https://github.com/valhalla/valhalla/pull/5965)
    * FIXED: super trivial connections snapping to excluded edges in CostMatrix [#5996](https://github.com/valhalla/valhalla/pull/5996)
+   * FIXED: CostMatrix crash on platforms without std::pmr support (e.g. iOS 15) [#6017](https://github.com/valhalla/valhalla/pull/6017)
 * **Enhancement**
    * ADDED: multimodal costing `auto_pedestrian` [#5780](https://github.com/valhalla/valhalla/pull/5780)
    * CHANGED: remove `baldr::{Location,PathLocation}` and use their protobuf versions instead [#5906](https://github.com/valhalla/valhalla/pull/5906) 

--- a/src/thor/costmatrix.cc
+++ b/src/thor/costmatrix.cc
@@ -68,22 +68,30 @@ namespace thor {
 
 class CostMatrix::ReachedMap {
 public:
-  using PmrVector = std::vector<uint32_t, std::pmr::polymorphic_allocator<uint32_t>>;
+#if defined(ANKERL_UNORDERED_DENSE_PMR)
+  using Vector = std::vector<uint32_t, std::pmr::polymorphic_allocator<uint32_t>>;
 
   ReachedMap()
       : pool_(std::pmr::new_delete_resource()), vec_alloc_(&pool_),
-        storage_(std::pmr::polymorphic_allocator<std::pair<const uint64_t, PmrVector>>(&pool_)) {
+        storage_(std::pmr::polymorphic_allocator<std::pair<const uint64_t, Vector>>(&pool_)) {
   }
+#else
+  using Vector = std::vector<uint32_t>;
+#endif
 
   void add(uint64_t key, uint32_t value) {
     auto it = storage_.find(key);
     if (it == storage_.end()) {
-      it = storage_.emplace(key, PmrVector(vec_alloc_)).first;
+#if defined(ANKERL_UNORDERED_DENSE_PMR)
+      it = storage_.emplace(key, Vector(vec_alloc_)).first;
+#else
+      it = storage_.emplace(key, Vector()).first;
+#endif
     }
     it->second.push_back(value);
   }
 
-  const PmrVector* get(uint64_t key) const {
+  const Vector* get(uint64_t key) const {
     auto it = storage_.find(key);
     if (it == storage_.end()) {
       return nullptr;
@@ -96,9 +104,13 @@ public:
   }
 
 private:
+#if defined(ANKERL_UNORDERED_DENSE_PMR)
   std::pmr::unsynchronized_pool_resource pool_;
   std::pmr::polymorphic_allocator<uint32_t> vec_alloc_;
-  ankerl::unordered_dense::pmr::map<uint64_t, PmrVector> storage_;
+  ankerl::unordered_dense::pmr::map<uint64_t, Vector> storage_;
+#else
+  ankerl::unordered_dense::map<uint64_t, Vector> storage_;
+#endif
 };
 
 // Constructor with cost threshold.
@@ -833,7 +845,7 @@ void CostMatrix::CheckConnections(const uint32_t loc_idx,
   // Get the opposing edge. Get a list of opposing locations whose
   // search has reached this edge.
   GraphId opp_edgeid = pred.opp_edgeid();
-  const ReachedMap::PmrVector* opp_locs = (FORWARD ? targets_ : sources_)->get(opp_edgeid);
+  const ReachedMap::Vector* opp_locs = (FORWARD ? targets_ : sources_)->get(opp_edgeid);
   if (!opp_locs) {
     return;
   }


### PR DESCRIPTION
## Summary
- `std::pmr::polymorphic_allocator` runtime support is unavailable on iOS 15 — symbols are missing despite the `<memory_resource>` header being present, causing a link-time/runtime crash
- Conditionally fall back to plain `std::vector` and `ankerl::unordered_dense::map` when `ANKERL_UNORDERED_DENSE_PMR` is not defined (which is already the case on platforms where pmr is unavailable)
- The PMR pool optimization is retained on server builds (Alpine/Linux) where it is supported

## Motivation
The `CostMatrix::ReachedMap` class uses `std::pmr::unsynchronized_pool_resource` and `std::pmr::polymorphic_allocator` for memory pooling. On iOS 15 (and other mobile platforms with incomplete C++17 library support), these symbols are not available at runtime even though the header exists, leading to crashes. This PR gates the PMR usage behind the existing `ANKERL_UNORDERED_DENSE_PMR` define that already tracks PMR availability.

## Discussion
This is primarily a mobile fix, but it costs nothing to support on systems without PMR — the fallback is plain `std::vector` and `ankerl::unordered_dense::map`, which work everywhere. Open to discussion on the approach.

## Test plan
- [x] Build on Linux — PMR path should be active, no behavioral change
- [x] Build for iOS/mobile with PMR disabled — should compile and run without crashes
- [x] CostMatrix tests pass on both configurations