### PR TITLE
fix: set shape correlation edges in FormPath trivial path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
    * FIXED: super trivial connections snapping to excluded edges in CostMatrix [#5996](https://github.com/valhalla/valhalla/pull/5996)
    * FIXED: edge walking should not end on a shortcut [#6034](https://github.com/valhalla/valhalla/pull/6034)
    * FIXED: Exclusion check in the reverse direction [#5375](https://github.com/valhalla/valhalla/pull/5375)
+   * FIXED: `edge_walk` returning error 443 for trivial single-edge traces [#6046](https://github.com/valhalla/valhalla/issues/6046)
 * **Enhancement**
    * ADDED: multimodal costing `auto_pedestrian` [#5780](https://github.com/valhalla/valhalla/pull/5780)
    * CHANGED: remove `baldr::{Location,PathLocation}` and use their protobuf versions instead [#5906](https://github.com/valhalla/valhalla/pull/5906) 

--- a/src/thor/route_matcher.cc
+++ b/src/thor/route_matcher.cc
@@ -553,6 +553,9 @@ bool RouteMatcher::FormPath(const sif::mode_costing_t& mode_costing,
 
           // Add end edge
           path_infos.emplace_back(mode, elapsed, GraphId(edge.graph_id()), 0, 0.f, -1);
+          options.mutable_shape(0)->mutable_correlation()->mutable_edges()->Add()->CopyFrom(edge);
+          options.mutable_shape()->rbegin()->mutable_correlation()->mutable_edges()->Add()->CopyFrom(
+              end.second.first);
           return true;
         }
       }

--- a/test/gurka/test_trace_attributes.cc
+++ b/test/gurka/test_trace_attributes.cc
@@ -455,6 +455,27 @@ TEST(Standalone, BeginShapeIndexAtDiscontinuity) {
   EXPECT_GT(bc_match.Distance(fg_match), 1000.0) << "Discontinuity is big enough";
 }
 
+TEST(Standalone, TrivialSingleEdgeRouteMatch) {
+  const std::string ascii_map = R"(
+    A---1----2---B---C
+  )";
+
+  const gurka::ways ways = {{"AB", {{"highway", "primary"}, {"name", "Main St"}}},
+                            {"BC", {{"highway", "primary"}, {"name", "Main St"}}}};
+
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100);
+  auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/trivial_single_edge_route_match");
+
+  std::string result_json;
+  ASSERT_NO_THROW(gurka::do_action(valhalla::Options::trace_attributes, map, {"1", "2"}, "auto",
+                                   {{"/shape_match", "edge_walk"}}, {}, &result_json, "via"));
+  rapidjson::Document result;
+  result.Parse(result_json.c_str());
+  ASSERT_TRUE(result.HasMember("edges"));
+  ASSERT_EQ(result["edges"].GetArray().Size(), 1u);
+  EXPECT_STREQ(result["edges"][0]["names"][0].GetString(), "Main St");
+}
+
 TEST(Standalone, PbfOut) {
   const std::string ascii_map = R"(
       1     2


### PR DESCRIPTION
_Please don't force-push once you received the first review._

The trivial branch in FormPath isn't copying the origin and destination PathEdge into the shape correlation edges which causes the match to always fail for short traces.

# Issue
fixes https://github.com/valhalla/valhalla/issues/6046

## Tasklist

 - [x] Add tests
 - [x] Add #fixes with the issue number that this PR addresses
 - [x] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [x] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [x] If you made changes to a translation file, [update transifex](docs/docs/locales.md) too

## Requirements / Relations

N/A