### PR TITLE
fix(tileheader): remove date_created field from road tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * **Removed**
    * REMOVED: dead `thor.max_reserved_locations_costmatrix` help entry from `valhalla_build_config` (live key is `thor.costmatrix.max_reserved_locations`) [#6083](https://github.com/valhalla/valhalla/issues/6083)
    * REMOVED: `json` request parameter, people can use CORS in 2026 [#6099](https://github.com/valhalla/valhalla/pull/6099)
+   * REMOVED: `date_created_` field from `baldr::GraphTileHeader` [#6115](https://github.com/valhalla/valhalla/pull/6115)
 * **Bug Fix**
    * FIXED: wrong mode used in loki for `auto_pedestrian` [#6065](https://github.com/valhalla/valhalla/pull/6065)
    * FIXED: Avoid creating loop edges during graph filtering [#6050](https://github.com/valhalla/valhalla/pull/6050)

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -561,7 +561,6 @@ void BuildTileSet(const std::string& ways_file,
       GraphTileBuilder graphtile(tile_dir, tile_id, false);
 
       // Information about tile creation
-      graphtile.AddTileCreationDate(tile_creation_date);
       graphtile.header_builder().set_dataset_id(osmdata.max_changeset_id_);
       graphtile.header_builder().set_checksum(osmdata.pbf_checksum_);
 

--- a/test/graphtilebuilder.cc
+++ b/test/graphtilebuilder.cc
@@ -92,7 +92,6 @@ void assert_tile_equalish(const GraphTile& a,
             bh->complex_restriction_forward_offset());
   EXPECT_EQ(ah->complex_restriction_reverse_offset() + difference,
             bh->complex_restriction_reverse_offset());
-  EXPECT_EQ(ah->date_created(), bh->date_created());
   EXPECT_EQ(ah->density(), bh->density());
   EXPECT_EQ(ah->departurecount(), bh->departurecount());
   EXPECT_EQ(ah->directededgecount(), bh->directededgecount());

--- a/test/gurka/test_reproduce_tile_build.cc
+++ b/test/gurka/test_reproduce_tile_build.cc
@@ -73,7 +73,6 @@ void assert_tile_equalish(const GraphTile& a, const GraphTile& b) {
   ASSERT_EQ(ah->admincount(), bh->admincount());
   ASSERT_EQ(ah->complex_restriction_forward_offset(), bh->complex_restriction_forward_offset());
   ASSERT_EQ(ah->complex_restriction_reverse_offset(), bh->complex_restriction_reverse_offset());
-  ASSERT_EQ(ah->date_created(), bh->date_created());
   ASSERT_EQ(ah->density(), bh->density());
   ASSERT_EQ(ah->departurecount(), bh->departurecount());
   ASSERT_EQ(ah->directededgecount(), bh->directededgecount());


### PR DESCRIPTION
ref #6112 

for some (copy/paste fail?) reason the road tiles were setting the tile header's `date_created_` field which is only used on transit tiles. for `date_created` to have any impact it need GTFS data which is not present in road tiles.