### PR TITLE
feat(mjolnir,sif): support OSM winter_road and ice_road tags (#6025)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
    * FIXED: Fix overestimated number of entries in `UnorderedIdTable::deserialize` [#5969](https://github.com/valhalla/valhalla/pull/5969)
    * FIXED: cleanup pkg-config to set the right variables [#5965](https://github.com/valhalla/valhalla/pull/5965)
    * FIXED: super trivial connections snapping to excluded edges in CostMatrix [#5996](https://github.com/valhalla/valhalla/pull/5996)
+   * ADDED: support for OSM `winter_road=yes` and `ice_road=yes` tags; these seasonal roads now carry a strong cost penalty in `auto` costing so they are avoided when an alternative route exists [#6028](https://github.com/valhalla/valhalla/pull/6028)
 * **Enhancement**
    * ADDED: multimodal costing `auto_pedestrian` [#5780](https://github.com/valhalla/valhalla/pull/5780)
    * CHANGED: remove `baldr::{Location,PathLocation}` and use their protobuf versions instead [#5906](https://github.com/valhalla/valhalla/pull/5906) 

--- a/src/baldr/directededge.cc
+++ b/src/baldr/directededge.cc
@@ -211,6 +211,16 @@ void DirectedEdge::set_indoor(const bool indoor) {
   indoor_ = indoor;
 }
 
+// Sets the winter_road flag (OSM winter_road=yes).
+void DirectedEdge::set_winter_road(const bool v) {
+  winter_road_ = v;
+}
+
+// Sets the ice_road flag (OSM ice_road=yes).
+void DirectedEdge::set_ice_road(const bool v) {
+  ice_road_ = v;
+}
+
 // Sets the hov type.
 void DirectedEdge::set_hov_type(const HOVEdgeType hov_type) {
   hov_type_ = static_cast<uint32_t>(hov_type);

--- a/src/mjolnir/directededgebuilder.cc
+++ b/src/mjolnir/directededgebuilder.cc
@@ -79,6 +79,8 @@ DirectedEdgeBuilder::DirectedEdgeBuilder(const OSMWay& way,
   set_roundabout(way.roundabout());
   set_bridge(way.bridge());
   set_indoor(way.indoor());
+  set_winter_road(way.winter_road());
+  set_ice_road(way.ice_road());
   set_link(way.link());
   set_hov_type(way.hov_type());
   set_classification(rc);

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -1640,6 +1640,8 @@ struct graph_parser {
     tag_handlers_["toll"] = [this]() { way_.set_toll(tag_.second == "true" ? true : false); };
     tag_handlers_["bridge"] = [this]() { way_.set_bridge(tag_.second == "true" ? true : false); };
     tag_handlers_["indoor"] = [this]() { way_.set_indoor(tag_.second == "yes" ? true : false); };
+    tag_handlers_["winter_road"] = [this]() { way_.set_winter_road(tag_.second == "yes"); };
+    tag_handlers_["ice_road"] = [this]() { way_.set_ice_road(tag_.second == "yes"); };
     tag_handlers_["bike_network_mask"] = [this]() { way_.set_bike_network(to_int(tag_.second)); };
     //    tag_handlers_["bike_national_ref"] = [this]() {
     //      if (!tag_.second.empty())

--- a/src/sif/autocost.cc
+++ b/src/sif/autocost.cc
@@ -99,6 +99,11 @@ constexpr float kSurfaceFactor[] = {
     1.0f  // kPath
 };
 
+// Factor applied to edges tagged winter_road=yes or ice_road=yes.
+// These are seasonal roads (e.g. across frozen lakes/tundra) that may be impassable
+// outside winter. Strongly disfavor them without completely blocking routing (#6025).
+constexpr float kWinterRoadFactor = 10.0f;
+
 // The basic costing for an edge is a trade off between time and distance. We allow the user to
 // specify which one is more important to them and then we use a linear combination to combine the two
 // into a final metric. The problem is that time in seconds and length in meters have two wildly
@@ -353,6 +358,7 @@ public:
   float alley_factor_;        // Avoid alleys factor.
   float toll_factor_;         // Factor applied when road has a toll
   float surface_factor_;      // How much the surface factors are applied.
+  float winter_road_penalty_; // Factor applied when road is winter_road or ice_road (#6025)
   float distance_factor_;     // How much distance factors in overall favorability
   float inv_distance_factor_; // How much time factors in overall favorability
 
@@ -371,6 +377,7 @@ AutoCost::AutoCost(const Costing& costing, uint32_t access_mask)
   // Get the vehicle type - enter as string and convert to enum.
   // Used to set the surface factor - penalize some roads based on surface type.
   surface_factor_ = 0.5f;
+  winter_road_penalty_ = kWinterRoadFactor;
   type_ = VehicleType::kCar;
 
   // Get the base transition costs
@@ -529,6 +536,12 @@ Cost AutoCost::EdgeCost(const baldr::DirectedEdge* edge,
             surface_factor_ * kSurfaceFactor[static_cast<uint32_t>(edge->surface())] +
             SpeedPenalty(edge, tile, time_info, flow_sources, edge_speed) +
             edge->toll() * toll_factor_;
+
+  // Strongly disfavor seasonal winter/ice roads (#6025): these roads (e.g. across frozen
+  // lakes or tundra) may be impassable outside winter and are dangerous even when open.
+  if (edge->winter_road() || edge->ice_road()) {
+    factor += winter_road_penalty_;
+  }
 
   switch (edge->use()) {
     case Use::kAlley:

--- a/test/gurka/test_winter_road.cc
+++ b/test/gurka/test_winter_road.cc
@@ -1,0 +1,83 @@
+// Test that OSM winter_road=yes and ice_road=yes tags apply a strong cost
+// penalty so the router prefers normal roads when an alternative exists,
+// but still routes across seasonal roads when there is no other option.
+// Covers issue #6025.
+
+#include "gurka.h"
+#include "test.h"
+
+#include <gtest/gtest.h>
+
+using namespace valhalla;
+
+namespace {
+
+// Map layout:
+//
+//   A---B---C
+//       |   |
+//       D---E
+//
+// AB, BC, CE, DE: normal primary roads
+// BD: winter_road=yes shortcut (same length as CE, but penalized)
+//
+// Route A→E: prefer A-B-C-E (all normal) over A-B-D-E (shortcut via winter road)
+
+const std::string kAsciiMap = R"(
+    A---B---C
+        |   |
+        D---E
+)";
+
+const gurka::ways kWays = {
+    {"AB", {{"highway", "primary"}}},
+    {"BC", {{"highway", "primary"}}},
+    {"CE", {{"highway", "primary"}}},
+    {"DE", {{"highway", "primary"}}},
+    {"BD", {{"highway", "primary"}, {"winter_road", "yes"}}},
+};
+
+TEST(WinterRoad, AvoidsWinterRoadWhenAlternativeExists) {
+  const auto layout = gurka::detail::map_to_coordinates(kAsciiMap, 100);
+  auto map = gurka::buildmap(layout, kWays, {});
+
+  // Router should choose A-B-C-E (normal roads) over A-B-D-E (BD is winter_road)
+  auto result = gurka::do_action(valhalla::Options::route, map, {"A", "E"}, "auto");
+  gurka::assert::raw::expect_path(result, {"AB", "BC", "CE"});
+}
+
+// Same topology but BD tagged ice_road=yes instead
+const gurka::ways kWaysIce = {
+    {"AB", {{"highway", "primary"}}},
+    {"BC", {{"highway", "primary"}}},
+    {"CE", {{"highway", "primary"}}},
+    {"DE", {{"highway", "primary"}}},
+    {"BD", {{"highway", "primary"}, {"ice_road", "yes"}}},
+};
+
+TEST(WinterRoad, AvoidsIceRoadWhenAlternativeExists) {
+  const auto layout = gurka::detail::map_to_coordinates(kAsciiMap, 100);
+  auto map = gurka::buildmap(layout, kWaysIce, {});
+
+  auto result = gurka::do_action(valhalla::Options::route, map, {"A", "E"}, "auto");
+  gurka::assert::raw::expect_path(result, {"AB", "BC", "CE"});
+}
+
+// When only a winter road connects origin to destination, routing must still succeed.
+const std::string kAsciiMapDirect = R"(
+    A---B
+)";
+
+const gurka::ways kWaysDirect = {
+    {"AB", {{"highway", "primary"}, {"winter_road", "yes"}}},
+};
+
+TEST(WinterRoad, RoutesAcrossWinterRoadWhenNoAlternative) {
+  const auto layout = gurka::detail::map_to_coordinates(kAsciiMapDirect, 100);
+  auto map = gurka::buildmap(layout, kWaysDirect, {});
+
+  auto result = gurka::do_action(valhalla::Options::route, map, {"A", "B"}, "auto");
+  gurka::assert::raw::expect_path(result, {"AB"});
+}
+
+} // namespace

--- a/valhalla/baldr/directededge.h
+++ b/valhalla/baldr/directededge.h
@@ -345,6 +345,30 @@ public:
   void set_indoor(const bool indoor);
 
   /**
+   * Is this a seasonal winter road (OSM winter_road=yes)?
+   */
+  bool winter_road() const {
+    return winter_road_;
+  }
+
+  /**
+   * Sets the winter_road flag.
+   */
+  void set_winter_road(const bool v);
+
+  /**
+   * Is this an ice road (OSM ice_road=yes — road across frozen water/ground)?
+   */
+  bool ice_road() const {
+    return ice_road_;
+  }
+
+  /**
+   * Sets the ice_road flag.
+   */
+  void set_ice_road(const bool v);
+
+  /**
    * Get the HOV type (see graphconstants.h).
    */
   HOVEdgeType hov_type() const {
@@ -1259,7 +1283,7 @@ protected:
   uint64_t tunnel_ : 1;         // Is this edge part of a tunnel
   uint64_t bridge_ : 1;         // Is this edge part of a bridge?
   uint64_t traffic_signal_ : 1; // Traffic signal at end of the directed edge
-  uint64_t spare1_ : 1;         // Used to be "seasonal", was never used, can be reclaimed
+  uint64_t winter_road_ : 1;    // OSM winter_road=yes or ice_road=yes (seasonal road)
   uint64_t deadend_ : 1;        // Leads to a dead-end (no other drivable roads) TODO
   uint64_t bss_connection_ : 1; // Does this lead to(come out from) a bike share station?
   uint64_t stop_sign_ : 1;      // Stop sign at end of the directed edge
@@ -1268,7 +1292,8 @@ protected:
   uint64_t indoor_ : 1;         // Is this edge indoor
   uint64_t lit_ : 1;            // Is the edge lit?
   uint64_t dest_only_hgv_ : 1;  // destonly for HGV specifically
-  uint64_t spare4_ : 3;
+  uint64_t ice_road_ : 1;       // OSM ice_road=yes (road across frozen water/ground)
+  uint64_t spare4_ : 2;
 
   // 5th 8-byte word
   uint64_t turntype_ : 24;      // Turn type (see graphconstants.h)

--- a/valhalla/mjolnir/osmway.h
+++ b/valhalla/mjolnir/osmway.h
@@ -2071,6 +2071,34 @@ struct OSMWay {
   }
 
   /**
+   * Sets the winter_road flag (OSM winter_road=yes — seasonal road open only in winter).
+   */
+  void set_winter_road(const bool v) {
+    winter_road_ = v;
+  }
+
+  /**
+   * Get the winter_road flag.
+   */
+  bool winter_road() const {
+    return winter_road_;
+  }
+
+  /**
+   * Sets the ice_road flag (OSM ice_road=yes — road across frozen water/ground).
+   */
+  void set_ice_road(const bool v) {
+    ice_road_ = v;
+  }
+
+  /**
+   * Get the ice_road flag.
+   */
+  bool ice_road() const {
+    return ice_road_;
+  }
+
+  /**
    * Sets the HOV Type.
    * @param  hov_type
    */
@@ -2708,7 +2736,8 @@ struct OSMWay {
   uint16_t bike_backward_ : 1;
   uint16_t lit_ : 1;
   uint16_t destination_only_hgv_ : 1;
-  uint16_t spare2_ : 2;
+  uint16_t winter_road_ : 1;
+  uint16_t ice_road_ : 1;
 
   uint16_t nodecount_;
 


### PR DESCRIPTION
## What

Parse OSM [`winter_road=yes`](https://wiki.openstreetmap.org/wiki/Key:winter_road) and [`ice_road=yes`](https://wiki.openstreetmap.org/wiki/Key:ice_road) tags into the graph and apply a strong cost penalty in `auto` costing.

These are **seasonal roads** — temporary routes across frozen lakes, tundra, or permafrost that only exist in winter and are potentially impassable or dangerous at other times. Until now, Valhalla treated them as normal roads.

## Changes

| File | Change |
|------|--------|
| `valhalla/mjolnir/osmway.h` | `winter_road_` + `ice_road_` bitfields (reclaims `spare2_`); getters/setters |
| `valhalla/baldr/directededge.h` | `winter_road_` (reclaims `spare1_`) + `ice_road_` (reclaims 1 bit of `spare4_`); getters/setters |
| `src/baldr/directededge.cc` | Setter implementations |
| `src/mjolnir/pbfgraphparser.cc` | `tag_handlers_["winter_road"]` + `tag_handlers_["ice_road"]` |
| `src/mjolnir/directededgebuilder.cc` | Transfer flags from `OSMWay` → `DirectedEdge` |
| `src/sif/autocost.cc` | `kWinterRoadFactor = 10.0f` penalty applied in `EdgeCost()` |
| `test/gurka/test_winter_road.cc` | 3 gurka tests: avoid winter_road, avoid ice_road, fallback when no alternative |

## Behaviour

- **When an alternative exists**: router avoids `winter_road`/`ice_road` edges (penalty ×10 vs base cost — ~same order as a 10× longer detour on a normal road)
- **When no alternative exists**: router still completes the route across the seasonal road
- Both tags share the same penalty; the distinction is preserved in the graph for future differentiation

## Rationale for penalty over hard block

A hard block would make isolated communities unreachable in winter (when the ice road is the only connection). The penalty approach lets the router use these roads only as a last resort, which matches real-world driver expectation.

Closes #6025.

*AI-assisted — authored with Claude, reviewed by Komada.*