### PR TITLE
fix(loki): clean up search when called multiple times during a worker::work call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * **Bug Fix**
    * FIXED: embedded route elevation decoding after a mid-edge `through` location [#6202](https://github.com/valhalla/valhalla/issues/6202)
    * FIXED: guard opposing edge lookup for transit edges in Loki reachability [#6222](https://github.com/valhalla/valhalla/pull/6222)
+   * FIXED: clear loki search when calling it multiple times [#6231](https://github.com/valhalla/valhalla/pull/6231)
 * **Enhancement**
    * UPDATED: timezone database to 2026c [#6199](https://github.com/valhalla/valhalla/pull/6199)
    * ADDED: `GraphReader::GetGraphTileHeader` to read just a tile's header without loading the tile [#6200](https://github.com/valhalla/valhalla/pull/6200)

--- a/src/loki/locate_action.cc
+++ b/src/loki/locate_action.cc
@@ -32,6 +32,7 @@ std::string loki_worker_t::locate(Api& request) {
     google::protobuf::RepeatedPtrField<Location> start_loc(locations->begin(),
                                                            locations->begin() + 1);
     search_.search(start_loc, mode_costing[static_cast<size_t>(TravelMode::kDrive)]);
+    search_.clear();
     google::protobuf::RepeatedPtrField<Location> end_loc(locations->begin() + 1,
                                                          locations->begin() + 2);
     search_.search(end_loc, mode_costing[static_cast<size_t>(TravelMode::kPedestrian)]);

--- a/src/loki/route_action.cc
+++ b/src/loki/route_action.cc
@@ -141,6 +141,7 @@ void loki_worker_t::route(Api& request) {
       search_.search(start_loc, mode_costing[static_cast<size_t>(TravelMode::kDrive)]);
       google::protobuf::RepeatedPtrField<Location> end_loc(locations->begin() + 1,
                                                            locations->begin() + 2);
+      search_.clear();
       search_.search(end_loc, mode_costing[static_cast<size_t>(TravelMode::kPedestrian)]);
       // merge them again
       locations->at(0).CopyFrom(start_loc.at(0));

--- a/src/loki/worker.cc
+++ b/src/loki/worker.cc
@@ -177,6 +177,7 @@ void loki_worker_t::parse_costing(Api& api, bool allow_none) {
     try {
       parse_locations(options.mutable_exclude_locations(), api);
       search_.search(*options.mutable_exclude_locations(), mode_costing[static_cast<size_t>(mode)]);
+      search_.clear();
       std::unordered_set<uint64_t> avoids;
       auto& co = *options.mutable_costings()->find(options.costing_type())->second.mutable_options();
       for (const auto& result : options.exclude_locations()) {


### PR DESCRIPTION
When I moved the call to `Search::clear` to the worker cleanup, to follow the pattern we use on the graph algorithms, I overlooked we have a few cases where we might call search more than once. 