### PR TITLE
fix(loki): forward declare `IncidentLayersBuilder` as a class

### DIFF
--- a/valhalla/loki/tiles.h
+++ b/valhalla/loki/tiles.h
@@ -55,7 +55,7 @@ protected:
   vtzero::index_value key_value_;
 };
 
-struct IncidentLayersBuilder;
+class IncidentLayersBuilder;
 struct IncidentsAttributeTile {
   const char* key_name;
   std::string_view attribute_flag;


### PR DESCRIPTION
I'm surprised how this went unnoticed in CI! Looks like most compilers do the right thing for you, but still... 