### PR TITLE
feat: configurable `dataset_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
    * CHANGED: auto-generate .pyi stubs with cmake, needs a full build [#6101](https://github.com/valhalla/valhalla/pull/6101)
    * ADDED: Bounding circles for faster loki (not yet enabled) [#5103](https://github.com/valhalla/valhalla/pull/5103)
    * ADDED: OpenAPI documentation [#6088](https://github.com/valhalla/valhalla/pull/6088)
+   * ADDED: `dataset_id` config to optionally set an arbitrary number to each tile's `dataset_id` header field [#6126](https://github.com/valhalla/valhalla/pull/6126)
 
 ## Release Date: 2026-04-28 Valhalla 3.7.0
 * **Removed**

--- a/scripts/valhalla_build_config
+++ b/scripts/valhalla_build_config
@@ -160,6 +160,7 @@ config = {
         "max_concurrent_reader_users": 1,
         "reclassify_links": True,
         "default_speeds_config": Optional(str),
+        "dataset_id": Optional(int),
         "data_processing": {
             "infer_internal_intersections": True,
             "infer_turn_channels": True,
@@ -498,6 +499,7 @@ help_text = {
         "max_concurrent_reader_users": "number of threads in the threadpool which can be used to fetch tiles over the network via curl",
         "reclassify_links": "bool indicating whether or not to reclassify links - reclassifies ramps based on the lowest class connecting road",
         "default_speeds_config": "a path indicating the json config file which graph enhancer will use to set the speeds of edges in the graph based on their geographic location (state/country), density (urban/rural), road class, road use (form of way)",
+        "dataset_id": "Optional integer id to identify the tile dataset. By default we try to set the maximum OSM changeset ID.",
         "data_processing": {
             "infer_internal_intersections": "bool indicating whether or not to infer internal intersections during the graph enhancer phase or use the internal_intersection key from the pbf",
             "infer_turn_channels": "bool indicating whether or not to infer turn channels during the graph enhancer phase or use the turn_channel key from the pbf",

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -561,8 +561,8 @@ void BuildTileSet(const std::string& ways_file,
       GraphTileBuilder graphtile(tile_dir, tile_id, false);
 
       // Information about tile creation (optionally by config)
-      const auto dataset_id = pt.get<uint64_t>("dataset_id", 0);
-      graphtile.header_builder().set_dataset_id(dataset_id ? dataset_id : osmdata.max_changeset_id_);
+      const auto dataset_id = pt.get<uint64_t>("dataset_id", osmdata.max_changeset_id_);
+      graphtile.header_builder().set_dataset_id(dataset_id);
       graphtile.header_builder().set_checksum(osmdata.pbf_checksum_);
 
       // Set the base lat,lon of the tile

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -560,8 +560,9 @@ void BuildTileSet(const std::string& ways_file,
       GraphId tile_id = tile.first.tile_base();
       GraphTileBuilder graphtile(tile_dir, tile_id, false);
 
-      // Information about tile creation
-      graphtile.header_builder().set_dataset_id(osmdata.max_changeset_id_);
+      // Information about tile creation (optionally by config)
+      const auto dataset_id = pt.get<uint64_t>("dataset_id", 0);
+      graphtile.header_builder().set_dataset_id(dataset_id ? dataset_id : osmdata.max_changeset_id_);
       graphtile.header_builder().set_checksum(osmdata.pbf_checksum_);
 
       // Set the base lat,lon of the tile

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -5405,6 +5405,7 @@ void PBFGraphParser::ParseNodes(const boost::property_tree::ptree& pt,
 
   // Some OSM extracts do not have changeset Ids. For these set the max changeset Id
   // to the max OSM Id
+  // Note, we also allow dataset_id to be set by config, which happens at tile build
   if (osmdata.max_changeset_id_ == 0) {
     osmdata.max_changeset_id_ = max_osm_id;
     LOG_INFO("Finished: max_osm_id " + std::to_string(osmdata.max_changeset_id_));

--- a/test/graphbuilder.cc
+++ b/test/graphbuilder.cc
@@ -268,8 +268,8 @@ TEST(GraphBuilder, ConfigDatasetId) {
   config.put("mjolnir.dataset_id", 424242);
   build_and_check(424242);
 
-  // a 0 (or absent) config id falls back to the OSM-derived changeset id
-  config.put("mjolnir.dataset_id", 0);
+  // with no dataset_id configured, fall back to the OSM-derived changeset id
+  config.get_child("mjolnir").erase("dataset_id");
   build_and_check(osm_data.max_changeset_id_);
 
   std::filesystem::remove_all(tile_dir);

--- a/test/graphbuilder.cc
+++ b/test/graphbuilder.cc
@@ -241,6 +241,40 @@ TEST(Graphbuilder, AdminBbox) {
             "BE/WAL");
 }
 
+// The tile header's dataset id comes from mjolnir.dataset_id when set, otherwise it falls back to
+// the OSM-derived changeset id gathered during parsing.
+TEST(GraphBuilder, ConfigDatasetId) {
+  ptree config;
+  config.put("mjolnir.tile_dir", tile_dir);
+  config.put("mjolnir.concurrency", 1);
+
+  OSMData osm_data{};
+  osm_data.read_from_temp_files(tile_dir);
+  osm_data.max_changeset_id_ = 555; // stand-in for the OSM-derived fallback id
+
+  std::map<baldr::GraphId, size_t> tiles =
+      GraphBuilder::BuildEdges(config, ways_file, way_nodes_file, nodes_file, edges_file);
+
+  const auto build_and_check = [&](uint64_t expected) {
+    std::filesystem::remove_all(tile_dir);
+    GraphBuilder::Build(config, osm_data, ways_file, way_nodes_file, nodes_file, edges_file,
+                        from_restriction_file, to_restriction_file, linguistic_node_file, tiles);
+    GraphReader reader(config.get_child("mjolnir"));
+    for (auto tile_id : reader.GetTileSet())
+      EXPECT_EQ(reader.GetGraphTile(tile_id)->header()->dataset_id(), expected);
+  };
+
+  // explicit config id wins over the OSM-derived changeset id
+  config.put("mjolnir.dataset_id", 424242);
+  build_and_check(424242);
+
+  // a 0 (or absent) config id falls back to the OSM-derived changeset id
+  config.put("mjolnir.dataset_id", 0);
+  build_and_check(osm_data.max_changeset_id_);
+
+  std::filesystem::remove_all(tile_dir);
+}
+
 class HarrisburgTestSuiteEnv : public ::testing::Environment {
 public:
   void SetUp() override {


### PR DESCRIPTION
closes #6114 

- adds `mjolnir.dataset_id` to config as `Optional(int)`, it's expected to be a `uint64_t`
- if set, it'll be value of the tile header's `dataset_id_` field
- default is current behavior to set `dataset_id_`