### PR TITLE
ci(npm): revert to token auth

### DIFF
--- a/.github/workflows/nodejs_bindings.yml
+++ b/.github/workflows/nodejs_bindings.yml
@@ -244,16 +244,11 @@ jobs:
           name: valhalla-npm-package
       
       - name: Publish to NPM
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           echo "[INFO] Downloaded package:"
           ls -lh *.tgz
-          
-          if [[ "${{ startsWith(github.ref, 'refs/tags/') }}" == "true" ]]; then
-            NPM_TAG="latest"
-          else
-            NPM_TAG="periodic"
-          fi
-          
-          echo "[INFO] Publishing to NPM with tag: ${NPM_TAG}..."
-          npm publish *.tgz --access public --tag ${NPM_TAG} --provenance
+          echo "[INFO] Publishing to NPM..."
+          npm publish *.tgz --access public --tag latest --provenance
 


### PR DESCRIPTION
the "trusted publisher" thing never worked for npm (seems to be very strict), so let's revert back to classic token usage.