### PR TITLE
fix(odin): guard past-the-end std::list deref in ProcessTurnLanes (#6170)

### DIFF
--- a/src/odin/maneuversbuilder.cc
+++ b/src/odin/maneuversbuilder.cc
@@ -3605,6 +3605,15 @@ void ManeuversBuilder::ProcessTurnLanes(std::list<Maneuver>& maneuvers) {
     // Only process driving maneuvers
     if (curr_man->travel_mode() == TravelMode::kDrive) {
 
+      // The destination maneuver of a driving route is itself kDrive, and
+      // curr_man / next_man advance in lockstep, so when curr_man reaches the
+      // final maneuver next_man == end(). Read the next maneuver's type only
+      // when a next maneuver exists; for the final maneuver use the kNone
+      // sentinel instead of dereferencing end() (past-the-end read).
+      const DirectionsLeg_Maneuver_Type next_maneuver_type =
+          (next_man != maneuvers.end()) ? next_man->type()
+                                        : DirectionsLeg_Maneuver_Type_kNone;
+
       // Walk maneuvers by node (prev_edge of node has the turn lane info)
       // Assign turn lane at transition point
       auto prev_edge = trip_path_->GetPrevEdge(curr_man->begin_node_index());
@@ -3615,7 +3624,7 @@ void ManeuversBuilder::ProcessTurnLanes(std::list<Maneuver>& maneuvers) {
                (curr_man->type() == DirectionsLeg_Maneuver_Type_kStayRight) ||
                (curr_man->type() == DirectionsLeg_Maneuver_Type_kStayStraight)))) {
           prev_edge->ActivateTurnLanes(GetExpectedTurnLaneDirection(prev_edge, *(curr_man)),
-                                       curr_man->length(), curr_man->type(), next_man->type());
+                                       curr_man->length(), curr_man->type(), next_maneuver_type);
         }
       }
 
@@ -3660,7 +3669,7 @@ void ManeuversBuilder::ProcessTurnLanes(std::list<Maneuver>& maneuvers) {
                 !has_directional_intersecting_edge && turn_lane_direction != kTurnLaneNone) {
               // Activate lanes matching upcoming turn direction
               prev_edge->ActivateTurnLanes(turn_lane_direction, curr_man->length(), curr_man->type(),
-                                           next_man->type());
+                                           next_maneuver_type);
             } else {
               // Activate through lanes
               prev_edge->ActivateTurnLanes(kTurnLaneThrough, remaining_step_distance,

--- a/test/gurka/test_turn_lanes.cc
+++ b/test/gurka/test_turn_lanes.cc
@@ -1071,3 +1071,68 @@ TEST(Standalone, ShortTurnLanesForks) {
                                {2, "[ through | *slight_right* ACTIVE ]"},
                                {0, ""}});
 }
+
+// Regression guard for issue #6170: ProcessTurnLanes walked curr_man / next_man
+// in lockstep, so on the final (destination) maneuver of a driving route
+// next_man == maneuvers.end(), and the two ActivateTurnLanes(..., next_man->type())
+// calls read past the end of the maneuver list. The destination maneuver of a
+// driving route is itself kDrive, so the "only driving maneuvers" filter did not
+// spare it. The read is silent UB (garbage type, no crash), which is why every
+// pre-existing turn-lane test still passed while the deref was live.
+//
+// This test drives an "auto" route that ends at a destination whose final
+// approach edge carries turn:lanes (including a non-directional "none" lane),
+// forcing ProcessTurnLanes through the next_man == end() iteration, and locks
+// the deterministic turn-lane rendering on that final edge.
+//
+// HONEST BOUND: this is a behaviour-lock / path-exercise test, not a
+// fail-before-the-fix test. At the destination maneuver GetExpectedTurnLaneDirection
+// returns kTurnLaneNone, and ActivateTurnLanes(kTurnLaneNone, ...) can activate
+// no lane (a matching lane makes HasNonDirectionalTurnLane() true -> early return;
+// a non-matching lane simply does not match), so the past-the-end value is dead:
+// garbage and the kNone sentinel yield identical observable output. The value of
+// the test is that it exercises the exact #6170 code path deterministically (it
+// would catch the past-the-end read under a sanitizer/valgrind build, and would
+// catch a future refactor that makes next_maneuver_type live at the destination
+// edge). See PR discussion for the full dataflow analysis.
+TEST(Standalone, TurnLanesDestinationFinalEdge) {
+
+  const std::string ascii_map = R"(
+    A----B----C
+         |
+         D)";
+
+  // Way ABC carries turn:lanes with a non-directional "none" lane; the B->C edge
+  // is the final approach edge to destination C. Way DB feeds the right turn at B.
+  const gurka::ways ways =
+      {{"ABC",
+        {{"highway", "primary"}, {"lanes", "3"}, {"turn:lanes", "through|none|right"}}},
+       {"DB",
+        {{"highway", "primary"},
+         {"lanes:forward", "2"},
+         {"lanes:backward", "0"},
+         {"turn:lanes", "left|right"}}}};
+
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100);
+  auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_turn_lanes_13");
+
+  // Driving route D -> B (right turn) -> C (destination); final edge B->C
+  // carries turn:lanes and arrives at the destination maneuver.
+  auto result = gurka::do_action(valhalla::Options::route, map, {"D", "C"}, "auto");
+
+  gurka::assert::osrm::expect_steps(result, {"DB", "ABC"});
+  gurka::assert::raw::expect_path(result, {"DB", "ABC"});
+
+  // The route must terminate in a destination maneuver -- this is the maneuver on
+  // which next_man == end() and the past-the-end read used to occur.
+  gurka::assert::raw::expect_maneuvers(result, {DirectionsLeg_Maneuver_Type_kStart,
+                                                DirectionsLeg_Maneuver_Type_kRight,
+                                                DirectionsLeg_Maneuver_Type_kDestination});
+
+  // Deterministic turn-lane state. Second entry is the final edge (B->C) arriving
+  // at destination C: no lane is activated there (destination -> kTurnLaneNone).
+  validate_turn_lanes(result, {
+                                  {2, "[ left | *right* ACTIVE ]"},
+                                  {3, "[ through | through | right ]"},
+                              });
+}


### PR DESCRIPTION
Fixes the past-the-end read reported in #6170.

## The bug

`ManeuversBuilder::ProcessTurnLanes` walks the maneuver list with `curr_man` and `next_man` one step apart. When `curr_man` reaches the final (destination) maneuver, `next_man == maneuvers.end()`. The destination maneuver of a driving route is itself `kDrive`, so the "only process driving maneuvers" filter does not stop the two `ActivateTurnLanes(..., next_man->type())` calls (before this change at `maneuversbuilder.cc:3618` and `:3663`) from dereferencing `end()`. It does not crash — it reads the `std::list` sentinel node — so it is silent UB rather than a segfault.

## The fix

Read `next_man->type()` only when a next maneuver exists; for the final maneuver pass `kNone` (the enum's no-maneuver value, already used as a maneuver-type argument elsewhere in this file) instead of dereferencing `end()`:

```cpp
const DirectionsLeg_Maneuver_Type next_maneuver_type =
    (next_man != maneuvers.end()) ? next_man->type()
                                  : DirectionsLeg_Maneuver_Type_kNone;
```

This is behavior-neutral, not merely crash-avoiding. At the destination maneuver the argument is a dead value: `GetExpectedTurnLaneDirection` returns `kTurnLaneNone` for the destination types, so the first `ActivateTurnLanes` call activates no lane, and the second call is guarded by `turn_lane_direction != kTurnLaneNone`, which is false for the destination. So the change replaces undefined garbage with defined behavior without altering any route's turn-lane output. `kNone` reaches `ActivateTurnLanes`'s `default` branch (activate matching lanes from the left) — the same neutral fallthrough the function already uses.

## Verification

- Reproduced by instrumenting the deref site and running `gurka_turn_lanes`: it printed `next_man==end() DEREF curr_type=4 (kDestination) mode=0 (kDrive)` while all tests still passed — confirming the past-the-end read on a driving destination.
- After the fix, the guard path is taken for every final maneuver (destination / destination-left / destination-right) and the turn-lane tests pass.
- `test/maneuversbuilder` (19 tests), `test/enhancedtrippath` (14), `gurka_instructions_uturn`, `gurka_guidance_views`, and `gurka_route_summary` all pass, built with `-Wall -Werror -Wextra` and no warnings.

## Added test

`Standalone.TurnLanesDestinationFinalEdge` exercises a driving route ending at a destination whose final approach edge carries `turn:lanes`. One honest note: because the UB is silent — and, per the analysis above, the value is dead at that maneuver — this test locks the deterministic behavior and exercises the exact `next_man == end()` iteration; it is not a fail-before-the-fix test, though it would flag the past-the-end read under an ASan/valgrind build. The evidence of the bug is the instrumented observation above.

Happy to adjust the sentinel (`kNone` vs. skipping activation for the final maneuver) or inline the const at the call sites if you'd prefer.

---

AI-assisted, reviewed and locally build-verified by a human before submitting (same as our earlier reports).
