### PR TITLE
fix: graphfilter should not introduce zero-length edges during aggregation

### DIFF
--- a/src/mjolnir/directededgebuilder.cc
+++ b/src/mjolnir/directededgebuilder.cc
@@ -8,8 +8,6 @@ using namespace valhalla::baldr;
 namespace valhalla {
 namespace mjolnir {
 
-constexpr uint32_t kMinimumEdgeLength = 1;
-
 // Constructor with parameters
 DirectedEdgeBuilder::DirectedEdgeBuilder(const OSMWay& way,
                                          const GraphId& endnode,
@@ -35,7 +33,7 @@ DirectedEdgeBuilder::DirectedEdgeBuilder(const OSMWay& way,
   set_truck_speed(truck_speed); // KPH
 
   // Protect against 0 length edges
-  set_length(std::max(length, kMinimumEdgeLength), true);
+  set_length(std::max(length, kMinEdgeLength), true);
 
   // Override use for ferries/rail ferries. TODO - set this in lua
   if (way.ferry() && way.use() != Use::kConstruction) {

--- a/src/mjolnir/graphfilter.cc
+++ b/src/mjolnir/graphfilter.cc
@@ -799,7 +799,8 @@ void AggregateTiles(GraphReader& reader, std::unordered_map<GraphId, GraphId>& o
 
         // Update length and curvature if the edge was aggregated
         if (aggregated) {
-          newedge.set_length(valhalla::midgard::length(shape));
+          double length = std::max(1.0, valhalla::midgard::length(shape));
+          newedge.set_length(length);
           newedge.set_curvature(compute_curvature(shape));
         }
 

--- a/test/gurka/test_graphfilter.cc
+++ b/test/gurka/test_graphfilter.cc
@@ -1,5 +1,6 @@
 #include "baldr/graphreader.h"
 #include "gurka.h"
+#include "midgard/util.h"
 
 #include <gtest/gtest.h>
 
@@ -22,7 +23,7 @@ TEST(Standalone, SimpleFilter) {
                   |    |         Q----S----T    |         |
                   N    O              |         V         X
                                       |
-                                      U 
+                                      U
   )";
 
   const gurka::ways ways = {
@@ -112,7 +113,7 @@ TEST(Standalone, SimpleFilter2) {
         A----B----C----D----E------------F----G
         |              |     \          /     |
         |              |      \        /      |
-        O              P       Q------R       S                  
+        O              P       Q------R       S
   )";
 
   const gurka::ways ways = {
@@ -199,7 +200,7 @@ TEST(Standalone, FilterTestComplexRestrictionsSignals) {
                           |
                           |
                           M--N
-                          |  | 
+                          |  |
                           |  |
        A------------------B--C----D-----------E
        |                  |  |
@@ -357,13 +358,13 @@ TEST(Standalone, FilterTestNodeTypeSignals) {
                 F
                 |
                 G--H
-                |  | 
+                |  |
                 |  |
      A----------B--C-------D
                 |
                 |
                 E
-  
+
   )";
 
   const gurka::ways ways = {
@@ -715,4 +716,37 @@ TEST(Standalone, FilterTestConsistencyTTHeadingsDriveability) {
     EXPECT_EQ((int)node->heading(CF_edge->localedgeidx()), 180);
     EXPECT_EQ((int)CF_edge->turntype(AC_edge->localedgeidx()), 2); // right
   }
+}
+
+TEST(Standalone, AggregateShortEdges) {
+  constexpr double gridsize_metres = 0.3;
+
+  const std::string ascii_map = R"(
+     A-B-C
+       |
+       D
+  )";
+
+  const gurka::ways ways = {
+      {"ABC", {{"highway", "unclassified"}, {"osm_id", "100"}, {"oneway", "yes"}}},
+      {"BD", {{"highway", "footway"}, {"osm_id", "101"}, {"footway", "crossing"}}},
+  };
+
+  auto layout = gurka::detail::map_to_coordinates(ascii_map, gridsize_metres, {11.24006, 43.77054});
+  auto map =
+      gurka::buildtiles(layout, ways, {}, {}, work_dir,
+                        {{"mjolnir.admin", {VALHALLA_SOURCE_DIR "test/data/language_admin.sqlite"}},
+                         {"mjolnir.include_pedestrian", "false"}});
+
+  GraphReader graph_reader(map.config.get_child("mjolnir"));
+
+  auto [AC_edge_id, AC_edge] = gurka::findEdgeByNodes(graph_reader, layout, "A", "C");
+  ASSERT_NE(AC_edge, nullptr);
+
+  auto shape = graph_reader.GetGraphTile(AC_edge_id)->edgeinfo(AC_edge).shape();
+  ASSERT_EQ(shape.size(), 3) << "AB and BC were not aggregated";
+  EXPECT_LT(valhalla::midgard::length(shape), 1.f) << "test needs a sub-metre aggregated shape";
+
+  EXPECT_GE(AC_edge->length(), 1)
+      << "zero length makes TripLeg::Edge::speed a 0/0 NaN in triplegbuilder";
 }

--- a/valhalla/baldr/graphconstants.h
+++ b/valhalla/baldr/graphconstants.h
@@ -188,6 +188,9 @@ constexpr uint8_t kMaxBicycleNetwork = 15;
 // Maximum offset to edge information
 constexpr uint32_t kMaxEdgeInfoOffset = 33554431; // 2^25 bytes
 
+// Minimum length of an edge
+constexpr uint32_t kMinEdgeLength = 1;
+
 // Maximum length of an edge
 constexpr uint32_t kMaxEdgeLength = 16777215; // 2^24 meters
 


### PR DESCRIPTION
_Please don't force-push once you received the first review._

# Issue

Just stepped over the case when `/trace_attributes` might return zero length edge in Italy.

https://www.openstreetmap.org/way/1351914202 way has a small tip right after intersection with pedestrian crossing that when aggregated back becomes 0.7m length long

<img width="370" height="444" alt="image" src="https://github.com/user-attachments/assets/fdea8a84-8bf5-429b-9559-319796a2d85e" />

Steps to reproduce

```
wget https://download.geofabrik.de/europe/italy/centro-latest.osm.pbf

./valhalla_build_config \
   --mjolnir-tile-dir=./valhalla_data \
   --mjolnir-tile-extract=./valhalla_data/tiles.tar \
   --mjolnir-traffic-extract=./valhalla_data/traffic.tar \
   --mjolnir-admin=./valhalla_data/admins.sqlite \
   --mjolnir-timezone=./valhalla_data/timezones.sqlite \
   --mjolnir-include-bicycle=False \
   --mjolnir-include-pedestrian=False \
   > ./valhalla_data/config.json;

... build tiles and run valhalla ...

curlie -s "http://localhost:8002/trace_attributes" -d '{
                             "encoded_polyline": "{fqnrAoj{lTvEsd@bG{f@fF{d@vCwYrAeNpBwQfDqWnEe]hEy]",
                             "costing": "auto", "shape_match": "map_snap", "units": "kilometers"
                           }'
```

<details>
  <summary>`/trace_attributes` JSON response</summary>
  
  ```json
  {
    "units": "kilometers",
    "osm_changeset": 14167407906,
    "shape": "yfqnrAoj{lT`Di\\b@yFZyCzLabAPyAtCeZ`BoP@I@G|@uJDq@BOTgCb@oDtA{KnCeThF}a@^yCPuA^yC",
    "confidence_score": 1.0,
    "raw_score": 1.891,
    "admins": [
        {
            "country_text": "None",
            "state_text": "None"
        }
    ],
    "edges": [
        {
            "truck_route": false,
            "speed_limit": 30,
            "density": 10,
            "sac_scale": 0,
            "shoulder": false,
            "sidewalk": "none",
            "bicycle_network": 0,
            "cycle_lane": "none",
            "lane_count": 1,
            "max_downward_grade": -500,
            "max_upward_grade": -500,
            "weighted_grade": 0.0,
            "way_id": 529664702,
            "id": 380546982626,
            "travel_mode": "drive",
            "vehicle_type": "car",
            "surface": "paved_smooth",
            "drive_on_right": false,
            "internal_intersection": false,
            "roundabout": false,
            "bridge": false,
            "tunnel": false,
            "unpaved": false,
            "toll": false,
            "use": "road",
            "traversability": "forward",
            "end_shape_index": 2,
            "begin_shape_index": 0,
            "end_heading": 102,
            "begin_heading": 103,
            "road_class": "unclassified",
            "speed": 30,
            "speed_type": "tagged",
            "speeds_non_faded": {
                "no_flow": 30
            },
            "country_crossing": false,
            "forward": true,
            "traffic_signal": false,
            "length": 0.048,
            "source_percent_along": 0.664,
            "names": [
                "Via Pisana"
            ],
            "end_node": {
                "intersecting_edges": [
                    {
                        "walkability": "both",
                        "cyclability": "backward",
                        "driveability": "backward",
                        "from_edge_name_consistency": false,
                        "to_edge_name_consistency": false,
                        "begin_heading": 23,
                        "use": "road",
                        "road_class": "unclassified"
                    },
                    {
                        "walkability": "both",
                        "cyclability": "backward",
                        "driveability": "backward",
                        "from_edge_name_consistency": false,
                        "to_edge_name_consistency": false,
                        "begin_heading": 213,
                        "use": "road",
                        "road_class": "residential"
                    }
                ],
                "elapsed_time": 5.879,
                "elapsed_cost": 6.466,
                "admin_index": 0,
                "type": "street_intersection",
                "traffic_signal": false,
                "fork": false,
                "time_zone": "Europe/Rome",
                "transition_time": 0.02
            }
        },
        {
            "truck_route": false,
            "speed_limit": 30,
            "density": 10,
            "sac_scale": 0,
            "shoulder": false,
            "sidewalk": "none",
            "bicycle_network": 0,
            "cycle_lane": "none",
            "lane_count": 1,
            "max_downward_grade": -500,
            "max_upward_grade": -500,
            "weighted_grade": 0.0,
            "way_id": 529664702,
            "id": 380848972514,
            "travel_mode": "drive",
            "vehicle_type": "car",
            "surface": "paved_smooth",
            "drive_on_right": false,
            "internal_intersection": false,
            "roundabout": false,
            "bridge": false,
            "tunnel": false,
            "unpaved": false,
            "toll": false,
            "use": "road",
            "traversability": "forward",
            "end_shape_index": 5,
            "begin_shape_index": 2,
            "end_heading": 106,
            "begin_heading": 105,
            "road_class": "unclassified",
            "speed": 30,
            "speed_type": "tagged",
            "speeds_non_faded": {
                "no_flow": 30
            },
            "country_crossing": false,
            "forward": true,
            "traffic_signal": false,
            "length": 0.099,
            "names": [
                "Via Pisana"
            ],
            "end_node": {
                "intersecting_edges": [
                    {
                        "walkability": "both",
                        "cyclability": "both",
                        "driveability": "both",
                        "from_edge_name_consistency": true,
                        "to_edge_name_consistency": true,
                        "begin_heading": 191,
                        "use": "road",
                        "road_class": "residential"
                    },
                    {
                        "walkability": "both",
                        "cyclability": "both",
                        "driveability": "both",
                        "from_edge_name_consistency": false,
                        "to_edge_name_consistency": true,
                        "begin_heading": 70,
                        "use": "road",
                        "road_class": "residential"
                    }
                ],
                "elapsed_time": 17.779,
                "elapsed_cost": 35.934,
                "admin_index": 0,
                "type": "street_intersection",
                "traffic_signal": false,
                "fork": false,
                "time_zone": "Europe/Rome",
                "transition_time": 0.008
            }
        },
        {
            "truck_route": false,
            "density": 10,
            "sac_scale": 0,
            "shoulder": false,
            "sidewalk": "none",
            "bicycle_network": 0,
            "cycle_lane": "none",
            "lane_count": 1,
            "max_downward_grade": -500,
            "max_upward_grade": -500,
            "weighted_grade": 0.0,
            "way_id": 1351914202,
            "id": 387492750050,
            "travel_mode": "drive",
            "vehicle_type": "car",
            "surface": "paved",
            "drive_on_right": false,
            "internal_intersection": false,
            "roundabout": false,
            "bridge": false,
            "tunnel": false,
            "unpaved": false,
            "toll": false,
            "use": "road",
            "traversability": "forward",
            "end_shape_index": 6,
            "begin_shape_index": 5,
            "end_heading": 103,
            "begin_heading": 103,
            "road_class": "unclassified",
            "speed": 35,
            "speed_type": "classified",
            "speeds_non_faded": {
                "no_flow": 35
            },
            "country_crossing": false,
            "forward": true,
            "traffic_signal": false,
            "length": 0.036,
            "names": [
                "Via Pisana"
            ],
            "end_node": {
                "intersecting_edges": [
                    {
                        "walkability": "both",
                        "cyclability": "forward",
                        "driveability": "forward",
                        "from_edge_name_consistency": false,
                        "to_edge_name_consistency": false,
                        "begin_heading": 132,
                        "use": "road",
                        "road_class": "unclassified"
                    }
                ],
                "elapsed_time": 21.491,
                "elapsed_cost": 51.408,
                "admin_index": 0,
                "type": "street_intersection",
                "traffic_signal": false,
                "fork": false,
                "time_zone": "Europe/Rome",
                "transition_time": 0.019
            }
        },
        {
            "truck_route": false,
            "density": 10,
            "sac_scale": 0,
            "shoulder": false,
            "sidewalk": "none",
            "bicycle_network": 0,
            "cycle_lane": "none",
            "lane_count": 1,
            "max_downward_grade": -500,
            "max_upward_grade": -500,
            "weighted_grade": 0.0,
            "way_id": 1351914202,
            "id": 385580147426,
            "travel_mode": "drive",
            "vehicle_type": "car",
            "surface": "paved",
            "drive_on_right": false,
            "internal_intersection": false,
            "roundabout": false,
            "bridge": false,
            "tunnel": false,
            "unpaved": false,
            "toll": false,
            "use": "road",
            "traversability": "forward",
            "end_shape_index": 7,
            "begin_shape_index": 6,
            "end_heading": 104,
            "begin_heading": 104,
            "road_class": "unclassified",
            "speed": 35,
            "speed_type": "classified",
            "speeds_non_faded": {
                "no_flow": 35
            },
            "country_crossing": false,
            "forward": true,
            "traffic_signal": false,
            "length": 0.023,
            "names": [
                "Via Pisana"
            ],
            "end_node": {
                "intersecting_edges": [
                    {
                        "walkability": "both",
                        "cyclability": "both",
                        "driveability": "both",
                        "from_edge_name_consistency": true,
                        "to_edge_name_consistency": true,
                        "begin_heading": 196,
                        "use": "road",
                        "road_class": "residential"
                    },
                    {
                        "walkability": "both",
                        "cyclability": "both",
                        "driveability": "both",
                        "from_edge_name_consistency": true,
                        "to_edge_name_consistency": false,
                        "begin_heading": 15,
                        "use": "road",
                        "road_class": "residential"
                    }
                ],
                "elapsed_time": 23.875,
                "elapsed_cost": 56.86,
                "admin_index": 0,
                "type": "street_intersection",
                "traffic_signal": false,
                "fork": false,
                "time_zone": "Europe/Rome",
                "transition_time": 0.02
            }
        },
        {
            "truck_route": false,
            "density": 10,
            "sac_scale": 0,
            "shoulder": false,
            "sidewalk": "none",
            "bicycle_network": 0,
            "cycle_lane": "none",
            "lane_count": 1,
            "max_downward_grade": -500,
            "max_upward_grade": -500,
            "weighted_grade": 0.0,
            "way_id": 1351914202,
            "id": 386452562658,
            "travel_mode": "drive",
            "vehicle_type": "car",
            "surface": "paved",
            "drive_on_right": false,
            "internal_intersection": false,
            "roundabout": false,
            "bridge": false,
            "tunnel": false,
            "unpaved": false,
            "toll": false,
            "use": "road",
            "traversability": "forward",
            "end_shape_index": 9,
            "begin_shape_index": 7,
            "end_heading": 107,
            "begin_heading": 107,
            "road_class": "unclassified",
            "speed": 0,
            "speed_type": "classified",
            "speeds_non_faded": {
                "no_flow": 35
            },
            "country_crossing": false,
            "forward": true,
            "traffic_signal": false,
            "length": 0.0,
            "names": [
                "Via Pisana"
            ],
            "end_node": {
                "elapsed_time": 23.896,
                "elapsed_cost": 73.26,
                "admin_index": 0,
                "type": "street_intersection",
                "traffic_signal": false,
                "fork": false,
                "time_zone": "Europe/Rome",
                "transition_time": 0.0
            }
        },
        {
            "truck_route": false,
            "density": 10,
            "sac_scale": 0,
            "shoulder": false,
            "sidewalk": "none",
            "bicycle_network": 0,
            "cycle_lane": "none",
            "lane_count": 1,
            "max_downward_grade": -500,
            "max_upward_grade": -500,
            "weighted_grade": 0.0,
            "way_id": 118932469,
            "id": 382627357410,
            "travel_mode": "drive",
            "vehicle_type": "car",
            "surface": "paved",
            "drive_on_right": false,
            "internal_intersection": false,
            "roundabout": false,
            "bridge": false,
            "tunnel": true,
            "unpaved": false,
            "toll": false,
            "use": "road",
            "traversability": "forward",
            "end_shape_index": 11,
            "begin_shape_index": 9,
            "end_heading": 102,
            "begin_heading": 103,
            "road_class": "unclassified",
            "speed": 35,
            "speed_type": "classified",
            "speeds_non_faded": {
                "no_flow": 35
            },
            "country_crossing": false,
            "forward": true,
            "traffic_signal": true,
            "length": 0.018,
            "names": [
                "Via Pisana"
            ],
            "end_node": {
                "elapsed_time": 25.747,
                "elapsed_cost": 75.296,
                "admin_index": 0,
                "type": "street_intersection",
                "traffic_signal": false,
                "fork": false,
                "time_zone": "Europe/Rome",
                "transition_time": 0.0
            }
        },
        {
            "truck_route": false,
            "density": 10,
            "sac_scale": 0,
            "shoulder": false,
            "sidewalk": "none",
            "bicycle_network": 0,
            "cycle_lane": "none",
            "lane_count": 1,
            "max_downward_grade": -500,
            "max_upward_grade": -500,
            "weighted_grade": 0.0,
            "way_id": 118932434,
            "id": 389506015970,
            "travel_mode": "drive",
            "vehicle_type": "car",
            "surface": "paved",
            "drive_on_right": false,
            "internal_intersection": false,
            "roundabout": false,
            "bridge": false,
            "tunnel": false,
            "unpaved": false,
            "toll": false,
            "use": "road",
            "traversability": "forward",
            "end_shape_index": 13,
            "begin_shape_index": 11,
            "end_heading": 103,
            "begin_heading": 103,
            "road_class": "unclassified",
            "speed": 35,
            "speed_type": "classified",
            "speeds_non_faded": {
                "no_flow": 35
            },
            "country_crossing": false,
            "forward": true,
            "traffic_signal": false,
            "length": 0.006,
            "names": [
                "Via Pisana"
            ],
            "end_node": {
                "intersecting_edges": [
                    {
                        "walkability": "both",
                        "cyclability": "forward",
                        "driveability": "forward",
                        "from_edge_name_consistency": false,
                        "to_edge_name_consistency": false,
                        "begin_heading": 206,
                        "use": "road",
                        "road_class": "unclassified"
                    },
                    {
                        "walkability": "both",
                        "cyclability": "backward",
                        "driveability": "backward",
                        "from_edge_name_consistency": false,
                        "to_edge_name_consistency": false,
                        "begin_heading": 25,
                        "use": "road",
                        "road_class": "residential"
                    }
                ],
                "elapsed_time": 26.365,
                "elapsed_cost": 75.975,
                "admin_index": 0,
                "type": "street_intersection",
                "traffic_signal": false,
                "fork": false,
                "time_zone": "Europe/Rome",
                "transition_time": 0.022
            }
        },
        {
            "truck_route": false,
            "density": 10,
            "sac_scale": 0,
            "shoulder": false,
            "sidewalk": "none",
            "bicycle_network": 0,
            "cycle_lane": "none",
            "lane_count": 1,
            "max_downward_grade": -500,
            "max_upward_grade": -500,
            "weighted_grade": 0.0,
            "way_id": 1351914197,
            "id": 379708121826,
            "travel_mode": "drive",
            "vehicle_type": "car",
            "surface": "paved",
            "drive_on_right": false,
            "internal_intersection": false,
            "roundabout": false,
            "bridge": false,
            "tunnel": false,
            "unpaved": false,
            "toll": false,
            "use": "road",
            "traversability": "forward",
            "end_shape_index": 15,
            "begin_shape_index": 13,
            "end_heading": 106,
            "begin_heading": 106,
            "road_class": "unclassified",
            "speed": 35,
            "speed_type": "classified",
            "speeds_non_faded": {
                "no_flow": 35
            },
            "country_crossing": false,
            "forward": true,
            "traffic_signal": false,
            "length": 0.024,
            "names": [
                "Borgo San Frediano"
            ],
            "end_node": {
                "elapsed_time": 28.855,
                "elapsed_cost": 95.091,
                "admin_index": 0,
                "type": "street_intersection",
                "traffic_signal": false,
                "fork": false,
                "time_zone": "Europe/Rome",
                "transition_time": 0.0
            }
        },
        {
            "truck_route": false,
            "density": 10,
            "sac_scale": 0,
            "shoulder": false,
            "sidewalk": "none",
            "bicycle_network": 0,
            "cycle_lane": "none",
            "lane_count": 1,
            "max_downward_grade": -500,
            "max_upward_grade": -500,
            "weighted_grade": 0.0,
            "way_id": 30029669,
            "id": 387224314594,
            "travel_mode": "drive",
            "vehicle_type": "car",
            "surface": "paved_smooth",
            "drive_on_right": false,
            "internal_intersection": false,
            "roundabout": false,
            "bridge": false,
            "tunnel": false,
            "unpaved": false,
            "toll": false,
            "use": "road",
            "traversability": "forward",
            "end_shape_index": 16,
            "begin_shape_index": 15,
            "end_heading": 106,
            "begin_heading": 106,
            "road_class": "unclassified",
            "speed": 35,
            "speed_type": "classified",
            "speeds_non_faded": {
                "no_flow": 35
            },
            "country_crossing": false,
            "forward": true,
            "traffic_signal": false,
            "length": 0.028,
            "names": [
                "Borgo San Frediano"
            ],
            "end_node": {
                "intersecting_edges": [
                    {
                        "walkability": "both",
                        "cyclability": "forward",
                        "driveability": "forward",
                        "from_edge_name_consistency": false,
                        "to_edge_name_consistency": false,
                        "begin_heading": 199,
                        "use": "road",
                        "road_class": "residential"
                    }
                ],
                "elapsed_time": 31.735,
                "elapsed_cost": 98.259,
                "admin_index": 0,
                "type": "street_intersection",
                "traffic_signal": false,
                "fork": false,
                "time_zone": "Europe/Rome",
                "transition_time": 0.017
            }
        },
        {
            "truck_route": false,
            "density": 10,
            "sac_scale": 0,
            "shoulder": false,
            "sidewalk": "none",
            "bicycle_network": 0,
            "cycle_lane": "none",
            "lane_count": 1,
            "max_downward_grade": -500,
            "max_upward_grade": -500,
            "weighted_grade": 0.0,
            "way_id": 30029669,
            "id": 380244992738,
            "travel_mode": "drive",
            "vehicle_type": "car",
            "surface": "paved_smooth",
            "drive_on_right": false,
            "internal_intersection": false,
            "roundabout": false,
            "bridge": false,
            "tunnel": false,
            "unpaved": false,
            "toll": false,
            "use": "road",
            "traversability": "forward",
            "end_shape_index": 18,
            "begin_shape_index": 16,
            "end_heading": 106,
            "begin_heading": 106,
            "road_class": "unclassified",
            "speed": 35,
            "speed_type": "classified",
            "speeds_non_faded": {
                "no_flow": 35
            },
            "country_crossing": false,
            "forward": true,
            "traffic_signal": false,
            "length": 0.053,
            "names": [
                "Borgo San Frediano"
            ],
            "end_node": {
                "intersecting_edges": [
                    {
                        "walkability": "both",
                        "cyclability": "forward",
                        "driveability": "forward",
                        "from_edge_name_consistency": false,
                        "to_edge_name_consistency": false,
                        "begin_heading": 184,
                        "use": "road",
                        "road_class": "residential"
                    }
                ],
                "elapsed_time": 37.205,
                "elapsed_cost": 107.105,
                "admin_index": 0,
                "type": "street_intersection",
                "traffic_signal": false,
                "fork": false,
                "time_zone": "Europe/Rome",
                "transition_time": 0.017
            }
        },
        {
            "truck_route": false,
            "density": 10,
            "sac_scale": 0,
            "shoulder": false,
            "sidewalk": "none",
            "bicycle_network": 0,
            "cycle_lane": "none",
            "lane_count": 1,
            "max_downward_grade": -500,
            "max_upward_grade": -500,
            "weighted_grade": 0.0,
            "way_id": 30029669,
            "id": 379305468642,
            "travel_mode": "drive",
            "vehicle_type": "car",
            "surface": "paved_smooth",
            "drive_on_right": false,
            "internal_intersection": false,
            "roundabout": false,
            "bridge": false,
            "tunnel": false,
            "unpaved": false,
            "toll": false,
            "use": "road",
            "traversability": "forward",
            "end_shape_index": 20,
            "begin_shape_index": 18,
            "end_heading": 106,
            "begin_heading": 106,
            "road_class": "unclassified",
            "speed": 35,
            "speed_type": "classified",
            "speeds_non_faded": {
                "no_flow": 35
            },
            "country_crossing": false,
            "forward": true,
            "traffic_signal": false,
            "length": 0.009,
            "target_percent_along": 0.597,
            "names": [
                "Borgo San Frediano"
            ],
            "end_node": {
                "elapsed_time": 38.206,
                "elapsed_cost": 116.038,
                "admin_index": 0,
                "type": "street_intersection",
                "traffic_signal": false,
                "fork": false,
                "transition_time": 0.0
            }
        }
    ],
    "matched_points": [
        {
            "lon": 11.237559,
            "lat": 43.771004,
            "type": "matched",
            "edge_index": 0,
            "distance_along_edge": 0.664439,
            "distance_from_trace_point": 0.13513
        },
        {
            "lon": 11.238154,
            "lat": 43.770906,
            "type": "matched",
            "edge_index": 0,
            "distance_along_edge": 1.0,
            "distance_from_trace_point": 1.091047
        },
        {
            "lon": 11.238802,
            "lat": 43.770773,
            "type": "matched",
            "edge_index": 1,
            "distance_along_edge": 0.542305,
            "distance_from_trace_point": 0.667063
        },
        {
            "lon": 11.239405,
            "lat": 43.770651,
            "type": "matched",
            "edge_index": 2,
            "distance_along_edge": 0.130439,
            "distance_from_trace_point": 0.089001
        },
        {
            "lon": 11.239834,
            "lat": 43.770577,
            "type": "matched",
            "edge_index": 3,
            "distance_along_edge": 0.179986,
            "distance_from_trace_point": 0.13432
        },
        {
            "lon": 11.240072,
            "lat": 43.770534,
            "type": "matched",
            "edge_index": 4,
            "distance_along_edge": 1.0,
            "distance_from_trace_point": 0.337966
        },
        {
            "lon": 11.240379,
            "lat": 43.770484,
            "type": "matched",
            "edge_index": 7,
            "distance_along_edge": 0.063897,
            "distance_from_trace_point": 0.822039
        },
        {
            "lon": 11.240773,
            "lat": 43.770401,
            "type": "matched",
            "edge_index": 8,
            "distance_along_edge": 0.349821,
            "distance_from_trace_point": 1.015682
        },
        {
            "lon": 11.241257,
            "lat": 43.770299,
            "type": "matched",
            "edge_index": 9,
            "distance_along_edge": 0.414124,
            "distance_from_trace_point": 1.252127
        },
        {
            "lon": 11.241749,
            "lat": 43.770196,
            "type": "matched",
            "edge_index": 10,
            "distance_along_edge": 0.597912,
            "distance_from_trace_point": 1.025097
        }
    ],
    "alternate_paths": [

    ]
}
  ```
</details>

## Tasklist

 - [ ] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [ ] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [ ] If you changed English narrative phrases, run `po_tools.py update` — see [locales](docs/docs/contributing/locales.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
