### PR TITLE
chore: Replace `GreatCircleDistance` and `GreatCircleDistanceSquared` by `Measurement::distance` and `Measurement::distance_squared`

### DIFF
--- a/src/meili/map_matcher.cc
+++ b/src/meili/map_matcher.cc
@@ -18,14 +18,6 @@ using namespace valhalla::baldr;
 
 constexpr float MAX_ACCUMULATED_COST = 99999999.f;
 
-inline float GreatCircleDistanceSquared(const Measurement& left, const Measurement& right) {
-  return left.lnglat().DistanceSquared(right.lnglat());
-}
-
-inline float GreatCircleDistance(const Measurement& left, const Measurement& right) {
-  return left.lnglat().Distance(right.lnglat());
-}
-
 inline float ClockDistance(const Measurement& left, const Measurement& right) {
   return right.epoch_time() < 0 || left.epoch_time() < 0 ? -1
                                                          : right.epoch_time() - left.epoch_time();
@@ -209,7 +201,7 @@ std::vector<MatchResult> InterpolateMeasurements(const MapMatcher& mapmatcher,
   for (const auto& measurement : measurements) {
     // we need some info about the measurement to figure out what the best interpolation would be
     const auto& match_measurement = mapmatcher.state_container().measurement(stateid.time());
-    const auto match_measurement_distance = GreatCircleDistance(measurement, match_measurement);
+    const auto match_measurement_distance = measurement.distance(match_measurement);
     const auto match_measurement_time = ClockDistance(measurement, match_measurement);
 
     // interpolate this point along the route
@@ -854,7 +846,7 @@ MapMatcher::AppendMeasurements(const std::vector<Measurement>& measurements) {
   auto time = AppendMeasurement(*last, sq_max_search_radius);
   double interpolated_epoch_time = -1;
   for (auto m = std::next(last); m != measurements.end(); ++m) {
-    const auto sq_distance = GreatCircleDistanceSquared(*last, *m);
+    const auto sq_distance = last->distance_squared(*m);
     // Always match the last measurement and if its far enough away
     if (sq_interpolation_distance < sq_distance || std::next(m) == measurements.end()) {
       // If there were interpolated points between these two points with time information

--- a/src/meili/transition_cost_model.cc
+++ b/src/meili/transition_cost_model.cc
@@ -1,13 +1,6 @@
 #include "meili/transition_cost_model.h"
 #include "meili/routing.h"
 
-namespace {
-inline float GreatCircleDistance(const valhalla::meili::Measurement& left,
-                                 const valhalla::meili::Measurement& right) {
-  return left.lnglat().Distance(right.lnglat());
-}
-} // namespace
-
 namespace valhalla {
 namespace meili {
 
@@ -77,8 +70,8 @@ float TransitionCostModel::operator()(const StateId& lhs, const StateId& rhs) co
     const auto& left_measurement = container_.measurement(lhs.time());
     const auto& right_measurement = container_.measurement(rhs.time());
     return CalculateTransitionCost(label->turn_cost(), label->cost().cost,
-                                   GreatCircleDistance(left_measurement, right_measurement),
-                                   label->cost().secs, ClockDistance(lhs.time(), rhs.time()));
+                                   left_measurement.distance(right_measurement), label->cost().secs,
+                                   ClockDistance(lhs.time(), rhs.time()));
   }
 
   // No path found
@@ -137,7 +130,7 @@ void TransitionCostModel::UpdateRoute(const StateId& lhs, const StateId& rhs) co
   const midgard::DistanceApproximator<midgard::PointLL> approximator(right_measurement.lnglat());
 
   auto max_route_distance =
-      std::min(GreatCircleDistance(left_measurement, right_measurement) * max_route_distance_factor_,
+      std::min(left_measurement.distance(right_measurement) * max_route_distance_factor_,
                breakage_distance_);
   // Route, we have to make sure that the max distance is greater
   // than 0 otherwise we wont be able to get any labels into the

--- a/valhalla/meili/measurement.h
+++ b/valhalla/meili/measurement.h
@@ -59,6 +59,14 @@ public:
     return stop_type_;
   }
 
+  float distance(const Measurement& other) const {
+    return lnglat_.Distance(other.lnglat_);
+  }
+
+  float distance_squared(const Measurement& other) const {
+    return lnglat_.DistanceSquared(other.lnglat_);
+  }
+
 private:
   midgard::PointLL lnglat_;
 


### PR DESCRIPTION
_Please don't force-push once you received the first review._

# Issue

This small cleanup fixes unity build issue caused by duplicated definition of `GreatCircleDistance`:

```
  In file included from src/meili/CMakeFiles/valhalla-meili.dir/Unity/unity_0_cxx.cxx:28:
  src/meili/transition_cost_model.cc:5:14: error: redefinition of 'GreatCircleDistance'
      5 | inline float GreatCircleDistance(const valhalla::meili::Measurement& left,
        |              ^
  src/meili/map_matcher.cc:25:14: note: previous definition is here
     25 | inline float GreatCircleDistance(const Measurement& left, const Measurement& right) {
        |              ^
  1 error generated.
```

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [ ] If you made changes to a translation file, [update transifex](docs/docs/locales.md) too

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
