### PR TITLE
[WIP] fix(mjolnir): don't demote trunk-links crossed by minor roads to tertiary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
    * REMOVED: dead `thor.max_reserved_locations_costmatrix` help entry from `valhalla_build_config` (live key is `thor.costmatrix.max_reserved_locations`) [#6083](https://github.com/valhalla/valhalla/issues/6083)
    * REMOVED: `json` request parameter, people can use CORS in 2026 [#6099](https://github.com/valhalla/valhalla/pull/6099)
 * **Bug Fix**
+   * FIXED: trunk/motorway links demoted to tertiary when crossed by an unclassified road [#6097](https://github.com/valhalla/valhalla/issues/6097)
    * FIXED: wrong mode used in loki for `auto_pedestrian` [#6065](https://github.com/valhalla/valhalla/pull/6065)
    * FIXED: Avoid creating loop edges during graph filtering [#6050](https://github.com/valhalla/valhalla/pull/6050)
    * FIXED: UB in adminbuilder in `&inner_rings.front()` if `inner_rings` is empty [#6077](https://github.com/valhalla/valhalla/pull/6077)

--- a/src/mjolnir/linkclassification.cc
+++ b/src/mjolnir/linkclassification.cc
@@ -380,8 +380,15 @@ struct LinkGraphBuilder {
     // Add new edge to the graph
     AddGraphEdge(parent, graph_idx, in_edge_idx);
 
+    // A high-class link crossed by a much-weaker road is not at its destination —
+    // it continues to another major road, so don't treat the crossing as a leaf.
+    const bool link_dominates_intersection =
+        in_edge.attributes.importance < static_cast<uint32_t>(RoadClass::kTertiary) &&
+        rc >= static_cast<uint32_t>(RoadClass::kUnclassified);
+
     // Check "stop criterions" only if this link intersects a "major" road
-    if (bundle.node.non_link_edge_ && rc <= static_cast<uint32_t>(RoadClass::kResidential)) {
+    if (bundle.node.non_link_edge_ && rc <= static_cast<uint32_t>(RoadClass::kResidential) &&
+        !link_dominates_intersection) {
       const auto edge_tags = WayTags::Parse(*data_.ways[in_edge.wayindex_], data_.osmdata);
       // We should stop if this node contains a destination road or if it doesn't belong
       // to any path from the root to a destination road
@@ -865,10 +872,17 @@ std::pair<uint32_t, uint32_t> ReclassifyLinkGraph(std::vector<LinkGraphNode>& li
 
         // Reclassify edge (if reclassify_links is true).
         if (reclassify_links && rc > edge.attributes.importance) {
-          if (rc < static_cast<uint32_t>(RoadClass::kUnclassified))
+          if (rc < static_cast<uint32_t>(RoadClass::kUnclassified)) {
             edge.attributes.importance = rc;
-          else
-            edge.attributes.importance = static_cast<uint32_t>(RoadClass::kTertiary);
+          } else {
+            // Clamp to tertiary, but never below the exit-node's class — a
+            // trunk-link must not be demoted to tertiary just because it ends
+            // at (or is crossed by) an unclassified road.
+            edge.attributes.importance =
+                std::min<uint32_t>(static_cast<uint32_t>(RoadClass::kTertiary),
+                                   std::max<uint32_t>(exit_classification,
+                                                      edge.attributes.importance));
+          }
 
           ++reclass_count;
         }

--- a/test/gurka/test_ramps_tc.cc
+++ b/test/gurka/test_ramps_tc.cc
@@ -493,6 +493,47 @@ TEST(LinkReclassification, test_use_dest_refs) {
   check_edge_classification(graph_reader, layout, "K", "C", baldr::RoadClass::kTrunk);
 }
 
+TEST(LinkReclassification, test_unclassified_crossing_no_refs) {
+  // Trunk_link ramps between a motorway and a trunk are crossed mid-ramp by an
+  // unclassified road and carry no ref/destination:ref tags. The links must
+  // keep their trunk classification (not be downgraded to tertiary).
+  constexpr double gridsize_metres = 10;
+
+  const std::string ascii_map = R"(
+  A------------B-------------C-----------D
+                \                       /
+                 \                     /
+     I------------J                   K-----------L
+                   \                 /
+                    \               /
+                     \             /
+                      F-----------G
+                      |
+                      E
+  )";
+
+  const gurka::ways ways = {
+      {"ABCD", {{"highway", "motorway"}}},
+      {"EFG", {{"highway", "trunk"}}},
+      {"BJF", {{"highway", "trunk_link"}, {"oneway", "yes"}}},
+      {"GKC", {{"highway", "trunk_link"}, {"oneway", "yes"}}},
+      {"IJ", {{"highway", "unclassified"}}},
+      {"KL", {{"highway", "unclassified"}}},
+  };
+
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, gridsize_metres);
+  auto map =
+      gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_ramps_unclassified_crossing_no_refs",
+                        {{"mjolnir.reclassify_links", "true"}});
+  baldr::GraphReader graph_reader(map.config.get_child("mjolnir"));
+
+  // The trunk_link should stay at trunk even without ref tags
+  check_edge_classification(graph_reader, layout, "B", "J", baldr::RoadClass::kTrunk);
+  check_edge_classification(graph_reader, layout, "J", "F", baldr::RoadClass::kTrunk);
+  check_edge_classification(graph_reader, layout, "G", "K", baldr::RoadClass::kTrunk);
+  check_edge_classification(graph_reader, layout, "K", "C", baldr::RoadClass::kTrunk);
+}
+
 TEST(LinkReclassification, test_hierarchical_reclass) {
   // Check that final road classes of links will be higher or equal to the classes of their children
   constexpr double gridsize_metres = 10;


### PR DESCRIPTION
# Issue
Fixes #

## Tasklist
- [x] Add tests
- [x] Add #fixes with the issue number that this PR addresses
- [ ] Update the docs with any new request parameters or changes to behavior described
- [x] Update the [changelog](CHANGELOG.md)
- [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too
- [ ] If you made changes to a translation file, [update transifex](docs/docs/locales.md) too

## Requirements / Relations
None. This is independent of #6089/#6091 (related routing-detour reports that surface the same underlying misclassification).

## Problem
The issue occurs because the link expansion logic stops at the first crossing it encounters, treating an unclassified road intersection as the ramp's endpoint. The reclassification code then uses that wrong endpoint to determine the ramp's final class, which always results in a tertiary classification.

## Solution
This fixes a bug where trunk and motorway ramps were being incorrectly downgraded to tertiary when crossed by unclassified roads.

The fix does two things:
- Lets high-class links continue expanding through unclassified crossings instead of stopping there
- Makes sure the clamping logic never downgrades a ramp below its exit road's classification

## Testing
Added a test case that reproduces the original bug and verifies the fix. All existing ramp tests still pass.

**Test Added:**
- LinkReclassification.test_unclassified_crossing_no_refs

**Behavior:**
- Fails on master (incorrectly returns `kTertiary`)
- Passes with the change included in the PR

**Additional regression checks executed locally on arm64 macOS:**
- gurka_ramps_tc — 9/9 PASS
- gurka_ferry_connections — 28/28 PASS
- gurka_config_speed — 5/5 PASS
- gurka_route — 35 PASS / 3 SKIPPED / 0 FAILED