### PR TITLE
perf: Perform external sort via offsetted read/write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
    * FIXED: Shortcut/transit/etc. edges should use `kNoElevationData` (-500.0) instead of 0.0 [#6306](https://github.com/valhalla/valhalla/pull/6306)
    * FIXED: Do not require Python for building libvalhalla [#6303](https://github.com/valhalla/valhalla/pull/6303)
    * HOTFIX: Limit `sequence<T>::sort()` concurrency to 8 [#6316](https://github.com/valhalla/valhalla/pull/6316)
+   * FIXED: Sequental writes in `sequence<T>::sort()` to stay hdd-friendly [#6320](https://github.com/valhalla/valhalla/pull/6320)
 * **Enhancement**
    * CHANGED: move `GraphTile::GetTileId` to `GraphId::FromTilePath` as a static factory ctor [#6237](https://github.com/valhalla/valhalla/pull/6237)
    * CHANGED: use `filtered_edges` in CostMatrix's second pass [#6236](https://github.com/valhalla/valhalla/pull/6236)

--- a/src/midgard/CMakeLists.txt
+++ b/src/midgard/CMakeLists.txt
@@ -1,6 +1,7 @@
 file(GLOB headers ${VALHALLA_SOURCE_DIR}/valhalla/midgard/*.h)
 
 set(sources
+  file_io.cc
   linesegment2.cc
   tiles.cc
   polyline2.cc

--- a/src/midgard/file_io.cc
+++ b/src/midgard/file_io.cc
@@ -1,0 +1,144 @@
+#include "midgard/file_io.h"
+
+#include <cerrno>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN 1
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX 1
+#endif
+#include <windows.h>
+#else
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
+namespace {
+
+// Requests are chunked so a single transfer never exceeds what the platform accepts in one call.
+constexpr size_t kMaxTransfer = 64 * 1024 * 1024;
+
+// the factories name the intent; the flag is an implementation detail of the platform call
+uintptr_t open_native(const std::string& path, bool replace) {
+#ifdef _WIN32
+  // CreateFile denies sharing by default where the CRT does not, and the same file gets mapped
+  // elsewhere while a handle is held, so the modes have to be spelled out
+  const HANDLE h =
+      ::CreateFileA(path.c_str(), GENERIC_READ | GENERIC_WRITE,
+                    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr,
+                    replace ? CREATE_ALWAYS : OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+  if (h == INVALID_HANDLE_VALUE) {
+    throw std::runtime_error("file_handle: cannot open " + path + ": windows error " +
+                             std::to_string(::GetLastError()));
+  }
+  return reinterpret_cast<uintptr_t>(h);
+#else
+  const int fd = ::open(path.c_str(), O_RDWR | (replace ? (O_CREAT | O_TRUNC) : 0), 0644);
+  if (fd == -1) {
+    throw std::runtime_error("file_handle: cannot open " + path + ": " + strerror(errno));
+  }
+  return static_cast<uintptr_t>(fd);
+#endif
+}
+
+#ifdef _WIN32
+[[noreturn]] void fail(const char* what) {
+  throw std::runtime_error(std::string("file_handle::") + what + ": windows error " +
+                           std::to_string(::GetLastError()));
+}
+#else
+[[noreturn]] void fail(const char* what) {
+  throw std::runtime_error(std::string("file_handle::") + what + ": " + strerror(errno));
+}
+#endif
+
+} // namespace
+
+namespace valhalla {
+namespace midgard {
+
+file_handle file_handle::open(const std::string& path) {
+  return file_handle(open_native(path, false));
+}
+
+file_handle file_handle::create(const std::string& path) {
+  return file_handle(open_native(path, true));
+}
+
+file_handle::~file_handle() {
+  if (handle_ == kEmpty) {
+    return; // moved from, the file belongs to someone else now
+  }
+  // nothing useful is left to do with a failure here, and a destructor must not throw
+#ifdef _WIN32
+  ::CloseHandle(reinterpret_cast<HANDLE>(handle_));
+#else
+  ::close(static_cast<int>(handle_));
+#endif
+}
+
+void file_handle::read_bytes_at(void* destination, size_t bytes, uint64_t offset) const {
+  auto* out = static_cast<char*>(destination);
+#ifdef _WIN32
+  const HANDLE h = reinterpret_cast<HANDLE>(handle_);
+#else
+  const int fd = static_cast<int>(handle_);
+#endif
+  while (bytes) {
+    const size_t want = bytes < kMaxTransfer ? bytes : kMaxTransfer;
+#ifdef _WIN32
+    OVERLAPPED ov{};
+    ov.Offset = static_cast<DWORD>(offset & 0xffffffffull);
+    ov.OffsetHigh = static_cast<DWORD>((offset >> 32) & 0xffffffffull);
+    DWORD got = 0;
+    if (!::ReadFile(h, out, static_cast<DWORD>(want), &got, &ov) || got == 0) {
+      fail("read_at");
+    }
+#else
+    const ssize_t got = ::pread(fd, out, want, static_cast<off_t>(offset));
+    if (got <= 0) {
+      fail("read_at");
+    }
+#endif
+    out += got;
+    offset += static_cast<uint64_t>(got);
+    bytes -= static_cast<size_t>(got);
+  }
+}
+
+void file_handle::write_bytes_at(const void* source, size_t bytes, uint64_t offset) {
+  const auto* in = static_cast<const char*>(source);
+#ifdef _WIN32
+  const HANDLE h = reinterpret_cast<HANDLE>(handle_);
+#else
+  const int fd = static_cast<int>(handle_);
+#endif
+  while (bytes) {
+    const size_t want = bytes < kMaxTransfer ? bytes : kMaxTransfer;
+#ifdef _WIN32
+    OVERLAPPED ov{};
+    ov.Offset = static_cast<DWORD>(offset & 0xffffffffull);
+    ov.OffsetHigh = static_cast<DWORD>((offset >> 32) & 0xffffffffull);
+    DWORD put = 0;
+    if (!::WriteFile(h, in, static_cast<DWORD>(want), &put, &ov) || put == 0) {
+      fail("write_at");
+    }
+#else
+    const ssize_t put = ::pwrite(fd, in, want, static_cast<off_t>(offset));
+    if (put <= 0) {
+      fail("write_at");
+    }
+#endif
+    in += put;
+    offset += static_cast<uint64_t>(put);
+    bytes -= static_cast<size_t>(put);
+  }
+}
+
+} // namespace midgard
+} // namespace valhalla

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -87,7 +87,7 @@ endif()
 ## Lists tests
 set(tests aabb2 access_restriction actor admin attributes_controller configuration datetime directededge
   distanceapproximator double_bucket_queue edgecollapser edgeinfo edgestatus ellipse encode
-  enhancedtrippath factory graphid graphtile graphtileheader gridded_data grid_range_query grid_traversal instructions json laneconnectivity linesegment2 logging maneuversbuilder map_matcher_factory mapmatch_config
+  enhancedtrippath factory file_io graphid graphtile graphtileheader gridded_data grid_range_query grid_traversal instructions json laneconnectivity linesegment2 logging maneuversbuilder map_matcher_factory mapmatch_config
   narrative_dictionary nodeinfo nodetransition obb2 openlr optimizer parse_request point2 pointll pointtileindex
   polyline2 predictedspeeds queue routing sample sequence sign signs statsd streetname streetnames streetnames_factory
   streetnames_us streetname_us tilehierarchy tiles transitdeparture transitroute transitschedule

--- a/test/file_io.cc
+++ b/test/file_io.cc
@@ -1,0 +1,247 @@
+#include "midgard/file_io.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstdint>
+#include <filesystem>
+#include <numeric>
+#include <optional>
+#include <span>
+#include <string>
+#include <thread>
+#include <type_traits>
+#include <vector>
+
+using namespace valhalla::midgard;
+
+namespace {
+
+// mirrors the shape sort_sequence moves around: trivially copyable, not a multiple of a word
+struct record {
+  uint64_t key;
+  uint32_t a, b;
+  uint64_t pad[3];
+  bool operator==(const record&) const = default;
+};
+static_assert(sizeof(record) == 40, "layout");
+
+static_assert(std::is_move_constructible_v<file_handle>, "handles are movable");
+static_assert(std::is_move_assignable_v<file_handle>, "handles are movable");
+static_assert(!std::is_copy_constructible_v<file_handle>, "handles own their file");
+static_assert(!std::is_copy_assignable_v<file_handle>, "handles own their file");
+static_assert(!std::is_default_constructible_v<file_handle>, "a handle always has a file");
+
+struct scoped_file {
+  explicit scoped_file(
+      const std::string& stem = ::testing::UnitTest::GetInstance()->current_test_info()->name())
+      : path((std::filesystem::temp_directory_path() / ("valhalla_file_io_" + stem)).string()) {
+    std::filesystem::remove(path);
+  }
+  ~scoped_file() {
+    std::filesystem::remove(path);
+  }
+  std::string path;
+};
+
+std::vector<record> make_records(size_t count, uint64_t seed = 0) {
+  std::vector<record> v(count);
+  for (size_t i = 0; i < count; ++i) {
+    v[i] = record{seed + i, static_cast<uint32_t>(i), static_cast<uint32_t>(i * 2), {i, i, i}};
+  }
+  return v;
+}
+
+std::vector<record> slice(const std::vector<record>& v, size_t at, size_t count) {
+  return {v.begin() + at, v.begin() + at + count};
+}
+
+std::vector<record> read_records(const file_handle& h, size_t count, size_t at = 0) {
+  std::vector<record> v(count);
+  h.read_at(std::span(v), at * sizeof(record));
+  return v;
+}
+
+size_t records_in(const std::string& path) {
+  return std::filesystem::file_size(path) / sizeof(record);
+}
+
+TEST(FileHandle, TransfersAtOffsets) {
+  scoped_file f;
+  const auto all = make_records(100, 7);
+  const auto h = file_handle::create(f.path);
+  h.write_at(std::span(all), 0);
+  EXPECT_EQ(records_in(f.path), all.size());
+  EXPECT_EQ(read_records(h, all.size()), all);
+  EXPECT_EQ(read_records(h, 10, 30), slice(all, 30, 10));
+
+  // overwriting a window leaves everything around it alone
+  const auto replacement = make_records(10, 9999);
+  h.write_at(std::span(replacement), 30 * sizeof(record));
+  const auto after = read_records(h, all.size());
+  EXPECT_EQ(slice(after, 0, 30), slice(all, 0, 30));
+  EXPECT_EQ(slice(after, 30, 10), replacement);
+  EXPECT_EQ(slice(after, 40, 60), slice(all, 40, 60));
+}
+
+// sort_sequence relies on this: the merge never pre-sizes its output, partitions just write their
+// own ranges and the file has to end up exactly as long as they cover
+TEST(FileHandle, ExtendsAFileThatAlreadyHasContent) {
+  scoped_file f;
+  const auto head = make_records(20, 1);
+  { file_handle::create(f.path).write_at(std::span(head), 0); }
+  const auto tail = make_records(5, 2);
+  const auto h = file_handle::open(f.path); // opened, not replaced
+  h.write_at(std::span(tail), 100 * sizeof(record));
+
+  EXPECT_EQ(records_in(f.path), 105u);
+  const auto all = read_records(h, 105);
+  EXPECT_EQ(slice(all, 0, 20), head);
+  EXPECT_EQ(slice(all, 20, 80), std::vector<record>(80)); // the gap reads as zeros
+  EXPECT_EQ(slice(all, 100, 5), tail);
+}
+
+TEST(FileHandle, TruncateEmptiesAnExistingFile) {
+  scoped_file f;
+  const auto initial = make_records(100, 3);
+  { file_handle::create(f.path).write_at(std::span(initial), 0); }
+  EXPECT_EQ(records_in(f.path), 100u);
+  { const auto h = file_handle::create(f.path); }
+  EXPECT_EQ(records_in(f.path), 0u);
+}
+
+TEST(FileHandle, ThrowsWhenTheFileIsMissing) {
+  scoped_file f;
+  try {
+    const auto h = file_handle::open(f.path);
+    FAIL();
+  } catch (const std::runtime_error& e) {
+    // the one failure that still names the file, since the caller handed it to us
+    EXPECT_NE(std::string(e.what()).find(f.path), std::string::npos);
+  }
+}
+
+TEST(FileHandle, ThrowsWhenReadingPastTheEnd) {
+  scoped_file f;
+  const auto h = file_handle::create(f.path);
+  std::vector<record> buffer(20);
+  h.write_at(std::span(buffer).first(10), 0); // only ten records exist
+  EXPECT_THROW(h.read_at(std::span(buffer), 0), std::runtime_error);
+}
+
+TEST(FileHandle, EmptyTransfersDoNothing) {
+  scoped_file f;
+  const auto h = file_handle::create(f.path);
+  std::vector<record> none;
+  EXPECT_NO_THROW(h.write_at(std::span(none), 0));
+  EXPECT_NO_THROW(h.read_at(std::span(none), 1 << 20)); // no bytes move, so the offset is moot
+  EXPECT_EQ(records_in(f.path), 0u);
+}
+
+// transfers longer than the internal chunk size loop, so the partial transfer bookkeeping runs
+TEST(FileHandle, ChunksTransfersLargerThanOneRequest) {
+  scoped_file f;
+  std::vector<uint64_t> written((64ull << 20) / sizeof(uint64_t) + 1024); // just over 64 MiB
+  std::iota(written.begin(), written.end(), 0);
+
+  const auto h = file_handle::create(f.path);
+  h.write_at(std::span(written), 0);
+  EXPECT_EQ(std::filesystem::file_size(f.path), written.size() * sizeof(uint64_t));
+
+  std::vector<uint64_t> read(written.size());
+  h.read_at(std::span(read), 0);
+  EXPECT_EQ(read, written);
+}
+
+// the property the whole design rests on: positioned transfers touch no shared cursor, so one
+// handle serves any number of threads
+TEST(FileHandle, OneHandleServesConcurrentWriters) {
+  scoped_file f;
+  constexpr size_t kThreads = 8, kPer = 4096;
+
+  const auto h = file_handle::create(f.path);
+  std::vector<std::thread> threads;
+  for (size_t t = 0; t < kThreads; ++t) {
+    // back to front, so the file is extended well before the gaps are filled
+    const size_t slot = kThreads - 1 - t;
+    threads.emplace_back([&h, slot]() {
+      const auto mine = make_records(kPer, slot * 1000000);
+      h.write_at(std::span(mine), slot * kPer * sizeof(record));
+    });
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  EXPECT_EQ(records_in(f.path), kThreads * kPer);
+  const auto all = read_records(h, kThreads * kPer);
+  for (size_t t = 0; t < kThreads; ++t) {
+    EXPECT_EQ(slice(all, t * kPer, kPer), make_records(kPer, t * 1000000)) << "slot " << t;
+  }
+}
+
+TEST(FileHandle, OneHandleServesConcurrentReaders) {
+  scoped_file f;
+  const auto written = make_records(8192, 11);
+  const auto h = file_handle::create(f.path);
+  h.write_at(std::span(written), 0);
+
+  std::atomic<size_t> mismatches(0);
+  std::vector<std::thread> threads;
+  threads.reserve(8);
+  for (size_t t = 0; t < 8; ++t) {
+    threads.emplace_back([&h, &written, &mismatches, t]() {
+      const size_t at = t * 512; // overlapping windows, so they genuinely contend
+      for (int repeat = 0; repeat < 16; ++repeat) {
+        if (read_records(h, 2048, at) != slice(written, at, 2048)) {
+          ++mismatches;
+        }
+      }
+    });
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+  EXPECT_EQ(mismatches.load(), 0u);
+}
+
+// guards a double close: if the moved from handle still owned the descriptor it would shut it
+// while the destination is still using it
+TEST(FileHandle, DestroyingTheMovedFromHandleLeavesTheFileUsable) {
+  scoped_file f;
+  const auto written = make_records(64, 2);
+
+  std::optional<file_handle> survivor;
+  {
+    auto source = file_handle::create(f.path);
+    source.write_at(std::span(written), 0);
+    survivor.emplace(std::move(source));
+  }
+  EXPECT_EQ(read_records(*survivor, written.size()), written);
+}
+
+TEST(FileHandle, MoveAssignmentAdoptsTheNewFileAndSurvivesSelfAssignment) {
+  scoped_file first("move_assign_first");
+  scoped_file second("move_assign_second");
+  const auto twos = make_records(32, 200);
+  {
+    const auto ones = make_records(32, 100);
+    file_handle::create(first.path).write_at(std::span(ones), 0);
+    file_handle::create(second.path).write_at(std::span(twos), 0);
+  }
+
+  auto h = file_handle::open(first.path);
+  h = file_handle::open(second.path); // the first descriptor is released here
+  EXPECT_EQ(read_records(h, twos.size()), twos);
+
+  auto& alias = h;
+  h = std::move(alias); // self assignment must not close the descriptor it is about to keep
+  EXPECT_EQ(read_records(h, twos.size()), twos);
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/file_io.cc
+++ b/test/file_io.cc
@@ -69,7 +69,7 @@ size_t records_in(const std::string& path) {
 TEST(FileHandle, TransfersAtOffsets) {
   scoped_file f;
   const auto all = make_records(100, 7);
-  const auto h = file_handle::create(f.path);
+  auto h = file_handle::create(f.path);
   h.write_at(std::span(all), 0);
   EXPECT_EQ(records_in(f.path), all.size());
   EXPECT_EQ(read_records(h, all.size()), all);
@@ -91,7 +91,7 @@ TEST(FileHandle, ExtendsAFileThatAlreadyHasContent) {
   const auto head = make_records(20, 1);
   { file_handle::create(f.path).write_at(std::span(head), 0); }
   const auto tail = make_records(5, 2);
-  const auto h = file_handle::open(f.path); // opened, not replaced
+  auto h = file_handle::open(f.path); // opened, not replaced
   h.write_at(std::span(tail), 100 * sizeof(record));
 
   EXPECT_EQ(records_in(f.path), 105u);
@@ -123,7 +123,7 @@ TEST(FileHandle, ThrowsWhenTheFileIsMissing) {
 
 TEST(FileHandle, ThrowsWhenReadingPastTheEnd) {
   scoped_file f;
-  const auto h = file_handle::create(f.path);
+  auto h = file_handle::create(f.path);
   std::vector<record> buffer(20);
   h.write_at(std::span(buffer).first(10), 0); // only ten records exist
   EXPECT_THROW(h.read_at(std::span(buffer), 0), std::runtime_error);
@@ -131,7 +131,7 @@ TEST(FileHandle, ThrowsWhenReadingPastTheEnd) {
 
 TEST(FileHandle, EmptyTransfersDoNothing) {
   scoped_file f;
-  const auto h = file_handle::create(f.path);
+  auto h = file_handle::create(f.path);
   std::vector<record> none;
   EXPECT_NO_THROW(h.write_at(std::span(none), 0));
   EXPECT_NO_THROW(h.read_at(std::span(none), 1 << 20)); // no bytes move, so the offset is moot
@@ -144,7 +144,7 @@ TEST(FileHandle, ChunksTransfersLargerThanOneRequest) {
   std::vector<uint64_t> written((64ull << 20) / sizeof(uint64_t) + 1024); // just over 64 MiB
   std::iota(written.begin(), written.end(), 0);
 
-  const auto h = file_handle::create(f.path);
+  auto h = file_handle::create(f.path);
   h.write_at(std::span(written), 0);
   EXPECT_EQ(std::filesystem::file_size(f.path), written.size() * sizeof(uint64_t));
 
@@ -159,7 +159,7 @@ TEST(FileHandle, OneHandleServesConcurrentWriters) {
   scoped_file f;
   constexpr size_t kThreads = 8, kPer = 4096;
 
-  const auto h = file_handle::create(f.path);
+  auto h = file_handle::create(f.path);
   std::vector<std::thread> threads;
   for (size_t t = 0; t < kThreads; ++t) {
     // back to front, so the file is extended well before the gaps are filled
@@ -183,7 +183,7 @@ TEST(FileHandle, OneHandleServesConcurrentWriters) {
 TEST(FileHandle, OneHandleServesConcurrentReaders) {
   scoped_file f;
   const auto written = make_records(8192, 11);
-  const auto h = file_handle::create(f.path);
+  auto h = file_handle::create(f.path);
   h.write_at(std::span(written), 0);
 
   std::atomic<size_t> mismatches(0);

--- a/valhalla/midgard/file_io.h
+++ b/valhalla/midgard/file_io.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <cstdint>
+#include <span>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace valhalla {
+namespace midgard {
+
+template <class T>
+inline constexpr bool is_byte_copyable_v =
+    std::is_trivially_copy_constructible_v<T>&& std::is_trivially_destructible_v<T>;
+
+/**
+ * Thin owning wrapper over the platform's file API. Abstracts platform-specific API for offseted
+ * read and write operations that mutate no inner state and thus could be done concurrently.
+ */
+class file_handle {
+public:
+  // Opens a file that must already exist. Throws otherwise.
+  static file_handle open(const std::string& path);
+  // Creates the file, emptying it if it is already there.
+  static file_handle create(const std::string& path);
+
+  ~file_handle();
+
+  file_handle(file_handle&& other) noexcept : handle_(other.handle_) {
+    other.handle_ = kEmpty;
+  }
+  file_handle& operator=(file_handle&& other) noexcept {
+    file_handle local(std::move(other));
+    std::swap(handle_, local.handle_);
+    return *this;
+  }
+  file_handle(const file_handle&) = delete;
+  file_handle& operator=(const file_handle&) = delete;
+
+  template <class T> void read_at(std::span<T> destination, uint64_t offset_bytes) const {
+    static_assert(is_byte_copyable_v<T>, "file_handle moves raw bytes");
+    static_assert(!std::is_const_v<T>, "read_at needs a writable destination");
+    read_bytes_at(destination.data(), destination.size_bytes(), offset_bytes);
+  }
+
+  template <class T> void write_at(std::span<T> source, uint64_t offset_bytes) {
+    static_assert(is_byte_copyable_v<std::remove_const_t<T>>, "file_handle moves raw bytes");
+    write_bytes_at(source.data(), source.size_bytes(), offset_bytes);
+  }
+
+private:
+  // Constructor is private. Use `open` or `create` functions instead
+  explicit file_handle(uintptr_t handle) : handle_(handle) {
+  }
+
+  void read_bytes_at(void* destination, size_t bytes, uint64_t offset) const;
+  void write_bytes_at(const void* source, size_t bytes, uint64_t offset);
+
+  // Platform-specific, file descriptor on POSIX and HANDLE on Windows.
+  static constexpr uintptr_t kEmpty = ~uintptr_t(0);
+  uintptr_t handle_;
+};
+
+} // namespace midgard
+} // namespace valhalla

--- a/valhalla/midgard/file_io.h
+++ b/valhalla/midgard/file_io.h
@@ -14,7 +14,7 @@ inline constexpr bool is_byte_copyable_v =
     std::is_trivially_copy_constructible_v<T>&& std::is_trivially_destructible_v<T>;
 
 /**
- * Thin owning wrapper over the platform's file API. Abstracts platform-specific API for offseted
+ * Thin owning wrapper over the platform's file API. Abstracts platform-specific API for offsetted
  * read and write operations that mutate no inner state and thus could be done concurrently.
  */
 class file_handle {

--- a/valhalla/midgard/sequence.h
+++ b/valhalla/midgard/sequence.h
@@ -340,7 +340,7 @@ public:
     }
 
     const size_t element_count = memmap.size();
-    // Sorting via offseted bulk reads/writes, so fstream and mmap handles have no use for us.
+    // Sorting via offsetted bulk reads/writes, so fstream and mmap handles have no use for us.
     file.reset();
     memmap.unmap();
 

--- a/valhalla/midgard/sequence.h
+++ b/valhalla/midgard/sequence.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "midgard/file_io.h"
+
 #include <algorithm>
 #include <atomic>
 #include <cerrno>
@@ -337,23 +339,36 @@ public:
       return;
     }
 
+    const size_t element_count = memmap.size();
+    // Sorting via offseted bulk reads/writes, so fstream and mmap handles have no use for us.
+    file.reset();
+    memmap.unmap();
+
     // No more threads than chunks so every worker handles at least ~buffer_size elements
-    const size_t chunk_count = 1 + (memmap.size() - 1) / buffer_size;
+    const size_t chunk_count = 1 + (element_count - 1) / buffer_size;
     // No more than 8 as it doesn't give much beyond that number while hits hard on old disks
     concurrency = std::min(std::clamp(concurrency, size_t(1), size_t(8)), chunk_count);
 
-    // Sort the subsections in parallel
+    // Read `buffer_size` size of items, sort them and write them back in parallel
     {
+      // positioned transfers consult no cursor, so every worker shares the same handle
+      file_handle handle = file_handle::open(file_name);
       std::atomic<size_t> next_chunk(0); // self-scheduling counter to avoid a slow tail
       std::vector<std::thread> threads;
       threads.reserve(concurrency);
       for (size_t i = 0; i < concurrency; ++i) {
-        threads.emplace_back([this, &predicate, buffer_size, &next_chunk, chunk_count]() {
+        threads.emplace_back([&handle, &predicate, buffer_size, element_count, &next_chunk,
+                              chunk_count]() {
+          const auto buffer = std::make_unique_for_overwrite<std::byte[]>(buffer_size * sizeof(T));
           for (size_t chunk = next_chunk++; chunk < chunk_count; chunk = next_chunk++) {
             const size_t begin = chunk * buffer_size;
-            std::sort(static_cast<T*>(memmap) + begin,
-                      static_cast<T*>(memmap) + std::min(memmap.size(), begin + buffer_size),
-                      predicate);
+            const size_t end = std::min(element_count, begin + buffer_size);
+            const std::span<T> view(reinterpret_cast<T*>(buffer.get()), end - begin);
+            const uint64_t offset_bytes = static_cast<uint64_t>(begin) * sizeof(T);
+
+            handle.read_at(view, offset_bytes);
+            std::sort(view.begin(), view.end(), predicate);
+            handle.write_at(view, offset_bytes);
           }
         });
       }
@@ -365,8 +380,9 @@ public:
     auto tmp_path = std::filesystem::path(file_name).replace_filename(
         std::filesystem::path(file_name).filename().string() + ".tmp");
     {
-      // chunks are partitioned by value so each partition merges into its own output range
-      const T* data = static_cast<const T*>(memmap);
+      mem_map<T> input;
+      input.map(file_name, element_count);
+      const T* data = static_cast<const T*>(input);
       // one merge thread per partition
       const size_t partition_count = concurrency;
 
@@ -375,7 +391,7 @@ public:
       samples.reserve(chunk_count * (partition_count - 1));
       for (size_t chunk = 0; chunk < chunk_count; ++chunk) {
         const size_t begin = chunk * buffer_size;
-        const size_t len = std::min(memmap.size(), begin + buffer_size) - begin;
+        const size_t len = std::min(element_count, begin + buffer_size) - begin;
         for (size_t k = 1; k < partition_count; ++k) {
           samples.push_back(data[begin + k * len / partition_count]);
         }
@@ -385,7 +401,7 @@ public:
       // per-chunk partition boundaries, partition_count + 1 monotonic indexes each
       std::vector<std::vector<size_t>> boundaries(chunk_count);
       for (size_t chunk = 0; chunk < chunk_count; ++chunk) {
-        const size_t end = std::min(memmap.size(), chunk * buffer_size + buffer_size);
+        const size_t end = std::min(element_count, chunk * buffer_size + buffer_size);
         auto& bounds = boundaries[chunk];
         bounds.reserve(partition_count + 1);
         bounds.push_back(chunk * buffer_size);
@@ -407,10 +423,7 @@ public:
         }
       }
 
-      // The temporary file the merged output is written into, mapped at full size upfront
-      std::filesystem::remove(tmp_path); // drop stale bytes of a previously interrupted sort
-      mem_map<T> output;
-      output.create(tmp_path.string(), memmap.size());
+      file_handle output = file_handle::create(tmp_path.string());
 
       // partitions are disjoint by value so each merges and writes its range without locking
       auto merge_partition = [&](size_t k) {
@@ -427,17 +440,34 @@ public:
         }
         std::make_heap(heap.begin(), heap.end(), cmp);
 
-        T* out = static_cast<T*>(output) + output_offsets[k];
+        // Merge in small 32MiB buffer before writing into file
+        std::vector<T> buffer;
+        buffer.reserve(32 * 1024 * 1024 / sizeof(T));
+        uint64_t at = static_cast<uint64_t>(output_offsets[k]) * sizeof(T);
+        auto drain = [&]() {
+          if (buffer.empty()) {
+            return;
+          }
+          const std::span written(buffer);
+          output.write_at(written, at);
+          at += written.size_bytes();
+          buffer.clear();
+        };
+
         while (!heap.empty()) {
           std::pop_heap(heap.begin(), heap.end(), cmp);
           const size_t chunk = heap.back();
-          *out++ = data[cursors[chunk]];
+          buffer.push_back(data[cursors[chunk]]);
+          if (buffer.size() == buffer.capacity()) {
+            drain();
+          }
           if (++cursors[chunk] < boundaries[chunk][k + 1]) {
             std::push_heap(heap.begin(), heap.end(), cmp);
           } else {
             heap.pop_back();
           }
         }
+        drain();
       };
       std::vector<std::thread> threads;
       threads.reserve(partition_count);
@@ -449,11 +479,6 @@ public:
       }
     }
 
-    // Forget about this file for a second so we can swap in the temp file
-    file.reset();
-    memmap.unmap();
-
-    // Move the sorted result back into place
     std::filesystem::remove(file_name);
     std::filesystem::rename(tmp_path, file_name);
 


### PR DESCRIPTION
_Please don't force-push once you received the first review._

# Issue

fixes https://github.com/valhalla/valhalla/issues/6312
The hypothesis is that concurrent implementation of `sequence::sort<T>` performs too many randomly positioned writes, which in turn destroyes the performance on spinning hard drives.

This PR changes the approach from "sort in a segment of mmap" to "read -> sort -> write" via offsetted read/write operations. 

Measurenments for sorting 108GiB `way_nodes.bin` file:

  | device |  master  |    PR     |    change     |
  | --- | --- | --- | --- |
  | M3 Max   | 446.0 s  | 274.6 s   | −38% (1.62×)  |
  | EC2 NVMe | 254.7 s  | 256.7 s   | +1% (neutral) |
  | EC2 st1  | 4712.8 s | 3071.4 s* | −34% (1.52×)  |

*EC2 here is m8gd.4xlarge instance with NVMe and attached st1 (hdd) 8TB volume*

## Tasklist

 - [x] Add tests
 - [x] Add #fixes with the issue number that this PR addresses
 - [ ] Update the docs with any new request parameters or changes to behavior described
 - [x] Update the [changelog](CHANGELOG.md)
 - [ ] If you made changes to the lua files, update the [taginfo](taginfo.json) too
 - [ ] If you changed English narrative phrases, run `po_tools.py update` — see [locales](docs/docs/contributing/locales.md)

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
