### PR TITLE
fix(release): 3.8.0 didn't land on pypi

### DIFF
--- a/.github/workflows/osx_win_python_builds.yml
+++ b/.github/workflows/osx_win_python_builds.yml
@@ -75,7 +75,7 @@ jobs:
     name: Build sdist
     runs-on: ubuntu-latest
     needs: [publish_pypi]
-    # if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' || (github.event_name == 'push' && github.ref == 'refs/heads/nn-fix-release-3.8.0') }}
+    if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' || (github.event_name == 'push' && github.ref == 'refs/heads/master') }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/osx_win_python_builds.yml
+++ b/.github/workflows/osx_win_python_builds.yml
@@ -75,7 +75,7 @@ jobs:
     name: Build sdist
     runs-on: ubuntu-latest
     needs: [publish_pypi]
-    if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' || (github.event_name == 'push' && github.ref == 'refs/heads/nn-fix-release-3.8.0') }}
+    # if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' || (github.event_name == 'push' && github.ref == 'refs/heads/nn-fix-release-3.8.0') }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/osx_win_python_builds.yml
+++ b/.github/workflows/osx_win_python_builds.yml
@@ -75,7 +75,7 @@ jobs:
     name: Build sdist
     runs-on: ubuntu-latest
     needs: [publish_pypi]
-    if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' }}
+    # if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -464,7 +464,7 @@ jobs:
     needs: [build_python_wheels_linux]
     runs-on: ${{  matrix.runner  }}
     container: python:3.13-slim-bookworm
-    if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' }}
+    # if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' }}
     strategy:
       matrix:
         include:
@@ -490,7 +490,7 @@ jobs:
   verify_wheels_osx:
     needs: [build_osx]
     runs-on: macos-14
-    if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' }}
+    # if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -513,7 +513,7 @@ jobs:
   verify_wheels_win:
     needs: [build_win]
     runs-on: windows-2022
-    if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' }}
+    # if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' }}
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/osx_win_python_builds.yml
+++ b/.github/workflows/osx_win_python_builds.yml
@@ -102,7 +102,7 @@ jobs:
     name: Build Linux Python wheels
     runs-on: ${{ matrix.runner }}
     needs: [build_sdist]
-    if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' }}
+    # if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' }}
     strategy:
       matrix:
         include:
@@ -281,7 +281,7 @@ jobs:
       # only package python bindings if it's not a PR
       
       - uses: pypa/cibuildwheel@v2.23.3
-        if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' }}
+        # if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' }}
         env:
           CIBW_ENVIRONMENT: >
             CMAKE_ARGS="-DVALHALLA_VERSION_MODIFIER=${{ env.VALHALLA_VERSION_MODIFIER }}"
@@ -436,7 +436,7 @@ jobs:
       # only package python bindings if it's not a PR
       
       - uses: pypa/cibuildwheel@v2.23.3
-        if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' }}
+        # if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' }}
         env:
           CIBW_ENVIRONMENT_WINDOWS: >-
             CMAKE_ARGS="-DENABLE_SERVICES=OFF -DENABLE_TESTS=OFF -DVALHALLA_VERSION_MODIFIER=${{ env.VALHALLA_VERSION_MODIFIER }} -DCMAKE_TOOLCHAIN_FILE=${{  env.VCPKG_TOOLCHAIN_FILE  }} -DVCPKG_TARGET_TRIPLET=${{  env.VCPKG_DEFAULT_TRIPLET  }}"

--- a/.github/workflows/osx_win_python_builds.yml
+++ b/.github/workflows/osx_win_python_builds.yml
@@ -280,7 +280,7 @@ jobs:
       # only package python bindings if it's not a PR
       
       - uses: pypa/cibuildwheel@v2.23.3
-        # if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' }}
+        if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' }}
         env:
           CIBW_ENVIRONMENT: >
             CMAKE_ARGS="-DVALHALLA_VERSION_MODIFIER=${{ env.VALHALLA_VERSION_MODIFIER }}"

--- a/.github/workflows/osx_win_python_builds.yml
+++ b/.github/workflows/osx_win_python_builds.yml
@@ -75,7 +75,7 @@ jobs:
     name: Build sdist
     runs-on: ubuntu-latest
     needs: [publish_pypi]
-    if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' || (github.event_name == 'push' && github.ref == 'refs/heads/master') }}
+    if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' || (github.event_name == 'push' && github.ref == 'refs/heads/nn-fix-release-3.8.0') }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/osx_win_python_builds.yml
+++ b/.github/workflows/osx_win_python_builds.yml
@@ -75,7 +75,7 @@ jobs:
     name: Build sdist
     runs-on: ubuntu-latest
     needs: [publish_pypi]
-    # if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' }}
+    if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' || (github.event_name == 'push' && github.ref == 'refs/heads/master') }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -102,7 +102,6 @@ jobs:
     name: Build Linux Python wheels
     runs-on: ${{ matrix.runner }}
     needs: [build_sdist]
-    # if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' }}
     strategy:
       matrix:
         include:
@@ -436,7 +435,7 @@ jobs:
       # only package python bindings if it's not a PR
       
       - uses: pypa/cibuildwheel@v2.23.3
-        # if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' }}
+        if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' }}
         env:
           CIBW_ENVIRONMENT_WINDOWS: >-
             CMAKE_ARGS="-DENABLE_SERVICES=OFF -DENABLE_TESTS=OFF -DVALHALLA_VERSION_MODIFIER=${{ env.VALHALLA_VERSION_MODIFIER }} -DCMAKE_TOOLCHAIN_FILE=${{  env.VCPKG_TOOLCHAIN_FILE  }} -DVCPKG_TARGET_TRIPLET=${{  env.VCPKG_DEFAULT_TRIPLET  }}"
@@ -464,7 +463,6 @@ jobs:
     needs: [build_python_wheels_linux]
     runs-on: ${{  matrix.runner  }}
     container: python:3.13-slim-bookworm
-    # if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' }}
     strategy:
       matrix:
         include:
@@ -490,7 +488,7 @@ jobs:
   verify_wheels_osx:
     needs: [build_osx]
     runs-on: macos-14
-    # if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' }}
+    if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -513,7 +511,7 @@ jobs:
   verify_wheels_win:
     needs: [build_win]
     runs-on: windows-2022
-    # if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' }}
+    if: ${{ needs.publish_pypi.outputs.PUBLISH_PYPI == 'true' || github.event.inputs.python_test_publish == 'true' }}
     steps:
       - uses: actions/checkout@v6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## UNRELEASED
 * **Removed**
 * **Bug Fix**
+   * FIXED: `cibuildhweel` had configuration issues preventing PyPI release; added CI protection for Linux wheels [#6179](https://github.com/valhalla/valhalla/issues/6179)
 * **Enhancement**
 
 ## Release Date: 2026-07-06 Valhalla 3.8.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ lint.ignore = ["E731", "F811"]
 [tool.cibuildwheel]
 # it's enough here to know it's importable, actual test is run on other CI
 # mostly to avoid building utrecht tiles within the bindings build
-test-command = "python -c \"from valhalla.utils.graph_utils import GraphId; g = GraphId(); assert g.is_valid() == False\""
+test-command = "python -c \"from valhalla.baldr import GraphId; g = GraphId(); assert g.is_valid() == False\""
 # find out current defaults: cibuildwheel --print-build-identifiers --platform linux
 build = "cp*"
 skip = "*musllinux*"


### PR DESCRIPTION
there was a dormant issue how cibuildwheel was called, which only surfaced now when releasing 3.8.0, due to https://github.com/valhalla/valhalla/pull/6133 (I think).

~~also aiming to add a PR before the next release to run cibuildwheel at least when merging to master. for now, I manually test all the way until publishing the wheels.~~

closes #6180 