### PR TITLE
perf: Move interrupt check one level up in map-matching

### DIFF
--- a/src/meili/map_matcher.cc
+++ b/src/meili/map_matcher.cc
@@ -705,6 +705,11 @@ std::vector<MatchResults> MapMatcher::OfflineMatch(const std::vector<Measurement
   // Reset everything
   Clear();
 
+  // Allow this process to be aborted
+  if (interrupt_) {
+    (*interrupt_)();
+  }
+
   std::vector<MatchResults> best_paths;
   best_paths.reserve(k);
 
@@ -721,6 +726,11 @@ std::vector<MatchResults> MapMatcher::OfflineMatch(const std::vector<Measurement
   // Without minimum number of edge candidates, throw a 443 - NoSegment error code.
   if (!container_.HasMinimumCandidates()) {
     throw valhalla_exception_t{443};
+  }
+
+  // Allow this process to be aborted
+  if (interrupt_) {
+    (*interrupt_)();
   }
 
   // For k paths
@@ -879,11 +889,6 @@ MapMatcher::AppendMeasurements(const std::vector<Measurement>& measurements) {
 
 StateId::Time MapMatcher::AppendMeasurement(const Measurement& measurement,
                                             const float sq_max_search_radius) {
-  // Test interrupt
-  if (interrupt_) {
-    (*interrupt_)();
-  }
-
   auto sq_radius = std::min(sq_max_search_radius,
                             std::max(measurement.sq_search_radius(), measurement.sq_gps_accuracy()));
 


### PR DESCRIPTION
_Please don't force-push once you received the first review._

# Issue

While profiling valhalla service against different types of requests I've noticed that `map_snap` checks interrupt literally for every point, which in turn takes actually more time than the work itself. This PR moves interruption check one level up to split `OfflineMatch()` into 3 stages - before `AppendMeasurements()`, `AppendMeasurements()` itself, and Viterbi search.

I've also considered using `kInterruptIterationsInterval` as in other places, but in reality the trace size is typically limited to 16k points and amount of work for each point is quite small.

<img width="1728" height="615" alt="image" src="https://github.com/user-attachments/assets/851c46f6-27b3-492b-866c-b9c89e939ca9" />

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [ ] If you made changes to a translation file, [update transifex](docs/docs/locales.md) too

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
