### PR TITLE
Fix cctype signed char; cast to unsigned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * **Removed**
 * **Bug Fix**
    * FIXED: don't advance bounding-circle iterator past the end [#6241](https://github.com/valhalla/valhalla/pull/6241)
+   * FIXED: fix assertion when checking non-ascii signed char [#6243](https://github.com/valhalla/valhalla/pull/6243)
 * **Enhancement**
    * CHANGED: move `GraphTile::GetTileId` to `GraphId::FromTilePath` as a static factory ctor [#6237](https://github.com/valhalla/valhalla/pull/6237)
 

--- a/src/midgard/util.cc
+++ b/src/midgard/util.cc
@@ -369,7 +369,9 @@ memory_status::memory_status(const std::unordered_set<std::string>& interest) {
       }
       // try to get the number of bytes
       line.erase(std::remove_if(line.begin(), line.end(),
-                                [](const char c) { return !std::isdigit(c); }),
+                                [](const char c) {
+                                  return !std::isdigit(static_cast<unsigned char>(c));
+                                }),
                  line.end());
       if (line.size() == 0) {
         continue;

--- a/src/midgard/util.cc
+++ b/src/midgard/util.cc
@@ -369,9 +369,7 @@ memory_status::memory_status(const std::unordered_set<std::string>& interest) {
       }
       // try to get the number of bytes
       line.erase(std::remove_if(line.begin(), line.end(),
-                                [](const char c) {
-                                  return !std::isdigit(static_cast<unsigned char>(c));
-                                }),
+                                [](const unsigned char c) { return !std::isdigit(c); }),
                  line.end());
       if (line.size() == 0) {
         continue;

--- a/src/mjolnir/convert_transit.cc
+++ b/src/mjolnir/convert_transit.cc
@@ -1202,7 +1202,8 @@ std::unordered_set<GraphId> convert_transit(const ptree& pt) {
   for (; transit_file_itr != end_file_itr; ++transit_file_itr) {
     auto tile_path = transit_file_itr->path();
     if (std::filesystem::is_regular_file(transit_file_itr->path()) &&
-        (tile_path.extension() == ".pbf" || std::isdigit(tile_path.string().back()))) {
+        (tile_path.extension() == ".pbf" ||
+         std::isdigit(static_cast<unsigned char>(tile_path.string().back())))) {
       all_tiles.emplace(GraphId::FromTilePath(tile_path.string()));
     }
   }

--- a/src/mjolnir/osmdata.cc
+++ b/src/mjolnir/osmdata.cc
@@ -739,7 +739,7 @@ void OSMData::add_to_name_map(const uint64_t member_id,
 
   std::string dir = direction;
   boost::algorithm::to_lower(dir);
-  dir[0] = std::toupper(dir[0]);
+  dir[0] = std::toupper(static_cast<unsigned char>(dir[0]));
 
   // TODO:  network=e-road with int_ref=E #
   if ((dir.starts_with("North (") || dir.starts_with("South (") || dir.starts_with("East (") ||

--- a/src/odin/util.cc
+++ b/src/odin/util.cc
@@ -173,7 +173,7 @@ Bcp47Locale parse_string_into_locale(const std::string& locale_string) {
     if (matches[kScriptIndex].matched) {
       locale.script = matches[kScriptIndex].str();
       if (!locale.script.empty()) {
-        locale.script[0] = std::toupper(locale.script[0]);
+        locale.script[0] = std::toupper(static_cast<unsigned char>(locale.script[0]));
         locale.langtag += "-";
         locale.langtag += locale.script;
       }

--- a/src/odin/util.cc
+++ b/src/odin/util.cc
@@ -232,7 +232,8 @@ size_t get_word_count(const std::string& street_name) {
 
   while (pos != end) {
     // Skip over space, white space, and punctuation
-    while (pos != end && ((*pos == ' ') || std::isspace(*pos) || std::ispunct(*pos))) {
+    while (pos != end && ((*pos == ' ') || std::isspace(static_cast<unsigned char>(*pos)) ||
+                          std::ispunct(static_cast<unsigned char>(*pos)))) {
       ++pos;
     }
 
@@ -240,7 +241,8 @@ size_t get_word_count(const std::string& street_name) {
     word_count += (pos != end);
 
     // Skip over letters in word
-    while (pos != end && ((*pos != ' ') && (!std::isspace(*pos)) && (!std::ispunct(*pos)))) {
+    while (pos != end && ((*pos != ' ') && (!std::isspace(static_cast<unsigned char>(*pos))) &&
+                          (!std::ispunct(static_cast<unsigned char>(*pos))))) {
       ++pos;
     }
   }

--- a/test/gurka/gurka.cc
+++ b/test/gurka/gurka.cc
@@ -132,8 +132,8 @@ std::vector<std::string> splitter(const std::string& in_pattern, const std::stri
 }
 
 namespace {
-bool is_not_space(int ch) {
-  return !std::isspace(static_cast<unsigned char>(ch));
+bool is_not_space(unsigned char ch) {
+  return !std::isspace(ch);
 }
 } // namespace
 

--- a/test/gurka/gurka.cc
+++ b/test/gurka/gurka.cc
@@ -131,12 +131,17 @@ std::vector<std::string> splitter(const std::string& in_pattern, const std::stri
   return split_content;
 }
 
+namespace {
+bool is_not_space(int ch) {
+  return !std::isspace(static_cast<unsigned char>(ch));
+}
+} // namespace
+
 void ltrim(std::string& s) {
-  s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int ch) { return !std::isspace(ch); }));
+  s.erase(s.begin(), std::find_if(s.begin(), s.end(), is_not_space));
 }
 void rtrim(std::string& s) {
-  s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) { return !std::isspace(ch); }).base(),
-          s.end());
+  s.erase(std::find_if(s.rbegin(), s.rend(), is_not_space).base(), s.end());
 }
 
 std::string trim(std::string s) {
@@ -185,8 +190,7 @@ nodelayout map_to_coordinates(const std::string& map,
     // be allowed to affect positioning
     if (trim(line).empty())
       continue;
-    auto pos =
-        std::find_if(line.begin(), line.end(), [](const auto& ch) { return !std::isspace(ch); });
+    auto pos = std::find_if(line.begin(), line.end(), is_not_space);
     min_whitespace = std::min(min_whitespace, static_cast<long>(std::distance(line.begin(), pos)));
     if (min_whitespace == 0) // No need to continue if something is up against the left
       break;
@@ -207,7 +211,7 @@ nodelayout map_to_coordinates(const std::string& map,
     for (std::size_t x = 0; x < lines[y].size(); x++) {
       auto ch = lines[y][x];
       // Only do A-Za-z0-9 for nodes - all other things are ignored
-      if (std::isalnum(ch)) {
+      if (std::isalnum(static_cast<unsigned char>(ch))) {
         // Always project west, then south, for consistency
         double lon = topleft.lng() + x2lon_m(x * gridsize_metres);
         double lat = topleft.lat() - y2lat_m(y * gridsize_metres);

--- a/test/gurka/test_gtfs.cc
+++ b/test/gurka/test_gtfs.cc
@@ -687,7 +687,7 @@ TEST(GtfsExample, MakeProto) {
       std::string fname = transit_file_itr->path().string();
       mjolnir::Transit transit = mjolnir::read_pbf(fname);
 
-      if (std::isdigit(fname.back())) {
+      if (std::isdigit(static_cast<unsigned char>(fname.back()))) {
         // we produce 2 pbf tiles on purpose, where the last one (xx.pbf.0) only has a bunch of stop
         // pairs
         EXPECT_NE(transit.stop_pairs_size(), 0);

--- a/valhalla/baldr/json.h
+++ b/valhalla/baldr/json.h
@@ -111,7 +111,7 @@ public:
           ostream_ << "\\t";
           break;
         default:
-          if (iscntrl(c)) {
+          if (iscntrl(static_cast<unsigned char>(c))) {
             // format changes for json hex
             ostream_.setf(std::ios::hex, std::ios::basefield);
             ostream_.setf(std::ios::uppercase);


### PR DESCRIPTION
The std::is* functions take an int param and assert the char value to not be < -1. Passing in a non-ascii signed char hits an assertion with msvc.
The character type of a std:string may be a signed char, so has to be cast to unsigned first.

I noticed this during debugging in src/odin/util.cc with a street name containing `ß`.

The underlying char type of `std::string` is `char` which may be signed or unsigned depending on the platform.