### PR TITLE
fix: handle transit edges in Loki reach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## UNRELEASED
 * **Removed**
 * **Bug Fix**
+   * FIXED: guard opposing edge lookup for transit edges in Loki reachability [#6222](https://github.com/valhalla/valhalla/pull/6222)
    * FIXED: embedded route elevation decoding after a mid-edge `through` location [#6202](https://github.com/valhalla/valhalla/issues/6202)
 * **Enhancement**
    * UPDATED: timezone database to 2026c [#6199](https://github.com/valhalla/valhalla/pull/6199)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## UNRELEASED
 * **Removed**
 * **Bug Fix**
-   * FIXED: guard opposing edge lookup for transit edges in Loki reachability [#6222](https://github.com/valhalla/valhalla/pull/6222)
    * FIXED: embedded route elevation decoding after a mid-edge `through` location [#6202](https://github.com/valhalla/valhalla/issues/6202)
+   * FIXED: guard opposing edge lookup for transit edges in Loki reachability [#6222](https://github.com/valhalla/valhalla/pull/6222)
 * **Enhancement**
    * UPDATED: timezone database to 2026c [#6199](https://github.com/valhalla/valhalla/pull/6199)
    * ADDED: `GraphReader::GetGraphTileHeader` to read just a tile's header without loading the tile [#6200](https://github.com/valhalla/valhalla/pull/6200)

--- a/src/loki/reach.cc
+++ b/src/loki/reach.cc
@@ -123,12 +123,14 @@ directed_reach Reach::operator()(const DirectedEdge* edge,
     if (!reader.GetGraphTile(node_id, tile))
       continue;
 
-    for (const auto& edge : tile->GetDirectedEdges(node_id)) {
+    const auto node_tile = tile;
+    auto edge_id = GraphId(node_id.tileid(), node_id.level(), node_tile->node(node_id)->edge_index());
+    for (const auto& edge : node_tile->GetDirectedEdges(node_id)) {
       // get the opposing edge
-      if (!reader.GetGraphTile(edge.endnode(), tile))
+      const auto* opp_edge = reader.GetOpposingEdge(edge_id, tile);
+      ++edge_id;
+      if (!opp_edge)
         continue;
-      const auto* node = tile->node(edge.endnode());
-      const auto* opp_edge = tile->directededge(node->edge_index() + edge.opp_index());
 
       // NOTE: we can go through the end of the restriction because only the start would mark a
       // potential stopping point (maybe a path followed the restriction). We also have to stop

--- a/test/gurka/test_gtfs.cc
+++ b/test/gurka/test_gtfs.cc
@@ -950,6 +950,17 @@ TEST(GtfsExample, MakeTile) {
   EXPECT_EQ(uses[Use::kRail], 3);
 }
 
+TEST(GtfsExample, bicycle_locate) {
+  std::string response;
+  gurka::do_action(valhalla::Options::locate, map, {"1"}, "bicycle", {}, {}, &response);
+
+  rapidjson::Document json;
+  json.Parse(response);
+  ASSERT_FALSE(json.HasParseError());
+  ASSERT_TRUE(json.IsArray());
+  EXPECT_EQ(json.Size(), 1);
+}
+
 TEST(GtfsExample, route_trip1) {
   // here we request with tmrw 05:50 am
   const auto tmrw_time =


### PR DESCRIPTION
Fixes #6217.

We were hitting an out-of-bounds read in `loki::Reach` when computing inbound reachability for bicycle locations. The correlation could place a location on a transit-line edge, but transit edges don't have opposing edges. The old code just did `edge_index + opp_index` directly; if `opp_index` happened to be `kMaxEdgesPerNode`, that would index past the `DirectedEdge` array.

The fix switches to the guarded `GraphReader::GetOpposingEdge` API. Now transit lines without an opposing edge are skipped, and normal road edges keep the existing validation logic.

I also added a GTFS Gurka regression test that exercises bicycle `/locate` near a transit station.

**Verification**

`gurka_gtfs`: 8 tests passed

`reach`: 2 tests passed

Manually tested bicycle `locate`, `route`, `sources_to_targets`, and `isochrone` on the original transit tiles that reproduced the issue.

**Tasklist**

- [x] Add tests
- [x] Add `Fixes #6217`
- [x] No API or request parameter documentation changes required
- [x] No Lua, translation, or taginfo changes required
- [x] No dependent pull requests
