### PR TITLE
fix: check bounds against correct dim

### DIFF
--- a/valhalla/midgard/gridded_data.h
+++ b/valhalla/midgard/gridded_data.h
@@ -443,7 +443,7 @@ public:
           box[1] = std::min(std::max(i - 1, 0), box[1]);
           // +1 extra because range is exclusive
           box[2] = std::max(std::min(j + 2, this->ncolumns_ - 1), box[2]);
-          box[3] = std::max(std::min(i + 2, this->ncolumns_ - 1), box[3]);
+          box[3] = std::max(std::min(i + 2, this->nrows_ - 1), box[3]);
         }
       }
     }


### PR DESCRIPTION
# Issue

Sometimes GeoTIFF generation fails with SEGFAULT. The reason it out-of-bounds access. The PR fixes it.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [ ] If you changed English narrative phrases, run `po_tools.py update` — see [locales](docs/docs/contributing/locales.md)

