### PR TITLE
fix leg_shape_index not set for intermediate location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
    * FIXED: super trivial connections snapping to excluded edges in CostMatrix [#5996](https://github.com/valhalla/valhalla/pull/5996)
    * FIXED: edge walking should not end on a shortcut [#6034](https://github.com/valhalla/valhalla/pull/6034)
    * FIXED: Exclusion check in the reverse direction [#5375](https://github.com/valhalla/valhalla/pull/5375)
+   * FIXED: `leg_shape_index not set for intermediate location` error thrown when consecutive through waypoints snap to the same graph node [#6043](https://github.com/valhalla/valhalla/pull/6043)
 * **Enhancement**
    * ADDED: multimodal costing `auto_pedestrian` [#5780](https://github.com/valhalla/valhalla/pull/5780)
    * CHANGED: remove `baldr::{Location,PathLocation}` and use their protobuf versions instead [#5906](https://github.com/valhalla/valhalla/pull/5906) 

--- a/src/thor/triplegbuilder.cc
+++ b/src/thor/triplegbuilder.cc
@@ -475,7 +475,7 @@ void CopyLocations(TripLeg& trip_path,
     valhalla::Location* tp_intermediate = trip_path.add_location();
     tp_intermediate->CopyFrom(intermediate);
     // we can grab the right edge index in the path because we temporarily set it for trimming
-    if (last_shape_index && intermediate.correlation().leg_shape_index() <= *last_shape_index) {
+    if (last_shape_index && intermediate.correlation().leg_shape_index() < *last_shape_index) {
       throw std::logic_error("leg_shape_index not set for intermediate location");
     }
     last_shape_index = intermediate.correlation().leg_shape_index();
@@ -2181,8 +2181,8 @@ void TripLegBuilder::Build(
 
     // If we are at a node or if we hit the edge index that matches our through location edge index,
     // we need to reset to the shape index then increment the iterator
-    if (intermediate_itr != trip_path.mutable_location()->end() &&
-        intermediate_itr->correlation().leg_shape_index() == edge_index) {
+    while (intermediate_itr != trip_path.mutable_location()->end() &&
+           intermediate_itr->correlation().leg_shape_index() == edge_index) {
       intermediate_itr->mutable_correlation()->set_leg_shape_index(trip_shape.size() - 1);
       intermediate_itr->mutable_correlation()->set_distance_from_leg_origin(total_distance);
       // NOTE:

--- a/test/gurka/test_via_waypoints.cc
+++ b/test/gurka/test_via_waypoints.cc
@@ -220,6 +220,49 @@ TEST_P(IntermediateLocations, test_back_to_back_via_uturns) {
   EXPECT_NEAR(d["routes"][0]["distance"].GetDouble(), total_dist, 1.0);
 }
 
+class ColocatedThroughs : public ::testing::TestWithParam<std::string> {
+protected:
+  static gurka::map map;
+  static void SetUpTestSuite() {
+    constexpr double gridsize_metres = 10;
+    const std::string ascii_map = R"(A1234B5678C)";
+    const gurka::ways ways = {
+        {"AB", {{"highway", "primary"}}},
+        {"BC", {{"highway", "primary"}}},
+    };
+    const auto layout = gurka::detail::map_to_coordinates(ascii_map, gridsize_metres, {0.0, 0.0});
+    map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_via_waypoints_colocated",
+                            build_config);
+  }
+};
+gurka::map ColocatedThroughs::map = {};
+
+TEST_P(ColocatedThroughs, same_node) {
+  auto result = gurka::do_action(valhalla::Options::route, map, {"A", "B", "B", "C"}, "auto",
+                                 {
+                                     {"/locations/0/type", "break"},
+                                     {"/locations/1/type", "through"},
+                                     {"/locations/2/type", "through"},
+                                     {"/locations/3/type", "break"},
+                                     {"/date_time/type", GetParam()},
+                                     {"/date_time/value", "2111-11-11T11:11"},
+                                 });
+  auto d = gurka::convert_to_json(result, valhalla::Options_Format_osrm);
+
+  EXPECT_EQ(d["routes"].Size(), 1);
+  EXPECT_EQ(d["routes"][0]["legs"].Size(), 1);
+  EXPECT_EQ(d["routes"][0]["legs"][0]["via_waypoints"].Size(), 2);
+  EXPECT_EQ(d["routes"][0]["legs"][0]["via_waypoints"][0]["waypoint_index"].GetInt(), 1);
+  EXPECT_EQ(d["routes"][0]["legs"][0]["via_waypoints"][1]["waypoint_index"].GetInt(), 2);
+  // Both intermediates snapped to the same point so they share a geometry index and distance.
+  EXPECT_EQ(d["routes"][0]["legs"][0]["via_waypoints"][0]["geometry_index"].GetInt(),
+            d["routes"][0]["legs"][0]["via_waypoints"][1]["geometry_index"].GetInt());
+  EXPECT_NEAR(d["routes"][0]["legs"][0]["via_waypoints"][0]["distance_from_start"].GetDouble(),
+              d["routes"][0]["legs"][0]["via_waypoints"][1]["distance_from_start"].GetDouble(), 1e-6);
+}
+
+INSTANTIATE_TEST_SUITE_P(ViaWaypoints, ColocatedThroughs, ::testing::Values("1", "2", "3"));
+
 // 1 is depart_at and 2 is arrive_by and 3 is invariant
 INSTANTIATE_TEST_SUITE_P(ViaWaypoints,
                          IntermediateLocations,


### PR DESCRIPTION
_Please don't force-push once you received the first review._

This PR fixes an issue cause by two consecutive `through` waypoints which snap to the same graph node causing the route to fail.

# Issue

fixes #3688

## Tasklist

 - [x] Add tests
 - [x] Add #fixes with the issue number that this PR addresses
 - [x] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [x] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [x] If you made changes to a translation file, [update transifex](docs/docs/locales.md) too

## Requirements / Relations

None
