### PR TITLE
fix(python): point get_config() at the top-level logging key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## UNRELEASED
 * **Removed**
 * **Bug Fix**
-   * FIXED: Python `get_config()` raised `KeyError('logging')` since 3.7.0 by writing the removed `mjolnir.logging` key after logging config moved to the top level in #5976 [#PLACEHOLDER](https://github.com/valhalla/valhalla/pull/PLACEHOLDER)
+   * FIXED: Python `get_config()` raised `KeyError('logging')` since 3.7.0 by writing the removed `mjolnir.logging` key after logging config moved to the top level in #5976 [#6185](https://github.com/valhalla/valhalla/pull/6185)
 * **Enhancement**
 
 ## Release Date: 2026-07-06 Valhalla 3.8.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## UNRELEASED
 * **Removed**
 * **Bug Fix**
+   * FIXED: Python `get_config()` raised `KeyError('logging')` since 3.7.0 by writing the removed `mjolnir.logging` key after logging config moved to the top level in #5976 [#PLACEHOLDER](https://github.com/valhalla/valhalla/pull/PLACEHOLDER)
 * **Enhancement**
 
 ## Release Date: 2026-07-06 Valhalla 3.8.1

--- a/src/bindings/python/valhalla/config.py
+++ b/src/bindings/python/valhalla/config.py
@@ -54,7 +54,7 @@ def get_config(
         if isinstance(tile_extract, str) and not str(tile_extract)
         else str(Path(tile_extract).resolve(strict=True))
     )
-    config["mjolnir"]["logging"]["type"] = "std_out" if verbose else ""
+    config["logging"]["type"] = "std_out" if verbose else ""
 
     return config
 

--- a/test/bindings/python/test_config.py
+++ b/test/bindings/python/test_config.py
@@ -5,7 +5,7 @@ import os
 import unittest
 from pathlib import Path
 
-from valhalla.config import parse_and_validate_config
+from valhalla.config import get_config, parse_and_validate_config
 
 
 class TestParseAndValidateConfig(unittest.TestCase):
@@ -195,6 +195,33 @@ class TestParseAndValidateConfig(unittest.TestCase):
         with self.assertRaises(AttributeError) as exc:
             parse_and_validate_config(config)
         self.assertIn("mjolnir.tile_extract and mjolnir.tile_dir are missing", str(exc.exception))
+
+
+class TestGetConfig(unittest.TestCase):
+    """Test suite for get_config function."""
+
+    def test_get_config_does_not_raise(self):
+        """get_config() must build a config without raising.
+
+        Regression test for #5976, which moved logging config from the
+        module-level `mjolnir.logging` to a top-level `logging` section but
+        left get_config() writing to the removed `mjolnir.logging` key, so it
+        raised KeyError('logging') for every caller.
+        """
+        # Empty tile paths avoid the strict filesystem resolve, so this runs
+        # without any tile data present.
+        config = get_config(tile_extract="", tile_dir="")
+
+        # Logging config lives at the top level, not under mjolnir.
+        self.assertIn("logging", config)
+        self.assertNotIn("logging", config["mjolnir"])
+
+    def test_get_config_verbose_toggles_logging_type(self):
+        """verbose controls the top-level logging.type value."""
+        self.assertEqual(
+            get_config(tile_extract="", tile_dir="", verbose=True)["logging"]["type"], "std_out"
+        )
+        self.assertEqual(get_config(tile_extract="", tile_dir="", verbose=False)["logging"]["type"], "")
 
 
 if __name__ == "__main__":

--- a/test/bindings/python/test_config.py
+++ b/test/bindings/python/test_config.py
@@ -201,13 +201,7 @@ class TestGetConfig(unittest.TestCase):
     """Test suite for get_config function."""
 
     def test_get_config_does_not_raise(self):
-        """get_config() must build a config without raising.
-
-        Regression test for #5976, which moved logging config from the
-        module-level `mjolnir.logging` to a top-level `logging` section but
-        left get_config() writing to the removed `mjolnir.logging` key, so it
-        raised KeyError('logging') for every caller.
-        """
+        """get_config() must build a config without raising."""
         # Empty tile paths avoid the strict filesystem resolve, so this runs
         # without any tile data present.
         config = get_config(tile_extract="", tile_dir="")


### PR DESCRIPTION
### Problem

The Python `get_config()` helper raises `KeyError('logging')` for every caller, regardless of the `verbose` flag:

```python
>>> from valhalla import get_config
>>> get_config(tile_extract="", tile_dir="")
KeyError: 'logging'
```

### Cause

#5976 moved logging config from the module-level `mjolnir.logging` to a top-level global `logging` section (per the 3.7.0 changelog: *"REMOVED: all module-level `logging` config in favor of a global one"*). The `valhalla_build_config` default config was updated accordingly, but `get_config()` was not — it still writes to the now-removed key:

```python
config["mjolnir"]["logging"]["type"] = "std_out" if verbose else ""
```

This has been broken since **3.7.0** and is still present on `master`.

### Fix

Point the assignment at the new top-level location, completing the migration:

```python
config["logging"]["type"] = "std_out" if verbose else ""
```

### Test

`get_config()` previously had no test coverage, which is how this shipped. Added `TestGetConfig` to `test/bindings/python/test_config.py` asserting logging lives at the top level (not under `mjolnir`) and that `verbose` toggles `logging.type`. The test raises `KeyError('logging')` without the fix and passes with it.