### PR TITLE
hotfix: Limit `sequence<T>::sort()` concurrency to 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
    * FIXED: Set `edge_index` for all interpolated points in `/trace_attributes` [#6278](https://github.com/valhalla/valhalla/pull/6278)
    * FIXED: Shortcut/transit/etc. edges should use `kNoElevationData` (-500.0) instead of 0.0 [#6306](https://github.com/valhalla/valhalla/pull/6306)
    * FIXED: Do not require Python for building libvalhalla [#6303](https://github.com/valhalla/valhalla/pull/6303)
+   * HOTFIX: Limit `sequence<T>::sort()` concurrency to 8 [#6316](https://github.com/valhalla/valhalla/pull/6316)
 * **Enhancement**
    * CHANGED: move `GraphTile::GetTileId` to `GraphId::FromTilePath` as a static factory ctor [#6237](https://github.com/valhalla/valhalla/pull/6237)
    * CHANGED: use `filtered_edges` in CostMatrix's second pass [#6236](https://github.com/valhalla/valhalla/pull/6236)

--- a/valhalla/midgard/sequence.h
+++ b/valhalla/midgard/sequence.h
@@ -339,7 +339,7 @@ public:
 
     // No more threads than chunks so every worker handles at least ~buffer_size elements
     const size_t chunk_count = 1 + (memmap.size() - 1) / buffer_size;
-    // No more than 8 as it doesn't give much beyond that number on fast SSDs while this hits hard on old disks
+    // No more than 8 as it doesn't give much beyond that number while hits hard on old disks
     concurrency = std::min(std::clamp(concurrency, size_t(1), size_t(8)), chunk_count);
 
     // Sort the subsections in parallel

--- a/valhalla/midgard/sequence.h
+++ b/valhalla/midgard/sequence.h
@@ -339,7 +339,8 @@ public:
 
     // No more threads than chunks so every worker handles at least ~buffer_size elements
     const size_t chunk_count = 1 + (memmap.size() - 1) / buffer_size;
-    concurrency = std::min(std::max(concurrency, size_t(1)), chunk_count);
+    // No more than 8 as it doesn't give much beyond that number on fast SSDs while this hits hard on old disks
+    concurrency = std::min(std::clamp(concurrency, size_t(1), size_t(8)), chunk_count);
 
     // Sort the subsections in parallel
     {


### PR DESCRIPTION
_Please don't force-push once you received the first review._

# Issue

It looks like recent sorting speed up https://github.com/valhalla/valhalla/pull/6226 actually creates problems on old spinning disks - https://github.com/valhalla/valhalla/issues/6312

As I measured on M3 Max, increasing number of workes for sorting beyond 8 doesn't give much improvement:

|  concurrency  |  forth   |   back   |   pass   | speedup | gain/core |
| --- | --- | --- | --- | --- | --- |
|   1 | 1051.4 s | 1049.3 s | 2100.8 s |   1.00× |         — |
|   2 |  663.7 s |  688.7 s | 1352.4 s |   1.55× |     0.55× |
|   4 |  494.7 s |  514.3 s | 1009.0 s |   2.08× |     0.27× |
|   8 |  419.1 s |  437.4 s |  856.5 s |   2.45× |     0.18× |
|  10 |  406.3 s |  433.1 s |  839.5 s |   2.50× |     0.15× |
|  14 |  401.7 s |  409.6 s |  811.3 s |   2.59× |     0.11× |

*Sorting the 108GB way_nodes.bin file, forth by node id and back by way id + shape index*

My guess is that sorting memory mapped pieces procuce so many random writes that spinning disks could literally die because of that amount of jumps. A more structural fix would be a proper organisation of writing pattern, but that would take a bit of time to test

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [ ] If you changed English narrative phrases, run `po_tools.py update` — see [locales](docs/docs/contributing/locales.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
