### PR TITLE
Bucket surface=laterite and surface=clay with mud/dirt/earth/ground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 * **Removed**
 * **Bug Fix**
 * **Enhancement**
-   * ADDED: classify `surface=laterite` and `surface=clay` as `Surface::kDirt` [#6171](https://github.com/valhalla/valhalla/issues/6171)
    * UPDATED: timezone database to 2026c [#6199](https://github.com/valhalla/valhalla/pull/6199)
    * ADDED: `GraphReader::GetGraphTileHeader` to read just a tile's header without loading the tile [#6200](https://github.com/valhalla/valhalla/pull/6200)
    * FIXED: use the new `GraphReader::GetGraphTileHeader` in `baldr/utils/graph_reader.cc:get_graph_tile_header` to prevent loading entire tiles into RAM [#6200](https://github.com/valhalla/valhalla/pull/6200)
+   * ADDED: classify `surface=laterite` and `surface=clay` as `Surface::kDirt` [#6171](https://github.com/valhalla/valhalla/issues/6171)
 
 ## Release Date: 2026-07-08 Valhalla 3.8.2
 * **Removed**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## UNRELEASED
 * **Removed**
 * **Bug Fix**
-   * FIXED: `surface=laterite` and `surface=clay` fell through the graph parser's surface substring-match chain unclassified (`has_surface_ = false`) instead of being bucketed with `dirt`/`earth`/`ground`/`mud` [#6171](https://github.com/valhalla/valhalla/issues/6171)
 * **Enhancement**
+   * ADDED: classify `surface=laterite` and `surface=clay` as `Surface::kDirt` [#6171](https://github.com/valhalla/valhalla/issues/6171)
    * UPDATED: timezone database to 2026c [#6199](https://github.com/valhalla/valhalla/pull/6199)
    * ADDED: `GraphReader::GetGraphTileHeader` to read just a tile's header without loading the tile [#6200](https://github.com/valhalla/valhalla/pull/6200)
    * FIXED: use the new `GraphReader::GetGraphTileHeader` in `baldr/utils/graph_reader.cc:get_graph_tile_header` to prevent loading entire tiles into RAM [#6200](https://github.com/valhalla/valhalla/pull/6200)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## UNRELEASED
 * **Removed**
 * **Bug Fix**
+   * FIXED: `surface=laterite` and `surface=clay` fell through the graph parser's surface substring-match chain unclassified (`has_surface_ = false`) instead of being bucketed with `dirt`/`earth`/`ground`/`mud` [#6171](https://github.com/valhalla/valhalla/issues/6171)
 * **Enhancement**
    * UPDATED: timezone database to 2026c [#6199](https://github.com/valhalla/valhalla/pull/6199)
    * ADDED: `GraphReader::GetGraphTileHeader` to read just a tile's header without loading the tile [#6200](https://github.com/valhalla/valhalla/pull/6200)

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -1515,7 +1515,9 @@ struct graph_parser {
                  value.find("natural") != std::string::npos ||
                  value.find("earth") != std::string::npos ||
                  value.find("ground") != std::string::npos ||
-                 value.find("mud") != std::string::npos) {
+                 value.find("mud") != std::string::npos ||
+                 value.find("clay") != std::string::npos ||
+                 value.find("laterite") != std::string::npos) {
         way_.set_surface(Surface::kDirt);
 
       } else if (value.find("gravel") != std::string::npos || // gravel, fine_gravel

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -1515,8 +1515,7 @@ struct graph_parser {
                  value.find("natural") != std::string::npos ||
                  value.find("earth") != std::string::npos ||
                  value.find("ground") != std::string::npos ||
-                 value.find("mud") != std::string::npos ||
-                 value.find("clay") != std::string::npos ||
+                 value.find("mud") != std::string::npos || value.find("clay") != std::string::npos ||
                  value.find("laterite") != std::string::npos) {
         way_.set_surface(Surface::kDirt);
 

--- a/test/gurka/test_parse_osm.cc
+++ b/test/gurka/test_parse_osm.cc
@@ -49,6 +49,27 @@ TEST(ParseWays, OsmWayMarshalling) {
   EXPECT_EQ(tossed.speed_limit(), 0);
 }
 
+TEST(ParseWays, SurfaceLateriteAndClay) {
+  const std::string ascii_map = R"(A----B----C----D)";
+  const gurka::ways ways = {
+      {"AB", {{"highway", "residential"}, {"surface", "laterite"}}},
+      {"BC", {{"highway", "residential"}, {"surface", "clay"}}},
+      {"CD", {{"highway", "residential"}, {"surface", "mud"}}},
+  };
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100);
+
+  // stop after parsing ways so we can assert on the raw OSMWay structs
+  auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_parse_ways_surface",
+                               {{"mjolnir.concurrency", "1"}}, mjolnir::BuildStage::kInitialize,
+                               mjolnir::BuildStage::kParseWays);
+
+  // laterite and clay should fall into the same bucket as mud/dirt/earth/ground
+  // rather than being left unclassified (has_surface_ == false)
+  EXPECT_EQ(gurka::findWay(map, "AB").surface(), baldr::Surface::kDirt);
+  EXPECT_EQ(gurka::findWay(map, "BC").surface(), baldr::Surface::kDirt);
+  EXPECT_EQ(gurka::findWay(map, "CD").surface(), baldr::Surface::kDirt);
+}
+
 TEST(ParseNodes, TwoPhaseWayNodesFill) {
   const std::string ascii_map = R"(
     A----B----C


### PR DESCRIPTION
## Summary

Follows up on the classification gap I flagged in [#6171](https://github.com/valhalla/valhalla/issues/6171): `surface=laterite` and `surface=clay` don't match any branch in the [`surface` tag handler's](https://github.com/valhalla/valhalla/blob/master/src/mjolnir/pbfgraphparser.cc#L1480-L1532) substring-match chain, so they fall through to `has_surface_ = false` and get a road-class-based default guess instead of any real surface classification.

This PR is the minimal fix: both values now match the same branch as `mud`/`dirt`/`earth`/`ground` → `Surface::kDirt`.

A finer-grained bucket for the wet-condition-risk surfaces (`mud`/`clay`/`laterite` split off from the merely-firm `dirt`/`earth`/`ground`) was also discussed in the issue thread, but that's a separate, bigger design question (touches costing weights, not just classification) and isn't part of this PR. Not waiting on that discussion to land this smaller, uncontroversial fix.

## Test plan
- [x] Added `ParseWays.SurfaceLateriteAndClay` in `test/gurka/test_parse_osm.cc`, asserting `laterite`, `clay`, and `mud` all classify to `Surface::kDirt`
- [x] Verified the exact substring-matching logic in isolation (no other existing surface values shift buckets)
- [ ] Full project build wasn't run locally (missing `spatialite-tools` in this environment); relying on CI to run the gurka suite