### PR TITLE
Fix per-leg has_toll/has_highway/has_ferry with directions_type=none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## UNRELEASED
 * **Removed**
 * **Bug Fix**
+   * FIXED: Per-leg `has_toll`/`has_highway`/`has_ferry` in the Valhalla JSON output were always `false` with `directions_type=none` because they were accumulated from maneuvers; fall back to the leg summary instead [#6151](https://github.com/valhalla/valhalla/issues/6151)
 * **Enhancement**
 
 ## Release Date: 2026-07-06 Valhalla 3.8.1

--- a/src/tyr/route_serializer_valhalla.cc
+++ b/src/tyr/route_serializer_valhalla.cc
@@ -642,10 +642,6 @@ void legs(valhalla::Api& api, int route_index, rapidjson::writer_wrapper_t& writ
     }
 
     writer("has_time_restrictions", has_time_restrictions);
-    // The has_toll/has_highway/has_ferry booleans above are accumulated from the maneuvers, which
-    // don't exist when directions_type is "none". Fall back to the leg summary (populated in
-    // TripLegBuilder from the edges themselves) so the flags are correct regardless of
-    // directions_type. See https://github.com/valhalla/valhalla/issues/6151
     writer("has_toll", has_toll || directions_leg.summary().has_toll());
     writer("has_highway", has_highway || directions_leg.summary().has_highway());
     writer("has_ferry", has_ferry || directions_leg.summary().has_ferry());

--- a/src/tyr/route_serializer_valhalla.cc
+++ b/src/tyr/route_serializer_valhalla.cc
@@ -642,9 +642,13 @@ void legs(valhalla::Api& api, int route_index, rapidjson::writer_wrapper_t& writ
     }
 
     writer("has_time_restrictions", has_time_restrictions);
-    writer("has_toll", has_toll);
-    writer("has_highway", has_highway);
-    writer("has_ferry", has_ferry);
+    // The has_toll/has_highway/has_ferry booleans above are accumulated from the maneuvers, which
+    // don't exist when directions_type is "none". Fall back to the leg summary (populated in
+    // TripLegBuilder from the edges themselves) so the flags are correct regardless of
+    // directions_type. See https://github.com/valhalla/valhalla/issues/6151
+    writer("has_toll", has_toll || directions_leg.summary().has_toll());
+    writer("has_highway", has_highway || directions_leg.summary().has_highway());
+    writer("has_ferry", has_ferry || directions_leg.summary().has_ferry());
     writer.set_precision(tyr::kCoordinatePrecision);
     writer("min_lat", directions_leg.summary().bbox().min_ll().lat());
     writer("min_lon", directions_leg.summary().bbox().min_ll().lng());

--- a/test/gurka/test_route_summary.cc
+++ b/test/gurka/test_route_summary.cc
@@ -267,9 +267,6 @@ TEST(Standalone, TripLegSummary) {
   EXPECT_TRUE(summary["has_toll"].GetBool());
   EXPECT_TRUE(summary["has_ferry"].GetBool());
 
-  // The per-leg JSON flags must match the leg summary regardless of directions_type. With
-  // directions_type "none" there are no maneuvers to accumulate from, so these come from the leg
-  // summary. See https://github.com/valhalla/valhalla/issues/6151
   auto leg_none = trip["legs"].GetArray()[0]["summary"].GetObject();
   EXPECT_TRUE(leg_none["has_highway"].GetBool());
   EXPECT_TRUE(leg_none["has_toll"].GetBool());

--- a/test/gurka/test_route_summary.cc
+++ b/test/gurka/test_route_summary.cc
@@ -266,6 +266,14 @@ TEST(Standalone, TripLegSummary) {
   EXPECT_TRUE(summary["has_highway"].GetBool());
   EXPECT_TRUE(summary["has_toll"].GetBool());
   EXPECT_TRUE(summary["has_ferry"].GetBool());
+
+  // The per-leg JSON flags must match the leg summary regardless of directions_type. With
+  // directions_type "none" there are no maneuvers to accumulate from, so these come from the leg
+  // summary. See https://github.com/valhalla/valhalla/issues/6151
+  auto leg_none = trip["legs"].GetArray()[0]["summary"].GetObject();
+  EXPECT_TRUE(leg_none["has_highway"].GetBool());
+  EXPECT_TRUE(leg_none["has_toll"].GetBool());
+  EXPECT_TRUE(leg_none["has_ferry"].GetBool());
   result_json.erase();
 
   valhalla::Api result4 = gurka::do_action(valhalla::Options::route, map, {"A", "D"}, "auto",
@@ -281,6 +289,11 @@ TEST(Standalone, TripLegSummary) {
   EXPECT_TRUE(summary["has_highway"].GetBool());
   EXPECT_TRUE(summary["has_toll"].GetBool());
   EXPECT_TRUE(summary["has_ferry"].GetBool());
+
+  auto leg_maneuvers = trip["legs"].GetArray()[0]["summary"].GetObject();
+  EXPECT_TRUE(leg_maneuvers["has_highway"].GetBool());
+  EXPECT_TRUE(leg_maneuvers["has_toll"].GetBool());
+  EXPECT_TRUE(leg_maneuvers["has_ferry"].GetBool());
 
   std::filesystem::remove_all(workdir);
 }


### PR DESCRIPTION
# Issue

Fixes #6151

The per-leg `has_toll` / `has_highway` / `has_ferry` flags in the Valhalla JSON response are always `false` when routing with `directions_type=none`, even though the leg's path uses a toll road / highway / ferry. The trip-total summary reports them correctly, so the two disagree for the same path.

## Cause

In the Valhalla JSON serializer, the per-leg flags are accumulated by iterating over the leg's maneuvers (`route_serializer_valhalla.cc`). With `directions_type=none` no maneuvers are generated, so the accumulated flags stay `false`. The trip-total summary is unaffected because it already reads the leg `Summary` populated by `TripLegBuilder` (added in #4706), directly from the edges.

## Fix

Fall back to that same leg summary for the per-leg flags:

```cpp
writer("has_toll", has_toll || directions_leg.summary().has_toll());
writer("has_highway", has_highway || directions_leg.summary().has_highway());
writer("has_ferry", has_ferry || directions_leg.summary().has_ferry());
```

This keeps the maneuver-derived values for the `directions_type=maneuvers`/`instructions` cases and adds the summary as the source of truth so the flags are correct regardless of `directions_type`.

## Tasklist

 - [x] Add tests — extended `Standalone.TripLegSummary` to assert the **per-leg JSON** flags for both `directions_type=none` and `maneuvers`. Verified the test fails without the serializer change and passes with it.
 - [x] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described — no request parameters changed; this only corrects existing output.
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too — n/a
 - [ ] If you made changes to a translation file, [update transifex](docs/docs/locales.md) too — n/a

## Requirements / Relations

Follow-up to #4706, which fixed the same flags on the proto leg `Summary` but did not update the Valhalla JSON serializer's per-leg output.
