### PR TITLE
chore: deprecate `jsonp`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## UNRELEASED
 * **Removed**
    * REMOVED: dead `thor.max_reserved_locations_costmatrix` help entry from `valhalla_build_config` (live key is `thor.costmatrix.max_reserved_locations`) [#6083](https://github.com/valhalla/valhalla/issues/6083)
+   * REMOVED: `json` request parameter, people can use CORS in 2026 [#]()
 * **Bug Fix**
    * FIXED: wrong mode used in loki for `auto_pedestrian` [#6065](https://github.com/valhalla/valhalla/pull/6065)
    * FIXED: Avoid creating loop edges during graph filtering [#6050](https://github.com/valhalla/valhalla/pull/6050)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## UNRELEASED
 * **Removed**
    * REMOVED: dead `thor.max_reserved_locations_costmatrix` help entry from `valhalla_build_config` (live key is `thor.costmatrix.max_reserved_locations`) [#6083](https://github.com/valhalla/valhalla/issues/6083)
-   * REMOVED: `json` request parameter, people can use CORS in 2026 [#]()
+   * REMOVED: `json` request parameter, people can use CORS in 2026 [#6099](https://github.com/valhalla/valhalla/pull/6099)
 * **Bug Fix**
    * FIXED: wrong mode used in loki for `auto_pedestrian` [#6065](https://github.com/valhalla/valhalla/pull/6065)
    * FIXED: Avoid creating loop edges during graph filtering [#6050](https://github.com/valhalla/valhalla/pull/6050)

--- a/proto/descriptors/options.proto
+++ b/proto/descriptors/options.proto
@@ -449,7 +449,7 @@ message Options {
     string id = 5;                                                 // id for the request
   }
   oneof has_jsonp {
-    string jsonp = 6;                                              // javascript callback for the request
+    string jsonp = 6 [deprecated = true];                         // javascript callback for the request
   }
   oneof has_encoded_polyline {
     string encoded_polyline = 7;                                   // polyline 6 encoded shape used in /height /trace_*

--- a/src/exceptions.cc
+++ b/src/exceptions.cc
@@ -134,6 +134,7 @@ const std::unordered_map<int, std::string> warning_codes = {
     R"(hov costing is deprecated, use "include_hov2" costing option instead)"},
   {102, R"(auto_data_fix is deprecated, use the "ignore_*" costing options instead)"},
   {103, R"(best_paths has been deprecated, use "alternates" instead)"},
+  {104, R"(jsonp has been deprecated, use CORS instead)"},
   // 2xx is used for ineffective parameters, i.e. we ignore them because of reasons
   {200, R"(path distance exceeds the max distance limit for time-dependent matrix, ignoring date_time)"},
   {201, R"("sources" have date_time set, but "arrive_by" was requested, ignoring date_time)"},

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -726,18 +726,15 @@ void from_json(rapidjson::Document& doc, Options::Action action, Api& api) {
     options.set_id(*id);
   }
 
+  // we deprecated jsonp, CORS should be used instead
   auto jsonp = rapidjson::get_optional<std::string>(doc, "/jsonp");
   if (jsonp) {
-    options.set_jsonp(*jsonp);
+    add_warning(api, 104);
   }
 
   if (!is_format_supported(options.action(), options.format())) {
     options.set_format(Options::json);
     add_warning(api, 211);
-  }
-  if (options.format() == Options::pbf) {
-    // jsonp wont work because javascript doesnt support byte arrays
-    options.clear_jsonp();
   }
 
   auto units = rapidjson::get_optional<std::string>(doc, "/units");
@@ -1341,8 +1338,7 @@ std::string serialize_error(const valhalla_exception_t& exception, Api& request)
 
   // overwrite with osrm error response
   if (request.options().format() == Options::osrm) {
-    body << (request.options().has_jsonp_case() ? request.options().jsonp() + "(" : "")
-         << exception.osrm_error << (request.options().has_jsonp_case() ? ")" : "");
+    body << exception.osrm_error;
   } // valhalla json error response
   else if (request.options().format() != Options::pbf) {
     // build up the json map
@@ -1351,8 +1347,7 @@ std::string serialize_error(const valhalla_exception_t& exception, Api& request)
     json_error->emplace("status_code", static_cast<uint64_t>(exception.http_code));
     json_error->emplace("error", std::string(exception.message));
     json_error->emplace("error_code", static_cast<uint64_t>(exception.code));
-    body << (request.options().has_jsonp_case() ? request.options().jsonp() + "(" : "") << *json_error
-         << (request.options().has_jsonp_case() ? ")" : "");
+    body << *json_error;
   }
 
   // keep track of what the error was
@@ -1603,9 +1598,7 @@ worker_t::result_t serialize_error(const valhalla_exception_t& exception,
                                    Api& request) {
   worker_t::result_t result{false, std::list<std::string>(), ""};
   http_response_t response(exception.http_code, exception.http_message,
-                           serialize_error(exception, request),
-                           headers_t{CORS, request.options().has_jsonp_case() ? worker::JS_MIME
-                                                                              : worker::JSON_MIME});
+                           serialize_error(exception, request), headers_t{CORS, worker::JSON_MIME});
   response.from_info(request_info);
   result.messages.emplace_back(response.to_string());
 
@@ -1625,24 +1618,10 @@ to_response(const std::string& data,
   if (fmt == Options::gpx)
     headers.insert(ATTACHMENT);
 
-  // jsonp needs wrapped in a javascript function call
   worker_t::result_t result{false, std::list<std::string>(), ""};
-  if (request.options().has_jsonp_case()) {
-    headers.insert(worker::JS_MIME); // reset content type to javascript
-    std::ostringstream stream;
-    stream << request.options().jsonp() << '(';
-    stream << data;
-    stream << ')';
-
-    http_response_t response(200, "OK", stream.str(), headers);
-    response.from_info(request_info);
-    result.messages.emplace_back(response.to_string());
-  } // everything else is bytes already
-  else {
-    http_response_t response(200, "OK", data, headers);
-    response.from_info(request_info);
-    result.messages.emplace_back(response.to_string());
-  }
+  http_response_t response(200, "OK", data, headers);
+  response.from_info(request_info);
+  result.messages.emplace_back(response.to_string());
   return result;
 }
 


### PR DESCRIPTION
ah feels good:)

closes https://github.com/valhalla/valhalla/issues/6093

if someone still requests with a jsonp callback, we'll emit a warning but otherwise process the request (not honoring jsonp).