### PR TITLE
fix: Shortcut/transit/etc. edges should use `kNoElevationData` (-500.0) instead of 0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
    * FIXED: don't advance bounding-circle iterator past the end [#6241](https://github.com/valhalla/valhalla/pull/6241)
    * FIXED: update final path distance in recosting for `CostMatrix` [#6258](https://github.com/valhalla/valhalla/pull/6258)
    * FIXED: Set `edge_index` for all interpolated points in `/trace_attributes` [#6278](https://github.com/valhalla/valhalla/pull/6278)
-   * FIXED: Shortcuts should use `kNoElevationData` (-500.0) instead of 0.0 [#6306](https://github.com/valhalla/valhalla/pull/6306)
+   * FIXED: Shortcut/transit/etc. edges should use `kNoElevationData` (-500.0) instead of 0.0 [#6306](https://github.com/valhalla/valhalla/pull/6306)
 * **Enhancement**
    * CHANGED: move `GraphTile::GetTileId` to `GraphId::FromTilePath` as a static factory ctor [#6237](https://github.com/valhalla/valhalla/pull/6237)
    * CHANGED: use `filtered_edges` in CostMatrix's second pass [#6236](https://github.com/valhalla/valhalla/pull/6236)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
    * FIXED: don't advance bounding-circle iterator past the end [#6241](https://github.com/valhalla/valhalla/pull/6241)
    * FIXED: update final path distance in recosting for `CostMatrix` [#6258](https://github.com/valhalla/valhalla/pull/6258)
    * FIXED: Set `edge_index` for all interpolated points in `/trace_attributes` [#6278](https://github.com/valhalla/valhalla/pull/6278)
+   * FIXED: Shortcuts should use `kNoElevationData` (-500.0) instead of 0.0 [#6306](https://github.com/valhalla/valhalla/pull/6306)
 * **Enhancement**
    * CHANGED: move `GraphTile::GetTileId` to `GraphId::FromTilePath` as a static factory ctor [#6237](https://github.com/valhalla/valhalla/pull/6237)
    * CHANGED: use `filtered_edges` in CostMatrix's second pass [#6236](https://github.com/valhalla/valhalla/pull/6236)

--- a/src/mjolnir/bssbuilder.cc
+++ b/src/mjolnir/bssbuilder.cc
@@ -342,9 +342,10 @@ void add_bss_nodes_and_edges(GraphTileBuilder& tilebuilder_local,
       uint32_t edge_info_offset =
           tilebuilder_local.AddEdgeInfo(tilebuilder_local.directededges().size(),
                                         new_bss_node_graphid, bss_to_waynode.way_node_id,
-                                        bss_to_waynode.wayid, 0, 0, 0, bss_to_waynode.shape,
-                                        bss_to_waynode.names, bss_to_waynode.tagged_values,
-                                        bss_to_waynode.linguistics, 0, added);
+                                        bss_to_waynode.wayid, kNoElevationData, 0, 0,
+                                        bss_to_waynode.shape, bss_to_waynode.names,
+                                        bss_to_waynode.tagged_values, bss_to_waynode.linguistics, 0,
+                                        added);
 
       directededge.set_edgeinfo_offset(edge_info_offset);
       tilebuilder_local.directededges().emplace_back(std::move(directededge));
@@ -483,9 +484,9 @@ void create_edges(GraphTileBuilder& tilebuilder_local,
       bool added;
       uint32_t edge_info_offset =
           tilebuilder_local.AddEdgeInfo(tilebuilder_local.directededges().size(), lower->way_node_id,
-                                        lower->bss_node_id, lower->wayid, 0, 0, 0, lower->shape,
-                                        lower->names, lower->tagged_values, lower->linguistics, 0,
-                                        added);
+                                        lower->bss_node_id, lower->wayid, kNoElevationData, 0, 0,
+                                        lower->shape, lower->names, lower->tagged_values,
+                                        lower->linguistics, 0, added);
 
       directededge.set_edgeinfo_offset(edge_info_offset);
 

--- a/src/mjolnir/convert_transit.cc
+++ b/src/mjolnir/convert_transit.cc
@@ -680,8 +680,8 @@ void AddToGraph(GraphTileBuilder& tilebuilder_transit,
         std::list<PointLL> shape = {egress_ll, station_ll};
 
         uint32_t edge_info_offset =
-            tilebuilder_transit.AddEdgeInfo(0, egress_graphid, station_graphid, 0, 0, 0, 0, shape,
-                                            names, tagged_values, linguistics, 0, added);
+            tilebuilder_transit.AddEdgeInfo(0, egress_graphid, station_graphid, 0, kNoElevationData,
+                                            0, 0, shape, names, tagged_values, linguistics, 0, added);
         directededge.set_edgeinfo_offset(edge_info_offset);
         directededge.set_forward(true);
 
@@ -728,8 +728,8 @@ void AddToGraph(GraphTileBuilder& tilebuilder_transit,
 
         // TODO - these need to be valhalla graph Ids
         uint32_t edge_info_offset =
-            tilebuilder_transit.AddEdgeInfo(0, station_graphid, egress_graphid, 0, 0, 0, 0, shape,
-                                            names, tagged_values, linguistics, 0, added);
+            tilebuilder_transit.AddEdgeInfo(0, station_graphid, egress_graphid, 0, kNoElevationData,
+                                            0, 0, shape, names, tagged_values, linguistics, 0, added);
         directededge.set_edgeinfo_offset(edge_info_offset);
         directededge.set_forward(false);
 
@@ -776,8 +776,8 @@ void AddToGraph(GraphTileBuilder& tilebuilder_transit,
 
         // TODO - these need to be valhalla graph Ids
         uint32_t edge_info_offset =
-            tilebuilder_transit.AddEdgeInfo(0, station_graphid, platform_graphid, 0, 0, 0, 0, shape,
-                                            names, tagged_values, linguistics, 0, added);
+            tilebuilder_transit.AddEdgeInfo(0, station_graphid, platform_graphid, 0, kNoElevationData,
+                                            0, 0, shape, names, tagged_values, linguistics, 0, added);
         directededge.set_edgeinfo_offset(edge_info_offset);
         directededge.set_forward(true);
 
@@ -855,8 +855,8 @@ void AddToGraph(GraphTileBuilder& tilebuilder_transit,
 
     // TODO - these need to be valhalla graph Ids
     uint32_t edge_info_offset =
-        tilebuilder_transit.AddEdgeInfo(0, platform_graphid, station_graphid, 0, 0, 0, 0, shape,
-                                        names, tagged_values, linguistics, 0, added);
+        tilebuilder_transit.AddEdgeInfo(0, platform_graphid, station_graphid, 0, kNoElevationData, 0,
+                                        0, shape, names, tagged_values, linguistics, 0, added);
 
     directededge.set_edgeinfo_offset(edge_info_offset);
     directededge.set_forward(false);
@@ -944,8 +944,8 @@ void AddToGraph(GraphTileBuilder& tilebuilder_transit,
 
       uint32_t edge_info_offset =
           tilebuilder_transit.AddEdgeInfo(transitedge.routeid, platform_graphid, end_platform_graphid,
-                                          0, 0, 0, 0, shape, names, tagged_values, linguistics, 0,
-                                          added);
+                                          0, kNoElevationData, 0, 0, shape, names, tagged_values,
+                                          linguistics, 0, added);
 
       directededge.set_edgeinfo_offset(edge_info_offset);
       directededge.set_forward(added);

--- a/src/mjolnir/shortcutbuilder.cc
+++ b/src/mjolnir/shortcutbuilder.cc
@@ -489,15 +489,15 @@ std::pair<uint32_t, uint32_t> AddShortcutEdges(GraphReader& reader,
       // Add the edge info. Use length and number of shape points to match an
       // edge in case multiple shortcut edges exist between the 2 nodes.
       // Test whether this shape is forward or reverse (in case an existing
-      // edge exists). Shortcuts use way Id = 0.Set mean elevation to 0 as a placeholder,
-      // set it later if adding elevation to this dataset. No need for names etc, shortcuts
-      // aren't used in guidance
+      // edge exists). Shortcuts use way Id = 0. ElevationBuilder runs after this stage and
+      // overwrites the mean elevation if the dataset has elevation. No need for names etc,
+      // shortcuts aren't used in guidance
       bool forward = true;
       uint32_t idx = ((length & 0xfffff) | ((shape.size() & 0xfff) << 20));
       uint32_t edge_info_offset =
-          tilebuilder.AddEdgeInfo(idx, start_node, end_node, 0, 0, edgeinfo.bike_network(),
-                                  edgeinfo.speed_limit(), shape, {}, {}, {}, 0, forward, false);
-      ;
+          tilebuilder.AddEdgeInfo(idx, start_node, end_node, 0, kNoElevationData,
+                                  edgeinfo.bike_network(), edgeinfo.speed_limit(), shape, {}, {}, {},
+                                  0, forward, false);
 
       newedge.set_edgeinfo_offset(edge_info_offset);
 

--- a/src/mjolnir/transitbuilder.cc
+++ b/src/mjolnir/transitbuilder.cc
@@ -1,4 +1,5 @@
 #include "mjolnir/transitbuilder.h"
+#include "baldr/graphconstants.h"
 #include "baldr/graphreader.h"
 #include "baldr/graphtile.h"
 #include "baldr/tilehierarchy.h"
@@ -162,8 +163,9 @@ void ConnectToGraph(GraphTileBuilder& tilebuilder_local,
       // Add edge info to the tile and set the offset in the directed edge
       bool added = false;
       uint32_t edge_info_offset =
-          tilebuilder_local.AddEdgeInfo(0, conn.osm_node, endnode, conn.wayid, 0, 0, 0, conn.shape,
-                                        conn.names, conn.tagged_values, conn.linguistics, 0, added);
+          tilebuilder_local.AddEdgeInfo(0, conn.osm_node, endnode, conn.wayid, kNoElevationData, 0, 0,
+                                        conn.shape, conn.names, conn.tagged_values, conn.linguistics,
+                                        0, added);
       directededge.set_edgeinfo_offset(edge_info_offset);
       directededge.set_forward(true);
       tilebuilder_local.directededges().emplace_back(std::move(directededge));
@@ -249,9 +251,9 @@ void ConnectToGraph(GraphTileBuilder& tilebuilder_local,
         auto r_shape = conn.shape;
         std::reverse(r_shape.begin(), r_shape.end());
         uint32_t edge_info_offset =
-            tilebuilder_transit.AddEdgeInfo(0, conn.stop_node, conn.osm_node, conn.wayid, 0, 0, 0,
-                                            r_shape, conn.names, conn.tagged_values, conn.linguistics,
-                                            0, added);
+            tilebuilder_transit.AddEdgeInfo(0, conn.stop_node, conn.osm_node, conn.wayid,
+                                            kNoElevationData, 0, 0, r_shape, conn.names,
+                                            conn.tagged_values, conn.linguistics, 0, added);
         LOG_DEBUG("Add conn from stop to OSM: ei offset = " + std::to_string(edge_info_offset));
         directededge.set_edgeinfo_offset(edge_info_offset);
         directededge.set_forward(true);

--- a/test/gurka/test_gtfs.cc
+++ b/test/gurka/test_gtfs.cc
@@ -855,6 +855,8 @@ TEST(GtfsExample, MakeTile) {
     }
     for (const auto& edge : tile->GetDirectedEdges()) {
       uses[edge.use()]++;
+      // nothing here was built with elevation, so every edge has to carry the no-data sentinel
+      EXPECT_EQ(tile->edgeinfo(&edge).mean_elevation(), kNoElevationData);
       if (edge.use() == Use::kTransitConnection) {
         EXPECT_TRUE((edge.forwardaccess() & kPedestrianAccess) ||
                     (edge.reverseaccess() & kPedestrianAccess));

--- a/test/gurka/test_shortcut.cc
+++ b/test/gurka/test_shortcut.cc
@@ -131,6 +131,7 @@ TEST(Shortcuts, ShortcutSpeed) {
       shortcut_infos.push_back(std::make_tuple(shortcutid, edge->speed(), edge->truck_speed()));
       // For current test case the values should be different
       EXPECT_NE(edge->speed(), edge->truck_speed());
+      EXPECT_EQ(tile->edgeinfo(edge).mean_elevation(), kNoElevationData); // no elevation sentinel
     }
   }
 


### PR DESCRIPTION
_Please don't force-push once you received the first review._

# Issue

This PR fixes slight inconsistency between regular edges and shortcuts - regular edges have `-500.0` guard value and shortcuts have zero.

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [ ] If you changed English narrative phrases, run `po_tools.py update` — see [locales](docs/docs/contributing/locales.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
