### PR TITLE
optionally skip installing prime_server in linux script

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Install deps
         run: |
           ./scripts/install-linux-deps.sh
-          python -m pip install requests shapely numpy
+          python -m pip install requests shapely numpy polib
       
       - name: Get timestamp & ccache dir
         run: |
@@ -153,7 +153,7 @@ jobs:
       - name: Install deps
         run: |
           ./scripts/install-linux-deps.sh
-          python -m pip install requests shapely numpy
+          python -m pip install requests shapely numpy polib
 
       - name: Get timestamp & ccache dir
         run: |
@@ -237,7 +237,7 @@ jobs:
       - name: Install deps
         run: |
           ./scripts/install-linux-deps.sh
-          python -m pip install requests shapely numpy
+          python -m pip install requests shapely numpy polib
 
       - name: Get timestamp & ccache dir
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Install deps
         run: |
           ./scripts/install-linux-deps.sh
-          python -m pip install requests shapely numpy polib
+          python -m pip install requests shapely numpy
       
       - name: Get timestamp & ccache dir
         run: |
@@ -153,7 +153,7 @@ jobs:
       - name: Install deps
         run: |
           ./scripts/install-linux-deps.sh
-          python -m pip install requests shapely numpy polib
+          python -m pip install requests shapely numpy
 
       - name: Get timestamp & ccache dir
         run: |
@@ -237,7 +237,7 @@ jobs:
       - name: Install deps
         run: |
           ./scripts/install-linux-deps.sh
-          python -m pip install requests shapely numpy polib
+          python -m pip install requests shapely numpy
 
       - name: Get timestamp & ccache dir
         run: |

--- a/scripts/install-linux-deps.sh
+++ b/scripts/install-linux-deps.sh
@@ -53,7 +53,6 @@ env DEBIAN_FRONTEND=noninteractive sudo apt install --yes --quiet \
     python3-all-dev \
     python3-shapely \
     python3-requests \
-    python3-polib \
     python3-pip \
     python3-polib \
     spatialite-bin \

--- a/scripts/install-linux-deps.sh
+++ b/scripts/install-linux-deps.sh
@@ -54,7 +54,6 @@ env DEBIAN_FRONTEND=noninteractive sudo apt install --yes --quiet \
     python3-shapely \
     python3-requests \
     python3-pip \
-    python3-polib \
     spatialite-bin \
     unzip \
     zlib1g-dev

--- a/scripts/install-linux-deps.sh
+++ b/scripts/install-linux-deps.sh
@@ -3,6 +3,15 @@
 
 set -x -o errexit -o pipefail -o nounset
 
+# --no-prime-server: not necessary when no services needed
+build_prime_server=true
+for arg in "$@"; do
+    case "$arg" in
+        --no-prime-server) build_prime_server=false ;;
+        *) echo "unknown argument: $arg" >&2; exit 1 ;;
+    esac
+done
+
 # Now, go through and install the build dependencies
 sudo apt-get update --assume-yes
 env DEBIAN_FRONTEND=noninteractive sudo apt install --yes --quiet \
@@ -46,16 +55,19 @@ env DEBIAN_FRONTEND=noninteractive sudo apt install --yes --quiet \
     python3-requests \
     python3-polib \
     python3-pip \
+    python3-polib \
     spatialite-bin \
     unzip \
     zlib1g-dev
   
-# build prime_server from source
-# readonly primeserver_version=0.7.0
-readonly primeserver_dir=/tmp/prime_server
-git clone --recurse-submodules https://github.com/kevinkreiser/prime_server $primeserver_dir
-pushd $primeserver_dir
-./autogen.sh && ./configure
-make -j${CONCURRENCY:-$(nproc)}
-sudo make install
-popd && rm -rf $primeserver_dir
+if [ "$build_prime_server" = true ]; then
+    # build prime_server from source
+    # readonly primeserver_version=0.7.0
+    readonly primeserver_dir=/tmp/prime_server
+    git clone --recurse-submodules https://github.com/kevinkreiser/prime_server $primeserver_dir
+    pushd $primeserver_dir
+    ./autogen.sh && ./configure
+    make -j${CONCURRENCY:-$(nproc)}
+    sudo make install
+    popd && rm -rf $primeserver_dir
+fi


### PR DESCRIPTION
oops.. currently FOSSGIS instance is failing, no `polib` installed. we missed adding it to `install-linux.sh` script.

this also adds `--no-prime-server` flag to that script. it's installed by ansible, all valhalla executables are installed to a custom, non-root location. shouldn't disturb anyone.