### PR TITLE
Treat access=unknown as destination-only, like access=private

### DIFF
--- a/lua/graph.lua
+++ b/lua/graph.lua
@@ -108,7 +108,8 @@ private = {
 ["customers"] = "true",
 ["delivery"] = "true",
 ["permit"] = "true",
-["residents"] = "true"
+["residents"] = "true",
+["unknown"] = "true"
 }
 
 no_thru_traffic = {

--- a/test/gurka/test_access.cc
+++ b/test/gurka/test_access.cc
@@ -599,6 +599,33 @@ TEST(Standalone, RouteOnPrivateAccess) {
   }
 }
 
+TEST(Standalone, RouteOnUnknownAccess) {
+  // access=unknown routes through the same destonly_ path as access=private.
+  constexpr double gridsize_metres = 10;
+
+  const std::string ascii_map = R"(
+        A---B---C
+            |
+            D
+    )";
+
+  const gurka::ways ways = {
+      {"AB", {{"highway", "primary"}}},
+      {"BC", {{"highway", "primary"}}},
+      {"BD", {{"highway", "track"}, {"access", "unknown"}}},
+  };
+
+  const auto layout =
+      gurka::detail::map_to_coordinates(ascii_map, gridsize_metres, {5.1079374, 52.0887174});
+  auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/gurka_route_on_unknown_access",
+                               build_config);
+
+  for (auto& c : costing) {
+    auto result = gurka::do_action(valhalla::Options::route, map, {"A", "D"}, c);
+    gurka::assert::raw::expect_path(result, {"AB", "BD"});
+  }
+}
+
 TEST(Standalone, AccessForwardBackward) {
   constexpr double gridsize_metres = 10;
 


### PR DESCRIPTION
access=unknown isn't recognized anywhere in lua/graph.lua, so ways tagged with it get default access, identical to having no access tag at all, even though the tag specifically signals unverified legal access (https://wiki.openstreetmap.org/wiki/Tag:access%3Dunknown).

Add "unknown" to the private table so it resolves through the existing destonly_ path, the same one access=private/destination/customers already use: reachable as an actual destination, not usable as a through route.

```lua
 private = {
 ["private"] = "true",
 ...
 ["residents"] = "true",
+["unknown"] = "true"
 }
```

This reuses the existing destination-only mechanism (tag_handlers_["private"] -> way_.set_destination_only(true) -> DirectedEdge::destonly()) instead of adding a new tile field, so it doesn't touch the frozen tile format.

Added test/gurka/test_access.cc's RouteOnUnknownAccess, modeled on the existing RouteOnPrivateAccess test. I don't have a full build environment available (no vcpkg), so I wasn't able to compile and run it locally, flagging that for CI/review rather than claiming it passes.