### PR TITLE
chore: `DirectedEdge::set_length` should handle rounding, non-zeroness, etc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
    * FIXED: Shortcut/transit/etc. edges should use `kNoElevationData` (-500.0) instead of 0.0 [#6306](https://github.com/valhalla/valhalla/pull/6306)
    * FIXED: Do not require Python for building libvalhalla [#6303](https://github.com/valhalla/valhalla/pull/6303)
    * HOTFIX: Limit `sequence<T>::sort()` concurrency to 8 [#6316](https://github.com/valhalla/valhalla/pull/6316)
+   * FIXED: A proper rounding and guarding against zero when calculating `DirectedEdge::length` for BSS/transit/shortcut edges [#6319](https://github.com/valhalla/valhalla/pull/6319)
 * **Enhancement**
    * CHANGED: move `GraphTile::GetTileId` to `GraphId::FromTilePath` as a static factory ctor [#6237](https://github.com/valhalla/valhalla/pull/6237)
    * CHANGED: use `filtered_edges` in CostMatrix's second pass [#6236](https://github.com/valhalla/valhalla/pull/6236)

--- a/src/baldr/directededge.cc
+++ b/src/baldr/directededge.cc
@@ -115,18 +115,17 @@ void DirectedEdge::set_sign(const bool exit) {
 // ------------------------- Geographic attributes ------------------------- //
 
 // Sets the length of the edge in meters.
-void DirectedEdge::set_length(const uint32_t length, bool should_error) {
-  if (length > kMaxEdgeLength) {
-    if (should_error) {
-      // Consider this a catastrophic error.
-      LOG_ERROR("Exceeding max. edge length: " + std::to_string(length));
-      throw std::runtime_error("DirectedEdgeBuilder: exceeded maximum edge length");
-    }
-    LOG_WARN("Exceeding max. edge length: " + std::to_string(length));
-    length_ = kMaxEdgeLength;
-  } else {
-    length_ = length;
+void DirectedEdge::set_length(const double length) {
+  uint32_t rounded = std::round(length);
+  if (rounded < kMinEdgeLength) {
+    rounded = kMinEdgeLength;
   }
+  if (rounded > kMaxEdgeLength) {
+    // Consider this a catastrophic error.
+    LOG_ERROR("Exceeding max. edge length: " + std::to_string(rounded));
+    throw std::runtime_error("DirectedEdgeBuilder: exceeded maximum edge length");
+  }
+  length_ = rounded;
 }
 
 // Sets the weighted_grade factor (0-15) for the edge.

--- a/src/baldr/directededge.cc
+++ b/src/baldr/directededge.cc
@@ -122,11 +122,7 @@ void DirectedEdge::set_length(const double length) {
     throw std::runtime_error("DirectedEdgeBuilder: exceeded maximum edge length");
   }
 
-  uint32_t rounded = std::round(length);
-  if (rounded < kMinEdgeLength) {
-    rounded = kMinEdgeLength;
-  }
-  length_ = rounded;
+  length_ = std::max(static_cast<uint32_t>(std::round(length)), kMinEdgeLength);
 }
 
 // Sets the weighted_grade factor (0-15) for the edge.

--- a/src/baldr/directededge.cc
+++ b/src/baldr/directededge.cc
@@ -116,14 +116,15 @@ void DirectedEdge::set_sign(const bool exit) {
 
 // Sets the length of the edge in meters.
 void DirectedEdge::set_length(const double length) {
+  if (length > kMaxEdgeLength) {
+    // Consider this a catastrophic error.
+    LOG_ERROR("Exceeding max. edge length: " + std::to_string(length));
+    throw std::runtime_error("DirectedEdgeBuilder: exceeded maximum edge length");
+  }
+
   uint32_t rounded = std::round(length);
   if (rounded < kMinEdgeLength) {
     rounded = kMinEdgeLength;
-  }
-  if (rounded > kMaxEdgeLength) {
-    // Consider this a catastrophic error.
-    LOG_ERROR("Exceeding max. edge length: " + std::to_string(rounded));
-    throw std::runtime_error("DirectedEdgeBuilder: exceeded maximum edge length");
   }
   length_ = rounded;
 }

--- a/src/mjolnir/convert_transit.cc
+++ b/src/mjolnir/convert_transit.cc
@@ -661,9 +661,7 @@ void AddToGraph(GraphTileBuilder& tilebuilder_transit,
         }
 
         // add the egress connection
-        // Make sure length is non-zero
-        double length = std::max(1.0, egress_ll.Distance(station_ll));
-        directededge.set_length(length);
+        directededge.set_length(egress_ll.Distance(station_ll));
         directededge.set_use(Use::kEgressConnection);
         directededge.set_speed(5);
         directededge.set_classification(RoadClass::kServiceOther);
@@ -710,9 +708,7 @@ void AddToGraph(GraphTileBuilder& tilebuilder_transit,
         directededge.set_endnode(egress_graphid);
 
         // add the platform connection
-        // Make sure length is non-zero
-        double length = std::max(1.0, station_ll.Distance(egress_ll));
-        directededge.set_length(length);
+        directededge.set_length(station_ll.Distance(egress_ll));
         directededge.set_use(Use::kEgressConnection);
         directededge.set_speed(5);
         directededge.set_classification(RoadClass::kServiceOther);
@@ -757,9 +753,7 @@ void AddToGraph(GraphTileBuilder& tilebuilder_transit,
         PointLL platform_ll = {platform.lon(), platform.lat()};
 
         // add the platform connection
-        // Make sure length is non-zero
-        double length = std::max(1.0, station_ll.Distance(platform_ll));
-        directededge.set_length(length);
+        directededge.set_length(station_ll.Distance(platform_ll));
         directededge.set_use(Use::kPlatformConnection);
         directededge.set_speed(5);
         directededge.set_classification(RoadClass::kServiceOther);
@@ -837,9 +831,7 @@ void AddToGraph(GraphTileBuilder& tilebuilder_transit,
     directededge.set_endnode(station_graphid);
 
     // add the platform connection
-    // Make sure length is non-zero
-    double length = std::max(1.0, platform_ll.Distance(station_ll));
-    directededge.set_length(length);
+    directededge.set_length(platform_ll.Distance(station_ll));
     directededge.set_use(Use::kPlatformConnection);
     directededge.set_speed(5);
     directededge.set_classification(RoadClass::kServiceOther);

--- a/src/mjolnir/directededgebuilder.cc
+++ b/src/mjolnir/directededgebuilder.cc
@@ -12,7 +12,7 @@ namespace mjolnir {
 DirectedEdgeBuilder::DirectedEdgeBuilder(const OSMWay& way,
                                          const GraphId& endnode,
                                          const bool forward,
-                                         const uint32_t length,
+                                         const double length,
                                          const uint32_t speed,
                                          const uint32_t truck_speed,
                                          const baldr::Use use,
@@ -32,8 +32,7 @@ DirectedEdgeBuilder::DirectedEdgeBuilder(const OSMWay& way,
   set_speed(speed);             // KPH
   set_truck_speed(truck_speed); // KPH
 
-  // Protect against 0 length edges
-  set_length(std::max(length, kMinEdgeLength), true);
+  set_length(length);
 
   // Override use for ferries/rail ferries. TODO - set this in lua
   if (way.ferry() && way.use() != Use::kConstruction) {

--- a/src/mjolnir/graphbuilder.cc
+++ b/src/mjolnir/graphbuilder.cc
@@ -1037,10 +1037,10 @@ void BuildTileSet(const std::string& ways_file,
           }
 
           // Add a directed edge and get a reference to it
-          DirectedEdgeBuilder de(w, (*nodes[target]).graph_id, forward,
-                                 static_cast<uint32_t>(std::get<0>(found->second) + .5), speed,
-                                 truck_speed, use, static_cast<RoadClass>(edge.attributes.importance),
-                                 n, has_signal, has_stop, has_yield,
+          DirectedEdgeBuilder de(w, (*nodes[target]).graph_id, forward, std::get<0>(found->second),
+                                 speed, truck_speed, use,
+                                 static_cast<RoadClass>(edge.attributes.importance), n, has_signal,
+                                 has_stop, has_yield,
                                  ((has_stop || has_yield) ? node.minor() : false), restrictions,
                                  bike_network, edge.attributes.reclass_ferry,
                                  static_cast<RoadClass>(edge.attributes.importance_hierarchy));

--- a/src/mjolnir/graphfilter.cc
+++ b/src/mjolnir/graphfilter.cc
@@ -799,8 +799,7 @@ void AggregateTiles(GraphReader& reader, std::unordered_map<GraphId, GraphId>& o
 
         // Update length and curvature if the edge was aggregated
         if (aggregated) {
-          double length = std::max(1.0, valhalla::midgard::length(shape));
-          newedge.set_length(length);
+          newedge.set_length(valhalla::midgard::length(shape));
           newedge.set_curvature(compute_curvature(shape));
         }
 

--- a/src/mjolnir/shortcutbuilder.cc
+++ b/src/mjolnir/shortcutbuilder.cc
@@ -484,7 +484,7 @@ std::pair<uint32_t, uint32_t> AddShortcutEdges(GraphReader& reader,
 
       // Get the length from the shape. This prevents roundoff issues when forming
       // elevation.
-      uint32_t length = valhalla::midgard::length(shape);
+      const double length = valhalla::midgard::length(shape);
 
       // Add the edge info. Use length and number of shape points to match an
       // edge in case multiple shortcut edges exist between the 2 nodes.
@@ -493,7 +493,7 @@ std::pair<uint32_t, uint32_t> AddShortcutEdges(GraphReader& reader,
       // overwrites the mean elevation if the dataset has elevation. No need for names etc,
       // shortcuts aren't used in guidance
       bool forward = true;
-      uint32_t idx = ((length & 0xfffff) | ((shape.size() & 0xfff) << 20));
+      uint32_t idx = ((static_cast<uint32_t>(length) & 0xfffff) | ((shape.size() & 0xfff) << 20));
       uint32_t edge_info_offset =
           tilebuilder.AddEdgeInfo(idx, start_node, end_node, 0, kNoElevationData,
                                   edgeinfo.bike_network(), edgeinfo.speed_limit(), shape, {}, {}, {},

--- a/src/odin/directionsbuilder.cc
+++ b/src/odin/directionsbuilder.cc
@@ -10,7 +10,7 @@
 
 namespace {
 // Minimum edge length to verify heading (~3 feet)
-constexpr auto kMinEdgeLength = 0.001f;
+constexpr auto kMinLengthHeading = 0.001f;
 
 } // namespace
 
@@ -69,15 +69,15 @@ void DirectionsBuilder::UpdateHeading(EnhancedTripLeg* etp) {
     auto next_edge = etp->GetNextEdge(x);
 
     // If very short edge and no headings
-    if (curr_edge && (curr_edge->length_km() <= kMinEdgeLength) &&
+    if (curr_edge && (curr_edge->length_km() <= kMinLengthHeading) &&
         (curr_edge->begin_heading() == 0) && (curr_edge->end_heading() == 0)) {
       // Use next edge to set the current begin/end heading
-      if (next_edge && (next_edge->length_km() > kMinEdgeLength)) {
+      if (next_edge && (next_edge->length_km() > kMinLengthHeading)) {
         curr_edge->set_begin_heading(next_edge->begin_heading());
         curr_edge->set_end_heading(next_edge->begin_heading());
       }
       // Use prev edge to set the current begin/end heading
-      else if (prev_edge && (prev_edge->length_km() > kMinEdgeLength)) {
+      else if (prev_edge && (prev_edge->length_km() > kMinLengthHeading)) {
         curr_edge->set_begin_heading(prev_edge->end_heading());
         curr_edge->set_end_heading(prev_edge->end_heading());
       }

--- a/test/directededge.cc
+++ b/test/directededge.cc
@@ -103,6 +103,26 @@ TEST(DirectedEdge, TestMaxSlope) {
   EXPECT_EQ(edge.max_down_slope(), -16);
 }
 
+TEST(DirectedEdge, TestLength) {
+  DirectedEdge edge;
+
+  // Zero-length
+  edge.set_length(0.0);
+  EXPECT_EQ(edge.length(), 1);
+
+  // Rounding
+  edge.set_length(3.0);
+  EXPECT_EQ(edge.length(), 3);
+  edge.set_length(3.3);
+  EXPECT_EQ(edge.length(), 3);
+  edge.set_length(3.5);
+  EXPECT_EQ(edge.length(), 4);
+
+  // Too long
+  EXPECT_ANY_THROW(edge.set_length(16777215.9));
+  EXPECT_ANY_THROW(edge.set_length(333.0e20));
+}
+
 } // namespace
 
 int main(int argc, char* argv[]) {

--- a/test/gurka/test_filter.cc
+++ b/test/gurka/test_filter.cc
@@ -127,16 +127,16 @@ TEST(Standalone, FerryEdges) {
 
     const auto big = gurka::findEdge(reader, layout, "DEF", "F");
     EXPECT_EQ(std::get<1>(big)->speed(), 6);
-    EXPECT_EQ(std::get<1>(big)->length(), 6199); // merged
+    EXPECT_EQ(std::get<1>(big)->length(), 6200); // merged
     EXPECT_EQ(std::get<3>(big)->speed(), 6);
-    EXPECT_EQ(std::get<3>(big)->length(), 6199);
+    EXPECT_EQ(std::get<3>(big)->length(), 6200);
 
     // Small and big edges got merged.
     const auto small = gurka::findEdge(reader, layout, "DEF", "D");
     EXPECT_EQ(std::get<1>(small)->speed(), 6);
-    EXPECT_EQ(std::get<1>(small)->length(), 6199);
+    EXPECT_EQ(std::get<1>(small)->length(), 6200);
     EXPECT_EQ(std::get<3>(small)->speed(), 6);
-    EXPECT_EQ(std::get<3>(small)->length(), 6199);
+    EXPECT_EQ(std::get<3>(small)->length(), 6200);
     EXPECT_EQ(std::get<0>(big), std::get<2>(small));
     EXPECT_EQ(std::get<2>(big), std::get<0>(small));
   }

--- a/test/gurka/test_graphfilter.cc
+++ b/test/gurka/test_graphfilter.cc
@@ -717,35 +717,3 @@ TEST(Standalone, FilterTestConsistencyTTHeadingsDriveability) {
     EXPECT_EQ((int)CF_edge->turntype(AC_edge->localedgeidx()), 2); // right
   }
 }
-
-TEST(Standalone, AggregateShortEdges) {
-  constexpr double gridsize_metres = 0.1;
-
-  const std::string ascii_map = R"(
-     A-B-C
-       |
-       D
-  )";
-
-  const gurka::ways ways = {
-      {"ABC", {{"highway", "unclassified"}, {"osm_id", "100"}, {"oneway", "yes"}}},
-      {"BD", {{"highway", "footway"}, {"osm_id", "101"}, {"footway", "crossing"}}},
-  };
-
-  auto layout = gurka::detail::map_to_coordinates(ascii_map, gridsize_metres, {11.24006, 43.77054});
-  auto map =
-      gurka::buildtiles(layout, ways, {}, {}, work_dir,
-                        {{"mjolnir.admin", {VALHALLA_SOURCE_DIR "test/data/language_admin.sqlite"}},
-                         {"mjolnir.include_pedestrian", "false"}});
-
-  GraphReader graph_reader(map.config.get_child("mjolnir"));
-
-  auto [AC_edge_id, AC_edge] = gurka::findEdgeByNodes(graph_reader, layout, "A", "C");
-  ASSERT_NE(AC_edge, nullptr);
-
-  auto shape = graph_reader.GetGraphTile(AC_edge_id)->edgeinfo(AC_edge).shape();
-  ASSERT_EQ(shape.size(), 3) << "AB and BC were not aggregated";
-  EXPECT_LT(valhalla::midgard::length(shape), 0.5f) << "test needs a sub-metre aggregated shape";
-
-  EXPECT_GE(AC_edge->length(), 1);
-}

--- a/test/gurka/test_graphfilter.cc
+++ b/test/gurka/test_graphfilter.cc
@@ -719,7 +719,7 @@ TEST(Standalone, FilterTestConsistencyTTHeadingsDriveability) {
 }
 
 TEST(Standalone, AggregateShortEdges) {
-  constexpr double gridsize_metres = 0.3;
+  constexpr double gridsize_metres = 0.1;
 
   const std::string ascii_map = R"(
      A-B-C
@@ -745,8 +745,7 @@ TEST(Standalone, AggregateShortEdges) {
 
   auto shape = graph_reader.GetGraphTile(AC_edge_id)->edgeinfo(AC_edge).shape();
   ASSERT_EQ(shape.size(), 3) << "AB and BC were not aggregated";
-  EXPECT_LT(valhalla::midgard::length(shape), 1.f) << "test needs a sub-metre aggregated shape";
+  EXPECT_LT(valhalla::midgard::length(shape), 0.5f) << "test needs a sub-metre aggregated shape";
 
-  EXPECT_GE(AC_edge->length(), 1)
-      << "zero length makes TripLeg::Edge::speed a 0/0 NaN in triplegbuilder";
+  EXPECT_GE(AC_edge->length(), 1);
 }

--- a/test/gurka/test_gtfs.cc
+++ b/test/gurka/test_gtfs.cc
@@ -985,7 +985,7 @@ TEST(GtfsExample, route_trip1) {
   EXPECT_EQ(res.directions().routes(0).legs().size(), 1);
 
   const auto& leg = res.directions().routes(0).legs(0);
-  EXPECT_NEAR(leg.summary().length(), 41.033, 0.001);
+  EXPECT_NEAR(leg.summary().length(), 41.036, 0.001);
   EXPECT_EQ(leg.maneuver(0).type(), DirectionsLeg_Maneuver_Type_kStart);
   EXPECT_EQ(leg.maneuver(1).type(), DirectionsLeg_Maneuver_Type_kTransitConnectionStart);
   EXPECT_EQ(leg.maneuver(2).type(), DirectionsLeg_Maneuver_Type_kTransit);
@@ -1010,8 +1010,8 @@ TEST(GtfsExample, route_trip1) {
   EXPECT_EQ(res_doc["trip"]["legs"].GetArray().Size(), 1);
 
   const auto& leg_json = res_doc["trip"]["legs"].GetArray()[0];
-  EXPECT_NEAR(leg_json["summary"]["time"].GetDouble(), 8769.058, 0.001);
-  EXPECT_NEAR(leg_json["summary"]["length"].GetDouble(), 41.033, 0.001);
+  EXPECT_NEAR(leg_json["summary"]["time"].GetDouble(), 8770.470, 0.001);
+  EXPECT_NEAR(leg_json["summary"]["length"].GetDouble(), 41.036, 0.001);
   EXPECT_EQ(leg_json["maneuvers"][0]["type"].GetUint(),
             static_cast<uint32_t>(DirectionsLeg::Maneuver::kStart));
   EXPECT_EQ(leg_json["maneuvers"][1]["type"].GetUint(),
@@ -1062,8 +1062,8 @@ TEST(GtfsExample, route_trip4) {
 
   // test the PBF output
   const auto& leg = res.directions().routes(0).legs(0);
-  EXPECT_NEAR(leg.summary().time(), 8529.033, 0.001);
-  EXPECT_NEAR(leg.summary().length(), 16.112, 0.001);
+  EXPECT_NEAR(leg.summary().time(), 8530.445, 0.001);
+  EXPECT_NEAR(leg.summary().length(), 16.115, 0.001);
 
   const auto& transit_info = leg.maneuver(2).transit_info();
   EXPECT_EQ(transit_info.transit_stops(0).departure_date_time(), "2023-02-27T23:58-05:00");

--- a/test/gurka/test_shortcut.cc
+++ b/test/gurka/test_shortcut.cc
@@ -216,12 +216,12 @@ TEST(Shortcuts, TruckSpeedPartiallySet) {
       {"AB",
        {{"highway", "motorway"},
         {"maxspeed", "100"},
-        {"maxspeed:hgv", "100"},
+        {"maxspeed:hgv", "90"},
         {"name", "High street"}}},
       {"BC",
        {{"highway", "motorway"},
         {"maxspeed", "100"},
-        {"maxspeed:hgv", "100"},
+        {"maxspeed:hgv", "90"},
         {"name", "High street"}}},
       {"CD", {{"highway", "motorway"}, {"maxspeed", "100"}, {"name", "High street"}}},
       {"DE", {{"highway", "motorway"}, {"maxspeed", "100"}, {"name", "High street"}}},
@@ -244,8 +244,10 @@ TEST(Shortcuts, TruckSpeedPartiallySet) {
       if (!edge->is_shortcut() || !(edge->forwardaccess() & baldr::kAutoAccess))
         continue;
 
-      EXPECT_GT(100, edge->truck_speed());
-      EXPECT_LT(90, edge->truck_speed());
+      // 4 equal-length edges, 2 have 100kmh and 2 have 90kmh for trucks which gives 95 as a result
+      EXPECT_EQ(95, edge->truck_speed());
+      // but as all 4 have the same 100kmh regular speed, shortcut also has 100kmh
+      EXPECT_EQ(100, edge->speed());
       found_shortcut = true;
     }
   }

--- a/valhalla/baldr/directededge.h
+++ b/valhalla/baldr/directededge.h
@@ -170,10 +170,8 @@ public:
   /**
    * Sets the length of the edge in meters.
    * @param  length  Length of the edge in meters.
-   * @param  should_error  Bool indicating whether or not to error or warn on length > kMaxEdgeLength
-   *
    */
-  void set_length(const uint32_t length, bool should_error = true);
+  void set_length(const double length);
 
   /**
    * Get the weighted grade factor

--- a/valhalla/mjolnir/directededgebuilder.h
+++ b/valhalla/mjolnir/directededgebuilder.h
@@ -38,7 +38,7 @@ public:
   DirectedEdgeBuilder(const OSMWay& way,
                       const baldr::GraphId& endnode,
                       const bool forward,
-                      const uint32_t length,
+                      const double length,
                       const uint32_t speed,
                       const uint32_t truck_speed,
                       const baldr::Use use,


### PR DESCRIPTION
_Please don't force-push once you received the first review._

# Issue

A follow-up after https://github.com/valhalla/valhalla/pull/6318 as I realized that it's better to consolidate that `length` logic in a single place.

Also fixes minor issues with shortcuts where because of too harsh rounding the speed was not correct.

## Tasklist

 - [x] Add tests
 - [ ] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [ ] If you changed English narrative phrases, run `po_tools.py update` — see [locales](docs/docs/contributing/locales.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
