### PR TITLE
feat: `lz4` support for OSM PBF files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * **Enhancement**
    * UPDATED: timezone database to 2026b [#6074](https://github.com/valhalla/valhalla/pull/6074)
    * ADDED: Ignore specific access restrictions via the linear features interface [#5942](https://github.com/valhalla/valhalla/pull/5942)
+   * ADDED: lz4 support for OSM PBF files [#6081](https://github.com/valhalla/valhalla/pull/6081)
 
 ## Release Date: 2026-04-28 Valhalla 3.7.0
 * **Removed**

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ option(PREFER_EXTERNAL_DEPS "Whether to use internally vendored headers or find 
 # useful to workaround issues likes this https://stackoverflow.com/questions/24078873/cmake-generated-xcode-project-wont-compile
 option(ENABLE_STATIC_LIBRARY_MODULES "If ON builds Valhalla modules as STATIC library targets" OFF)
 option(ENABLE_GEOTIFF "Whether to include libgeotiff; currently only used for raster serialization of isotile grid" ON)
-option(ENABLE_LZ4 "Enable LZ4 decompression support for elevation tiles" ON)
+option(ENABLE_LZ4 "Enable LZ4 decompression support for elevation tiles and OSM PBF files" ON)
 option(INSTALL_TEST_LIB "Install Valhalla's own test lib" OFF)
 
 set(LOGGING_LEVEL "" CACHE STRING "Logging level, default is INFO")

--- a/src/mjolnir/CMakeLists.txt
+++ b/src/mjolnir/CMakeLists.txt
@@ -90,6 +90,11 @@ if(EXPAT_FOUND)
   list(APPEND mjolnir_depends PkgConfig::EXPAT)
 endif()
 
+# support lz4 PBF internal compression instead of zlib if available
+if(lz4_target)
+  list(APPEND mjolnir_depends ${lz4_target})
+endif()
+
 valhalla_module(NAME mjolnir
   SOURCES ${sources}
   HEADERS ${headers}
@@ -113,4 +118,8 @@ valhalla_module(NAME mjolnir
 
 if(EXPAT_FOUND)
   target_compile_definitions(valhalla-mjolnir PRIVATE HAVE_EXPAT)
+endif()
+
+if(lz4_target)
+  target_compile_definitions(valhalla-mjolnir PRIVATE OSMIUM_WITH_LZ4)
 endif()


### PR DESCRIPTION
this is a sweet little PR!

I just found out that `pyosmium-up-to-date` has support for re-compressing the OSM PBF to `lz4` (from `zlib`). so any planet updated with that tool will get much faster deserialized objects out of libosmium. won't save too much, my guess is 30ish mins, claude kinda agrees. 

the thing is, there's no `lz4` compressed planet out there apparently. also no idea how big the planet PBF gets when re-compressed like that. I might play around a bit when the ansible setup is live and watch monitoring. 