### PR TITLE
Proposal: Report which locations a route error is about

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
    * ADDED: documentation page for the pedestrian areas feature [#6266](https://github.com/valhalla/valhalla/pull/6266)
    * ADDED: Add use_distance to truck, bus, taxi, motorcycle and motor_scooter cost [#6214](https://github.com/valhalla/valhalla/pull/6214)
    * ADDED: limitations, future work and performance sections to the pedestrian areas documentation [#6279](https://github.com/valhalla/valhalla/pull/6279)
+   * ADDED: `location_indices` to route errors 171 and 442, the indices of the request locations that failed, in the JSON error body and on pyvalhalla's `ValhallaError` [#6281](https://github.com/valhalla/valhalla/issues/6281)
 
 ## Release Date: 2026-07-24 Valhalla 3.8.3
 * **Removed**

--- a/docs/docs/api/openapi.yaml
+++ b/docs/docs/api/openapi.yaml
@@ -318,6 +318,13 @@ components:
               error:       { type: string }
               status_code: { type: integer }
               status:      { type: string }
+              location_indices:
+                type: array
+                items: { type: integer }
+                description: >-
+                  Positions in the request's `locations` the error is about. Only present for
+                  error 171 (the locations no road was found near) and 442 (the two ends of the
+                  leg no path was found for).
 
     RateLimited:
       description: |

--- a/src/bindings/python/README.md
+++ b/src/bindings/python/README.md
@@ -105,7 +105,10 @@ except ValhallaError as e:
     print(e.message)       # "No suitable edges near location"
     print(e.http_code)     # 400
     print(e.http_message)  # "Bad Request"
+    print(e.location_indices)  # [0, 1]
 ```
+
+`location_indices` are positions in the request's `locations`: for error 171 the locations no road was found near, for error 442 the two ends of the leg no path was found for. It is empty for every other error.
 
 #### Graph Utilities
 

--- a/src/bindings/python/src/exceptions.cc
+++ b/src/bindings/python/src/exceptions.cc
@@ -23,7 +23,12 @@ void init_exceptions(nb::module_& m) {
                                 ":ivar http_code: Corresponding HTTP status code.\n"
                                 ":vartype http_code: int\n"
                                 ":ivar http_message: Corresponding HTTP status message.\n"
-                                ":vartype http_message: str\n",
+                                ":vartype http_message: str\n"
+                                ":ivar location_indices: Indices into the request's ``locations`` "
+                                "this error is about: the locations no road was found for "
+                                "(code 171), or the two ends of the leg no path was found for "
+                                "(code 442). Empty for other errors.\n"
+                                ":vartype location_indices: list[int]\n",
                                 PyExc_RuntimeError, nullptr);
   // don't increase refcount, it's static
   m.attr("ValhallaError") = nb::borrow(ValhallaError);
@@ -45,6 +50,11 @@ void init_exceptions(nb::module_& m) {
             exc.attr("message") = nb::str(e.message.c_str());
             exc.attr("http_code") = nb::int_(e.http_code);
             exc.attr("http_message") = nb::str(e.http_message.c_str());
+            nb::list location_indices;
+            for (auto index : e.location_indices) {
+              location_indices.append(nb::int_(index));
+            }
+            exc.attr("location_indices") = location_indices;
             // Set the Python error indicator: raise exc
             PyErr_SetObject(type, exc.ptr());
           }

--- a/src/bindings/python/valhalla/_valhalla.pyi
+++ b/src/bindings/python/valhalla/_valhalla.pyi
@@ -24,6 +24,8 @@ class ValhallaError(RuntimeError):
     :vartype http_code: int
     :ivar http_message: Corresponding HTTP status message.
     :vartype http_message: str
+    :ivar location_indices: Indices into the request's ``locations`` this error is about: the locations no road was found for (code 171), or the two ends of the leg no path was found for (code 442). Empty for other errors.
+    :vartype location_indices: list[int]
     """
 
 class _Actor:

--- a/src/loki/route_action.cc
+++ b/src/loki/route_action.cc
@@ -152,10 +152,16 @@ void loki_worker_t::route(Api& request) {
 
     // throw if there's a location we did not find any
     // candidates for
+    std::vector<uint32_t> unreachable;
     for (const auto& location : *locations) {
       if (location.correlation().edges().empty() && location.correlation().filtered_edges().empty()) {
-        throw valhalla_exception_t(171);
+        unreachable.push_back(location.correlation().original_index());
       }
+    }
+    if (!unreachable.empty()) {
+      valhalla_exception_t e{171};
+      e.location_indices = std::move(unreachable);
+      throw e;
     }
 
     if (connectivity_map) {

--- a/src/thor/route_action.cc
+++ b/src/thor/route_action.cc
@@ -123,6 +123,14 @@ template <typename Predicate> inline void remove_path_edges(valhalla::Location& 
       ->DeleteSubrange(start_idx, loc.correlation().filtered_edges_size() - start_idx);
 }
 
+valhalla_exception_t no_path_between(const valhalla::Location& origin,
+                                     const valhalla::Location& destination) {
+  valhalla_exception_t e{442};
+  e.location_indices = {origin.correlation().original_index(),
+                        destination.correlation().original_index()};
+  return e;
+}
+
 /**
 // removes any edges from the location that aren't connected to it (because of radius)
 void remove_edges(const GraphId& edge_id, valhalla::Location& loc, GraphReader& reader) {
@@ -702,6 +710,7 @@ void thor_worker_t::path_arrive_by(Api& api, const std::string& costing) {
   while (origin != correlated.rend()) {
     auto destination = std::prev(origin);
     if (!route_two_locations(origin, destination)) {
+      const auto no_path = no_path_between(*origin, *destination);
       // if routing failed because an intermediate waypoint was snapped to the low reachability road
       // (such road lies in a small connectivity component that is not connected to other locations)
       // we should leave only high reachability candidates and try to route again
@@ -717,7 +726,7 @@ void thor_worker_t::path_arrive_by(Api& api, const std::string& costing) {
           // it doesn't make sense to continue if there are no more path edges
           if (loc->correlation().edges_size() == 0)
             // no route found
-            throw valhalla_exception_t{442};
+            throw no_path;
         }
         // resets the entire state of all the legs of the route and starts completely
         // over from the beginning doing all the legs over
@@ -731,7 +740,7 @@ void thor_worker_t::path_arrive_by(Api& api, const std::string& costing) {
         continue;
       }
       // no route found
-      throw valhalla_exception_t{442};
+      throw no_path;
     }
     ++origin;
   }
@@ -899,6 +908,7 @@ void thor_worker_t::path_depart_at(Api& api, const std::string& costing) {
   while (destination != correlated.end()) {
     auto origin = std::prev(destination);
     if (!route_two_locations(origin, destination)) {
+      const auto no_path = no_path_between(*origin, *destination);
       // if routing failed because an intermediate waypoint was snapped to the low reachability road
       // (such road lies in a small connectivity component that is not connected to other locations)
       // we should leave only high reachability candidates and try to route again
@@ -914,7 +924,7 @@ void thor_worker_t::path_depart_at(Api& api, const std::string& costing) {
           // it doesn't make sense to continue if there are no more path edges
           if (loc->correlation().edges_size() == 0)
             // no route found
-            throw valhalla_exception_t{442};
+            throw no_path;
         }
         // resets the entire state of all the legs of the route and starts completely
         // over from the beginning doing all the legs over
@@ -928,7 +938,7 @@ void thor_worker_t::path_depart_at(Api& api, const std::string& costing) {
         continue;
       }
       // no route found
-      throw valhalla_exception_t{442};
+      throw no_path;
     }
     ++destination;
   }

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -1347,6 +1347,13 @@ std::string serialize_error(const valhalla_exception_t& exception, Api& request)
     json_error->emplace("status_code", static_cast<uint64_t>(exception.http_code));
     json_error->emplace("error", std::string(exception.message));
     json_error->emplace("error_code", static_cast<uint64_t>(exception.code));
+    if (!exception.location_indices.empty()) {
+      auto location_indices = baldr::json::array({});
+      for (auto index : exception.location_indices) {
+        location_indices->emplace_back(static_cast<uint64_t>(index));
+      }
+      json_error->emplace("location_indices", location_indices);
+    }
     body << *json_error;
   }
 

--- a/test/bindings/python/test_actor.py
+++ b/test/bindings/python/test_actor.py
@@ -179,7 +179,27 @@ class TestBindings(unittest.TestCase):
         self.assertEqual(e.http_code, 400)
         self.assertEqual(e.message, "No suitable edges near location")
         self.assertEqual(e.http_message, "Bad Request")
+        self.assertEqual(e.location_indices, [0, 1])
         self.assertEqual(str(e), e.message)
+
+    def test_router_error_no_path(self):
+        # the last stop snaps onto a road stub the extract boundary cut off from the network
+        query = {
+            "locations": [
+                {"lat": 52.0907, "lon": 5.1214},
+                {"lat": 52.0950, "lon": 5.1150},
+                {"lat": 52.047005, "lon": 5.074808, "minimum_reachability": 0, "radius": 1},
+            ],
+            "costing": "auto"
+        }
+
+        with self.assertRaises(ValhallaError) as ctx:
+            self.actor.route(query)
+
+        e = ctx.exception
+        self.assertEqual(e.code, 442)
+        self.assertEqual(e.message, "No path could be found for input")
+        self.assertEqual(e.location_indices, [1, 2])
 
     def test_change_config(self):
         with NamedTemporaryFile('w+') as tmp:

--- a/test/gurka/test_access.cc
+++ b/test/gurka/test_access.cc
@@ -318,6 +318,13 @@ TEST_F(MultipleBarriers, BothClosed) {
   } catch (const std::runtime_error& e) {
     EXPECT_STREQ(e.what(), "No path could be found for input");
   }
+  try {
+    auto result = gurka::do_action(valhalla::Options::route, map, {"A", "C", "B"}, "auto");
+    gurka::assert::raw::expect_path(result, {}, "Unexpected path found");
+  } catch (const valhalla_exception_t& e) {
+    EXPECT_EQ(e.code, 442);
+    EXPECT_EQ(e.location_indices, (std::vector<uint32_t>{1, 2}));
+  }
 }
 
 TEST_F(MultipleBarriers, BothPrivate) {
@@ -678,6 +685,7 @@ TEST(Standalone, ViaFerrataDefault) {
     gurka::assert::raw::expect_path(result, {}, "Unexpected path found");
   } catch (const valhalla_exception_t& e) {
     EXPECT_STREQ(e.what(), "No suitable edges near location");
+    EXPECT_EQ(e.location_indices, (std::vector<uint32_t>{0, 1}));
   }
 }
 

--- a/valhalla/exceptions.h
+++ b/valhalla/exceptions.h
@@ -1,8 +1,10 @@
 #ifndef __VALHALLA_EXCEPTIONS_H__
 #define __VALHALLA_EXCEPTIONS_H__
 
+#include <cstdint>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 namespace valhalla {
 class Api;
@@ -36,6 +38,9 @@ struct valhalla_exception_t : public std::runtime_error {
   std::string http_message;
   std::string osrm_error;
   std::string statsd_key;
+  // indices into the request's locations this error is about (171: unsnappable locations,
+  // 442: the two ends of the leg without a path); empty for every other error
+  std::vector<uint32_t> location_indices;
 };
 
 /**


### PR DESCRIPTION
While building an app that uses Valhalla I found that a general "failed to route" error left the user experience lacking. On a multi-step route I had to do a human binary search on which location failed.

It would be good to be able to get an index reference to the location or segment that failed the route calculation. That was the UI can match that up with the input location and provide UI affordances (zoom to or visualise the problematic locations/segments).

# Issue

This is a proposal for #6281

I'm not sure if adding the location indices to the root exception type is appropriate here. I'm open to other channel to rely the data back to the python bindings.

## Tasklist

 - [x] Add tests
 - [x] Add #fixes with the issue number that this PR addresses
 - [x] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] ~~If you made changes to the lua files, update the [taginfo](taginfo.json) too~~
 - [ ] ~~If you changed English narrative phrases, run `po_tools.py update` — see [locales](docs/docs/contributing/locales.md)~~
