### PR TITLE
Add breakage_distance to the default meili customizable list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
    * ADDED: `cost` in verbose matrix output [#6249](https://github.com/valhalla/valhalla/pull/6249)
    * ADDED: `expansion_index` expansion property [#6251](https://github.com/valhalla/valhalla/pull/6251)
    * ADDED: route through pedestrian areas via generated medial axis traversals, behind the `mjolnir.pedestrian_areas` config option [#6195](https://github.com/valhalla/valhalla/pull/6195)
+   * CHANGED: add `breakage_distance` to the default `meili.customizable` list so the documented `trace_options.breakage_distance` can be raised per request [#6270](https://github.com/valhalla/valhalla/pull/6270)
 
 ## Release Date: 2026-07-24 Valhalla 3.8.3
 * **Removed**

--- a/scripts/valhalla_build_config
+++ b/scripts/valhalla_build_config
@@ -277,6 +277,7 @@ config = {
             "beta",
             "max_route_distance_factor",
             "max_route_time_factor",
+            "breakage_distance",
         ],
         "verbose": False,
         "default": {


### PR DESCRIPTION
Fixes #6268.

`trace_options.breakage_distance` is documented as a per-request option, but a supplied
value only ever takes effect in one direction:

- **lowering** it works — Loki's `check_distance()` uses the request value and rejects the
  trace with `Exceeded breakage distance for all pairs`;
- **raising** it does nothing — `MapMatcherFactory::MergeConfig()` drops it, because
  `breakage_distance` is absent from the default `meili.customizable` list, so Meili keeps
  the service-config value.

A caller who raises it to handle a sparse feed therefore passes input validation and then
silently hits the unchanged internal limit, with an error that points somewhere else.

This adds `breakage_distance` to the default `customizable` list. **No default value
changes**; the option simply becomes symmetric, like `search_radius` and
`turn_penalty_factor` already are.

### Verification

Two points 2400 m apart along the road, on a 3.8.3 instance with default config and the
same tiles, before and after adding the entry to `meili.customizable`:

| `trace_options.breakage_distance` | stock config | with this change |
|---|---|---|
| not supplied | 0 m | 0 m |
| 4000 | **0 m** | **2401 m** |
| 20000 | **0 m** | **2401 m** |

Behaviour with no option supplied is unchanged, so existing deployments are unaffected
unless they opt in.

The asymmetry also reproduces on the public FOSSGIS/OSM instance — see #6268 for
copy-pasteable `curl` commands against `valhalla1.openstreetmap.de`.

### Note

This makes the limit reachable per request; it does not address *why* the limit makes
matching impossible rather than merely unlikely. That is the subject of #6269, which
proposes bounding the route excess rather than the absolute route length, and which is a
behaviour change better discussed separately.
