### PR TITLE
fix(midgard): fix precisioin errors for azimuthal projection and cartesian distances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
    * FIXED: Fix errors in cost_inline_tests [#6117](https://github.com/valhalla/valhalla/pull/6117)
    * FIXED: JSON serialization of NaN values [#6147](https://github.com/valhalla/valhalla/pull/6147)
    * BREAKING: apply `low_class_penalty` only when transitioning from a higher class road in `TruckCost::TransitionCost`(impacts truck routes) [#6143](https://github.com/valhalla/valhalla/pull/6143)
+   * FIXED: bounding circle precision issues [#6169](https://github.com/valhalla/valhalla/pull/6169)
 * **Enhancement**
    * UPDATED: timezone database to 2026b [#6074](https://github.com/valhalla/valhalla/pull/6074)
    * ADDED: Ignore specific access restrictions via the linear features interface [#5942](https://github.com/valhalla/valhalla/pull/5942)

--- a/src/midgard/pointll.cc
+++ b/src/midgard/pointll.cc
@@ -92,7 +92,7 @@ PrecisionT GeoPoint<PrecisionT>::Distance(const GeoPoint& other) const {
 
   // d = 2r * arcsin(sqrt(h))
   const double d = 2.0 * std::asin(std::sqrt(h));
-  const double meters = kRadEarthMeters * d;
+  const double meters = kRadEarthMetersD * d;
   return static_cast<PrecisionT>(meters);
 }
 

--- a/src/midgard/util.cc
+++ b/src/midgard/util.cc
@@ -80,7 +80,7 @@ projected_circle_t welzl_impl(std::span<Point2d> points, std::vector<Point2d>& b
     }
   }
 
-  const Point2d pt = points.front();
+  const Point2d& pt = points.front();
   projected_circle_t d = welzl_impl(points.subspan(1), boundary);
 
   if (d.second + 1e-10 >= d.first.Distance(pt))
@@ -932,15 +932,15 @@ std::string decode64(const std::string& encoded) {
 }
 
 AzimuthalEquidistant::AzimuthalEquidistant(const PointLL& center)
-    : center_(center), center_rad_(center_.lng() * kRadPerDeg, center_.lat() * kRadPerDeg),
+    : center_(center), center_rad_(center_.lng() * kRadPerDegD, center_.lat() * kRadPerDegD),
       sin_lat_center_(std::sin(center_rad_.second)), cos_lat_center_(std::cos(center_rad_.second)) {
 }
 
 Point2d AzimuthalEquidistant::project(const PointLL& ll) const {
 
   // convert to radians
-  const double lon = ll.lng() * kRadPerDeg;
-  const double lat = ll.lat() * kRadPerDeg;
+  const double lon = ll.lng() * kRadPerDegD;
+  const double lat = ll.lat() * kRadPerDegD;
 
   const double sin_lat = std::sin(lat);
   const double cos_lat = std::cos(lat);
@@ -963,14 +963,14 @@ Point2d AzimuthalEquidistant::project(const PointLL& ll) const {
   const double y = k * (cos_lat_center_ * sin_lat - sin_lat_center_ * cos_lat * cos_dlon);
 
   // scale from radians to meters using earth's radius
-  return {x * kRadEarthMeters, y * kRadEarthMeters};
+  return {x * kRadEarthMetersD, y * kRadEarthMetersD};
 }
 
 PointLL AzimuthalEquidistant::project_inverse(const Point2d& pt) const {
 
   // back to radians from meters
-  const double x = pt.x() / kRadEarthMeters;
-  const double y = pt.y() / kRadEarthMeters;
+  const double x = pt.x() / kRadEarthMetersD;
+  const double y = pt.y() / kRadEarthMetersD;
 
   // formula 7: angular distance from center
   const double c = std::sqrt(x * x + y * y);
@@ -988,16 +988,16 @@ PointLL AzimuthalEquidistant::project_inverse(const Point2d& pt) const {
 
   // formula 6 with special cases for center point at 90° or -90°
   double lon;
-  if (std::abs(center_rad_.second - kPiOver2) < 1e-10) {
+  if (std::abs(center_rad_.second - kPiOver2D) < 1e-10) {
     lon = center_rad_.first + std::atan2(x, -y);
-  } else if (std::abs(center_rad_.second + kPiOver2) < 1e-10) {
+  } else if (std::abs(center_rad_.second + kPiOver2D) < 1e-10) {
     lon = center_rad_.first + std::atan2(x, y);
   } else {
     lon = center_rad_.first +
           std::atan2(x * sin_c, c * cos_lat_center_ * cos_c - y * sin_lat_center_ * sin_c);
   }
 
-  return {lon * kDegPerRad, lat * kDegPerRad};
+  return {lon * kDegPerRadD, lat * kDegPerRadD};
 }
 
 std::optional<circle_t> minimum_bounding_circle(const std::vector<PointLL>& points,
@@ -1029,7 +1029,7 @@ std::optional<circle_t> minimum_bounding_circle(const std::vector<PointLL>& poin
 
   // finally reproject the center to lat/lon
   const PointLL center = azimuthal_equidistant.project_inverse(result.first);
-  return circle_t{Point2d{center.lng(), center.lat()}, result.second};
+  return circle_t{center, result.second};
 }
 
 } // namespace midgard

--- a/test/pointll.cc
+++ b/test/pointll.cc
@@ -340,7 +340,7 @@ TEST(PointLL, TestMidPoint) {
 
 TEST(PointLL, TestDistance) {
   auto d = PointLL(-90.0, 0.0).Distance({90.0, 0.0});
-  EXPECT_EQ(d, kPiD * kRadEarthMeters) << "Distance 180 from each other should be PI * earth radius";
+  EXPECT_EQ(d, kPiD * kRadEarthMetersD) << "Distance 180 from each other should be PI * earth radius";
 
   d = PointLL(-90.0, 0.0).Distance({-90.0, 0.0});
   EXPECT_EQ(d, 0.0) << "Distance between same points should be 0";

--- a/valhalla/midgard/constants.h
+++ b/valhalla/midgard/constants.h
@@ -28,6 +28,7 @@ constexpr float kMilePerKm = 0.621371f;
 constexpr float kMilePerMeter = kMilePerKm / 1000;
 constexpr float kKmPerMile = 1.609344f;
 constexpr float kRadEarthMeters = 6378160.187f;
+constexpr double kRadEarthMetersD = 6378160.187;
 constexpr double kMetersPerDegreeLat = 110567.0f;
 constexpr double kKmPerDecimeter = 0.0001;
 constexpr double kMeterPerDecimeter = 0.1;
@@ -49,6 +50,7 @@ constexpr double kDegPerRadD = (180.0 / kPiD); // Radians to degrees conversion 
 constexpr float kRadPerDeg = (kPi / 180.0f);   // Degrees to radians conversion
 constexpr double kRadPerDegD = (kPiD / 180.0); // Degrees to radians conversion in double precision
 constexpr float kEpsilon = 0.000001f;
+constexpr double kPiOver2D = (kPiD * 0.5);
 
 // To avoid using M_PI
 constexpr double kPiDouble = 3.14159265358979323846;

--- a/valhalla/midgard/point2.h
+++ b/valhalla/midgard/point2.h
@@ -105,7 +105,7 @@ public:
    * @return  Returns the distance between this point and p.
    */
   PrecisionT Distance(const PointXY<PrecisionT>& p) const {
-    return sqrtf(DistanceSquared(p));
+    return std::sqrt(DistanceSquared(p));
   }
 
   /**


### PR DESCRIPTION
I noticed that some bounding circles (the non-quantized ones) were just slightly too small and hence sometimes cut off one or two points by a few centimeters. Turns out there were a few errors due to precision mismatch in the projection code as well as in the cartesian distance calculations. 

These were so small that they didn't meaningfully change the final circles we store in the tiles, but still worth fixing, since a few centimeters of error on longer edges could still push a few edges into a lower quantized radius. 

With these fixes, the highest errors I observed when building tiles for the Netherlands were around 0.01 cm, which is about the error of 7 digit precision coordinates in OSM around the equator (see https://wiki.openstreetmap.org/wiki/Precision_of_coordinates). 

