### PR TITLE
Fix reverse pedestrian transition reading the predecessor edge from the wrong tile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
    * FIXED: bg-BG spoke the literal text `<STREET_NAME>` in some case(s) [#6210](https://github.com/valhalla/valhalla/pull/6210)
    * FIXED: don't advance bounding-circle iterator past the end [#6241](https://github.com/valhalla/valhalla/pull/6241)
    * FIXED: update final path distance in recosting for `CostMatrix` [#6258](https://github.com/valhalla/valhalla/pull/6258)
+   * FIXED: read the predecessor edge levels from its own tile in reverse pedestrian transitions [#6290](https://github.com/valhalla/valhalla/pull/6290)
 * **Enhancement**
    * CHANGED: move `GraphTile::GetTileId` to `GraphId::FromTilePath` as a static factory ctor [#6237](https://github.com/valhalla/valhalla/pull/6237)
    * CHANGED: use `filtered_edges` in CostMatrix's second pass [#6236](https://github.com/valhalla/valhalla/pull/6236)

--- a/src/sif/pedestriancost.cc
+++ b/src/sif/pedestriancost.cc
@@ -847,8 +847,14 @@ Cost PedestrianCost::TransitionCostReverse(const uint32_t idx,
     // call functor to get limited access to reader
     baldr::LimitedGraphReader reader = reader_getter();
     auto to_tile = reader.GetGraphTile(edge_id);
+    if (to_tile == nullptr) {
+      return {elevator_penalty_, 0.0f};
+    }
     auto levels = tile->edgeinfo(pred).levels();
-    auto prev_levels = to_tile->edgeinfo(edge).levels();
+    // edge is the opposing edge of edge_id, so it belongs to the tile of edge_id's end node and its
+    // edge info offset means nothing in to_tile. Both directions share the same edge info, so read
+    // it through edge_id itself.
+    auto prev_levels = to_tile->edgeinfo(to_tile->directededge(edge_id)).levels();
     unsigned int traversed_levels = levels.first.size() == 1 && prev_levels.first.size() == 1 &&
                                             levels.first[0].first == levels.first[0].second &&
                                             prev_levels.first[0].first == prev_levels.first[0].second

--- a/test/gurka/test_indoor.cc
+++ b/test/gurka/test_indoor.cc
@@ -700,3 +700,51 @@ TEST(StandAlone, GenericLevelChange) {
   gurka::assert::raw::expect_instructions_at_maneuver_index(result, 1, "Continue to Level 1.", "", "",
                                                             "", "");
 }
+
+TEST(Standalone, ElevatorNodeReverseSearchAcrossTiles) {
+  // 100m per character leaves C and D in one level 2 tile and puts A, B and E in the next one, so
+  // the two directions of CA live in different tiles. Riding the elevator node A crosses three
+  // levels, which the reverse search has to pay for; the detour CDEB is the cheaper way round.
+  constexpr double gridsize_metres = 100;
+
+  const std::string ascii_map = R"(
+      C---A---B
+      |       |
+      |       |
+      |       |
+      |       |
+      D-------E
+    )";
+
+  const gurka::ways ways = {
+      {"AB", {{"highway", "corridor"}, {"indoor", "yes"}, {"level", "3"}}},
+      {"CA", {{"highway", "corridor"}, {"indoor", "yes"}, {"level", "0"}}},
+      {"CD", {{"highway", "corridor"}, {"indoor", "yes"}}},
+      {"DE", {{"highway", "corridor"}, {"indoor", "yes"}}},
+      {"EB", {{"highway", "corridor"}, {"indoor", "yes"}}},
+  };
+
+  const gurka::nodes nodes = {
+      {"A", {{"highway", "elevator"}, {"indoor", "yes"}}},
+  };
+
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, gridsize_metres, {0.2497, 0.1});
+  auto map =
+      gurka::buildtiles(layout, ways, nodes, {}, "test/data/gurka_elevator_cross_tile", build_config);
+
+  baldr::GraphReader reader(map.config.get_child("mjolnir"));
+  ASSERT_NE(std::get<0>(gurka::findEdge(reader, layout, "CA", "A")).tileid(),
+            std::get<0>(gurka::findEdge(reader, layout, "CA", "C")).tileid());
+  ASSERT_EQ(reader.nodeinfo(gurka::findNode(reader, layout, "A"))->type(),
+            baldr::NodeType::kElevator);
+
+  // arrive_by keeps the search reverse only, so it reaches the elevator node A over the
+  // predecessor edge CA, whose two directions sit in different tiles. Reading CA through the
+  // wrong tile loses its level and makes the ride look like a single level, cheap enough to beat
+  // the detour.
+  auto result = gurka::do_action(valhalla::Options::route, map, {"B", "C"}, "pedestrian",
+                                 {{"/date_time/type", "2"},
+                                  {"/date_time/value", "2024-01-01T10:00"},
+                                  {"/costing_options/pedestrian/elevator_penalty", "400"}});
+  gurka::assert::raw::expect_path(result, {"EB", "DE", "CD"});
+}


### PR DESCRIPTION
Fixes #6288.

`TransitionCostReverse` is handed the opposing directed edge, which lives in the tile of the end node, but reads its edge info through the tile of `edge_id`. The offset then belongs to a different tile, and at an elevator node on a tile boundary it lands past the end of the edge info section — `GetTags` throws "offset exceeds size of text list".

Reading the levels through `edge_id` and its own tile fixes it: both directions of an edge carry the same edge info, so the levels are the same and the offset is valid where it is applied. A missing tile now returns the flat elevator penalty instead of dereferencing null.

The test routes `arrive_by` over an elevator whose predecessor edge crosses a tile boundary, so only the reverse search runs. Without the fix the elevator ride is read as a single level and wins over the detour.
