### PR TITLE
truck costing: ADR tunnel-category restrictions (opt-in adr_tunnel_code)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * **Enhancement**
    * CHANGED: move `GraphTile::GetTileId` to `GraphId::FromTilePath` as a static factory ctor [#6237](https://github.com/valhalla/valhalla/pull/6237)
    * CHANGED: use `filtered_edges` in CostMatrix's second pass [#6236](https://github.com/valhalla/valhalla/pull/6236) 
+   * ADDED: `truck` costing option `adr_tunnel_code` restricting passage through tunnels by ADR tunnel category (ADR 8.6.4), with categories extracted from OSM `hazmat:adr_tunnel_cat`/`hazmat:tunnel_cat` tags and, on tunnels, from `hazmat:B..E=no` exclusion tagging
 
 ## Release Date: 2026-07-24 Valhalla 3.8.3
 * **Removed**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * **Enhancement**
    * CHANGED: move `GraphTile::GetTileId` to `GraphId::FromTilePath` as a static factory ctor [#6237](https://github.com/valhalla/valhalla/pull/6237)
    * CHANGED: use `filtered_edges` in CostMatrix's second pass [#6236](https://github.com/valhalla/valhalla/pull/6236) 
-   * ADDED: `truck` costing option `adr_tunnel_code` restricting passage through tunnels by ADR tunnel category (ADR 8.6.4), with categories extracted from OSM `hazmat:adr_tunnel_cat`/`hazmat:tunnel_cat` tags and, on tunnels, from `hazmat:B..E=no` exclusion tagging
+   * ADDED: `truck` costing option `adr_tunnel_code` restricting passage through tunnels by ADR tunnel category (ADR 8.6.4), with categories extracted from OSM `hazmat:adr_tunnel_cat`/`hazmat:tunnel_cat` tags and from per-code `hazmat:B..E` tagging [#6244](https://github.com/valhalla/valhalla/pull/6244)
 
 ## Release Date: 2026-07-24 Valhalla 3.8.3
 * **Removed**

--- a/docs/docs/api/route/api-reference.md
+++ b/docs/docs/api/route/api-reference.md
@@ -165,6 +165,7 @@ The following options are available for `truck` costing.
 | `axle_load` | The axle load of the truck (in metric tons). Default 9.07. |
 | `axle_count` | The axle count of the truck. Default 5. |
 | `hazmat` | A value indicating if the truck is carrying hazardous materials. Default false. |
+| `adr_tunnel_code` | The ADR 8.6.4 tunnel restriction code of the load, e.g. `B`, `B1000C`, `B/D`, `B/E`, `C`, `C5000D`, `C/D`, `C/E`, `D`, `D/E` or `E` (case-insensitive; `(—)`, `-` or `none` declare an explicitly unrestricted load). Only takes effect when `hazmat` is true: passage is then denied through tunnels whose ADR category (derived from OSM `hazmat:adr_tunnel_cat`, `hazmat:tunnel_cat` or `hazmat:B..E=no` exclusion tagging) is at or above the code's first letter, assuming the worst case for quantity- and tank/bulk-conditional clauses. A hazmat truck with no code is conservatively treated as code `B` (denied through every categorised tunnel). Default empty. |
 | `hgv_no_access_penalty` | A penalty applied to roads with no HGV/truck access. If set to a value less than 43200 seconds, HGV will be allowed on these roads and the penalty applies. Default 43200, i.e. trucks are not allowed. |
 | `low_class_penalty` | A penalty (in seconds) which is applied when transitioning down onto residential or service roads. Default is 30 seconds. |
 | `low_class_factor` | A factor which is applied to residential or service roads. Default is 1.5. |

--- a/lua/graph.lua
+++ b/lua/graph.lua
@@ -295,6 +295,17 @@ hazmat = {
 ["delivery"] = "false"
 }
 
+--parses an ADR tunnel category value: a single letter A-E, matched
+--case-insensitively with surrounding whitespace ignored. anything else is
+--nil so that malformed values fall through to the next source
+--(https://wiki.openstreetmap.org/wiki/Key:hazmat)
+function parse_adr_tunnel_cat(value)
+  if value == nil then
+    return nil
+  end
+  return string.match(string.upper(value), "^%s*([ABCDE])%s*$")
+end
+
 shoulder = {
 ["yes"] = "true",
 ["both"] = "true",
@@ -1898,6 +1909,26 @@ function filter_tags_generic(kv)
     end
   end
 
+  --ADR tunnel category (https://wiki.openstreetmap.org/wiki/Key:hazmat):
+  --explicit hazmat:adr_tunnel_cat wins over the generic hazmat:tunnel_cat;
+  --otherwise, on ways tagged tunnel=yes only (checked before the tunnel
+  --value is normalised below), infer the category from hazmat:B..E=no
+  --exclusions. the category is the highest letter excluded (scan E->B): a
+  --load of restriction group X is only forbidden in tunnels of category >= X,
+  --so hazmat:E=no can only be true of a category E tunnel while hazmat:B=no
+  --alone implies (at minimum) category B
+  local adr_cat = parse_adr_tunnel_cat(kv["hazmat:adr_tunnel_cat"]) or
+                  parse_adr_tunnel_cat(kv["hazmat:tunnel_cat"])
+  if adr_cat == nil and kv["tunnel"] == "yes" then
+    for _, letter in ipairs({"E", "D", "C", "B"}) do
+      if kv["hazmat:" .. letter] == "no" then
+        adr_cat = letter
+        break
+      end
+    end
+  end
+  kv["adr_tunnel_cat"] = adr_cat
+
   kv["tunnel"] = tunnel[kv["tunnel"]] or "false"
   kv["toll"] = toll[kv["toll"]] or "false"
   kv["destination"] = kv["destination"]
@@ -1931,8 +1962,17 @@ function filter_tags_generic(kv)
   kv["maxwidth_backward"] = normalize_measurement(kv["maxwidth:backward"])
 
   --TODO: hazmat really should have subcategories
-  kv["hazmat"] = hazmat[kv["hazmat"]] or hazmat[kv["hazmat:water"]] or hazmat[kv["hazmat:A"]] or hazmat[kv["hazmat:B"]] or
-                 hazmat[kv["hazmat:C"]] or hazmat[kv["hazmat:D"]] or hazmat[kv["hazmat:E"]]
+  --when the hazmat:B..E exclusions expressed a tunnel categorisation (see
+  --above) they must not double as a blanket hazmat ban: the tunnel category
+  --carries their meaning instead. hazmat=true trucks remain excluded from
+  --such tunnels because an undeclared tunnel restriction code is treated
+  --as the most conservative code B at costing time
+  local hazmat_b_to_e = nil
+  if kv["adr_tunnel_cat"] == nil then
+    hazmat_b_to_e = hazmat[kv["hazmat:B"]] or hazmat[kv["hazmat:C"]] or
+                    hazmat[kv["hazmat:D"]] or hazmat[kv["hazmat:E"]]
+  end
+  kv["hazmat"] = hazmat[kv["hazmat"]] or hazmat[kv["hazmat:water"]] or hazmat[kv["hazmat:A"]] or hazmat_b_to_e
   kv["hazmat_forward"] = hazmat[kv["hazmat:forward"]] or hazmat[kv["hazmat:water:forward"]] or hazmat[kv["hazmat:A:forward"]] or hazmat[kv["hazmat:B:forward"]] or
                  hazmat[kv["hazmat:C:forward"]] or hazmat[kv["hazmat:D:forward"]] or hazmat[kv["hazmat:E:forward"]]
   kv["hazmat_backward"] = hazmat[kv["hazmat:backward"]] or hazmat[kv["hazmat:water:backward"]] or hazmat[kv["hazmat:A:backward"]] or hazmat[kv["hazmat:B:backward"]] or

--- a/lua/graph.lua
+++ b/lua/graph.lua
@@ -1911,17 +1911,44 @@ function filter_tags_generic(kv)
 
   --ADR tunnel category (https://wiki.openstreetmap.org/wiki/Key:hazmat):
   --explicit hazmat:adr_tunnel_cat wins over the generic hazmat:tunnel_cat;
-  --otherwise, on ways tagged tunnel=yes only (checked before the tunnel
-  --value is normalised below), infer the category from hazmat:B..E=no
-  --exclusions. the category is the highest letter excluded (scan E->B): a
-  --load of restriction group X is only forbidden in tunnels of category >= X,
-  --so hazmat:E=no can only be true of a category E tunnel while hazmat:B=no
-  --alone implies (at minimum) category B
+  --otherwise infer the category from the per-code hazmat:B..E sub-keys. the
+  --category is the highest letter excluded (scan E->B): a load of
+  --restriction group X is only forbidden in tunnels of category >= X, so
+  --hazmat:E=no can only be true of a category E way while hazmat:B=no alone
+  --implies (at minimum) category B. the inference is deliberately NOT
+  --limited to tunnel=yes ways: signed ADR tunnel restrictions are tagged on
+  --whole corridors (verified against the Beneluxtunnel and Botlektunnel,
+  --whose A4/A15 approach ways carry hazmat:B=no + hazmat:C=no +
+  --hazmat:D=yes + hazmat:E=yes without tunnel=yes; gating on tunnel=yes
+  --left those ways on the blanket hazmat ban below, blanket-detouring
+  --every hazmat load regardless of its declared code). two tagging styles
+  --feed the inference:
+  --  * exclusion style: hazmat:B=no .. hazmat:E=yes - excluded letters are
+  --    tagged no
+  --  * blanket-plus-allowance style: hazmat=no refined by hazmat:D=yes /
+  --    hazmat:E=yes - the blanket ban excludes every letter not explicitly
+  --    allowed
+  --plain hazmat=no with NO per-code sub-keys derives nothing and stays a
+  --binary hazmat ban (conservative: it may ban dangerous goods generally,
+  --not only by ADR tunnel code)
   local adr_cat = parse_adr_tunnel_cat(kv["hazmat:adr_tunnel_cat"]) or
                   parse_adr_tunnel_cat(kv["hazmat:tunnel_cat"])
-  if adr_cat == nil and kv["tunnel"] == "yes" then
+  local adr_subkeys = false
+  local adr_allowance = false
+  for _, letter in ipairs({"B", "C", "D", "E"}) do
+    local sub = hazmat[kv["hazmat:" .. letter]]
+    if sub ~= nil then
+      adr_subkeys = true
+      if sub == "true" then
+        adr_allowance = true
+      end
+    end
+  end
+  if adr_cat == nil and adr_subkeys then
+    local blanket_ban = hazmat[kv["hazmat"]] == "false"
     for _, letter in ipairs({"E", "D", "C", "B"}) do
-      if kv["hazmat:" .. letter] == "no" then
+      local sub = hazmat[kv["hazmat:" .. letter]]
+      if sub == "false" or (blanket_ban and sub ~= "true") then
         adr_cat = letter
         break
       end
@@ -1965,14 +1992,24 @@ function filter_tags_generic(kv)
   --when the hazmat:B..E exclusions expressed a tunnel categorisation (see
   --above) they must not double as a blanket hazmat ban: the tunnel category
   --carries their meaning instead. hazmat=true trucks remain excluded from
-  --such tunnels because an undeclared tunnel restriction code is treated
+  --such ways because an undeclared tunnel restriction code is treated
   --as the most conservative code B at costing time
   local hazmat_b_to_e = nil
   if kv["adr_tunnel_cat"] == nil then
     hazmat_b_to_e = hazmat[kv["hazmat:B"]] or hazmat[kv["hazmat:C"]] or
                     hazmat[kv["hazmat:D"]] or hazmat[kv["hazmat:E"]]
   end
-  kv["hazmat"] = hazmat[kv["hazmat"]] or hazmat[kv["hazmat:water"]] or hazmat[kv["hazmat:A"]] or hazmat_b_to_e
+  --likewise, when plain hazmat=no was refined by per-code allowances
+  --(hazmat=no + hazmat:E=yes and the like), the blanket key is the crude
+  --summary of a graded restriction the derived category now carries with
+  --per-code granularity; keep it only when no allowance shows graded
+  --intent. hazmat:water and hazmat:A bans are unrelated to ADR tunnel
+  --categories and are always kept
+  local hazmat_plain = hazmat[kv["hazmat"]]
+  if adr_cat ~= nil and adr_allowance and hazmat_plain == "false" then
+    hazmat_plain = nil
+  end
+  kv["hazmat"] = hazmat_plain or hazmat[kv["hazmat:water"]] or hazmat[kv["hazmat:A"]] or hazmat_b_to_e
   kv["hazmat_forward"] = hazmat[kv["hazmat:forward"]] or hazmat[kv["hazmat:water:forward"]] or hazmat[kv["hazmat:A:forward"]] or hazmat[kv["hazmat:B:forward"]] or
                  hazmat[kv["hazmat:C:forward"]] or hazmat[kv["hazmat:D:forward"]] or hazmat[kv["hazmat:E:forward"]]
   kv["hazmat_backward"] = hazmat[kv["hazmat:backward"]] or hazmat[kv["hazmat:water:backward"]] or hazmat[kv["hazmat:A:backward"]] or hazmat[kv["hazmat:B:backward"]] or

--- a/proto/descriptors/options.proto
+++ b/proto/descriptors/options.proto
@@ -362,6 +362,11 @@ message Costing {
     oneof has_low_class_factor {
       float low_class_factor = 97;
     }
+    // ADR 8.6.4 tunnel restriction code of the load for truck costing, e.g.
+    // "B", "B1000C", "B/D", "C", "C5000D", "C/D", "D", "D/E", "E"; "(—)",
+    // "-" or "none" declare an explicitly unrestricted load. Empty = no code
+    // declared (a hazmat load is then treated conservatively as code "B").
+    string adr_tunnel_code = 98;
   }
 
   oneof has_options {

--- a/src/baldr/directededge.cc
+++ b/src/baldr/directededge.cc
@@ -201,6 +201,17 @@ void DirectedEdge::set_tunnel(const bool tunnel) {
   tunnel_ = tunnel;
 }
 
+// Sets the ADR (dangerous goods) tunnel category of this edge
+// (0 = no category / category A, 1-4 = ADR categories B-E).
+void DirectedEdge::set_adr_tunnel_category(const uint8_t category) {
+  if (category > static_cast<uint8_t>(AdrTunnelCategory::kE)) {
+    LOG_WARN("Exceeding max ADR tunnel category: " + std::to_string(category));
+    adr_tunnel_cat_ = static_cast<uint8_t>(AdrTunnelCategory::kE);
+  } else {
+    adr_tunnel_cat_ = category;
+  }
+}
+
 // Sets the flag indicating this edge has is a bridge of part of a bridge.
 void DirectedEdge::set_bridge(const bool bridge) {
   bridge_ = bridge;
@@ -624,6 +635,7 @@ void DirectedEdge::json(rapidjson::writer_wrapper_t& writer) const {
   writer("destination_only", static_cast<bool>(dest_only_));
   writer("destination_only_hgv", static_cast<bool>(dest_only_hgv_));
   writer("tunnel", static_cast<bool>(tunnel_));
+  writer("adr_tunnel_category", static_cast<uint64_t>(adr_tunnel_cat_));
   writer("bridge", static_cast<bool>(bridge_));
   writer("round_about", static_cast<bool>(roundabout_));
   writer("traffic_signal", static_cast<bool>(traffic_signal_));

--- a/src/mjolnir/directededgebuilder.cc
+++ b/src/mjolnir/directededgebuilder.cc
@@ -71,6 +71,7 @@ DirectedEdgeBuilder::DirectedEdgeBuilder(const OSMWay& way,
   }
 
   set_dest_only_hgv(way.destination_only_hgv());
+  set_adr_tunnel_category(way.adr_tunnel_category());
   set_dismount(way.dismount());
   set_use_sidepath(way.use_sidepath());
   set_sac_scale(way.sac_scale());

--- a/src/mjolnir/pbfgraphparser.cc
+++ b/src/mjolnir/pbfgraphparser.cc
@@ -1044,6 +1044,14 @@ struct graph_parser {
       osmdata_.access_restrictions.insert(
           AccessRestrictionsMultiMap::value_type(osmid_, restriction));
     };
+    tag_handlers_["adr_tunnel_cat"] = [this]() {
+      // ADR tunnel category emitted by the lua transform ("A".."E").
+      // Category A carries no dangerous-goods restriction (ADR 1.9.5.2.2),
+      // so it collapses to AdrTunnelCategory::kNone.
+      if (tag_.second.size() == 1 && tag_.second[0] >= 'B' && tag_.second[0] <= 'E') {
+        way_.set_adr_tunnel_category(static_cast<uint8_t>(tag_.second[0] - 'A'));
+      }
+    };
     tag_handlers_["maxheight"] = [this]() {
       OSMAccessRestriction restriction;
       restriction.set_type(AccessType::kMaxHeight);

--- a/src/sif/truckcost.cc
+++ b/src/sif/truckcost.cc
@@ -7,6 +7,10 @@
 #include "proto_conversions.h"
 #include "sif/osrm_car_duration.h"
 
+#include <algorithm>
+#include <cctype>
+#include <unordered_map>
+
 #ifdef INLINE_TEST
 #include "test.h"
 #include "worker.h"
@@ -36,6 +40,67 @@ constexpr float kDefaultUseTracks = 0.f; // Avoid tracks by default. Factor betw
 constexpr float kDefaultUseLivingStreets =
     0.f;                                    // Avoid living streets by default. Factor between 0 and 1
 constexpr float kDefaultUseHighways = 0.5f; // Factor between 0 and 1
+
+// Parses an ADR 8.6.4 tunnel restriction code (UNECE,
+// https://unece.org/transport/dangerous-goods) into the least tunnel
+// category (AdrTunnelCategory numeric value) the load is forbidden from.
+// The router does not know net explosive mass or tank/bulk carriage, so the
+// quantity-conditional (B1000C, C5000D) and carriage-conditional (B/D, B/E,
+// C/D, C/E, D/E) clauses are assumed to apply (worst case); every code then
+// collapses to a single threshold - its first letter - and passage is
+// forbidden through a tunnel of category cat iff cat >= threshold.
+//
+// Accepted spellings: the canonical ADR notation, case-insensitively, with
+// surrounding whitespace ignored and one pair of parentheses stripped (ADR
+// Table A column (15) prints codes in parentheses). The "no restriction"
+// code parses from "(—)", "—" (em dash), "–" (en dash), "-",
+// "none" or a whitespace-only string, and returns 0 (never forbidden).
+// Unrecognised input returns the category B threshold (the most conservative
+// non-quantity code) and reports validity through the optional out param.
+uint8_t ParseAdrTunnelCode(const std::string& raw, bool* valid = nullptr) {
+  if (valid) {
+    *valid = true;
+  }
+  const std::string whitespace = " \t\r\n";
+  auto trim = [&whitespace](const std::string& s) -> std::string {
+    auto b = s.find_first_not_of(whitespace);
+    if (b == std::string::npos) {
+      return "";
+    }
+    auto e = s.find_last_not_of(whitespace);
+    return s.substr(b, e - b + 1);
+  };
+  std::string code = trim(raw);
+  if (code.size() >= 2 && code.front() == '(' && code.back() == ')') {
+    code = trim(code.substr(1, code.size() - 2));
+  }
+  std::transform(code.begin(), code.end(), code.begin(),
+                 [](unsigned char c) { return std::toupper(c); });
+  if (code.empty() || code == "-" || code == "—" || code == "–" || code == "NONE") {
+    return 0;
+  }
+  static const std::unordered_map<std::string, uint8_t> kAdrCodeThresholds = {
+      {"B", static_cast<uint8_t>(AdrTunnelCategory::kB)},
+      {"B1000C", static_cast<uint8_t>(AdrTunnelCategory::kB)},
+      {"B/D", static_cast<uint8_t>(AdrTunnelCategory::kB)},
+      {"B/E", static_cast<uint8_t>(AdrTunnelCategory::kB)},
+      {"C", static_cast<uint8_t>(AdrTunnelCategory::kC)},
+      {"C5000D", static_cast<uint8_t>(AdrTunnelCategory::kC)},
+      {"C/D", static_cast<uint8_t>(AdrTunnelCategory::kC)},
+      {"C/E", static_cast<uint8_t>(AdrTunnelCategory::kC)},
+      {"D", static_cast<uint8_t>(AdrTunnelCategory::kD)},
+      {"D/E", static_cast<uint8_t>(AdrTunnelCategory::kD)},
+      {"E", static_cast<uint8_t>(AdrTunnelCategory::kE)},
+  };
+  auto found = kAdrCodeThresholds.find(code);
+  if (found != kAdrCodeThresholds.end()) {
+    return found->second;
+  }
+  if (valid) {
+    *valid = false;
+  }
+  return static_cast<uint8_t>(AdrTunnelCategory::kB);
+}
 
 // Default turn costs
 constexpr float kTCStraight = 0.5f;
@@ -333,6 +398,10 @@ public:
   float highway_factor_;         // Factor applied when road is a motorway or trunk
   float non_truck_route_factor_; // Factor applied when road is not part of a designated truck route
   uint8_t axle_count_;           // Vehicle axle count
+  uint8_t adr_tunnel_threshold_; // Least ADR tunnel category (AdrTunnelCategory
+                                 // value) this vehicle is forbidden from; 0 when
+                                 // tunnel categories never block it (not carrying
+                                 // hazmat, or an explicitly unrestricted load)
 
   // determine if we should allow hgv=no edges and penalize them instead
   float no_hgv_access_penalty_;
@@ -363,6 +432,19 @@ TruckCost::TruckCost(const Costing& costing)
   width_ = costing_options.width();
   length_ = costing_options.length();
   axle_count_ = costing_options.axle_count();
+
+  // ADR tunnel restriction: precompute the least tunnel category the load is
+  // forbidden from (ADR 8.6.4, worst-case reading). Only dangerous-goods
+  // loads are subject to tunnel categories; a hazmat load with no declared
+  // tunnel restriction code is treated conservatively as code "B" (forbidden
+  // through every categorised B-E tunnel, allowed through A/uncategorised).
+  if (!hazmat_) {
+    adr_tunnel_threshold_ = 0;
+  } else if (costing_options.adr_tunnel_code().empty()) {
+    adr_tunnel_threshold_ = static_cast<uint8_t>(AdrTunnelCategory::kB);
+  } else {
+    adr_tunnel_threshold_ = ParseAdrTunnelCode(costing_options.adr_tunnel_code());
+  }
 
   // Create speed cost table
   // Preference to use highways. Is a value from 0 to 1
@@ -467,6 +549,9 @@ inline bool TruckCost::Allowed(const baldr::DirectedEdge* edge,
       ((pred.restrictions() & (1 << edge->localedgeidx())) && (!ignore_turn_restrictions_)) ||
       edge->surface() == Surface::kImpassable || IsUserAvoidEdge(edgeid) ||
       (!allow_destination_only_ && !pred.destonly() && edge->destonly_hgv()) ||
+      // ADR: passage through a tunnel of category >= the load's threshold is
+      // a legal ban (hard block), like a physical height gate
+      (adr_tunnel_threshold_ && edge->adr_tunnel_category() >= adr_tunnel_threshold_) ||
       (pred.closure_pruning() && IsClosed(edge, tile)) ||
       (exclude_unpaved_ && !pred.unpaved() && edge->unpaved()) || CheckExclusions<true>(edge, pred)) {
     return false;
@@ -492,6 +577,8 @@ bool TruckCost::AllowedReverse(const baldr::DirectedEdge* edge,
       ((opp_edge->restrictions() & (1 << pred.opp_local_idx())) && !ignore_turn_restrictions_) ||
       opp_edge->surface() == Surface::kImpassable || IsUserAvoidEdge(opp_edgeid) ||
       (!allow_destination_only_ && !pred.destonly() && opp_edge->destonly_hgv()) ||
+      // ADR tunnel categories are direction-independent; identical rule to Allowed()
+      (adr_tunnel_threshold_ && opp_edge->adr_tunnel_category() >= adr_tunnel_threshold_) ||
       (pred.closure_pruning() && IsClosed(opp_edge, tile)) ||
       (exclude_unpaved_ && !pred.unpaved() && opp_edge->unpaved()) ||
       CheckExclusions<false>(opp_edge, pred)) {
@@ -750,6 +837,21 @@ void ParseTruckCostOptions(const rapidjson::Document& doc,
   JSON_PBF_RANGED_DEFAULT(co, kLowClassFactorRange, json, "/low_class_factor", low_class_factor,
                           warnings);
   JSON_PBF_DEFAULT_V2(co, false, json, "/hazmat", hazmat);
+  // ADR 8.6.4 tunnel restriction code of the load (empty = not declared; a
+  // hazmat load without a declared code is treated conservatively as "B")
+  co->set_adr_tunnel_code(
+      rapidjson::get<std::string>(json, "/adr_tunnel_code", co->adr_tunnel_code()));
+  {
+    bool adr_code_valid = true;
+    ParseAdrTunnelCode(co->adr_tunnel_code(), &adr_code_valid);
+    if (!adr_code_valid) {
+      auto warning = warnings.Add();
+      warning->set_code(500);
+      warning->set_description("'adr_tunnel_code' '" + co->adr_tunnel_code() +
+                               "' is not an ADR 8.6.4 tunnel restriction code; "
+                               "treating it conservatively as 'B'");
+    }
+  }
   JSON_PBF_RANGED_DEFAULT(co, kTruckAxleLoadRange, json, "/axle_load", axle_load, warnings);
   JSON_PBF_RANGED_DEFAULT(co, kUseTollsRange, json, "/use_tolls", use_tolls, warnings);
   JSON_PBF_RANGED_DEFAULT(co, kUseHighwaysRange, json, "/use_highways", use_highways, warnings);

--- a/test/gurka/test_truck_adr_tunnel.cc
+++ b/test/gurka/test_truck_adr_tunnel.cc
@@ -181,7 +181,8 @@ protected:
         {"AB", {{"highway", "residential"}}},
         {"BC",
          {{"highway", "residential"}, {"tunnel", "yes"}, {"hazmat:B", "no"}, {"hazmat:E", "no"}}},
-        // hazmat exclusion off a tunnel: no category, blanket hazmat ban
+        // hazmat exclusion off a tunnel: same inference (ADR corridors are
+        // tagged on approach ways too), category C
         {"DE", {{"highway", "residential"}}},
         {"EF", {{"highway", "residential"}, {"hazmat:C", "no"}}},
         // hazmat:X=yes is not an exclusion: no category, no ban
@@ -215,11 +216,19 @@ TEST_F(TruckAdrInferenceTest, ExclusionInferenceHighestLetterWins) {
   gurka::assert::raw::expect_path(route, {"AB", "BC"});
 }
 
-TEST_F(TruckAdrInferenceTest, HazmatExclusionOffTunnelStaysBlanketBan) {
-  // hazmat:C=no without tunnel=yes derives no category; the pre-existing
-  // blanket hazmat access restriction applies to every hazmat load, even an
-  // explicitly unrestricted one
-  expect_no_path(map, {"D", "F"}, hazmat_options("(—)"));
+TEST_F(TruckAdrInferenceTest, HazmatExclusionOffTunnelDerivesCategory) {
+  // hazmat:C=no without tunnel=yes derives category C all the same: signed
+  // ADR restrictions are tagged on whole corridors (approach ways included),
+  // so the inference is not limited to tunnel=yes ways. A code-C load is
+  // blocked, a code-D load and an explicitly unrestricted load pass, and a
+  // hazmat load with no declared code stays conservatively excluded.
+  expect_no_path(map, {"D", "F"}, hazmat_options("C"));
+  expect_no_path(map, {"D", "F"}, hazmat_options(""));
+  auto route_d = gurka::do_action(Options::route, map, {"D", "F"}, "truck", hazmat_options("D"));
+  gurka::assert::raw::expect_path(route_d, {"DE", "EF"});
+  auto route_unrestricted =
+      gurka::do_action(Options::route, map, {"D", "F"}, "truck", hazmat_options("(—)"));
+  gurka::assert::raw::expect_path(route_unrestricted, {"DE", "EF"});
   auto route = gurka::do_action(Options::route, map, {"D", "F"}, "truck");
   gurka::assert::raw::expect_path(route, {"DE", "EF"});
 }
@@ -303,4 +312,127 @@ TEST_F(TruckAdrDetourTest, HeightAloneKeepsTunnelOpen) {
   auto route = gurka::do_action(Options::route, map, {"A", "D"}, "truck",
                                 {{"/costing_options/truck/height", "4.5"}});
   gurka::assert::raw::expect_path(route, {"AB", "BC", "CD"});
+}
+
+// Real-world corridor tagging, mirroring the Beneluxtunnel (Rotterdam, OSM
+// ways 29245400/34886842) and the Botlektunnel style named in the OSM hazmat
+// scheme: the signed ADR restriction is tagged per-code on the approach ways
+// (no tunnel=yes, no explicit category key) as well as on the tunnel way
+// itself. Every way of the corridor must derive the same category or the
+// blanket hazmat ban on the approaches blanket-detours every code alike.
+class TruckAdrCorridorTest : public ::testing::Test {
+protected:
+  static gurka::map map;
+
+  static void SetUpTestSuite() {
+    constexpr double gridsize = 100;
+
+    // Every restricted edge sits BEHIND an unrestricted approach edge:
+    // costing (blanket hazmat restriction and ADR category alike) binds in
+    // Allowed()/AllowedReverse() when the search EXPANDS onto an edge, while
+    // origin/destination edges are correlated by loki's plain access filter.
+    // A single-edge corridor would make every route trivial and bypass the
+    // very checks under test.
+    const std::string ascii_map = R"(
+      A----B----C----D
+      E----F----K
+      G----H----L
+      I----J----M
+    )";
+
+    const gurka::ways ways = {
+        // the Beneluxtunnel corridor: approaches AB/CD carry the per-code
+        // tags with no tunnel and no explicit category; the tunnel way BC
+        // carries the identical tags plus tunnel=yes and the explicit
+        // category, exactly as the real ways do. Everything derives/reads
+        // category C.
+        {"AB",
+         {{"highway", "residential"},
+          {"hazmat:B", "no"},
+          {"hazmat:C", "no"},
+          {"hazmat:D", "yes"},
+          {"hazmat:E", "yes"}}},
+        {"BC",
+         {{"highway", "residential"},
+          {"tunnel", "yes"},
+          {"hazmat:adr_tunnel_cat", "C"},
+          {"hazmat:B", "no"},
+          {"hazmat:C", "no"},
+          {"hazmat:D", "yes"},
+          {"hazmat:E", "yes"}}},
+        {"CD",
+         {{"highway", "residential"},
+          {"hazmat:B", "no"},
+          {"hazmat:C", "no"},
+          {"hazmat:D", "yes"},
+          {"hazmat:E", "yes"}}},
+        // blanket-plus-allowance style: hazmat=no refined by hazmat:E=yes is
+        // a graded restriction - category D (the highest letter not
+        // explicitly allowed), with the crude blanket ban suppressed
+        {"EF", {{"highway", "residential"}}},
+        {"FK", {{"highway", "residential"}, {"hazmat", "no"}, {"hazmat:E", "yes"}}},
+        // plain hazmat=no with no per-code sub-keys: no category, binary ban
+        {"GH", {{"highway", "residential"}}},
+        {"HL", {{"highway", "residential"}, {"hazmat", "no"}}},
+        // blanket plus an exclusion but no allowance: category E derives,
+        // yet without graded intent the blanket ban is conservatively kept
+        {"IJ", {{"highway", "residential"}}},
+        {"JM", {{"highway", "residential"}, {"hazmat", "no"}, {"hazmat:E", "no"}}},
+    };
+
+    const auto layout = gurka::detail::map_to_coordinates(ascii_map, gridsize);
+    map = gurka::buildtiles(layout, ways, {}, {}, "test/data/truck_adr_corridor");
+  }
+};
+
+gurka::map TruckAdrCorridorTest::map = {};
+
+TEST_F(TruckAdrCorridorTest, PerCodeCorridorGrantsGranularPassage) {
+  // the Beneluxtunnel granularity case: codes D and E (and an explicitly
+  // unrestricted load) pass the whole category-C corridor
+  for (const auto* code : {"D", "E", "(—)"}) {
+    SCOPED_TRACE(std::string("code ") + code);
+    auto route = gurka::do_action(Options::route, map, {"A", "D"}, "truck", hazmat_options(code));
+    gurka::assert::raw::expect_path(route, {"AB", "BC", "CD"});
+  }
+}
+
+TEST_F(TruckAdrCorridorTest, PerCodeCorridorStillBlocksItsCategory) {
+  // codes B and C - and a hazmat load with no declared code - stay barred
+  for (const auto* code : {"B", "C", ""}) {
+    SCOPED_TRACE(std::string("code '") + code + "'");
+    expect_no_path(map, {"A", "D"}, hazmat_options(code));
+  }
+}
+
+TEST_F(TruckAdrCorridorTest, PerCodeCorridorIgnoredWithoutHazmat) {
+  auto route = gurka::do_action(Options::route, map, {"A", "D"}, "truck");
+  gurka::assert::raw::expect_path(route, {"AB", "BC", "CD"});
+}
+
+TEST_F(TruckAdrCorridorTest, BlanketPlusAllowanceDerivesCategory) {
+  // hazmat=no + hazmat:E=yes is category D: a code-E load passes, a code-D
+  // load is blocked, an unrestricted load passes (the blanket is suppressed)
+  auto route_e = gurka::do_action(Options::route, map, {"E", "K"}, "truck", hazmat_options("E"));
+  gurka::assert::raw::expect_path(route_e, {"EF", "FK"});
+  expect_no_path(map, {"E", "K"}, hazmat_options("D"));
+  auto route_unrestricted =
+      gurka::do_action(Options::route, map, {"E", "K"}, "truck", hazmat_options("(—)"));
+  gurka::assert::raw::expect_path(route_unrestricted, {"EF", "FK"});
+}
+
+TEST_F(TruckAdrCorridorTest, PlainBlanketStaysBinary) {
+  // plain hazmat=no with no per-code sub-keys keeps banning every hazmat
+  // load, even an explicitly unrestricted one
+  expect_no_path(map, {"G", "L"}, hazmat_options("(—)"));
+  auto route = gurka::do_action(Options::route, map, {"G", "L"}, "truck");
+  gurka::assert::raw::expect_path(route, {"GH", "HL"});
+}
+
+TEST_F(TruckAdrCorridorTest, ExclusionWithoutAllowanceKeepsBlanket) {
+  // hazmat=no + hazmat:E=no shows no graded intent (no allowance), so the
+  // conservative blanket ban stays even though category E derives
+  expect_no_path(map, {"I", "M"}, hazmat_options("(—)"));
+  auto route = gurka::do_action(Options::route, map, {"I", "M"}, "truck");
+  gurka::assert::raw::expect_path(route, {"IJ", "JM"});
 }

--- a/test/gurka/test_truck_adr_tunnel.cc
+++ b/test/gurka/test_truck_adr_tunnel.cc
@@ -1,0 +1,306 @@
+#include "gurka.h"
+#include "valhalla/worker.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+using namespace valhalla;
+
+namespace {
+
+// Expects the route to fail with "no path could be found for input" (442).
+void expect_no_path(gurka::map& map,
+                    const std::vector<std::string>& waypoints,
+                    const std::unordered_map<std::string, std::string>& options) {
+  try {
+    gurka::do_action(Options::route, map, waypoints, "truck", options);
+    FAIL() << "Expected no path to be found";
+  } catch (const valhalla_exception_t& err) { EXPECT_EQ(err.code, 442); } catch (...) {
+    FAIL() << "Expected valhalla_exception_t.";
+  }
+}
+
+std::unordered_map<std::string, std::string> hazmat_options(const std::string& adr_tunnel_code) {
+  std::unordered_map<std::string, std::string> options{{"/costing_options/truck/hazmat", "1"}};
+  if (!adr_tunnel_code.empty()) {
+    options["/costing_options/truck/adr_tunnel_code"] = adr_tunnel_code;
+  }
+  return options;
+}
+
+// The ADR 8.6.4 decision matrix under the conservative (worst-case) reading:
+// quantity-conditional (B1000C, C5000D) and tank/bulk-conditional (B/D, B/E,
+// C/D, C/E, D/E) clauses are assumed to apply, so passage is forbidden
+// through a tunnel of category cat iff cat >= first_letter(code).
+//
+// This table is the shared truth table with the sn-adr Rust crate: it must
+// stay cell-for-cell identical to fork/adr_matrix_test_vectors.json
+// (generated from SPEC-ADR-COSTING.md §2.4/§2.5, which cites ADR 8.6.4,
+// https://unece.org/transport/dangerous-goods).
+struct AdrVector {
+  // request spelling of the code; "" = hazmat load with no declared code
+  std::string code;
+  // passage allowed through tunnel categories A, B, C, D, E
+  bool allowed[5];
+};
+
+// clang-format off
+const std::vector<AdrVector> kAdrMatrix = {
+    // code           A      B      C      D      E
+    {"(—)",         {true,  true,  true,  true,  true}},
+    {"B",           {true,  false, false, false, false}},
+    {"B1000C",      {true,  false, false, false, false}},
+    {"B/D",         {true,  false, false, false, false}},
+    {"B/E",         {true,  false, false, false, false}},
+    {"C",           {true,  true,  false, false, false}},
+    {"C5000D",      {true,  true,  false, false, false}},
+    {"C/D",         {true,  true,  false, false, false}},
+    {"C/E",         {true,  true,  false, false, false}},
+    {"D",           {true,  true,  true,  false, false}},
+    {"D/E",         {true,  true,  true,  false, false}},
+    {"E",           {true,  true,  true,  true,  false}},
+    // hazmat load, no code declared: conservatively treated as code "B"
+    {"",            {true,  false, false, false, false}},
+};
+// clang-format on
+
+} // namespace
+
+// Five disconnected corridors, one per explicit ADR tunnel category. The
+// middle of each corridor is a tunnel tagged hazmat:adr_tunnel_cat=A..E.
+class TruckAdrMatrixTest : public ::testing::Test {
+protected:
+  static gurka::map map;
+  // {origin, destination, first way, tunnel way} per category A..E
+  static constexpr std::array<std::array<const char*, 4>, 5> kCorridors = {{
+      {"A", "C", "AB", "BC"},
+      {"D", "F", "DE", "EF"},
+      {"G", "I", "GH", "HI"},
+      {"J", "L", "JK", "KL"},
+      {"M", "O", "MN", "NO"},
+  }};
+
+  static void SetUpTestSuite() {
+    constexpr double gridsize = 100;
+
+    const std::string ascii_map = R"(
+      A----B----C
+      D----E----F
+      G----H----I
+      J----K----L
+      M----N----O
+    )";
+
+    const gurka::ways ways = {
+        {"AB", {{"highway", "residential"}}},
+        {"BC", {{"highway", "residential"}, {"tunnel", "yes"}, {"hazmat:adr_tunnel_cat", "A"}}},
+        {"DE", {{"highway", "residential"}}},
+        {"EF", {{"highway", "residential"}, {"tunnel", "yes"}, {"hazmat:adr_tunnel_cat", "B"}}},
+        {"GH", {{"highway", "residential"}}},
+        {"HI", {{"highway", "residential"}, {"tunnel", "yes"}, {"hazmat:adr_tunnel_cat", "C"}}},
+        {"JK", {{"highway", "residential"}}},
+        {"KL", {{"highway", "residential"}, {"tunnel", "yes"}, {"hazmat:adr_tunnel_cat", "D"}}},
+        {"MN", {{"highway", "residential"}}},
+        {"NO", {{"highway", "residential"}, {"tunnel", "yes"}, {"hazmat:adr_tunnel_cat", "E"}}},
+    };
+
+    const auto layout = gurka::detail::map_to_coordinates(ascii_map, gridsize);
+    map = gurka::buildtiles(layout, ways, {}, {}, "test/data/truck_adr_matrix");
+  }
+};
+
+gurka::map TruckAdrMatrixTest::map = {};
+constexpr std::array<std::array<const char*, 4>, 5> TruckAdrMatrixTest::kCorridors;
+
+// The full shared truth table: 13 profiles x 5 tunnel categories.
+TEST_F(TruckAdrMatrixTest, MatrixHazmat) {
+  for (const auto& vector : kAdrMatrix) {
+    for (size_t cat = 0; cat < kCorridors.size(); ++cat) {
+      const auto& corridor = kCorridors[cat];
+      const auto options = hazmat_options(vector.code);
+      SCOPED_TRACE("code '" + vector.code + "' through category tunnel " + corridor[3]);
+      if (vector.allowed[cat]) {
+        auto route =
+            gurka::do_action(Options::route, map, {corridor[0], corridor[1]}, "truck", options);
+        gurka::assert::raw::expect_path(route, {corridor[2], corridor[3]});
+      } else {
+        expect_no_path(map, {corridor[0], corridor[1]}, options);
+      }
+    }
+  }
+}
+
+// Without hazmat, tunnel categories are ignored entirely, even when a
+// (contradictory) code is supplied.
+TEST_F(TruckAdrMatrixTest, NonHazmatIgnoresCategories) {
+  for (const auto* code : {"", "B", "E"}) {
+    for (const auto& corridor : kCorridors) {
+      std::unordered_map<std::string, std::string> options;
+      if (*code) {
+        options["/costing_options/truck/adr_tunnel_code"] = code;
+      }
+      auto route =
+          gurka::do_action(Options::route, map, {corridor[0], corridor[1]}, "truck", options);
+      gurka::assert::raw::expect_path(route, {corridor[2], corridor[3]});
+    }
+  }
+}
+
+// An unrecognised code is treated conservatively as code "B": blocked from
+// the category B tunnel, allowed through category A.
+TEST_F(TruckAdrMatrixTest, UnrecognisedCodeIsConservative) {
+  const auto options = hazmat_options("B-D");
+  expect_no_path(map, {"D", "F"}, options);
+  auto route = gurka::do_action(Options::route, map, {"A", "C"}, "truck", options);
+  gurka::assert::raw::expect_path(route, {"AB", "BC"});
+}
+
+// Tag extraction tiers of SPEC-ADR-COSTING §3 / the OSM hazmat scheme
+// (https://wiki.openstreetmap.org/wiki/Key:hazmat).
+class TruckAdrInferenceTest : public ::testing::Test {
+protected:
+  static gurka::map map;
+
+  static void SetUpTestSuite() {
+    constexpr double gridsize = 100;
+
+    const std::string ascii_map = R"(
+      A----B----C
+      D----E----F
+      G----H----I
+      J----K----L
+      M----N----O
+    )";
+
+    const gurka::ways ways = {
+        // exclusion inference: highest excluded letter wins (E over B)
+        {"AB", {{"highway", "residential"}}},
+        {"BC",
+         {{"highway", "residential"}, {"tunnel", "yes"}, {"hazmat:B", "no"}, {"hazmat:E", "no"}}},
+        // hazmat exclusion off a tunnel: no category, blanket hazmat ban
+        {"DE", {{"highway", "residential"}}},
+        {"EF", {{"highway", "residential"}, {"hazmat:C", "no"}}},
+        // hazmat:X=yes is not an exclusion: no category, no ban
+        {"GH", {{"highway", "residential"}}},
+        {"HI", {{"highway", "residential"}, {"tunnel", "yes"}, {"hazmat:C", "yes"}}},
+        // malformed explicit value falls through to exclusion inference
+        {"JK", {{"highway", "residential"}}},
+        {"KL",
+         {{"highway", "residential"},
+          {"tunnel", "yes"},
+          {"hazmat:adr_tunnel_cat", "category-c"},
+          {"hazmat:D", "no"}}},
+        // plain tunnel with no hazmat tagging: unset category
+        {"MN", {{"highway", "residential"}}},
+        {"NO", {{"highway", "residential"}, {"tunnel", "yes"}}},
+    };
+
+    const auto layout = gurka::detail::map_to_coordinates(ascii_map, gridsize);
+    map = gurka::buildtiles(layout, ways, {}, {}, "test/data/truck_adr_inference");
+  }
+};
+
+gurka::map TruckAdrInferenceTest::map = {};
+
+TEST_F(TruckAdrInferenceTest, ExclusionInferenceHighestLetterWins) {
+  // tunnel=yes + hazmat:B=no + hazmat:E=no => category E: only a code E load
+  // (and every lower threshold) is blocked, an unrestricted "(—)" load passes
+  expect_no_path(map, {"A", "C"}, hazmat_options("E"));
+  expect_no_path(map, {"A", "C"}, hazmat_options("")); // no code -> treated as B
+  auto route = gurka::do_action(Options::route, map, {"A", "C"}, "truck", hazmat_options("(—)"));
+  gurka::assert::raw::expect_path(route, {"AB", "BC"});
+}
+
+TEST_F(TruckAdrInferenceTest, HazmatExclusionOffTunnelStaysBlanketBan) {
+  // hazmat:C=no without tunnel=yes derives no category; the pre-existing
+  // blanket hazmat access restriction applies to every hazmat load, even an
+  // explicitly unrestricted one
+  expect_no_path(map, {"D", "F"}, hazmat_options("(—)"));
+  auto route = gurka::do_action(Options::route, map, {"D", "F"}, "truck");
+  gurka::assert::raw::expect_path(route, {"DE", "EF"});
+}
+
+TEST_F(TruckAdrInferenceTest, HazmatYesIsNotAnExclusion) {
+  // tunnel=yes + hazmat:C=yes derives no category and no ban
+  auto route = gurka::do_action(Options::route, map, {"G", "I"}, "truck", hazmat_options("C"));
+  gurka::assert::raw::expect_path(route, {"GH", "HI"});
+}
+
+TEST_F(TruckAdrInferenceTest, MalformedExplicitValueFallsThrough) {
+  // hazmat:adr_tunnel_cat=category-c is unparseable, so the category comes
+  // from the hazmat:D=no exclusion: blocked at threshold D, open at E, hence
+  // exactly category D
+  expect_no_path(map, {"J", "L"}, hazmat_options("D/E"));
+  auto route = gurka::do_action(Options::route, map, {"J", "L"}, "truck", hazmat_options("E"));
+  gurka::assert::raw::expect_path(route, {"JK", "KL"});
+}
+
+TEST_F(TruckAdrInferenceTest, UncategorisedTunnelUnaffected) {
+  auto route = gurka::do_action(Options::route, map, {"M", "O"}, "truck", hazmat_options("B"));
+  gurka::assert::raw::expect_path(route, {"MN", "NO"});
+}
+
+// A category C tunnel with a height-limited bypass: ADR restrictions and
+// dimensional gates compose.
+class TruckAdrDetourTest : public ::testing::Test {
+protected:
+  static gurka::map map;
+
+  static void SetUpTestSuite() {
+    constexpr double gridsize = 100;
+
+    const std::string ascii_map = R"(
+      A----B----C----D
+           |    |
+           E----F
+    )";
+
+    const gurka::ways ways = {
+        {"AB", {{"highway", "residential"}}},
+        {"BC", {{"highway", "residential"}, {"tunnel", "yes"}, {"hazmat:adr_tunnel_cat", "C"}}},
+        {"CD", {{"highway", "residential"}}},
+        {"BE", {{"highway", "residential"}}},
+        {"EF", {{"highway", "residential"}, {"maxheight", "4.2"}}},
+        {"FC", {{"highway", "residential"}}},
+    };
+
+    const auto layout = gurka::detail::map_to_coordinates(ascii_map, gridsize);
+    map = gurka::buildtiles(layout, ways, {}, {}, "test/data/truck_adr_detour");
+  }
+};
+
+gurka::map TruckAdrDetourTest::map = {};
+
+TEST_F(TruckAdrDetourTest, NoCodeUsesTunnel) {
+  auto route = gurka::do_action(Options::route, map, {"A", "D"}, "truck");
+  gurka::assert::raw::expect_path(route, {"AB", "BC", "CD"});
+}
+
+TEST_F(TruckAdrDetourTest, CodeCDetoursAroundCategoryC) {
+  auto route = gurka::do_action(Options::route, map, {"A", "D"}, "truck", hazmat_options("C"));
+  gurka::assert::raw::expect_path(route, {"AB", "BE", "EF", "FC", "CD"});
+}
+
+TEST_F(TruckAdrDetourTest, CodeDUnaffectedByCategoryC) {
+  auto route = gurka::do_action(Options::route, map, {"A", "D"}, "truck", hazmat_options("D"));
+  gurka::assert::raw::expect_path(route, {"AB", "BC", "CD"});
+}
+
+TEST_F(TruckAdrDetourTest, AdrAndHeightGatesCompose) {
+  // the tunnel is barred by ADR and the bypass by maxheight=4.2: no path
+  auto options = hazmat_options("C");
+  options["/costing_options/truck/height"] = "4.5";
+  expect_no_path(map, {"A", "D"}, options);
+}
+
+TEST_F(TruckAdrDetourTest, HeightAloneKeepsTunnelOpen) {
+  // without hazmat the ADR category is ignored; only the bypass is
+  // height-limited, so the tall truck routes through the tunnel
+  auto route = gurka::do_action(Options::route, map, {"A", "D"}, "truck",
+                                {{"/costing_options/truck/height", "4.5"}});
+  gurka::assert::raw::expect_path(route, {"AB", "BC", "CD"});
+}

--- a/valhalla/baldr/directededge.h
+++ b/valhalla/baldr/directededge.h
@@ -303,6 +303,24 @@ public:
   void set_dest_only_hgv(const bool destonly_hgv);
 
   /**
+   * ADR (dangerous goods) tunnel category of this edge. 0 means no category
+   * is assigned or the tunnel is category A (never restricted); values 1-4
+   * correspond to ADR tunnel categories B-E (see AdrTunnelCategory in
+   * graphconstants.h).
+   * @return  Returns the AdrTunnelCategory numeric value (0-4).
+   */
+  uint8_t adr_tunnel_category() const {
+    return adr_tunnel_cat_;
+  }
+
+  /**
+   * Sets the ADR (dangerous goods) tunnel category of this edge.
+   * @param  category  AdrTunnelCategory numeric value: 0 = no category or
+   *                   category A, 1-4 = ADR tunnel categories B-E.
+   */
+  void set_adr_tunnel_category(const uint8_t category);
+
+  /**
    * Is this edge part of a tunnel?
    * @return  Returns true if this edge is part of a tunnel, false if not.
    */
@@ -1268,7 +1286,7 @@ protected:
   uint64_t indoor_ : 1;         // Is this edge indoor
   uint64_t lit_ : 1;            // Is the edge lit?
   uint64_t dest_only_hgv_ : 1;  // destonly for HGV specifically
-  uint64_t spare4_ : 3;
+  uint64_t adr_tunnel_cat_ : 3; // ADR tunnel category (0 = none/A, 1-4 = B-E)
 
   // 5th 8-byte word
   uint64_t turntype_ : 24;      // Turn type (see graphconstants.h)

--- a/valhalla/baldr/graphconstants.h
+++ b/valhalla/baldr/graphconstants.h
@@ -776,6 +776,21 @@ constexpr unsigned int kMaxWeightMask = 16;
 constexpr unsigned int kMaxAxleLoadMask = 32;
 constexpr unsigned int kMaxAxlesMask = 64;
 
+// ADR (dangerous goods) tunnel category assigned to a tunnel edge, per the
+// ADR agreement 1.9.5.2.2 (https://unece.org/transport/dangerous-goods) and
+// the OSM hazmat tagging scheme (https://wiki.openstreetmap.org/wiki/Key:hazmat).
+// Categories are totally ordered A < B < C < D < E, where E is the most
+// restrictive. kNone doubles as category A: category A tunnels carry no
+// dangerous-goods restriction, so for routing they are indistinguishable
+// from uncategorised tunnels.
+enum class AdrTunnelCategory : uint8_t {
+  kNone = 0, // no category assigned, or category A (never restricted)
+  kB = 1,
+  kC = 2,
+  kD = 3,
+  kE = 4,
+};
+
 // convert between the enum value and the corresponding mask
 constexpr std::array<uint8_t, 32> populate_access_restriction_masks() {
   std::array<uint8_t, 32> masks{};

--- a/valhalla/mjolnir/osmway.h
+++ b/valhalla/mjolnir/osmway.h
@@ -1659,6 +1659,23 @@ struct OSMWay {
   }
 
   /**
+   * Sets the ADR (dangerous goods) tunnel category of the way.
+   * @param  category  AdrTunnelCategory numeric value: 0 = no category or
+   *                   category A, 1-4 = ADR tunnel categories B-E.
+   */
+  void set_adr_tunnel_category(const uint8_t category) {
+    adr_tunnel_category_ = category;
+  }
+
+  /**
+   * Get the ADR (dangerous goods) tunnel category of the way.
+   * @return  Returns 0 for no category / category A, 1-4 for categories B-E.
+   */
+  uint8_t adr_tunnel_category() const {
+    return adr_tunnel_category_;
+  }
+
+  /**
    * Sets the has_user_tags flag.
    * @param  has_user_tags   Did a user enter the access tags?
    */
@@ -2725,7 +2742,8 @@ struct OSMWay {
   uint16_t lit_ : 1;
   uint16_t destination_only_hgv_ : 1;
   uint16_t area_ : 1;
-  uint16_t spare2_ : 1;
+  uint16_t adr_tunnel_category_ : 3; // ADR tunnel category (0 = none/A, 1-4 = B-E)
+  uint16_t spare2_ : 13;
 
   uint16_t nodecount_;
 


### PR DESCRIPTION
## Motivation

ADR 8.6.4 assigns European road tunnels dangerous-goods categories A to E, and every dangerous load carries a tunnel restriction code (B, B1000C, C/D, E, ...) that determines which categories it may pass. Valhalla's truck costing currently only knows the binary `hazmat` flag, so a hazmat truck is either banned from everything tagged against hazmat or allowed through everything else, regardless of its code. Issues like #3861 and #4401 show the demand for hazmat handling in truck costing; this PR adds the per-category granularity on top of the existing flag.

The motivating real-world case is the Beneluxtunnel corridor near Rotterdam: the tunnel way itself carries `hazmat:adr_tunnel_cat=C`, while its ~130 A4 approach ways carry only per-code tagging (`hazmat:B=no` + `hazmat:C=no` + `hazmat:D=yes` + `hazmat:E=yes`, no `tunnel` tag). Without category awareness, a code E load (which may legally pass a category C tunnel) and a code B load (which may not) both get detoured identically around the corridor.

## Design

Everything is opt-in and behaviour without the new option is identical to today.

* **baldr**: a 3-bit `adr_tunnel_cat_` edge attribute in the previously spare `spare4_` bits of `DirectedEdge` word 4 (`0 = none/A`, `1-4 = B-E`). Tile size and layout are unchanged; the existing `sizeof(DirectedEdge)` test still passes. The value is included in the tile JSON dump.
* **mjolnir**: categories are extracted in `lua/graph.lua` with precedence `hazmat:adr_tunnel_cat` > `hazmat:tunnel_cat` > inference from per-code `hazmat:B..E` sub-keys (highest excluded letter wins; the blanket-plus-allowance style `hazmat=no` + `hazmat:D..E=yes` derives the highest letter not explicitly allowed). Where the sub-keys express a tunnel categorisation, the crude blanket hazmat ban they would otherwise produce is suppressed; plain `hazmat=no` with no sub-keys stays a binary ban exactly as before. Malformed values fall through to current behaviour.
* **sif**: new `truck` costing option `adr_tunnel_code` (proto field 98, plain string, empty = no code declared). The parser accepts the canonical ADR spellings case-insensitively, plus the dash and `none` spellings (including ADR's parenthesised-dash notation) for an explicitly unrestricted load, and collapses each code to its first letter as a conservative worst-case reading of the quantity- and carriage-conditional clauses (the router does not know net explosive mass or tank carriage per movement, so it may avoid a tunnel a fully informed check would permit, but will never use one ADR could forbid). Enforcement is a hard block in `TruckCost::Allowed`/`AllowedReverse`, matching how other legal bans are handled. The option only takes effect when `hazmat` is true; a hazmat load with no declared code is conservatively treated as code B. Unrecognised codes add a request warning (code 500) and are treated as undeclared.

## Test coverage

`test/gurka/test_truck_adr_tunnel.cc` embeds a 13x5 truth table (13 code spellings x 5 tunnel categories) over explicit A-E tunnels, plus maps covering non-hazmat traffic ignoring categories, the extraction tiers (explicit keys, per-code inference, the blanket-ban boundary, malformed fallthrough, unset tunnels), corridor tagging mirroring the Beneluxtunnel's real tags, and a detour map exercising the interplay with dimensional restrictions. The same truth table is enforced against a second, independent implementation in MapMap's production stack, so the two cannot drift apart silently.

## Status

This series ships in production at MapMap on top of 3.8.2, rebased here onto master. Docs (`docs/docs/api/route/api-reference.md`) and CHANGELOG entries are included.

The series is five commits (edge attribute, extraction, costing option, gurka coverage, corridor derivation) and we are very happy to split it into smaller PRs, rename things, or change the extraction precedence if the maintainers prefer a different shape. Feedback welcome on the conservative first-letter collapse in particular, since it trades some route optimality for legal safety.
