### PR TITLE
chore(monitoring): add note about X-Client-Id in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ There are several key features that we hope can differentiate the Valhalla proje
 
 [FOSSGIS e.V.](https://fossgis.de) hosts a demo server which is open to the public and includes a full planet graph with an [open-source web app](https://github.com/gis-ops/valhalla-app) on <https://valhalla.openstreetmap.de>. The HTTP API is accessible on a slightly different subdomain, e.g. <https://valhalla1.openstreetmap.de/isochrone>. Usage of the demo server follows the usual fair-usage policy as OSRM & Nominatim demo servers (somewhat enforced by [rate limits](https://github.com/valhalla/valhalla/discussions/3373#discussioncomment-1644713)).
 
+> [!NOTE]
+> In case you publish apps to end users (be it mobile, web or desktop) which request to the public demo server, we'd ask you to let us know via Github Discussions and to include an identifying `X-Client-Id` request header, e.g. `X-Client-Id: newroutingapp.io`.
+
 ## Platform Compatibility
 
 Valhalla is fully functional on many Linux and Mac OS distributions, and is also used on iOS and Android devices.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ There are several key features that we hope can differentiate the Valhalla proje
 [FOSSGIS e.V.](https://fossgis.de) hosts a demo server which is open to the public and includes a full planet graph with an [open-source web app](https://github.com/gis-ops/valhalla-app) on <https://valhalla.openstreetmap.de>. The HTTP API is accessible on a slightly different subdomain, e.g. <https://valhalla1.openstreetmap.de/isochrone>. Usage of the demo server follows the usual fair-usage policy as OSRM & Nominatim demo servers (somewhat enforced by [rate limits](https://github.com/valhalla/valhalla/discussions/3373#discussioncomment-1644713)).
 
 > [!NOTE]
-> In case you publish apps to end users (be it mobile, web or desktop) which request to the public demo server, we'd ask you to let us know via Github Discussions and to include an identifying `X-Client-Id` request header, e.g. `X-Client-Id: newroutingapp.io`.
+> In case you **publish apps to end users** (be it mobile, web or desktop) which request to the public demo server, we'd ask you to let us know via Github Discussions and to include an identifying `X-Client-Id` request header, e.g. `X-Client-Id: newroutingapp.io`.
 
 ## Platform Compatibility
 


### PR DESCRIPTION
just a small note about adding `X-Client-Id` request header to published apps requesting the demo server. it'd help a bit to keep track of things. I also find it interesting to find out how many requests we get from the public web app & QGIS plugin.