### PR TITLE
fix(thor): drop dead `max_reserved_locations_costmatrix` help text (#6083)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## UNRELEASED
 * **Removed**
+   * REMOVED: dead `thor.max_reserved_locations_costmatrix` help entry from `valhalla_build_config` (live key is `thor.costmatrix.max_reserved_locations`) [#6083](https://github.com/valhalla/valhalla/issues/6083)
 * **Bug Fix**
    * FIXED: wrong mode used in loki for `auto_pedestrian` [#6065](https://github.com/valhalla/valhalla/pull/6065)
    * FIXED: Avoid creating loop edges during graph filtering [#6050](https://github.com/valhalla/valhalla/pull/6050)

--- a/scripts/valhalla_build_config
+++ b/scripts/valhalla_build_config
@@ -540,7 +540,6 @@ help_text = {
         "max_reserved_labels_count_bidir_astar": "Maximum capacity allowed to keep reserved for bidirectional A*.",
         "max_reserved_labels_count_dijkstras": "Maximum capacity allowed to keep reserved for unidirectional Dijkstras.",
         "max_reserved_labels_count_bidir_dijkstras": "Maximum capacity allowed to keep reserved for bidirectional Dijkstras.",
-        "max_reserved_locations_costmatrix": "Maximum amount of locations allowed to to keep reserved between requests for CostMatrix",
         "clear_reserved_memory": "If True clean reserved memory in path algorithms",
         "extended_search": "If True and 1 side of the bidirectional search is exhausted, causes the other side to continue if the starting location of that side began on a not_thru or closed edge",
         "costmatrix": {

--- a/test/scripts/test_valhalla_build_config.py
+++ b/test/scripts/test_valhalla_build_config.py
@@ -450,5 +450,16 @@ class TestShouldRemoveKey(unittest.TestCase):
         )
 
 
+class TestNoDeadThorKeys(unittest.TestCase):
+    """Guard against re-introducing flat thor keys that no read site honours."""
+
+    def test_dead_costmatrix_key_absent(self):
+        thor_config = valhalla_build_config.config["thor"]
+        thor_help = valhalla_build_config.help_text["thor"]
+        self.assertNotIn("max_reserved_locations_costmatrix", thor_config)
+        self.assertNotIn("max_reserved_locations_costmatrix", thor_help)
+        self.assertIn("max_reserved_locations", thor_config["costmatrix"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/scripts/test_valhalla_build_config.py
+++ b/test/scripts/test_valhalla_build_config.py
@@ -450,16 +450,5 @@ class TestShouldRemoveKey(unittest.TestCase):
         )
 
 
-class TestNoDeadThorKeys(unittest.TestCase):
-    """Guard against re-introducing flat thor keys that no read site honours."""
-
-    def test_dead_costmatrix_key_absent(self):
-        thor_config = valhalla_build_config.config["thor"]
-        thor_help = valhalla_build_config.help_text["thor"]
-        self.assertNotIn("max_reserved_locations_costmatrix", thor_config)
-        self.assertNotIn("max_reserved_locations_costmatrix", thor_help)
-        self.assertIn("max_reserved_locations", thor_config["costmatrix"])
-
-
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Issue

Fixes #6083. @kevinkreiser said "go ahead and submit a pr to remove it and the accompanying help text". The flat `thor.max_reserved_locations_costmatrix` entry exists only in `help_text` and is never read; the live key is `thor.costmatrix.max_reserved_locations`.

## Tasklist

 - [x] Add tests
 - [x] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [ ] If you made changes to a translation file, [update transifex](docs/docs/locales.md) too

## Requirements / Relations
