### PR TITLE
mjolnir: make the short-ferry reclassification cutoff configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * **Enhancement**
    * CHANGED: move `GraphTile::GetTileId` to `GraphId::FromTilePath` as a static factory ctor [#6237](https://github.com/valhalla/valhalla/pull/6237)
    * CHANGED: use `filtered_edges` in CostMatrix's second pass [#6236](https://github.com/valhalla/valhalla/pull/6236) 
+   * ADDED: `mjolnir.short_ferry_max_length` config option to make the short-ferry reclassification cutoff configurable; the default of 2000 m keeps current behaviour and 0 reclassifies every ferry connection [#6245](https://github.com/valhalla/valhalla/pull/6245)
 
 ## Release Date: 2026-07-24 Valhalla 3.8.3
 * **Removed**

--- a/scripts/valhalla_build_config
+++ b/scripts/valhalla_build_config
@@ -160,6 +160,7 @@ config = {
         "max_concurrent_reader_users": 1,
         "reclassify_links": True,
         "pedestrian_areas": False,
+        "short_ferry_max_length": 2000.0,
         "default_speeds_config": Optional(str),
         "dataset_id": Optional(int),
         "data_processing": {
@@ -500,6 +501,7 @@ help_text = {
         "max_concurrent_reader_users": "number of threads in the threadpool which can be used to fetch tiles over the network via curl",
         "reclassify_links": "bool indicating whether or not to reclassify links - reclassifies ramps based on the lowest class connecting road",
         "pedestrian_areas": "bool indicating whether or not to generate traversal edges for pedestrian areas - default to False",
+        "short_ferry_max_length": "ferries shorter than this many metres are treated as minor crossings and their land connections are not reclassified onto the highway hierarchy; 0 reclassifies every ferry",
         "default_speeds_config": "a path indicating the json config file which graph enhancer will use to set the speeds of edges in the graph based on their geographic location (state/country), density (urban/rural), road class, road use (form of way)",
         "dataset_id": "Optional integer id to identify the tile dataset. By default we try to set the maximum OSM changeset ID.",
         "data_processing": {

--- a/src/mjolnir/ferry_connections.cc
+++ b/src/mjolnir/ferry_connections.cc
@@ -264,7 +264,8 @@ bool ShortFerry(const uint32_t node_index,
                 node_bundle& bundle,
                 sequence<Edge>& edges,
                 sequence<Node>& nodes,
-                sequence<OSMWayNode>& way_nodes) {
+                sequence<OSMWayNode>& way_nodes,
+                const float short_ferry_max_length) {
   // Method to get the shape for an edge - since LL is stored as a pair of
   // floats we need to change into PointLL to get length of an edge
   const auto EdgeShape = [&way_nodes](size_t idx, const size_t count) {
@@ -300,7 +301,7 @@ bool ShortFerry(const uint32_t node_index,
       // If the end node has a non-ferry edge check the length of the edge
       if (bundle2.node.non_ferry_edge_) {
         auto shape = EdgeShape(edge.first.llindex_, edge.first.attributes.llcount);
-        if (midgard::length(shape) < 2000.0f) {
+        if (midgard::length(shape) < short_ferry_max_length) {
           short_edge = true;
         }
       } else {
@@ -316,7 +317,8 @@ bool ShortFerry(const uint32_t node_index,
 void ReclassifyFerryConnections(const std::string& ways_file,
                                 const std::string& way_nodes_file,
                                 const std::string& nodes_file,
-                                const std::string& edges_file) {
+                                const std::string& edges_file,
+                                const float short_ferry_max_length) {
   SCOPED_TIMER();
   LOG_INFO("Reclassifying ferry connection graph edges...");
 
@@ -338,7 +340,7 @@ void ReclassifyFerryConnections(const std::string& ways_file,
     auto bundle = collect_node_edges(node_itr, nodes, edges);
     if (bundle.node.ferry_edge_ && bundle.node.non_ferry_edge_ &&
         GetBestNonFerryClass(bundle.node_edges) > kFerryUpClass &&
-        !ShortFerry(node_itr.position(), bundle, edges, nodes, way_nodes)) {
+        !ShortFerry(node_itr.position(), bundle, edges, nodes, way_nodes, short_ferry_max_length)) {
       bool inbound_path_found = false;
       bool outbound_path_found = false;
       [[maybe_unused]] const PointLL ll = (*nodes[node_itr.position()]).node.latlng();

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -1541,7 +1541,9 @@ void GraphBuilder::Build(const boost::property_tree::ptree& pt,
   // Do not reclassify ferry connection edges if no hierarchies are built. If reclassifying,
   // we use RoadClass::kPrimary (highway classification) as cutoff.
   if (pt.get<bool>("mjolnir.hierarchy", true)) {
-    ReclassifyFerryConnections(ways_file, way_nodes_file, nodes_file, edges_file);
+    ReclassifyFerryConnections(ways_file, way_nodes_file, nodes_file, edges_file,
+                               pt.get<float>("mjolnir.short_ferry_max_length",
+                                             kDefaultShortFerryMaxLength));
   } else {
     LOG_WARN("Not reclassifying ferry connections since no hierarches are being created");
   }

--- a/test/gurka/test_ferry_connections.cc
+++ b/test/gurka/test_ferry_connections.cc
@@ -831,3 +831,65 @@ INSTANTIATE_TEST_SUITE_P(ExcludeFerry,
 INSTANTIATE_TEST_SUITE_P(FerryConnectionTest,
                          FerryTest,
                          ::testing::Values("motorcar", "hgv", "moped", "motorcycle", "taxi", "bus"));
+
+// A single short ferry whose land connections are service roads — the
+// Kamenari-Lepetane (Bay of Kotor) shape, where the crossing is under a
+// kilometre but skipping it means a 35 km detour around the bay.
+//
+// Note this differs from the ShortFerry case above: there the crossing is
+// mapped as two ferry ways meeting at a node, which ShortFerry treats as
+// "not short" out of caution, so those connections are reclassified. Here
+// one ferry way joins land at both ends, so the length test actually
+// decides, and by default the connections stay on the local hierarchy
+// where long routes can never reach them.
+class ShortFerryReclassification : public ::testing::Test {
+protected:
+  // Builds the map with the given config overrides and reports whether the
+  // ferry's land connections reached the highway hierarchy level.
+  static bool
+  connections_on_highway_level(const std::unordered_map<std::string, std::string>& config_options) {
+    const std::string ascii_map = R"(
+          A--B--C==D--E--F
+    )";
+
+    const gurka::ways ways = {{"AB", {{"highway", "trunk"}}},
+                              {"BC", {{"highway", "service"}}},
+                              {"CD",
+                               {{"motor_vehicle", "yes"},
+                                {"motorcar", "yes"},
+                                {"route", "ferry"},
+                                {"name", "Short Strait Ferry"}}},
+                              {"DE", {{"highway", "service"}}},
+                              {"EF", {{"highway", "trunk"}}}};
+
+    // 100 m per character: the ferry way spans three cells, so ~300 m —
+    // far below the 2000 m default cutoff, and the same order as the
+    // 972 m crossing that motivated this.
+    const auto layout = gurka::detail::map_to_coordinates(ascii_map, 100);
+    auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_short_ferry_reclassification",
+                                 config_options);
+    baldr::GraphReader graph_reader(map.config.get_child("mjolnir"));
+
+    auto BC_edge_id = std::get<0>(gurka::findEdgeByNodes(graph_reader, layout, "B", "C"));
+    auto DE_edge_id = std::get<0>(gurka::findEdgeByNodes(graph_reader, layout, "D", "E"));
+    return BC_edge_id.level() == LEVEL_O && DE_edge_id.level() == LEVEL_O;
+  }
+};
+
+TEST_F(ShortFerryReclassification, DefaultLeavesShortFerryConnectionsLocal) {
+  EXPECT_FALSE(connections_on_highway_level({{"mjolnir.concurrency", "1"}}))
+      << "upstream default (2000 m) must be unchanged when the option is unset";
+}
+
+TEST_F(ShortFerryReclassification, ZeroLengthCutoffReclassifiesEveryFerry) {
+  EXPECT_TRUE(connections_on_highway_level(
+      {{"mjolnir.concurrency", "1"}, {"mjolnir.short_ferry_max_length", "0"}}))
+      << "with the exclusion disabled a short ferry's connections must reach the "
+         "highway hierarchy so long routes can still find the crossing";
+}
+
+TEST_F(ShortFerryReclassification, CutoffBelowFerryLengthReclassifies) {
+  // The ferry is ~300 m; a 50 m cutoff puts it above "minor crossing".
+  EXPECT_TRUE(connections_on_highway_level(
+      {{"mjolnir.concurrency", "1"}, {"mjolnir.short_ferry_max_length", "50"}}));
+}

--- a/valhalla/mjolnir/ferry_connections.h
+++ b/valhalla/mjolnir/ferry_connections.h
@@ -30,6 +30,13 @@ constexpr uint32_t kTemporary = 2;
 
 constexpr uint32_t kFerryUpClass = static_cast<uint32_t>(baldr::RoadClass::kPrimary);
 
+// Ferry edges shorter than this (metres) are treated as minor crossings
+// (a river punt rather than a strait crossing) and their land connections
+// are left at their original classification. Configurable via
+// mjolnir.short_ferry_max_length; 0 disables the exclusion so every ferry
+// has its connections reclassified.
+constexpr float kDefaultShortFerryMaxLength = 2000.0f;
+
 // NodeLabel - for simple shortest path
 struct NodeLabel {
   float cost;
@@ -61,7 +68,8 @@ struct NodeStatusInfo {
 void ReclassifyFerryConnections(const std::string& ways_file,
                                 const std::string& way_nodes_file,
                                 const std::string& nodes_file,
-                                const std::string& edges_file);
+                                const std::string& edges_file,
+                                const float short_ferry_max_length = kDefaultShortFerryMaxLength);
 
 } // namespace mjolnir
 } // namespace valhalla


### PR DESCRIPTION
## Motivation

`ReclassifyFerryConnections` lifts a ferry's land connections onto the highway hierarchy so that hierarchy pruning cannot cut the crossing out of a long route, but `ShortFerry` exempts any ferry under a hardcoded 2000 m.

The case that surfaced this: the 972 m Kamenari-Lepetane ferry carries the M-1/M-11 across the Verige strait in the Bay of Kotor (Montenegro). Its endpoint nodes touch only `highway=service` slipways, so the reclassification condition is met and then discarded by the length test. The connections stay on the local hierarchy, and any route long enough to have transitioned to the arterial or highway level cannot see the crossing: a 20 km route across the bay uses the ferry, while at 60 km Valhalla prefers driving 35 km around the bay over a 25 km route using the crossing. No runtime option reaches this (`use_ferry=1`, `ferry_cost=0` and `disable_hierarchy_pruning` all leave the route unchanged) because it is a graph-construction decision.

This is not an isolated tagging quirk: counting `route=ferry` ways with motor-vehicle access in OSM via Overpass, 1206 of 3057 European vehicle ferry ways (39.5%) are under 2000 m and share the exemption. Related reclassification gaps have been reported in #5510 and #5893; this PR addresses a different and simpler one, the hardcoded cutoff itself.

## Design

The cutoff becomes the `mjolnir.short_ferry_max_length` config value.

* Default is 2000 m, so an unset config produces byte-identical behaviour to today.
* `0` disables the exemption entirely, reclassifying every ferry connection.
* Documented in `scripts/valhalla_build_config` and the CHANGELOG.

## Test coverage

Gurka coverage in `test/gurka/test_ferry_connections.cc` builds the same short-crossing map twice and pins both sides: with the default the land connections are not reclassified (current behaviour), and with `short_ferry_max_length=0` they reach the highway hierarchy level.

## Status

This ships in production at MapMap (built with `short_ferry_max_length=0`), rebased here from 3.8.2 onto master. Happy to adjust naming, default, or test shape as the maintainers prefer.
