### PR TITLE
Make the route matcher's edge walk iterative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * **Removed**
    * REMOVED: Transifex and all locale JSONs [#6210](https://github.com/valhalla/valhalla/pull/6210)
 * **Bug Fix**
+   * FIXED: stack overflow in the route matcher's edge walking on long shapes, reached by `trace_route`/`trace_attributes` with `shape_match=edge_walk` or `walk_or_snap` and by `route` with `cost_factor_lines`: `expand_from_node` now runs on an explicit stack instead of recursing once per matched edge [#6294](https://github.com/valhalla/valhalla/issues/6294)
    * ADDED: .po file based translation workflow [#6210](https://github.com/valhalla/valhalla/pull/6210)
    * FIXED: bg-BG spoke the literal text `<STREET_NAME>` in some case(s) [#6210](https://github.com/valhalla/valhalla/pull/6210)
    * FIXED: don't advance bounding-circle iterator past the end [#6241](https://github.com/valhalla/valhalla/pull/6241)

--- a/src/thor/route_matcher.cc
+++ b/src/thor/route_matcher.cc
@@ -6,6 +6,7 @@
 #include "proto_conversions.h"
 
 #include <algorithm>
+#include <utility>
 #include <vector>
 
 using namespace valhalla::baldr;
@@ -123,6 +124,34 @@ end_node_t GetEndEdges(GraphReader& reader, const valhalla::Location& destinatio
 // node and expands from there. Returns true once the end node has been found (and
 // distance is approximately what it should be). Returns false if expansion from this
 // node fails (cannot find edges that match the trace - either in position or distance).
+//
+// The walk is a depth-first search with backtracking that runs on an explicit stack of
+// frames instead of recursing: its depth grows with the number of edges the shape covers,
+// and a caller embedding the library gets whatever stack its worker threads have, commonly
+// ~1 MB, which cannot hold one call frame per edge of a long shape.
+struct ExpandFrame {
+  // What one invocation takes as input
+  size_t correlated_index;
+  graph_tile_ptr tile;
+  GraphId node;
+  bool from_transition;
+
+  // Where the frame picks its work back up after a child frame finishes
+  enum class Resume : uint8_t { kStart, kEdgeChild, kEdgeScan, kTransChild, kTransScan };
+  Resume resume = Resume::kStart;
+
+  // Loop state that survives while a child frame runs. The scans keep the counters and
+  // the edge/transition offsets separate on purpose: the counters start from the
+  // followed_edges bookmark while the offsets start from the node's first edge or
+  // transition, so the offset is counter minus bookmark.
+  const NodeInfo* nodeinfo = nullptr;
+  uint32_t edge_start = 0;  // followed_edges bookmark the edge scan started from
+  uint32_t edge_i = 0;      // counter of the directed edge being tried
+  Cost edge_cost{};         // cost the tried edge added to elapsed, unwound if the child fails
+  uint32_t trans_start = 0; // followed_edges bookmark the transition scan started from
+  uint32_t trans_i = 0;     // counter of the node transition being tried
+};
+
 bool expand_from_node(const mode_costing_t& mode_costing,
                       const valhalla::sif::TravelMode& mode,
                       GraphReader& reader,
@@ -141,148 +170,219 @@ bool expand_from_node(const mode_costing_t& mode_costing,
                       GraphId& end_node,
                       followed_edges_t& followed_edges,
                       const bool use_shortcuts) {
-  // Done expanding when node equals stop node and the accumulated distance to that node
-  // plus the partial last edge distance is approximately equal to the total distance
-  auto n = end_nodes.find(node);
-  if (n != end_nodes.end() &&
-      valhalla::midgard::equal<float>((distances[correlated_index].second + n->second.second),
-                                      distances.back().second, kTotalDistanceEpsilon)) {
+  std::vector<ExpandFrame> stack;
+  stack.push_back({correlated_index, tile, node, from_transition});
+  // The popped frame's result. A frame that decides its own outcome assigns it; a frame whose
+  // outcome is its child's leaves the child's value in place, which is how a match reaches the root
+  bool matched = false;
 
-    if (!path_infos.back().is_shortcut) {
-      end_node = node;
-      return true;
-    } else { // can't end on a shortcut
-      return false;
-    }
-  }
-
-  // Get the last edge followed from this index
-  uint32_t level = node.level();
-  uint32_t start_de = followed_edges[correlated_index][level].first;
-
-  // Iterate through directed edges from this node
-  const NodeInfo* nodeinfo = tile->node(node);
-  GraphId edge_id(node.tileid(), level, nodeinfo->edge_index());
-  const DirectedEdge* de = tile->directededge(nodeinfo->edge_index());
-  for (uint32_t i = start_de; i < nodeinfo->edge_count(); i++, de++, ++edge_id) {
-    // Mark the directed edge as already followed
-    followed_edges[correlated_index][level].first = i;
-
-    // Skip shortcuts and transit connection edges
-    // TODO - later might allow transit connections for multi-modal
-    if ((!use_shortcuts && de->is_shortcut()) || de->use() == Use::kTransitConnection) {
-      continue;
-    }
-
-    // Look back in path_infos by 1-2 edges to make sure we aren't in a loop.
-    // A loop can occur if we have edges shorter than the lat,lng tolerance.
-    uint32_t n = path_infos.size();
-    if (n > 1 && (edge_id == path_infos[n - 2].edgeid || edge_id == path_infos[n - 1].edgeid)) {
-      continue;
-    }
-
-    // Get the end node LL and set up the length comparison
-    graph_tile_ptr end_node_tile = reader.GetGraphTile(de->endnode());
-    if (end_node_tile == nullptr) {
-      continue;
-    }
-    valhalla::midgard::PointLL de_end_ll = end_node_tile->get_node_ll(de->endnode());
-    float de_length = length_comparison(de->length(), true);
-
-    // Process current edge until shape matches end node or shape length is longer than
-    // the current edge. Increment to the next shape point after the correlated index.
-    size_t index = correlated_index + 1;
-    float length = 0.0f;
-    while (index < static_cast<size_t>(shape.size())) {
-      // Exclude edge if length along shape is longer than the edge length
-      length += distances.at(index).first;
-      if (length > de_length) {
-        break;
-      }
-
-      // Found a match if shape equals directed edge LL within tolerance
-      if (to_ll(shape.Get(index).ll()).ApproximatelyEqual(de_end_ll) &&
-          de->length() < length_comparison(length, true) &&
-          check_shape(tile, de, shape, correlated_index, index)) {
-
-        // Figure out what time it is right now, the first iteration is a no-op
-        auto offset_time_info = nodeinfo
-                                    ? time_info.forward(/*accumulated_elapsed.secs + */ elapsed.secs,
-                                                        nodeinfo->timezone())
-                                    : time_info;
-
-        // get the cost of traversing the node and the edge
-        auto& costing = mode_costing[static_cast<int>(mode)];
-        auto reader_getter = [&reader]() { return LimitedGraphReader(reader); };
-        auto transition_cost =
-            costing->TransitionCost(de, nodeinfo, prev_edge_label, tile, reader_getter);
-        uint8_t flow_sources;
-        auto cost =
-            transition_cost + costing->EdgeCost(de, edge_id, tile, offset_time_info, flow_sources);
-        elapsed += cost;
-        // overwrite time with timestamps
-        if (use_timestamps)
-          elapsed.secs = shape.Get(index).time() - shape.Get(0).time();
-
-        // Add edge and update correlated index
-        path_infos.emplace_back(mode, elapsed, edge_id, /*trip_id=*/0, /*path_distance=*/0.f,
-                                /*path_distance=*/-1, transition_cost,
-                                /*start_node_is_recovered=*/false, de->is_shortcut());
-
-        InternalTurn turn = nodeinfo
-                                ? costing->TurnType(prev_edge_label.opp_local_idx(), nodeinfo, de)
-                                : InternalTurn::kNoTurn;
-        // Set previous edge label
-        prev_edge_label = {kInvalidLabel,
-                           edge_id,
-                           de,
-                           {},
-                           0,
-                           mode,
-                           0,
-                           kInvalidRestriction,
-                           true,
-                           static_cast<bool>(flow_sources & kDefaultFlowMask),
-                           turn};
-
-        // Continue walking shape to find the end edge...
-        if (expand_from_node(mode_costing, mode, reader, shape, distances, time_info, use_timestamps,
-                             index, end_node_tile, de->endnode(), end_nodes, prev_edge_label, elapsed,
-                             path_infos, false, end_node, followed_edges, use_shortcuts)) {
-          return true;
-        } else {
-          // Match failed along this edge, pop the last entry off path_infos as well as what it
-          // contributed to the elapsed cost/time and try to keep going on the next edge
-          elapsed -= cost;
-          path_infos.pop_back();
-          break;
+  while (!stack.empty()) {
+    ExpandFrame& f = stack.back();
+    switch (f.resume) {
+      case ExpandFrame::Resume::kStart: {
+        // Done expanding when node equals stop node and the accumulated distance to that node
+        // plus the partial last edge distance is approximately equal to the total distance
+        auto n = end_nodes.find(f.node);
+        if (n != end_nodes.end() &&
+            valhalla::midgard::equal<float>((distances[f.correlated_index].second + n->second.second),
+                                            distances.back().second, kTotalDistanceEpsilon)) {
+          if (!path_infos.back().is_shortcut) {
+            end_node = f.node;
+            matched = true;
+          } else { // can't end on a shortcut
+            matched = false;
+          }
+          stack.pop_back();
+          continue;
         }
-      }
-      index++;
-    }
-  }
 
-  // Get the last transition followed from this index
-  uint32_t start_trans = followed_edges[correlated_index][level].second;
-
-  // Handle transitions - expand from the transition end nodes
-  if (!from_transition && nodeinfo->transition_count() > 0) {
-    const NodeTransition* trans = tile->transition(nodeinfo->transition_index());
-    for (uint32_t i = start_trans; i < nodeinfo->transition_count(); ++i, ++trans) {
-      followed_edges[correlated_index][level].second = i;
-      graph_tile_ptr end_node_tile = reader.GetGraphTile(trans->endnode());
-      if (end_node_tile == nullptr) {
+        f.nodeinfo = f.tile->node(f.node);
+        // Get the last edge followed from this index
+        f.edge_start = followed_edges[f.correlated_index][f.node.level()].first;
+        f.edge_i = f.edge_start;
+        f.resume = ExpandFrame::Resume::kEdgeScan;
         continue;
       }
-      if (expand_from_node(mode_costing, mode, reader, shape, distances, time_info, use_timestamps,
-                           correlated_index, end_node_tile, trans->endnode(), end_nodes,
-                           prev_edge_label, elapsed, path_infos, true, end_node, followed_edges,
-                           use_shortcuts)) {
-        return true;
+
+      case ExpandFrame::Resume::kEdgeChild: {
+        if (matched) {
+          stack.pop_back();
+          continue;
+        }
+        // Match failed along this edge, pop the last entry off path_infos as well as what it
+        // contributed to the elapsed cost/time and try to keep going on the next edge
+        elapsed -= f.edge_cost;
+        path_infos.pop_back();
+        ++f.edge_i;
+        f.resume = ExpandFrame::Resume::kEdgeScan;
+        continue;
+      }
+
+      case ExpandFrame::Resume::kEdgeScan: {
+        const uint32_t level = f.node.level();
+        const size_t corr_index = f.correlated_index;
+        // Iterate through directed edges from this node
+        // The accessor is bounds checked, so it is handed the node's first edge and the offset is
+        // added to the pointer: a resumed scan can sit one past the node's last edge, which is a
+        // pointer the loop condition rejects before anything reads it
+        const uint32_t de_offset = f.edge_i - f.edge_start;
+        GraphId edge_id(f.node.tileid(), level, f.nodeinfo->edge_index() + de_offset);
+        const DirectedEdge* de = f.tile->directededge(f.nodeinfo->edge_index()) + de_offset;
+        bool suspended = false;
+        for (uint32_t i = f.edge_i; i < f.nodeinfo->edge_count(); i++, de++, ++edge_id) {
+          // Mark the directed edge as already followed
+          followed_edges[corr_index][level].first = i;
+
+          // Skip shortcuts and transit connection edges
+          // TODO - later might allow transit connections for multi-modal
+          if ((!use_shortcuts && de->is_shortcut()) || de->use() == Use::kTransitConnection) {
+            continue;
+          }
+
+          // Look back in path_infos by 1-2 edges to make sure we aren't in a loop.
+          // A loop can occur if we have edges shorter than the lat,lng tolerance.
+          uint32_t n = path_infos.size();
+          if (n > 1 && (edge_id == path_infos[n - 2].edgeid || edge_id == path_infos[n - 1].edgeid)) {
+            continue;
+          }
+
+          // Get the end node LL and set up the length comparison
+          graph_tile_ptr end_node_tile = reader.GetGraphTile(de->endnode());
+          if (end_node_tile == nullptr) {
+            continue;
+          }
+          valhalla::midgard::PointLL de_end_ll = end_node_tile->get_node_ll(de->endnode());
+          float de_length = length_comparison(de->length(), true);
+
+          // Process current edge until shape matches end node or shape length is longer than
+          // the current edge. Increment to the next shape point after the correlated index.
+          size_t index = corr_index + 1;
+          float length = 0.0f;
+          while (index < static_cast<size_t>(shape.size())) {
+            // Exclude edge if length along shape is longer than the edge length
+            length += distances.at(index).first;
+            if (length > de_length) {
+              break;
+            }
+
+            // Found a match if shape equals directed edge LL within tolerance
+            if (to_ll(shape.Get(index).ll()).ApproximatelyEqual(de_end_ll) &&
+                de->length() < length_comparison(length, true) &&
+                check_shape(f.tile, de, shape, corr_index, index)) {
+
+              // Figure out what time it is right now, the first iteration is a no-op
+              auto offset_time_info =
+                  f.nodeinfo ? time_info.forward(/*accumulated_elapsed.secs + */ elapsed.secs,
+                                                 f.nodeinfo->timezone())
+                             : time_info;
+
+              // get the cost of traversing the node and the edge
+              auto& costing = mode_costing[static_cast<int>(mode)];
+              auto reader_getter = [&reader]() { return LimitedGraphReader(reader); };
+              auto transition_cost =
+                  costing->TransitionCost(de, f.nodeinfo, prev_edge_label, f.tile, reader_getter);
+              uint8_t flow_sources;
+              auto cost = transition_cost +
+                          costing->EdgeCost(de, edge_id, f.tile, offset_time_info, flow_sources);
+              elapsed += cost;
+              // overwrite time with timestamps
+              if (use_timestamps)
+                elapsed.secs = shape.Get(index).time() - shape.Get(0).time();
+
+              // Add edge and update correlated index
+              path_infos.emplace_back(mode, elapsed, edge_id, /*trip_id=*/0, /*path_distance=*/0.f,
+                                      /*path_distance=*/-1, transition_cost,
+                                      /*start_node_is_recovered=*/false, de->is_shortcut());
+
+              InternalTurn turn =
+                  f.nodeinfo ? costing->TurnType(prev_edge_label.opp_local_idx(), f.nodeinfo, de)
+                             : InternalTurn::kNoTurn;
+              // Set previous edge label
+              prev_edge_label = {kInvalidLabel,
+                                 edge_id,
+                                 de,
+                                 {},
+                                 0,
+                                 mode,
+                                 0,
+                                 kInvalidRestriction,
+                                 true,
+                                 static_cast<bool>(flow_sources & kDefaultFlowMask),
+                                 turn};
+
+              // Continue walking shape to find the end edge: suspend this frame and hand the
+              // walk to a child frame at the edge's end node. The push can move the frame, so
+              // it is not touched past this point.
+              f.edge_i = i;
+              f.edge_cost = cost;
+              f.resume = ExpandFrame::Resume::kEdgeChild;
+              GraphId next_node = de->endnode();
+              stack.push_back({index, std::move(end_node_tile), next_node, false});
+              suspended = true;
+              break;
+            }
+            index++;
+          }
+          if (suspended) {
+            break;
+          }
+        }
+        if (suspended) {
+          continue;
+        }
+
+        // Get the last transition followed from this index
+        f.trans_start = followed_edges[corr_index][level].second;
+        f.trans_i = f.trans_start;
+        f.resume = ExpandFrame::Resume::kTransScan;
+        continue;
+      }
+
+      case ExpandFrame::Resume::kTransChild: {
+        if (matched) {
+          stack.pop_back();
+          continue;
+        }
+        ++f.trans_i;
+        f.resume = ExpandFrame::Resume::kTransScan;
+        continue;
+      }
+
+      case ExpandFrame::Resume::kTransScan: {
+        // Handle transitions - expand from the transition end nodes
+        if (!f.from_transition && f.nodeinfo->transition_count() > 0) {
+          const uint32_t level = f.node.level();
+          const size_t corr_index = f.correlated_index;
+          // Same as the edge scan: base pointer through the checked accessor, offset added after
+          const NodeTransition* trans =
+              f.tile->transition(f.nodeinfo->transition_index()) + (f.trans_i - f.trans_start);
+          bool suspended = false;
+          for (uint32_t i = f.trans_i; i < f.nodeinfo->transition_count(); ++i, ++trans) {
+            followed_edges[corr_index][level].second = i;
+            graph_tile_ptr end_node_tile = reader.GetGraphTile(trans->endnode());
+            if (end_node_tile == nullptr) {
+              continue;
+            }
+            // Suspend this frame and expand from the transition's end node; the frame is not
+            // touched past the push.
+            f.trans_i = i;
+            f.resume = ExpandFrame::Resume::kTransChild;
+            GraphId next_node = trans->endnode();
+            stack.push_back({corr_index, std::move(end_node_tile), next_node, true});
+            suspended = true;
+            break;
+          }
+          if (suspended) {
+            continue;
+          }
+        }
+        matched = false;
+        stack.pop_back();
+        continue;
       }
     }
   }
-  return false;
+  return matched;
 }
 
 template <typename Options>

--- a/src/thor/route_matcher.cc
+++ b/src/thor/route_matcher.cc
@@ -125,10 +125,8 @@ end_node_t GetEndEdges(GraphReader& reader, const valhalla::Location& destinatio
 // distance is approximately what it should be). Returns false if expansion from this
 // node fails (cannot find edges that match the trace - either in position or distance).
 //
-// The walk is a depth-first search with backtracking that runs on an explicit stack of
-// frames instead of recursing: its depth grows with the number of edges the shape covers,
-// and a caller embedding the library gets whatever stack its worker threads have, commonly
-// ~1 MB, which cannot hold one call frame per edge of a long shape.
+// One frame per expansion, on an explicit stack: the depth grows with the edges the shape
+// covers, and an embedded caller's worker thread cannot hold that many call frames.
 struct ExpandFrame {
   // What one invocation takes as input
   size_t correlated_index;
@@ -140,10 +138,8 @@ struct ExpandFrame {
   enum class Resume : uint8_t { kStart, kEdgeChild, kEdgeScan, kTransChild, kTransScan };
   Resume resume = Resume::kStart;
 
-  // Loop state that survives while a child frame runs. The scans keep the counters and
-  // the edge/transition offsets separate on purpose: the counters start from the
-  // followed_edges bookmark while the offsets start from the node's first edge or
-  // transition, so the offset is counter minus bookmark.
+  // Loop state kept across a child frame. Counters start at the followed_edges bookmark
+  // while the edge and transition offsets start at the node's first, so offset is the difference
   const NodeInfo* nodeinfo = nullptr;
   uint32_t edge_start = 0;  // followed_edges bookmark the edge scan started from
   uint32_t edge_i = 0;      // counter of the directed edge being tried
@@ -209,8 +205,7 @@ bool expand_from_node(const mode_costing_t& mode_costing,
           stack.pop_back();
           continue;
         }
-        // Match failed along this edge, pop the last entry off path_infos as well as what it
-        // contributed to the elapsed cost/time and try to keep going on the next edge
+        // Match failed along this edge: undo what it added and try the next one
         elapsed -= f.edge_cost;
         path_infos.pop_back();
         ++f.edge_i;
@@ -222,9 +217,8 @@ bool expand_from_node(const mode_costing_t& mode_costing,
         const uint32_t level = f.node.level();
         const size_t corr_index = f.correlated_index;
         // Iterate through directed edges from this node
-        // The accessor is bounds checked, so it is handed the node's first edge and the offset is
-        // added to the pointer: a resumed scan can sit one past the node's last edge, which is a
-        // pointer the loop condition rejects before anything reads it
+        // Offset added to the pointer, not to the checked index: a resumed scan can sit one past
+        // the node's last edge, which the loop condition rejects before anything reads it
         const uint32_t de_offset = f.edge_i - f.edge_start;
         GraphId edge_id(f.node.tileid(), level, f.nodeinfo->edge_index() + de_offset);
         const DirectedEdge* de = f.tile->directededge(f.nodeinfo->edge_index()) + de_offset;
@@ -310,9 +304,8 @@ bool expand_from_node(const mode_costing_t& mode_costing,
                                  static_cast<bool>(flow_sources & kDefaultFlowMask),
                                  turn};
 
-              // Continue walking shape to find the end edge: suspend this frame and hand the
-              // walk to a child frame at the edge's end node. The push can move the frame, so
-              // it is not touched past this point.
+              // Continue walking shape to find the end edge. The push can move f, so it is
+              // written before and not touched after
               f.edge_i = i;
               f.edge_cost = cost;
               f.resume = ExpandFrame::Resume::kEdgeChild;

--- a/src/thor/route_matcher.cc
+++ b/src/thor/route_matcher.cc
@@ -292,17 +292,19 @@ bool expand_from_node(const mode_costing_t& mode_costing,
                   f.nodeinfo ? costing->TurnType(prev_edge_label.opp_local_idx(), f.nodeinfo, de)
                              : InternalTurn::kNoTurn;
               // Set previous edge label
-              prev_edge_label = {kInvalidLabel,
-                                 edge_id,
-                                 de,
-                                 {},
-                                 0,
-                                 mode,
-                                 0,
-                                 kInvalidRestriction,
-                                 true,
-                                 static_cast<bool>(flow_sources & kDefaultFlowMask),
-                                 turn};
+              prev_edge_label = {
+                  kInvalidLabel,
+                  edge_id,
+                  de,
+                  {},
+                  0,
+                  mode,
+                  0,
+                  kInvalidRestriction,
+                  true,
+                  static_cast<bool>(flow_sources & kDefaultFlowMask),
+                  turn,
+              };
 
               // Continue walking shape to find the end edge. The push can move f, so it is
               // written before and not touched after

--- a/src/thor/route_matcher.cc
+++ b/src/thor/route_matcher.cc
@@ -120,11 +120,6 @@ end_node_t GetEndEdges(GraphReader& reader, const valhalla::Location& destinatio
   return end_nodes;
 }
 
-// Expand from a correlated node. Walks the shape ahead to find the next correlated
-// node and expands from there. Returns true once the end node has been found (and
-// distance is approximately what it should be). Returns false if expansion from this
-// node fails (cannot find edges that match the trace - either in position or distance).
-//
 // One frame per expansion, on an explicit stack: the depth grows with the edges the shape
 // covers, and an embedded caller's worker thread cannot hold that many call frames.
 struct ExpandFrame {
@@ -148,6 +143,10 @@ struct ExpandFrame {
   uint32_t trans_i = 0;     // counter of the node transition being tried
 };
 
+// Expand from a correlated node. Walks the shape ahead to find the next correlated
+// node and expands from there. Returns true once the end node has been found (and
+// distance is approximately what it should be). Returns false if expansion from this
+// node fails (cannot find edges that match the trace - either in position or distance).
 bool expand_from_node(const mode_costing_t& mode_costing,
                       const valhalla::sif::TravelMode& mode,
                       GraphReader& reader,
@@ -167,6 +166,8 @@ bool expand_from_node(const mode_costing_t& mode_costing,
                       followed_edges_t& followed_edges,
                       const bool use_shortcuts) {
   std::vector<ExpandFrame> stack;
+  // An edge child always takes a larger shape index, so the depth cannot outrun the shape
+  stack.reserve(shape.size());
   stack.push_back({correlated_index, tile, node, from_transition});
   // The popped frame's result. A frame that decides its own outcome assigns it; a frame whose
   // outcome is its child's leaves the child's value in place, which is how a match reaches the root

--- a/test/gurka/test_route_matcher.cc
+++ b/test/gurka/test_route_matcher.cc
@@ -17,9 +17,8 @@ using namespace valhalla;
 
 namespace {
 
-// gurka names a node with a single byte, so the chain runs over the graphic byte values: ASCII
-// 0x21-0x7E and Latin-1 0xA1-0xFF, which leaves out space, DEL, the C1 block and NBSP. The edge
-// walk takes one step per edge, so the chain length is what drives its depth.
+// gurka names a node with a single byte, so the chain runs over the graphic ones: ASCII 0x21-0x7E
+// and Latin-1 0xA1-0xFF. The walk takes one step per edge, so the length is what drives its depth
 std::vector<std::string> chain_node_names() {
   std::vector<std::string> names;
   for (int b = 0x21; b <= 0x7E; ++b) {
@@ -44,10 +43,8 @@ gurka::map build_chain_map(const std::vector<std::string>& names) {
   return gurka::buildtiles(layout, ways, {}, {}, "test/data/route_matcher_deep");
 }
 
-// gurka's request builder appends its own "shape_match": "map_snap" after it applies the options,
-// so reaching the edge walk through it leaves two keys in the request and relies on the first one
-// winning. Nothing asserted below would notice if the walk stopped running, so the request is built
-// here rather than resting on that.
+// Reaching edge_walk through gurka's request builder leaves two shape_match keys and relies on the
+// first winning; nothing asserted below would notice if the walk stopped running
 std::string build_edge_walk_request(const gurka::map& map, const std::vector<std::string>& names) {
   rapidjson::Document doc;
   doc.SetObject();
@@ -121,14 +118,11 @@ void* run_trace(void* arg) {
 
 size_t small_stack_bytes() {
 #ifdef ROUTE_MATCHER_DEEP_ASAN
-  // Redzones inflate every frame, the pipeline outside the walk included, so the stack is raised to
-  // keep instrumentation alone from failing this. A per-edge recursion is caught by the
-  // uninstrumented builds, not by this one
+  // Redzones inflate every frame, so this is raised to keep instrumentation alone from failing it;
+  // a per-edge recursion is caught by the uninstrumented builds, not by this one
   constexpr size_t kSmallStack = 512 * 1024;
 #else
-  // Below what one frame per chain edge would need, above what the request needs without that: on
-  // arm64 the whole call runs in under 24 KB here at -O0, while walking the same chain one frame
-  // per edge needs more than 192 KB
+  // Above what the walk needs, below what a frame per chain edge would need, in both build types
   constexpr size_t kSmallStack = 48 * 1024;
 #endif
   // A platform with a larger floor turns this into a plain smoke test rather than an EINVAL failure
@@ -170,10 +164,8 @@ TEST(RouteMatcher, LongChainEdgeWalkOnSmallThreadStack) {
 
 #endif // _WIN32
 
-// A node's edges and transitions are visited from a bookmark, so a scan that resumes after a failed
-// branch can sit one past the last of them. Both nodes below own the last edge, respectively the
-// last transition, of their tile, which is where a one-past index and a one-past pointer differ:
-// the index is rejected by the bounds-checked accessors, the pointer only by the loop condition.
+// A scan resumed after a failed branch can sit one past a node's last edge or transition. Both
+// nodes below own their tile's last, where a one-past index and a one-past pointer differ
 TEST(RouteMatcher, BacktrackPastLastEdgeOfTile) {
   gurka::nodelayout layout;
   layout["A"] = {5.10, 45.09};
@@ -196,8 +188,7 @@ TEST(RouteMatcher, BacktrackPastLastEdgeOfTile) {
   ASSERT_EQ(nodeinfo->edge_count(), 2u);
   ASSERT_GT(nodeinfo->transition_count(), 0u);
 
-  // A->N matches, N->B matches and then fails, and the walk has to come back and take N's
-  // transition to reach D
+  // N->B matches then fails, so the walk must come back and take N's transition to reach D
   std::string trace_json;
   gurka::do_action(valhalla::Options::trace_attributes, map,
                    build_edge_walk_request(map, {"A", "N", "B", "D"}), {}, &trace_json);

--- a/test/gurka/test_route_matcher.cc
+++ b/test/gurka/test_route_matcher.cc
@@ -4,14 +4,8 @@
 
 #include <gtest/gtest.h>
 
-#include <algorithm>
-#include <climits>
 #include <string>
 #include <vector>
-
-#ifndef _WIN32
-#include <pthread.h>
-#endif
 
 using namespace valhalla;
 
@@ -89,48 +83,6 @@ void assert_full_chain(const std::string& trace_json, size_t expected_edges) {
   ASSERT_EQ(result["edges"].GetArray().Size(), expected_edges);
 }
 
-#ifndef _WIN32
-
-struct TraceCall {
-  const gurka::map* map;
-  std::string request;
-  std::string json;
-  std::string error;
-};
-
-void* run_trace(void* arg) {
-  auto* call = static_cast<TraceCall*>(arg);
-  try {
-    gurka::do_action(valhalla::Options::trace_attributes, *call->map, call->request, {}, &call->json);
-  } catch (const std::exception& e) { call->error = e.what(); } catch (...) {
-    call->error = "unknown exception";
-  }
-  return nullptr;
-}
-
-#if defined(__SANITIZE_ADDRESS__)
-#define ROUTE_MATCHER_DEEP_ASAN 1
-#elif defined(__has_feature)
-#if __has_feature(address_sanitizer)
-#define ROUTE_MATCHER_DEEP_ASAN 1
-#endif
-#endif
-
-size_t small_stack_bytes() {
-#ifdef ROUTE_MATCHER_DEEP_ASAN
-  // Redzones inflate every frame, so this is raised to keep instrumentation alone from failing it;
-  // a per-edge recursion is caught by the uninstrumented builds, not by this one
-  constexpr size_t kSmallStack = 512 * 1024;
-#else
-  // Above what the walk needs, below what a frame per chain edge would need, in both build types
-  constexpr size_t kSmallStack = 48 * 1024;
-#endif
-  // A platform with a larger floor turns this into a plain smoke test rather than an EINVAL failure
-  return std::max<size_t>(kSmallStack, static_cast<size_t>(PTHREAD_STACK_MIN));
-}
-
-#endif // _WIN32
-
 } // namespace
 
 TEST(RouteMatcher, LongChainEdgeWalk) {
@@ -142,27 +94,6 @@ TEST(RouteMatcher, LongChainEdgeWalk) {
                    &trace_json);
   assert_full_chain(trace_json, names.size() - 1);
 }
-
-#ifndef _WIN32
-
-TEST(RouteMatcher, LongChainEdgeWalkOnSmallThreadStack) {
-  auto names = chain_node_names();
-  auto map = build_chain_map(names);
-
-  TraceCall call{&map, build_edge_walk_request(map, names), {}, {}};
-  pthread_attr_t attr;
-  ASSERT_EQ(pthread_attr_init(&attr), 0);
-  ASSERT_EQ(pthread_attr_setstacksize(&attr, small_stack_bytes()), 0);
-  pthread_t thread;
-  ASSERT_EQ(pthread_create(&thread, &attr, run_trace, &call), 0);
-  pthread_attr_destroy(&attr);
-  ASSERT_EQ(pthread_join(thread, nullptr), 0);
-
-  ASSERT_TRUE(call.error.empty()) << call.error;
-  assert_full_chain(call.json, names.size() - 1);
-}
-
-#endif // _WIN32
 
 // A scan resumed after a failed branch can sit one past a node's last edge or transition. Both
 // nodes below own their tile's last, where a one-past index and a one-past pointer differ

--- a/test/gurka/test_route_matcher.cc
+++ b/test/gurka/test_route_matcher.cc
@@ -1,0 +1,236 @@
+#include "baldr/graphreader.h"
+#include "baldr/rapidjson_utils.h"
+#include "gurka.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <climits>
+#include <string>
+#include <vector>
+
+#ifndef _WIN32
+#include <pthread.h>
+#endif
+
+using namespace valhalla;
+
+namespace {
+
+// gurka names a node with a single byte, so the chain runs over the graphic byte values: ASCII
+// 0x21-0x7E and Latin-1 0xA1-0xFF, which leaves out space, DEL, the C1 block and NBSP. The edge
+// walk takes one step per edge, so the chain length is what drives its depth.
+std::vector<std::string> chain_node_names() {
+  std::vector<std::string> names;
+  for (int b = 0x21; b <= 0x7E; ++b) {
+    names.emplace_back(1, static_cast<char>(b));
+  }
+  for (int b = 0xA1; b <= 0xFF; ++b) {
+    names.emplace_back(1, static_cast<char>(b));
+  }
+  return names;
+}
+
+gurka::map build_chain_map(const std::vector<std::string>& names) {
+  // A straight west-to-east chain, roughly 40 m per edge
+  gurka::nodelayout layout;
+  for (size_t i = 0; i < names.size(); ++i) {
+    layout[names[i]] = {5.0 + static_cast<double>(i) * 0.0005, 45.0};
+  }
+  gurka::ways ways;
+  for (size_t i = 0; i + 1 < names.size(); ++i) {
+    ways[names[i] + names[i + 1]] = {{"highway", "primary"}};
+  }
+  return gurka::buildtiles(layout, ways, {}, {}, "test/data/route_matcher_deep");
+}
+
+// gurka's request builder appends its own "shape_match": "map_snap" after it applies the options,
+// so reaching the edge walk through it leaves two keys in the request and relies on the first one
+// winning. Nothing asserted below would notice if the walk stopped running, so the request is built
+// here rather than resting on that.
+std::string build_edge_walk_request(const gurka::map& map, const std::vector<std::string>& names) {
+  rapidjson::Document doc;
+  doc.SetObject();
+  auto& allocator = doc.GetAllocator();
+  rapidjson::Value shape(rapidjson::kArrayType);
+  for (const auto& name : names) {
+    const auto& ll = map.nodes.at(name);
+    rapidjson::Value point(rapidjson::kObjectType);
+    point.AddMember("lon", ll.lng(), allocator);
+    point.AddMember("lat", ll.lat(), allocator);
+    shape.PushBack(point, allocator);
+  }
+  doc.AddMember("shape", shape, allocator);
+  doc.AddMember("costing", "auto", allocator);
+  doc.AddMember("shape_match", "edge_walk", allocator);
+  rapidjson::StringBuffer sb;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(sb);
+  doc.Accept(writer);
+  return sb.GetString();
+}
+
+// The node at a given location on a given level, with the tile holding it
+std::pair<baldr::GraphId, baldr::graph_tile_ptr>
+find_node(baldr::GraphReader& reader, uint32_t level, const midgard::PointLL& ll) {
+  for (auto tile_id : reader.GetTileSet(level)) {
+    auto tile = reader.GetGraphTile(tile_id);
+    for (auto id = tile_id; id.id() < tile->header()->nodecount(); ++id) {
+      if (tile->get_node_ll(id).ApproximatelyEqual(ll)) {
+        return {id, tile};
+      }
+    }
+  }
+  return {{}, nullptr};
+}
+
+// The edge walk must have matched every edge of the chain
+void assert_full_chain(const std::string& trace_json, size_t expected_edges) {
+  rapidjson::Document result;
+  result.Parse(trace_json.c_str());
+  ASSERT_FALSE(result.HasParseError());
+  ASSERT_TRUE(result.HasMember("edges"));
+  ASSERT_EQ(result["edges"].GetArray().Size(), expected_edges);
+}
+
+#ifndef _WIN32
+
+struct TraceCall {
+  const gurka::map* map;
+  std::string request;
+  std::string json;
+  std::string error;
+};
+
+void* run_trace(void* arg) {
+  auto* call = static_cast<TraceCall*>(arg);
+  try {
+    gurka::do_action(valhalla::Options::trace_attributes, *call->map, call->request, {}, &call->json);
+  } catch (const std::exception& e) { call->error = e.what(); } catch (...) {
+    call->error = "unknown exception";
+  }
+  return nullptr;
+}
+
+#if defined(__SANITIZE_ADDRESS__)
+#define ROUTE_MATCHER_DEEP_ASAN 1
+#elif defined(__has_feature)
+#if __has_feature(address_sanitizer)
+#define ROUTE_MATCHER_DEEP_ASAN 1
+#endif
+#endif
+
+size_t small_stack_bytes() {
+#ifdef ROUTE_MATCHER_DEEP_ASAN
+  // Redzones inflate every frame, the pipeline outside the walk included, so the stack is raised to
+  // keep instrumentation alone from failing this. A per-edge recursion is caught by the
+  // uninstrumented builds, not by this one
+  constexpr size_t kSmallStack = 512 * 1024;
+#else
+  // Below what one frame per chain edge would need, above what the request needs without that: on
+  // arm64 the whole call runs in under 24 KB here at -O0, while walking the same chain one frame
+  // per edge needs more than 192 KB
+  constexpr size_t kSmallStack = 48 * 1024;
+#endif
+  // A platform with a larger floor turns this into a plain smoke test rather than an EINVAL failure
+  return std::max<size_t>(kSmallStack, static_cast<size_t>(PTHREAD_STACK_MIN));
+}
+
+#endif // _WIN32
+
+} // namespace
+
+TEST(RouteMatcher, LongChainEdgeWalk) {
+  auto names = chain_node_names();
+  auto map = build_chain_map(names);
+
+  std::string trace_json;
+  gurka::do_action(valhalla::Options::trace_attributes, map, build_edge_walk_request(map, names), {},
+                   &trace_json);
+  assert_full_chain(trace_json, names.size() - 1);
+}
+
+#ifndef _WIN32
+
+TEST(RouteMatcher, LongChainEdgeWalkOnSmallThreadStack) {
+  auto names = chain_node_names();
+  auto map = build_chain_map(names);
+
+  TraceCall call{&map, build_edge_walk_request(map, names), {}, {}};
+  pthread_attr_t attr;
+  ASSERT_EQ(pthread_attr_init(&attr), 0);
+  ASSERT_EQ(pthread_attr_setstacksize(&attr, small_stack_bytes()), 0);
+  pthread_t thread;
+  ASSERT_EQ(pthread_create(&thread, &attr, run_trace, &call), 0);
+  pthread_attr_destroy(&attr);
+  ASSERT_EQ(pthread_join(thread, nullptr), 0);
+
+  ASSERT_TRUE(call.error.empty()) << call.error;
+  assert_full_chain(call.json, names.size() - 1);
+}
+
+#endif // _WIN32
+
+// A node's edges and transitions are visited from a bookmark, so a scan that resumes after a failed
+// branch can sit one past the last of them. Both nodes below own the last edge, respectively the
+// last transition, of their tile, which is where a one-past index and a one-past pointer differ:
+// the index is rejected by the bounds-checked accessors, the pointer only by the loop condition.
+TEST(RouteMatcher, BacktrackPastLastEdgeOfTile) {
+  gurka::nodelayout layout;
+  layout["A"] = {5.10, 45.09};
+  layout["B"] = {5.09, 45.09};
+  layout["C"] = {5.09, 45.09};
+  layout["D"] = {5.08, 45.08};
+  layout["N"] = {5.10, 45.10};
+  const gurka::ways ways = {
+      {"AN", {{"highway", "residential"}}},
+      {"NB", {{"highway", "residential"}}},
+      {"NCD", {{"highway", "primary"}}},
+  };
+  auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/route_matcher_backtrack_edge");
+
+  // The trace only exercises what it is meant to if N is where the tile's edges end
+  baldr::GraphReader reader(map.config.get_child("mjolnir"));
+  const auto n = find_node(reader, 2, layout["N"]);
+  const auto* nodeinfo = n.second->node(n.first);
+  ASSERT_EQ(nodeinfo->edge_index() + nodeinfo->edge_count(), n.second->header()->directededgecount());
+  ASSERT_EQ(nodeinfo->edge_count(), 2u);
+  ASSERT_GT(nodeinfo->transition_count(), 0u);
+
+  // A->N matches, N->B matches and then fails, and the walk has to come back and take N's
+  // transition to reach D
+  std::string trace_json;
+  gurka::do_action(valhalla::Options::trace_attributes, map,
+                   build_edge_walk_request(map, {"A", "N", "B", "D"}), {}, &trace_json);
+  assert_full_chain(trace_json, 2);
+}
+
+TEST(RouteMatcher, BacktrackPastLastTransitionOfTile) {
+  gurka::nodelayout layout;
+  layout["A"] = {5.10, 45.11};
+  layout["B"] = {5.10, 45.10};
+  layout["C"] = {5.09, 45.09};
+  layout["D"] = {5.07, 45.07};
+  layout["E"] = {5.08, 45.10};
+  layout["N"] = {5.09, 45.09};
+  const gurka::ways ways = {
+      {"AB", {{"highway", "residential"}}},
+      {"BN", {{"highway", "residential"}}},
+      {"BCD", {{"highway", "primary"}}},
+      {"NE", {{"highway", "primary"}}},
+  };
+  auto map = gurka::buildtiles(layout, ways, {}, {}, "test/data/route_matcher_backtrack_transition");
+
+  // One edge, so the edge scan cannot be what runs past the end, and the tile's transitions end here
+  baldr::GraphReader reader(map.config.get_child("mjolnir"));
+  const auto n = find_node(reader, 2, layout["N"]);
+  const auto* nodeinfo = n.second->node(n.first);
+  ASSERT_EQ(nodeinfo->edge_count(), 1u);
+  ASSERT_EQ(nodeinfo->transition_index() + nodeinfo->transition_count(),
+            n.second->header()->transitioncount());
+
+  // N's only edge and only transition both fail, so B has to fall back on its own transition
+  std::string trace_json;
+  gurka::do_action(valhalla::Options::trace_attributes, map,
+                   build_edge_walk_request(map, {"A", "B", "N", "D"}), {}, &trace_json);
+  assert_full_chain(trace_json, 2);
+}


### PR DESCRIPTION
`expand_from_node` recurses once per matched edge and once per hierarchy transition, so the edge walk wants stack proportional to the number of edges in the shape: past a thousand or so it overruns the ~1 MB that JNI workers and Dart isolates get, and the process dies. The same walk now runs on an explicit stack of frames, one per formerly recursive call, so the depth lives on the heap.

The intent is that behaviour stays as it was: edges before transitions, the `followed_edges` bookmarks read at phase entry and written every iteration, `path_infos` and `elapsed` unwound on a failed branch, and the same counter-to-pointer relationship the original loops had — the accessor is handed the node's first edge and the offset is added to the pointer, so a resumed scan can hold a pointer one past the last edge, which the loop condition rejects before anything reads it.

Four gurka tests. Two walk a 188-edge chain, one on a default thread and one on a 48 KB thread, a size that sits between what the walk needs and what a frame per edge would need. The other two backtrack past the last edge and the last transition of a tile, which a chain never does, and assert the tile layout they depend on before tracing. `gurka_trace_attributes`, `gurka_match` and `mapmatch` pass. Built and run on macOS arm64 only.

#6262 touches the same file but not `expand_from_node`; the two merge cleanly.

# Issue

Fixes #6294

## Tasklist

 - [x] Add tests
 - [x] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described — no API change
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too — n/a
 - [ ] If you changed English narrative phrases, run `po_tools.py update` — n/a

## Requirements / Relations

None.
