### PR TITLE
fix: `Resize` is deprecated [-Werror,-Wdeprecated-declarations] in protobuf v35

### DIFF
--- a/valhalla/thor/matrixalgorithm.h
+++ b/valhalla/thor/matrixalgorithm.h
@@ -159,11 +159,23 @@ protected:
   inline static void
   reserve_pbf_arrays(valhalla::Matrix& matrix, size_t size, bool verbose, uint32_t pass = 0) {
     if (pass == 0) {
+
+      // Yep, since 35.0 protobuf renamed `Resize` to `resize` for repeated fields.
+      // https://github.com/protocolbuffers/protobuf/pull/26025
+      #if PROTOBUF_VERSION < 7035000
       matrix.mutable_from_indices()->Resize(size, 0U);
       matrix.mutable_to_indices()->Resize(size, 0U);
       matrix.mutable_distances()->Resize(size, 0U);
       matrix.mutable_times()->Resize(size, 0U);
       matrix.mutable_second_pass()->Resize(size, false);
+      #else
+      matrix.mutable_from_indices()->resize(size, 0U);
+      matrix.mutable_to_indices()->resize(size, 0U);
+      matrix.mutable_distances()->resize(size, 0U);
+      matrix.mutable_times()->resize(size, 0U);
+      matrix.mutable_second_pass()->resize(size, false);
+      #endif
+
       // repeated strings don't support Resize()
       matrix.mutable_date_times()->Reserve(size);
       matrix.mutable_time_zone_offsets()->Reserve(size);
@@ -181,12 +193,24 @@ protected:
       }
       if (verbose) {
         // fill with sentinel values meaning "no data"
+
+        // Yep, since 35.0 protobuf renamed `Resize` to `resize` for repeated fields.
+        // https://github.com/protocolbuffers/protobuf/pull/26025
+        #if PROTOBUF_VERSION < 7035000
         matrix.mutable_begin_heading()->Resize(size, kInvalidHeading);
         matrix.mutable_end_heading()->Resize(size, kInvalidHeading);
         matrix.mutable_begin_lat()->Resize(size, midgard::INVALID_LL);
         matrix.mutable_begin_lon()->Resize(size, midgard::INVALID_LL);
         matrix.mutable_end_lat()->Resize(size, midgard::INVALID_LL);
         matrix.mutable_end_lon()->Resize(size, midgard::INVALID_LL);
+        #else
+        matrix.mutable_begin_heading()->resize(size, kInvalidHeading);
+        matrix.mutable_end_heading()->resize(size, kInvalidHeading);
+        matrix.mutable_begin_lat()->resize(size, midgard::INVALID_LL);
+        matrix.mutable_begin_lon()->resize(size, midgard::INVALID_LL);
+        matrix.mutable_end_lat()->resize(size, midgard::INVALID_LL);
+        matrix.mutable_end_lon()->resize(size, midgard::INVALID_LL);
+        #endif
       }
     }
   }

--- a/valhalla/thor/matrixalgorithm.h
+++ b/valhalla/thor/matrixalgorithm.h
@@ -159,11 +159,11 @@ protected:
   inline static void
   reserve_pbf_arrays(valhalla::Matrix& matrix, size_t size, bool verbose, uint32_t pass = 0) {
     if (pass == 0) {
-      matrix.mutable_from_indices()->resize(size, 0U);
-      matrix.mutable_to_indices()->resize(size, 0U);
-      matrix.mutable_distances()->resize(size, 0U);
-      matrix.mutable_times()->resize(size, 0U);
-      matrix.mutable_second_pass()->resize(size, false);
+      matrix.mutable_from_indices()->Resize(size, 0U);
+      matrix.mutable_to_indices()->Resize(size, 0U);
+      matrix.mutable_distances()->Resize(size, 0U);
+      matrix.mutable_times()->Resize(size, 0U);
+      matrix.mutable_second_pass()->Resize(size, false);
       // repeated strings don't support Resize()
       matrix.mutable_date_times()->Reserve(size);
       matrix.mutable_time_zone_offsets()->Reserve(size);
@@ -181,12 +181,12 @@ protected:
       }
       if (verbose) {
         // fill with sentinel values meaning "no data"
-        matrix.mutable_begin_heading()->resize(size, kInvalidHeading);
-        matrix.mutable_end_heading()->resize(size, kInvalidHeading);
-        matrix.mutable_begin_lat()->resize(size, midgard::INVALID_LL);
-        matrix.mutable_begin_lon()->resize(size, midgard::INVALID_LL);
-        matrix.mutable_end_lat()->resize(size, midgard::INVALID_LL);
-        matrix.mutable_end_lon()->resize(size, midgard::INVALID_LL);
+        matrix.mutable_begin_heading()->Resize(size, kInvalidHeading);
+        matrix.mutable_end_heading()->Resize(size, kInvalidHeading);
+        matrix.mutable_begin_lat()->Resize(size, midgard::INVALID_LL);
+        matrix.mutable_begin_lon()->Resize(size, midgard::INVALID_LL);
+        matrix.mutable_end_lat()->Resize(size, midgard::INVALID_LL);
+        matrix.mutable_end_lon()->Resize(size, midgard::INVALID_LL);
       }
     }
   }

--- a/valhalla/thor/matrixalgorithm.h
+++ b/valhalla/thor/matrixalgorithm.h
@@ -160,21 +160,21 @@ protected:
   reserve_pbf_arrays(valhalla::Matrix& matrix, size_t size, bool verbose, uint32_t pass = 0) {
     if (pass == 0) {
 
-      // Yep, since 35.0 protobuf renamed `Resize` to `resize` for repeated fields.
-      // https://github.com/protocolbuffers/protobuf/pull/26025
-      #if PROTOBUF_VERSION < 7035000
+// Yep, since 35.0 protobuf renamed `Resize` to `resize` for repeated fields.
+// https://github.com/protocolbuffers/protobuf/pull/26025
+#if PROTOBUF_VERSION < 7035000
       matrix.mutable_from_indices()->Resize(size, 0U);
       matrix.mutable_to_indices()->Resize(size, 0U);
       matrix.mutable_distances()->Resize(size, 0U);
       matrix.mutable_times()->Resize(size, 0U);
       matrix.mutable_second_pass()->Resize(size, false);
-      #else
+#else
       matrix.mutable_from_indices()->resize(size, 0U);
       matrix.mutable_to_indices()->resize(size, 0U);
       matrix.mutable_distances()->resize(size, 0U);
       matrix.mutable_times()->resize(size, 0U);
       matrix.mutable_second_pass()->resize(size, false);
-      #endif
+#endif
 
       // repeated strings don't support Resize()
       matrix.mutable_date_times()->Reserve(size);
@@ -194,23 +194,23 @@ protected:
       if (verbose) {
         // fill with sentinel values meaning "no data"
 
-        // Yep, since 35.0 protobuf renamed `Resize` to `resize` for repeated fields.
-        // https://github.com/protocolbuffers/protobuf/pull/26025
-        #if PROTOBUF_VERSION < 7035000
+// Yep, since 35.0 protobuf renamed `Resize` to `resize` for repeated fields.
+// https://github.com/protocolbuffers/protobuf/pull/26025
+#if PROTOBUF_VERSION < 7035000
         matrix.mutable_begin_heading()->Resize(size, kInvalidHeading);
         matrix.mutable_end_heading()->Resize(size, kInvalidHeading);
         matrix.mutable_begin_lat()->Resize(size, midgard::INVALID_LL);
         matrix.mutable_begin_lon()->Resize(size, midgard::INVALID_LL);
         matrix.mutable_end_lat()->Resize(size, midgard::INVALID_LL);
         matrix.mutable_end_lon()->Resize(size, midgard::INVALID_LL);
-        #else
+#else
         matrix.mutable_begin_heading()->resize(size, kInvalidHeading);
         matrix.mutable_end_heading()->resize(size, kInvalidHeading);
         matrix.mutable_begin_lat()->resize(size, midgard::INVALID_LL);
         matrix.mutable_begin_lon()->resize(size, midgard::INVALID_LL);
         matrix.mutable_end_lat()->resize(size, midgard::INVALID_LL);
         matrix.mutable_end_lon()->resize(size, midgard::INVALID_LL);
-        #endif
+#endif
       }
     }
   }

--- a/valhalla/thor/matrixalgorithm.h
+++ b/valhalla/thor/matrixalgorithm.h
@@ -159,11 +159,11 @@ protected:
   inline static void
   reserve_pbf_arrays(valhalla::Matrix& matrix, size_t size, bool verbose, uint32_t pass = 0) {
     if (pass == 0) {
-      matrix.mutable_from_indices()->Resize(size, 0U);
-      matrix.mutable_to_indices()->Resize(size, 0U);
-      matrix.mutable_distances()->Resize(size, 0U);
-      matrix.mutable_times()->Resize(size, 0U);
-      matrix.mutable_second_pass()->Resize(size, false);
+      matrix.mutable_from_indices()->resize(size, 0U);
+      matrix.mutable_to_indices()->resize(size, 0U);
+      matrix.mutable_distances()->resize(size, 0U);
+      matrix.mutable_times()->resize(size, 0U);
+      matrix.mutable_second_pass()->resize(size, false);
       // repeated strings don't support Resize()
       matrix.mutable_date_times()->Reserve(size);
       matrix.mutable_time_zone_offsets()->Reserve(size);
@@ -181,12 +181,12 @@ protected:
       }
       if (verbose) {
         // fill with sentinel values meaning "no data"
-        matrix.mutable_begin_heading()->Resize(size, kInvalidHeading);
-        matrix.mutable_end_heading()->Resize(size, kInvalidHeading);
-        matrix.mutable_begin_lat()->Resize(size, midgard::INVALID_LL);
-        matrix.mutable_begin_lon()->Resize(size, midgard::INVALID_LL);
-        matrix.mutable_end_lat()->Resize(size, midgard::INVALID_LL);
-        matrix.mutable_end_lon()->Resize(size, midgard::INVALID_LL);
+        matrix.mutable_begin_heading()->resize(size, kInvalidHeading);
+        matrix.mutable_end_heading()->resize(size, kInvalidHeading);
+        matrix.mutable_begin_lat()->resize(size, midgard::INVALID_LL);
+        matrix.mutable_begin_lon()->resize(size, midgard::INVALID_LL);
+        matrix.mutable_end_lat()->resize(size, midgard::INVALID_LL);
+        matrix.mutable_end_lon()->resize(size, midgard::INVALID_LL);
       }
     }
   }


### PR DESCRIPTION
_Please don't force-push once you received the first review._

# Issue

protobuf maintainers decided that `Resize` doesn't look nice, so it should be deprecated and new `resize` function should be used instead - https://github.com/protocolbuffers/protobuf/pull/26025

And that "deprecate" produce a lot of compilation errors with recent protobuf:

```
$ cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo && cmake --build .
-- The CXX compiler identification is AppleClang 21.0.0.21000101
-- The C compiler identification is AppleClang 21.0.0.21000101
...
-- Found Protobuf: /opt/homebrew/bin/protoc-35.0.0 (found version "35.0.0")
-- Using protoc from /opt/homebrew/bin/protoc-35.0.0
-- Using pbf headers from /opt/homebrew/include
-- Using pbf libs from /opt/homebrew/lib/libprotobuf.35.0.0.dylib
-- Using pbf-lite
...
In file included from src/thor/timedistancebssmatrix.cc:1:
In file included from valhalla/thor/timedistancebssmatrix.h:13:
valhalla/thor/matrixalgorithm.h:162:38: error: 'Resize' is deprecated [-Werror,-Wdeprecated-declarations]
  162 |       matrix.mutable_from_indices()->Resize(size, 0U);
      |                                      ^
/opt/homebrew/include/google/protobuf/repeated_field.h:925:1: note: 'Resize' has been explicitly marked deprecated here
  925 | ABSL_DEPRECATE_AND_INLINE()
      | ^
/opt/homebrew/include/absl/base/macros.h:229:39: note: expanded from macro 'ABSL_DEPRECATE_AND_INLINE'
  229 | #define ABSL_DEPRECATE_AND_INLINE() [[deprecated]] ABSL_REFACTOR_INLINE
      |                                       ^
In file included from src/thor/timedistancebssmatrix.cc:1:
In file included from valhalla/thor/timedistancebssmatrix.h:13:
valhalla/thor/matrixalgorithm.h:163:36: error: 'Resize' is deprecated [-Werror,-Wdeprecated-declarations]
  163 |       matrix.mutable_to_indices()->Resize(size, 0U);
      |                                    ^
/opt/homebrew/include/google/protobuf/repeated_field.h:925:1: note: 'Resize' has been explicitly marked deprecated here
  925 | ABSL_DEPRECATE_AND_INLINE()
      | ^
/opt/homebrew/include/absl/base/macros.h:229:39: note: expanded from macro 'ABSL_DEPRECATE_AND_INLINE'
  229 | #define ABSL_DEPRECATE_AND_INLINE() [[deprecated]] ABSL_REFACTOR_INLINE
      |
```

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [ ] If you made changes to a translation file, [update transifex](docs/docs/locales.md) too

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
