### PR TITLE
Fix tile api reference for directional attributes

### DIFF
--- a/docs/docs/api/tile/api-reference.md
+++ b/docs/docs/api/tile/api-reference.md
@@ -1,11 +1,11 @@
 # Valhalla tile service API reference [BETA]
 
-Valhalla's `/tile` service provides a graph representation as [Mapbox Vector Tiles](https://docs.mapbox.com/data/tilesets/guides/vector-tiles-introduction/) (MVT). Currently the tiles contain 5 layers: 
+Valhalla's `/tile` service provides a graph representation as [Mapbox Vector Tiles](https://docs.mapbox.com/data/tilesets/guides/vector-tiles-introduction/) (MVT). Currently the tiles contain 5 layers:
  - edges
  - nodes
- - shortcuts 
- - access restrictions 
- - incidents  
+ - shortcuts
+ - access restrictions
+ - incidents
 
 with a lot of attributes (akin to [`verbose` /locate](../locate/api-reference.md) requests). It's under active development, hence the BETA label.
 
@@ -31,7 +31,7 @@ We support the usual GET & POST with the common "Slippy Map"/XYZ request pattern
 
 While we're re-using the same code as for `trace_attributes`, we don't support the full list for the tile endpoint and added some which are not implemented for `trace_attributes`. If not specified otherwise, the meaning of the attribute values is either trivial or available at https://valhalla.github.io/valhalla/api/map-matching/api-reference/#edge-items. `access` attributes are returning the numeric representation of a bit mask which needs to be decoded, see https://github.com/valhalla/valhalla/blob/c5151e19f65c3b498aa606a9cc9d6d274fba11bc/valhalla/baldr/graphconstants.h#L37-L47, e.g. a value of 1033 (`0b10000001001`) indicates `auto`, `truck` and `motorcycle` access etc.
 
-Note that `fwd`/`bwd` refer to the direction drawn in OSM and can be replaced in `<direction>`:
+Note that `forward`/`backward` refer to the direction drawn in OSM and can be replaced in `<direction>`:
 
 ```
 // bidirectional attributes


### PR DESCRIPTION
# Issue

The tile api reference say to replace `<direction>` with `fwd/bwd`, but should be `forward/backward` instead. e. g. `edge.speed_forward`, though in the tile the attribute is written as `speed:fwd`, maybe that's worth pointing out, too.

https://github.com/valhalla/valhalla/blob/d010c641f867a24dbcf5bb76d32800b42d25854d/docs/docs/api/tile/api-reference.md#L34
https://github.com/valhalla/valhalla/blob/d010c641f867a24dbcf5bb76d32800b42d25854d/docs/docs/api/tile/api-reference.md#L77-L78
In the tests it is used correctly:
https://github.com/valhalla/valhalla/blob/d010c641f867a24dbcf5bb76d32800b42d25854d/test/gurka/test_vector_tiles.cc#L561

## Tasklist

 - [x] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
