### PR TITLE
feat(python): add writer functions to graphtileheader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * **Bug Fix**
    * FIXED: Python `get_config()` raised `KeyError('logging')` since 3.7.0 by writing the removed `mjolnir.logging` key after logging config moved to the top level in #5976 [#6185](https://github.com/valhalla/valhalla/pull/6185)
 * **Enhancement**
+   * ADDED: write support for metadata fields in graph tile headers in the python bindings [#6194](https://github.com/valhalla/valhalla/pull/6194)
 
 ## Release Date: 2026-07-06 Valhalla 3.8.1
 * **Removed**

--- a/src/bindings/python/src/baldr/graph_tile_header.cc
+++ b/src/bindings/python/src/baldr/graph_tile_header.cc
@@ -2,20 +2,71 @@
 #include "module.h"
 
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/filesystem.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/tuple.h>
 
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
 #include <string>
 
 namespace nb = nanobind;
 namespace vb = valhalla::baldr;
+
+namespace {
+
+constexpr size_t kHeaderSize = sizeof(vb::GraphTileHeader);
+
+vb::GraphTileHeader from_bytes(const uint8_t* data, size_t size) {
+  if (size < kHeaderSize)
+    throw std::invalid_argument("buffer too small for a graph tile header (" + std::to_string(size) +
+                                " < " + std::to_string(kHeaderSize) + ")");
+  vb::GraphTileHeader h;
+  std::memcpy(&h, data, kHeaderSize);
+  return h;
+}
+
+vb::GraphTileHeader from_file(const std::filesystem::path& path) {
+  std::ifstream in(path, std::ios::binary);
+  if (!in)
+    throw std::runtime_error("cannot open " + path.string());
+  uint8_t buf[kHeaderSize];
+  in.read(reinterpret_cast<char*>(buf), kHeaderSize);
+  if (static_cast<size_t>(in.gcount()) < kHeaderSize)
+    throw std::invalid_argument("file too small for a graph tile header: " + path.string());
+  return from_bytes(buf, kHeaderSize);
+}
+
+void save(const vb::GraphTileHeader& h, const std::filesystem::path& path) {
+  // Patch an existing tile's header in place — never create or grow a file:
+  // a header without tile data behind it is not a tile.
+  std::error_code ec;
+  const auto size = std::filesystem::file_size(path, ec);
+  if (ec || size < kHeaderSize)
+    throw std::invalid_argument("not an existing graph tile file: " + path.string());
+  std::fstream out(path, std::ios::binary | std::ios::in | std::ios::out);
+  if (!out)
+    throw std::runtime_error("cannot open " + path.string());
+  out.write(reinterpret_cast<const char*>(&h), kHeaderSize);
+  if (!out)
+    throw std::runtime_error("failed writing " + path.string());
+}
+
+} // namespace
 
 namespace pyvalhalla::baldr {
 
 void init_graphtileheader(nb::module_& m) {
   nb::class_<vb::GraphTileHeader>(
       m, "GraphTileHeader",
-      "Read-only information about a graph tile. Obtain one via GraphUtils.get_graph_tile_header().")
+      "Header of a graph tile. Read one via GraphUtils.get_graph_tile_header(), from_file() or "
+      "from_bytes(), or default-construct one. The tileset identity fields (dataset_id, "
+      "date_created, raw_checksum) are writable; everything else is read-only — it identifies "
+      "the tile or is derived from its data. save() patches the header span of an existing tile "
+      "file in place.")
+      .def(nb::init<>())
       .def_prop_ro("graphid", &vb::GraphTileHeader::graphid,
                    "GraphId (tile id + level) of this tile.")
       .def_prop_ro(
@@ -26,8 +77,20 @@ void init_graphtileheader(nb::module_& m) {
           },
           "(lon, lat) of the tile's south-western corner, in degrees.")
       .def_prop_ro("version", &vb::GraphTileHeader::version, "Tile format version string.")
-      .def_prop_ro("dataset_id", &vb::GraphTileHeader::dataset_id,
+      .def_prop_rw("dataset_id", &vb::GraphTileHeader::dataset_id,
+                   &vb::GraphTileHeader::set_dataset_id,
                    "Data set id (e.g. latest OSM changeset id).")
+      .def_prop_rw("date_created", &vb::GraphTileHeader::date_created,
+                   &vb::GraphTileHeader::set_date_created,
+                   "Tile creation date (days since the pivot date).")
+      .def_prop_rw(
+          "raw_checksum",
+          [](const vb::GraphTileHeader& h) {
+            return (static_cast<uint64_t>(h.build_id()) << vb::kTileHashBits) | h.tile_checksum();
+          },
+          &vb::GraphTileHeader::set_raw_checksum,
+          "Raw 64-bit checksum field: tileset build id in the high 16 bits, the tile's 48-bit "
+          "data hash in the low bits. See also the derived tile_checksum and build_id.")
       .def_prop_ro("density", &vb::GraphTileHeader::density, "Relative road density (0-15).")
       .def_prop_ro("has_elevation", &vb::GraphTileHeader::has_elevation,
                    "True if the tile carries edge elevation data.")
@@ -56,13 +119,31 @@ void init_graphtileheader(nb::module_& m) {
                    "Number of transit schedules.")
       .def_prop_ro("transfercount", &vb::GraphTileHeader::transfercount,
                    "Number of transit transfers.")
-      .def_prop_ro("date_created", &vb::GraphTileHeader::date_created,
-                   "Tile creation date (days since the pivot date).")
       .def_prop_ro("end_offset", &vb::GraphTileHeader::end_offset, "Tile size in bytes.")
       .def_prop_ro("tile_checksum", &vb::GraphTileHeader::tile_checksum,
                    "Integer checksum (48 bit) of the tile's data.")
       .def_prop_ro("build_id", &vb::GraphTileHeader::build_id,
                    "Integer additive checksum (16 bit) of the tileset.")
+      .def_static(
+          "byte_size", []() { return kHeaderSize; },
+          "Size of the on-disk header in bytes (the header span at the start of a tile).")
+      .def_static(
+          "from_bytes",
+          [](nb::bytes data) {
+            return from_bytes(reinterpret_cast<const uint8_t*>(data.c_str()), data.size());
+          },
+          nb::arg("data"),
+          "Read a header from a buffer (a whole tile or just its first byte_size() bytes).")
+      .def_static("from_file", &from_file, nb::arg("path"), "Read the header of a graph tile file.")
+      .def(
+          "to_bytes",
+          [](const vb::GraphTileHeader& h) {
+            return nb::bytes(reinterpret_cast<const char*>(&h), kHeaderSize);
+          },
+          "Serialize the header to its byte_size() on-disk bytes.")
+      .def("save", &save, nb::arg("path"),
+           "Patch this header over the header span of an existing graph tile file, in place. "
+           "The file must already exist and hold at least byte_size() bytes.")
       .def("__repr__", [](const vb::GraphTileHeader& h) {
         return "<GraphTileHeader " + std::to_string(h.graphid()) +
                " nodes=" + std::to_string(h.nodecount()) +

--- a/src/bindings/python/src/baldr/graph_tile_header.cc
+++ b/src/bindings/python/src/baldr/graph_tile_header.cc
@@ -120,10 +120,22 @@ void init_graphtileheader(nb::module_& m) {
       .def_prop_ro("transfercount", &vb::GraphTileHeader::transfercount,
                    "Number of transit transfers.")
       .def_prop_ro("end_offset", &vb::GraphTileHeader::end_offset, "Tile size in bytes.")
-      .def_prop_ro("tile_checksum", &vb::GraphTileHeader::tile_checksum,
-                   "Integer checksum (48 bit) of the tile's data.")
-      .def_prop_ro("build_id", &vb::GraphTileHeader::build_id,
-                   "Integer additive checksum (16 bit) of the tileset.")
+      .def_prop_rw(
+          "tile_checksum", &vb::GraphTileHeader::tile_checksum,
+          [](vb::GraphTileHeader& h, uint64_t checksum) {
+            if (checksum >> vb::kTileHashBits)
+              throw std::invalid_argument("tile_checksum exceeds 48 bits");
+            h.set_raw_checksum((static_cast<uint64_t>(h.build_id()) << vb::kTileHashBits) | checksum);
+          },
+          "Integer checksum (48 bit) of the tile's data. Setting it keeps the build_id.")
+      .def_prop_rw(
+          "build_id", &vb::GraphTileHeader::build_id,
+          [](vb::GraphTileHeader& h, uint16_t build_id) {
+            h.set_raw_checksum((static_cast<uint64_t>(build_id) << vb::kTileHashBits) |
+                               h.tile_checksum());
+          },
+          "Integer additive checksum (16 bit) of the tileset. Setting it keeps the "
+          "tile_checksum.")
       .def_static(
           "byte_size", []() { return kHeaderSize; },
           "Size of the on-disk header in bytes (the header span at the start of a tile).")

--- a/src/bindings/python/valhalla/_valhalla.pyi
+++ b/src/bindings/python/valhalla/_valhalla.pyi
@@ -3,6 +3,7 @@
 # See src/bindings/python/README.md ("Type stubs") for the regeneration workflow.
 
 from collections.abc import Sequence
+import os
 from typing import Annotated, overload
 
 import numpy
@@ -131,8 +132,10 @@ class GraphId:
 
 class GraphTileHeader:
     """
-    Read-only information about a graph tile. Obtain one via GraphUtils.get_graph_tile_header().
+    Header of a graph tile. Read one via GraphUtils.get_graph_tile_header(), from_file() or from_bytes(), or default-construct one. The tileset identity fields (dataset_id, date_created, raw_checksum) are writable; everything else is read-only — it identifies the tile or is derived from its data. save() patches the header span of an existing tile file in place.
     """
+
+    def __init__(self) -> None: ...
 
     @property
     def graphid(self) -> GraphId:
@@ -149,6 +152,25 @@ class GraphTileHeader:
     @property
     def dataset_id(self) -> int:
         """Data set id (e.g. latest OSM changeset id)."""
+
+    @dataset_id.setter
+    def dataset_id(self, arg: int, /) -> None: ...
+
+    @property
+    def date_created(self) -> int:
+        """Tile creation date (days since the pivot date)."""
+
+    @date_created.setter
+    def date_created(self, arg: int, /) -> None: ...
+
+    @property
+    def raw_checksum(self) -> int:
+        """
+        Raw 64-bit checksum field: tileset build id in the high 16 bits, the tile's 48-bit data hash in the low bits. See also the derived tile_checksum and build_id.
+        """
+
+    @raw_checksum.setter
+    def raw_checksum(self, arg: int, /) -> None: ...
 
     @property
     def density(self) -> int:
@@ -219,10 +241,6 @@ class GraphTileHeader:
         """Number of transit transfers."""
 
     @property
-    def date_created(self) -> int:
-        """Tile creation date (days since the pivot date)."""
-
-    @property
     def end_offset(self) -> int:
         """Tile size in bytes."""
 
@@ -233,6 +251,30 @@ class GraphTileHeader:
     @property
     def build_id(self) -> int:
         """Integer additive checksum (16 bit) of the tileset."""
+
+    @staticmethod
+    def byte_size() -> int:
+        """
+        Size of the on-disk header in bytes (the header span at the start of a tile).
+        """
+
+    @staticmethod
+    def from_bytes(data: bytes) -> GraphTileHeader:
+        """
+        Read a header from a buffer (a whole tile or just its first byte_size() bytes).
+        """
+
+    @staticmethod
+    def from_file(path: str | os.PathLike) -> GraphTileHeader:
+        """Read the header of a graph tile file."""
+
+    def to_bytes(self) -> bytes:
+        """Serialize the header to its byte_size() on-disk bytes."""
+
+    def save(self, path: str | os.PathLike) -> None:
+        """
+        Patch this header over the header span of an existing graph tile file, in place. The file must already exist and hold at least byte_size() bytes.
+        """
 
     def __repr__(self) -> str: ...
 

--- a/src/bindings/python/valhalla/_valhalla.pyi
+++ b/src/bindings/python/valhalla/_valhalla.pyi
@@ -246,11 +246,21 @@ class GraphTileHeader:
 
     @property
     def tile_checksum(self) -> int:
-        """Integer checksum (48 bit) of the tile's data."""
+        """
+        Integer checksum (48 bit) of the tile's data. Setting it keeps the build_id.
+        """
+
+    @tile_checksum.setter
+    def tile_checksum(self, arg: int, /) -> None: ...
 
     @property
     def build_id(self) -> int:
-        """Integer additive checksum (16 bit) of the tileset."""
+        """
+        Integer additive checksum (16 bit) of the tileset. Setting it keeps the tile_checksum.
+        """
+
+    @build_id.setter
+    def build_id(self, arg: int, /) -> None: ...
 
     @staticmethod
     def byte_size() -> int:

--- a/test/bindings/python/test_graph_tile_header.py
+++ b/test/bindings/python/test_graph_tile_header.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from valhalla.baldr import GraphId, GraphTileHeader
+
+# Real header values.
+DATASET_ID = 13283935569
+TILE_CHECKSUM = 26351030317371
+BUILD_ID = 25426
+RAW_CHECKSUM = (BUILD_ID << 48) | TILE_CHECKSUM
+
+
+def make_header() -> GraphTileHeader:
+    h = GraphTileHeader()
+    h.dataset_id = DATASET_ID
+    h.date_created = 20276
+    h.raw_checksum = RAW_CHECKSUM
+    return h
+
+
+class TestGraphTileHeaderBuilder(unittest.TestCase):
+    """GraphTileHeader as a standalone, mutable value class with I/O.
+
+    Only the tileset identity fields are writable (dataset_id, date_created,
+    raw_checksum) — everything else identifies the tile or is derived from its
+    contents and stays read-only.
+    """
+
+    def test_default_constructible_and_mutable(self):
+        h = make_header()
+        # the default constructor stamps the library's own tile version
+        self.assertTrue(h.version)
+        self.assertEqual(h.dataset_id, DATASET_ID)
+        self.assertEqual(h.date_created, 20276)
+        # raw_checksum splits into the two derived read-only views
+        self.assertEqual(h.raw_checksum, RAW_CHECKSUM)
+        self.assertEqual(h.tile_checksum, TILE_CHECKSUM)
+        self.assertEqual(h.build_id, BUILD_ID)
+
+    def test_everything_else_stays_read_only(self):
+        h = GraphTileHeader()
+        for attr, value in (
+            ("graphid", GraphId(820135, 2, 0)),
+            ("base_ll", (13.25, 52.5)),
+            ("version", "9.9.9"),
+            ("nodecount", 1),
+            ("directededgecount", 1),
+        ):
+            with self.assertRaises(AttributeError, msg=attr):
+                setattr(h, attr, value)
+
+    def test_bytes_roundtrip(self):
+        h = make_header()
+        buf = h.to_bytes()
+        self.assertEqual(len(buf), GraphTileHeader.byte_size())
+
+        h2 = GraphTileHeader.from_bytes(buf)
+        self.assertEqual(h2.graphid, h.graphid)
+        self.assertEqual(h2.version, h.version)
+        self.assertEqual(h2.dataset_id, h.dataset_id)
+        self.assertEqual(h2.date_created, h.date_created)
+        self.assertEqual(h2.raw_checksum, h.raw_checksum)
+        self.assertEqual(h2.to_bytes(), buf)
+
+    def test_from_bytes_accepts_a_whole_tile_buffer(self):
+        # A tile file is header + payload; from_bytes must only look at the
+        # header span so callers can hand it a full tile they hold in memory.
+        buf = make_header().to_bytes() + b"\xab" * 4096
+        h = GraphTileHeader.from_bytes(buf)
+        self.assertEqual(h.dataset_id, DATASET_ID)
+
+    def test_file_roundtrip_touches_only_the_header(self):
+        payload = bytes(range(256)) * 16
+        with tempfile.TemporaryDirectory() as td:
+            tile = Path(td) / "135.gph"
+            tile.write_bytes(make_header().to_bytes() + payload)
+
+            # the normalize/stamp shape: load, mutate ids, save in place
+            h = GraphTileHeader.from_file(tile)
+            h.dataset_id = 0
+            h.raw_checksum = h.tile_checksum  # zero the build id, keep the hash
+            h.save(tile)
+
+            reread = GraphTileHeader.from_file(tile)
+            self.assertEqual(reread.dataset_id, 0)
+            self.assertEqual(reread.build_id, 0)
+            self.assertEqual(reread.tile_checksum, TILE_CHECKSUM)
+            self.assertEqual(reread.version, GraphTileHeader().version)
+            # payload untouched, file size unchanged
+            data = tile.read_bytes()
+            self.assertEqual(len(data), GraphTileHeader.byte_size() + len(payload))
+            self.assertEqual(data[GraphTileHeader.byte_size() :], payload)
+
+    def test_short_buffer_refused(self):
+        with self.assertRaises(ValueError):
+            GraphTileHeader.from_bytes(b"\x00" * 16)
+
+    def test_short_or_missing_file_refused(self):
+        with tempfile.TemporaryDirectory() as td:
+            stub = Path(td) / "stub.gph"
+            stub.write_bytes(b"\x00" * 16)
+            with self.assertRaises(ValueError):
+                GraphTileHeader.from_file(stub)
+            # save must never grow/create a file: it patches an existing tile
+            with self.assertRaises(ValueError):
+                make_header().save(stub)
+            with self.assertRaises((RuntimeError, ValueError)):
+                GraphTileHeader.from_file(Path(td) / "missing.gph")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/bindings/python/test_graph_tile_header.py
+++ b/test/bindings/python/test_graph_tile_header.py
@@ -40,6 +40,28 @@ class TestGraphTileHeaderBuilder(unittest.TestCase):
         self.assertEqual(h.tile_checksum, TILE_CHECKSUM)
         self.assertEqual(h.build_id, BUILD_ID)
 
+    def test_checksum_convenience_setters_keep_the_other_half(self):
+        h = make_header()
+        h.build_id = 0  # the normalize shape
+        self.assertEqual(h.build_id, 0)
+        self.assertEqual(h.tile_checksum, TILE_CHECKSUM)
+
+        h.build_id = BUILD_ID  # the stamp shape
+        self.assertEqual(h.raw_checksum, RAW_CHECKSUM)
+
+        h.tile_checksum = 1234
+        self.assertEqual(h.tile_checksum, 1234)
+        self.assertEqual(h.build_id, BUILD_ID)
+
+    def test_checksum_setters_range_checked(self):
+        h = make_header()
+        with self.assertRaises(ValueError):
+            h.tile_checksum = 1 << 48  # more than the 48 hash bits
+        with self.assertRaises((TypeError, ValueError, OverflowError)):
+            h.build_id = 1 << 16  # more than the 16 build id bits
+        # failed sets must not have clobbered anything
+        self.assertEqual(h.raw_checksum, RAW_CHECKSUM)
+
     def test_everything_else_stays_read_only(self):
         h = GraphTileHeader()
         for attr, value in (
@@ -81,7 +103,7 @@ class TestGraphTileHeaderBuilder(unittest.TestCase):
             # the normalize/stamp shape: load, mutate ids, save in place
             h = GraphTileHeader.from_file(tile)
             h.dataset_id = 0
-            h.raw_checksum = h.tile_checksum  # zero the build id, keep the hash
+            h.build_id = 0  # keeps the tile_checksum
             h.save(tile)
 
             reread = GraphTileHeader.from_file(tile)


### PR DESCRIPTION
I needed to be able to set the `dataset_id` etc via the python bindings ideally. in summary:

- makes a few field r/w:
  - `dataset_id`
  - `date_created` (new)
  - `raw_checksum` (new)
  - `tile_checksum` (new)
  - `build_id` (new)
- adds `from_bytes()` & `from_file()` factories
- adds `byte_size` to give back its current width
- `save()` to patch the header of an existing tile file