### PR TITLE
fix(ci): update `actions/checkout`, previous one was buggy

### DIFF
--- a/.github/workflows/check_compilers.yml
+++ b/.github/workflows/check_compilers.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Install Linux compiler
       - name: Install ${{ matrix.c_compiler }}

--- a/.github/workflows/check_tz_releases.yml
+++ b/.github/workflows/check_tz_releases.yml
@@ -10,7 +10,7 @@ jobs:
     name: Check if latest tag commit differs from the commit the submodule currently points to
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: "recursive"
           fetch-depth: 0

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3
         uses: actions/setup-python@v4

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -54,9 +54,7 @@ jobs:
     name: Lint & Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
+      - uses: actions/checkout@v6
 
       - name: Run Formatter & Linter
         run: |
@@ -69,10 +67,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [lint_format]
     steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 1
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-python@v6
         with:
@@ -145,10 +140,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint_format]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
-          fetch-depth: 1
 
       - uses: actions/setup-python@v6
         with:
@@ -230,10 +224,9 @@ jobs:
     runs-on: ubuntu-24.04-arm
     needs: [lint_format]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
-          fetch-depth: 1
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -68,6 +68,8 @@ jobs:
     needs: [lint_format]
     steps:
       - uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/no_git_blame.yml
+++ b/.github/workflows/no_git_blame.yml
@@ -21,7 +21,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/nodejs_bindings.yml
+++ b/.github/workflows/nodejs_bindings.yml
@@ -58,10 +58,9 @@ jobs:
       # since we are running in a container, we need to set the ccache directory to folder accessible from GHA runner
       CCACHE_DIR: ${{ matrix.os == 'linux' && '.ccache' || '' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
-          fetch-depth: 0
           fetch-tags: true
       
       - name: Setup ccache
@@ -123,7 +122,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build_nodejs_bindings]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: |
             src/bindings/nodejs/
@@ -131,7 +130,6 @@ jobs:
             valhalla/valhalla.h
             proto/
           sparse-checkout-cone-mode: false
-          fetch-depth: 0
           fetch-tags: true
 
       - name: Download all binding artifacts
@@ -184,7 +182,7 @@ jobs:
           node-version: '18'
 
       - name: Checkout test files
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             src/bindings/nodejs/test/

--- a/.github/workflows/osx_win_python_builds.yml
+++ b/.github/workflows/osx_win_python_builds.yml
@@ -77,10 +77,10 @@ jobs:
     needs: [publish_pypi]
     if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
-          fetch-depth: 0
+          # we need to fetch all tags for setuptools-scm to work properly
           fetch-tags: true
 
       - name: Get version modifier
@@ -111,11 +111,10 @@ jobs:
           - arch: aarch64
             runner: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
           # we need to fetch all tags for setuptools-scm to work properly
-          fetch-depth: 0
           fetch-tags: true
 
       # this is only used to run cibuildwheel
@@ -208,11 +207,10 @@ jobs:
     name: Build OSX & Python wheels
     needs: [publish_pypi]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
           # we need to fetch all tags for setuptools-scm to work properly
-          fetch-depth: 0
           fetch-tags: true
 
       - name: Install dependencies
@@ -320,11 +318,10 @@ jobs:
       VCPKG_DISABLE_COMPILER_TRACKING: ON
       VCPKG_ROOT: ${{ github.workspace }}/vcpkg
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
           # we need to fetch all tags for setuptools-scm to work properly
-          fetch-depth: 0
           fetch-tags: true
 
       # we add a custom triplet to avoid cache misses as much as possible
@@ -476,7 +473,7 @@ jobs:
           - arch: aarch64
             runner: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/download-artifact@v4
         with:
@@ -495,7 +492,7 @@ jobs:
     runs-on: macos-14
     if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-python@v4
         with:
@@ -518,7 +515,7 @@ jobs:
     runs-on: windows-2022
     if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -22,7 +22,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/protobuf.yml
+++ b/.github/workflows/protobuf.yml
@@ -3,8 +3,6 @@ name: release protobuf generated code
 on:
   push:
     tags: ["*"]
-    branches:
-      - 'nn-fix-3.7.0'
  
 defaults:
   run:
@@ -19,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
-          fetch-depth: 0  # versioning schema (git describe / setuptools_scm) needs tag history reachable from HEAD
+          fetch-tags: true  # versioning schema needs tags
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -28,7 +26,7 @@ jobs:
         with:
           packages-dir: proto/python/dist/
           # uncomment when testing!
-          repository-url: https://test.pypi.org/legacy/
+          # repository-url: https://test.pypi.org/legacy/
  
   release-ts:
     runs-on: ubuntu-latest
@@ -36,7 +34,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
-          fetch-depth: 0  # versioning schema (git describe / setuptools_scm) needs tag history reachable from HEAD
+          fetch-tags: true  # versioning schema needs tags
       - uses: actions/setup-node@v4
         with:
           node-version: "22"

--- a/.github/workflows/protobuf.yml
+++ b/.github/workflows/protobuf.yml
@@ -3,6 +3,8 @@ name: release protobuf generated code
 on:
   push:
     tags: ["*"]
+    branches:
+      - 'nn-fix-3.7.0'
  
 defaults:
   run:
@@ -26,7 +28,7 @@ jobs:
         with:
           packages-dir: proto/python/dist/
           # uncomment when testing!
-          # repository-url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/
  
   release-ts:
     runs-on: ubuntu-latest

--- a/.github/workflows/protobuf.yml
+++ b/.github/workflows/protobuf.yml
@@ -19,11 +19,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
-          fetch-tags: true  # versioning schema needs tags
+          fetch-depth: 0  # versioning schema (git describe / setuptools_scm) needs tag history reachable from HEAD
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: python -m build python
+      - run: python -m pip install build && python -m build python
       - uses: pypa/gh-action-pypi-publish@v1.14.0
         with:
           packages-dir: proto/python/dist/
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
-          fetch-tags: true  # versioning schema needs tags
+          fetch-depth: 0  # versioning schema (git describe / setuptools_scm) needs tag history reachable from HEAD
       - uses: actions/setup-node@v4
         with:
           node-version: "22"

--- a/.github/workflows/protobuf.yml
+++ b/.github/workflows/protobuf.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       id-token: write  # for trusted publishing to PyPI
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
           fetch-tags: true  # versioning schema needs tags
@@ -31,7 +31,7 @@ jobs:
   release-ts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
           fetch-tags: true  # versioning schema needs tags

--- a/.github/workflows/protobuf.yml
+++ b/.github/workflows/protobuf.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
-      - run: make release-ts
+      - run: make release-ts-tag
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
  

--- a/.github/workflows/publish_tz_db.yml
+++ b/.github/workflows/publish_tz_db.yml
@@ -16,10 +16,7 @@ jobs:
     name: Publish tzdb on GHA artifacts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: "recursive"
-          fetch-depth: 0
+      - uses: actions/checkout@v6
 
       - name: Compile tzdb
         shell: bash

--- a/.github/workflows/update_public_servers.yml
+++ b/.github/workflows/update_public_servers.yml
@@ -23,9 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'valhalla'
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v6
 
       - name: Run script
         run: |


### PR DESCRIPTION
`protobuf` bindings release failed: `actions/checkout@v4` had a bug: https://github.com/actions/checkout/issues/1467. which prevented the new protobuf bindings to be released properly.

also the npm release failed for the node bindings, but that's again a npmjs.com error: `npm error 403 403 Forbidden - PUT https://registry.npmjs.org/@valhallajs%2fvalhallajs - Two-factor authentication is required to publish this package but an automation token was specified`. I just changed the package settings, but seems it's not propagated yet for some reason. will try later again.

~~I propose to do a 3.7.1 release right away so protobuf gets a proper release.~~ or we just release 3.7.0 manually on pypi, also easy enough. 

BTW, I also updated all other actions/checkout versions and removed `fetch-tags`  or `fetch-depth: 0` (_all_ history) where appropriate.