### PR TITLE
Fix missing size check before memcpy in CacheTileURL

### DIFF
--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -230,29 +230,32 @@ graph_tile_ptr GraphTile::CacheTileURL(const std::string& tile_url,
                                        uint64_t range_offset,
                                        uint64_t range_size,
                                        const std::filesystem::path& id_txt_path,
-                                       uint64_t id_checksum) {
+                                       std::optional<uint64_t> id_checksum) {
   // Don't bother with invalid ids
   if (!graphid.is_valid() || graphid.level() > TileHierarchy::get_max_level() || !tile_getter) {
     return nullptr;
   }
 
-  auto check_tile_checksum = [&](uint64_t tile_checksum) {
-    if (tile_checksum == 0) {
+  auto check_tile_checksum = [&](const GraphTileHeader& header) {
+    // only the build id (identical across the tileset) tells us whether the remote was rebuilt; the
+    // per-tile hash differs from tile to tile
+    uint64_t build_id = header.build_id();
+    if (build_id == 0 && header.tile_checksum() == 0) {
       // loading tilesets built by older valhalla commits has the potential to corrupt the GraphReader
       LOG_WARN(
           "Remote tile is missing the checksum attribute, please update the tile building valhalla instance");
     }
     if (!tile_dir.empty()) {
-      if (id_checksum == 0) {
-        // this is the first tile in a fresh tile_dir
+      if (!id_checksum) {
+        // first tile in a fresh tile_dir: record the URL & tileset build id
         static std::mutex mutex;
         std::lock_guard lock{mutex};
         std::ofstream id_txt_file(id_txt_path, std::ios::binary);
         if (id_txt_file) {
           id_txt_file << tile_url << std::endl;
-          id_txt_file << tile_checksum << std::endl;
+          id_txt_file << build_id << std::endl;
         }
-      } else if (tile_checksum != id_checksum) {
+      } else if (build_id != *id_checksum) {
         LOG_ERROR("Remote tar file has changed, remove the tile_dir and restart.");
         throw valhalla_exception_t(446);
       }
@@ -285,7 +288,7 @@ graph_tile_ptr GraphTile::CacheTileURL(const std::string& tile_url,
     }
     GraphTileHeader header;
     std::memcpy(&header, result.bytes_.data(), sizeof(header));
-    check_tile_checksum(header.checksum());
+    check_tile_checksum(header);
   }
 
   // try to cache it on disk so we dont have to keep fetching it from url
@@ -294,7 +297,7 @@ graph_tile_ptr GraphTile::CacheTileURL(const std::string& tile_url,
   // turn the memory into a tile
   if (tile_getter->gzipped()) {
     auto tile = DecompressTile(graphid, result.bytes_);
-    check_tile_checksum(tile.get()->header()->checksum());
+    check_tile_checksum(*tile.get()->header());
     return tile;
   }
 

--- a/src/baldr/graphtile.cc
+++ b/src/baldr/graphtile.cc
@@ -230,32 +230,29 @@ graph_tile_ptr GraphTile::CacheTileURL(const std::string& tile_url,
                                        uint64_t range_offset,
                                        uint64_t range_size,
                                        const std::filesystem::path& id_txt_path,
-                                       std::optional<uint64_t> id_checksum) {
+                                       uint64_t id_checksum) {
   // Don't bother with invalid ids
   if (!graphid.is_valid() || graphid.level() > TileHierarchy::get_max_level() || !tile_getter) {
     return nullptr;
   }
 
-  auto check_tile_checksum = [&](const GraphTileHeader& header) {
-    // only the build id (identical across the tileset) tells us whether the remote was rebuilt; the
-    // per-tile hash differs from tile to tile
-    uint64_t build_id = header.build_id();
-    if (build_id == 0 && header.tile_checksum() == 0) {
+  auto check_tile_checksum = [&](uint64_t tile_checksum) {
+    if (tile_checksum == 0) {
       // loading tilesets built by older valhalla commits has the potential to corrupt the GraphReader
       LOG_WARN(
           "Remote tile is missing the checksum attribute, please update the tile building valhalla instance");
     }
     if (!tile_dir.empty()) {
-      if (!id_checksum) {
-        // first tile in a fresh tile_dir: record the URL & tileset build id
+      if (id_checksum == 0) {
+        // this is the first tile in a fresh tile_dir
         static std::mutex mutex;
         std::lock_guard lock{mutex};
         std::ofstream id_txt_file(id_txt_path, std::ios::binary);
         if (id_txt_file) {
           id_txt_file << tile_url << std::endl;
-          id_txt_file << build_id << std::endl;
+          id_txt_file << tile_checksum << std::endl;
         }
-      } else if (build_id != *id_checksum) {
+      } else if (tile_checksum != id_checksum) {
         LOG_ERROR("Remote tar file has changed, remove the tile_dir and restart.");
         throw valhalla_exception_t(446);
       }
@@ -283,9 +280,12 @@ graph_tile_ptr GraphTile::CacheTileURL(const std::string& tile_url,
   if (!tile_getter->gzipped()) {
     // inspect the header for the checksum
     // it's a POD type and thus trivially copyable
+    if (result.bytes_.size() < sizeof(GraphTileHeader)) {
+        return nullptr;
+    }
     GraphTileHeader header;
     std::memcpy(&header, result.bytes_.data(), sizeof(header));
-    check_tile_checksum(header);
+    check_tile_checksum(header.checksum());
   }
 
   // try to cache it on disk so we dont have to keep fetching it from url
@@ -294,7 +294,7 @@ graph_tile_ptr GraphTile::CacheTileURL(const std::string& tile_url,
   // turn the memory into a tile
   if (tile_getter->gzipped()) {
     auto tile = DecompressTile(graphid, result.bytes_);
-    check_tile_checksum(*tile.get()->header());
+    check_tile_checksum(tile.get()->header()->checksum());
     return tile;
   }
 


### PR DESCRIPTION
The CacheTileURL function copies sizeof(GraphTileHeader) bytes from the HTTP response into a header struct without first checking that the response buffer is large enough. If a server returns HTTP 200 with a body smaller than 272 bytes, the memcpy reads past the vector allocation into adjacent heap.

This adds a size check before the memcpy, matching the existing pattern already used in GraphTile::Initialize() at line 313.

Fixes #6146