### PR TITLE
fix(loki): don't advance bounding-circle iterator past the end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## UNRELEASED
 * **Removed**
 * **Bug Fix**
+   * FIXED: don't advance bounding-circle iterator past the end [#6241](https://github.com/valhalla/valhalla/pull/6241)
 * **Enhancement**
    * CHANGED: move `GraphTile::GetTileId` to `GraphId::FromTilePath` as a static factory ctor [#6237](https://github.com/valhalla/valhalla/pull/6237)
 
@@ -62,7 +63,7 @@
    * ADDED: partial gurka tile build and `findWay` & `findWayNodes` gurka lookups for temp .bin files [#6136](https://github.com/valhalla/valhalla/pull/6136)
    * CHANGED: `checksum_` field in GraphTileHeader reflects now global tileset ID & tile data checksum [#6123](https://github.com/valhalla/valhalla/pull/6123)
    * BREAKING: overhauled `pyvalhalla` package layout, some `valhalla.utils` imports will break [#6133](https://github.com/valhalla/valhalla/pull/6133)
-   * ADDED: enabled bounding circles for faster candidate search in `/locate` and `/tile` [#6141/](https://github.com/valhalla/valhalla/pull/6141) 
+   * ADDED: enabled bounding circles for faster candidate search in `/locate` and `/tile` [#6141/](https://github.com/valhalla/valhalla/pull/6141)
    * BREAKING: add `low_class_factor` for truck costing (impacts truck routes) [#6143](https://github.com/valhalla/valhalla/pull/6143)
    * ADDED: `get_graph_tile_header` & `GraphTileHeader` bindings [#6134](https://github.com/valhalla/valhalla/pull/6134)
    * CHANGED: `CostMatrix` reverse trees use time-dependent speeds with `invariant` date_time [#6168](https://github.com/valhalla/valhalla/pull/6168)

--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -603,9 +603,8 @@ struct bin_handler_t {
     bool has_bounding_circles = tile->header()->has_bounding_circles();
     auto edges = tile->GetBin(begin->bin_index);
     auto bounding_circles = tile->GetBoundingCircles(begin->bin_index);
-    size_t edge_index = 0;
-    for (auto edge_it = edges.begin(); edge_it != edges.end(); ++edge_it, ++edge_index) {
-      auto edge_id = *edge_it;
+    for (size_t edge_index = 0; edge_index < edges.size(); ++edge_index) {
+      auto edge_id = edges[edge_index];
       bool all_prefiltered = true;
       std::pair<PointLL, double> circle({0, 0}, 0.);
       if (has_bounding_circles && bounding_circles[edge_index].is_valid())
@@ -1036,9 +1035,8 @@ void Search::edges_in_bounds(const midgard::AABB2<midgard::PointLL>& bounds,
       tile = reader_.GetGraphTile(tileid);
       auto edges = tile->GetBin(bin);
       auto bounding_circles = tile->GetBoundingCircles(bin);
-      size_t edge_index = 0;
-      for (auto edge_it = edges.begin(); edge_it != edges.end(); ++edge_it, ++edge_index) {
-        auto edge_id = *edge_it;
+      for (size_t edge_index = 0; edge_index < edges.size(); ++edge_index) {
+        auto edge_id = edges[edge_index];
         tile = reader_.GetGraphTile(edge_id);
 
         if (!tile)

--- a/src/loki/search.cc
+++ b/src/loki/search.cc
@@ -603,13 +603,13 @@ struct bin_handler_t {
     bool has_bounding_circles = tile->header()->has_bounding_circles();
     auto edges = tile->GetBin(begin->bin_index);
     auto bounding_circles = tile->GetBoundingCircles(begin->bin_index);
-    auto bounding_circle = bounding_circles.begin();
-    for (auto edge_it = edges.begin(); edge_it != edges.end(); ++edge_it, ++bounding_circle) {
+    size_t edge_index = 0;
+    for (auto edge_it = edges.begin(); edge_it != edges.end(); ++edge_it, ++edge_index) {
       auto edge_id = *edge_it;
       bool all_prefiltered = true;
       std::pair<PointLL, double> circle({0, 0}, 0.);
-      if (has_bounding_circles && bounding_circle->is_valid())
-        circle = bounding_circle->get(begin->bin_center_approximator, begin->bin_center);
+      if (has_bounding_circles && bounding_circles[edge_index].is_valid())
+        circle = bounding_circles[edge_index].get(begin->bin_center_approximator, begin->bin_center);
       double radius = circle.second;
 
       // reset the prefiltered flag, in order to not carry over information
@@ -1036,8 +1036,8 @@ void Search::edges_in_bounds(const midgard::AABB2<midgard::PointLL>& bounds,
       tile = reader_.GetGraphTile(tileid);
       auto edges = tile->GetBin(bin);
       auto bounding_circles = tile->GetBoundingCircles(bin);
-      auto bounding_circle = bounding_circles.begin();
-      for (auto edge_it = edges.begin(); edge_it != edges.end(); ++edge_it, ++bounding_circle) {
+      size_t edge_index = 0;
+      for (auto edge_it = edges.begin(); edge_it != edges.end(); ++edge_it, ++edge_index) {
         auto edge_id = *edge_it;
         tile = reader_.GetGraphTile(edge_id);
 
@@ -1045,8 +1045,8 @@ void Search::edges_in_bounds(const midgard::AABB2<midgard::PointLL>& bounds,
           continue;
 
         std::pair<PointLL, double> circle({0, 0}, 0);
-        if (has_bounding_circles && bounding_circle->is_valid())
-          circle = bounding_circle->get(bin_center_approximator, bin_center);
+        if (has_bounding_circles && bounding_circles[edge_index].is_valid())
+          circle = bounding_circles[edge_index].get(bin_center_approximator, bin_center);
         double radius = circle.second;
         if (radius != 0) {
           // we have a circle


### PR DESCRIPTION
# Issue

The bounding circle iterator is unconditionally advanced past the end when no bounding circles are available (`++bounding_circle`), which triggers an assertion in msvc debug build.
 